### PR TITLE
Rendering issue - Streckengrafik (graphical timetable) when node are closed (transition line not shown)

### DIFF
--- a/src/app/streckengrafik/components/train-run-node/trainrun-node.component.scss
+++ b/src/app/streckengrafik/components/train-run-node/trainrun-node.component.scss
@@ -1,7 +1,7 @@
 path.edge_line {
   fill: none;
   stroke: var(--NODE_TEXT_FOCUS);
-  stroke-width: 1px;
+  stroke-width: 2px;
   shape-rendering: crispEdges;
 }
 


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->
# Description

The problem is fixed 

Before fix:

![image](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/assets/10423646/6c52a4df-d9db-4bd3-a5ca-3e27557f251d)


After: 
![image](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/assets/10423646/9f05592a-1d7d-47e7-950a-2d073cfa26e1)


# Issues

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] This PR contains a description of the changes I'm making
* [x] I've read the [Contribution Guidelines](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/CONTRIBUTING.md)
* [x] I've added tests for changes or features I've introduced
* [x] I documented any high-level concepts I'm introducing in `documentation/`
* [x] CI is currently green and this is ready for review

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation.
-->
