### PR TITLE
rendering - frustum culling implemented  

### DIFF
--- a/src/app/services/ui/ui.interaction.service.ts
+++ b/src/app/services/ui/ui.interaction.service.ts
@@ -217,7 +217,7 @@ export class UiInteractionService implements OnDestroy {
   }
 
 
-  private checkIsElementPositionInViewport(pos: Vec2D, strSvgName: string, extraPixelsIn = 32): ViewportOut {
+  private checkIsElementPositionInViewport(pos: Vec2D, strSvgName: string, extraPixelsIn = 32): ViewportOut[] {
 
     const vp = this.getViewboxProperties(strSvgName);
     const extraPixels = extraPixelsIn / (vp.zoomFactor * 100);
@@ -226,19 +226,23 @@ export class UiInteractionService implements OnDestroy {
     const x1 = x0 + Number(vp.panZoomWidth) + 2.0 * extraPixels;
     const y1 = y0 + Number(vp.panZoomHeight) + 2.0 * extraPixels;
 
+    const retOut : ViewportOut[] = [];
     if (pos.getX() < x0) {
-      return ViewportOut.LeftOutside;
+      retOut.push( ViewportOut.LeftOutside);
     }
     if (pos.getX() > x1) {
-      return ViewportOut.RightOutside;
+      retOut.push( ViewportOut.RightOutside);
     }
     if (pos.getY() < y0) {
-      return ViewportOut.TopOutside;
+      retOut.push( ViewportOut.TopOutside);
     }
     if (pos.getY() > y1) {
-      return ViewportOut.BottomOutside;
+      retOut.push( ViewportOut.BottomOutside);
     }
-    return ViewportOut.ElmentIsInside;
+    if (retOut.length === 0 ) {
+      return [ViewportOut.ElmentIsInside];
+    }
+    return retOut;
   }
 
   checkIsPositionInViewport(positions: Vec2D[], strSvgName, extraPixelsIn = 32): boolean {
@@ -250,17 +254,17 @@ export class UiInteractionService implements OnDestroy {
     const mappedPositions = positions.map((el: Vec2D) =>
       this.checkIsElementPositionInViewport(el, strSvgName, extraPixelsIn));
 
-    if (mappedPositions.find(el => el === ViewportOut.ElmentIsInside) !== undefined) {
+    if (mappedPositions.find(el => el.find( el2 => el2 === ViewportOut.ElmentIsInside) !== undefined) !== undefined) {
       // check whether an element is inside the "Viewport"
       return true;
     }
-    if (mappedPositions.find(el => el === ViewportOut.LeftOutside) !== undefined) {
-      if (mappedPositions.find(el => el === ViewportOut.RightOutside) !== undefined) {
+    if (mappedPositions.find(el => el.find( el2 => el2 === ViewportOut.LeftOutside) !== undefined) !== undefined) {
+      if (mappedPositions.find(el => el.find( el2 => el2 === ViewportOut.RightOutside) !== undefined) !== undefined) {
         return true;
       }
     } else {
-      if (mappedPositions.find(el => el === ViewportOut.TopOutside) !== undefined) {
-        if (mappedPositions.find(el => el === ViewportOut.BottomOutside) !== undefined) {
+      if (mappedPositions.find(el => el.find( el2 => el2 === ViewportOut.TopOutside) !== undefined) !== undefined) {
+        if (mappedPositions.find(el => el.find( el2 => el2 === ViewportOut.BottomOutside) !== undefined) !== undefined) {
           return true;
         }
       }

--- a/src/app/services/ui/ui.interaction.service.ts
+++ b/src/app/services/ui/ui.interaction.service.ts
@@ -240,7 +240,7 @@ export class UiInteractionService implements OnDestroy {
       retOut.push( ViewportOut.BottomOutside);
     }
     if (retOut.length === 0 ) {
-      return [ViewportOut.ElmentIsInside];
+      return [ViewportOut.ElementIsInside];
     }
     return retOut;
   }
@@ -254,7 +254,7 @@ export class UiInteractionService implements OnDestroy {
     const mappedPositions = positions.map((el: Vec2D) =>
       this.checkIsElementPositionInViewport(el, strSvgName, extraPixelsIn));
 
-    if (mappedPositions.find(el => el.find( el2 => el2 === ViewportOut.ElmentIsInside) !== undefined) !== undefined) {
+    if (mappedPositions.find(el => el.find( el2 => el2 === ViewportOut.ElementIsInside) !== undefined) !== undefined) {
       // check whether an element is inside the "Viewport"
       return true;
     }

--- a/src/app/services/ui/ui.interaction.service.ts
+++ b/src/app/services/ui/ui.interaction.service.ts
@@ -209,6 +209,9 @@ export class UiInteractionService implements OnDestroy {
   }
 
   onViewportChangeUpdateRendering(doCheckIsInViewport: boolean = true) {
+    // The doCheckIsInViewport should only be set to false when the entire netzgrafik
+    // needs to be rendered, for example, when the entire graphic has to be exported
+    // as SVG or PNG.
     this.doCheckIsInViewport = doCheckIsInViewport;
     this.nodeService.nodesUpdated();
     this.nodeService.connectionsUpdated();
@@ -216,9 +219,7 @@ export class UiInteractionService implements OnDestroy {
     this.trainrunSectionService.trainrunSectionsUpdated();
   }
 
-
   private checkIsElementPositionInViewport(pos: Vec2D, strSvgName: string, extraPixels = 64): ViewportOut[] {
-
     const vp = this.getViewboxProperties(strSvgName);
     const x0 = Number(vp.panZoomLeft) - extraPixels;
     const y0 = Number(vp.panZoomTop) - extraPixels;
@@ -244,7 +245,7 @@ export class UiInteractionService implements OnDestroy {
     return retOut;
   }
 
-  checkIsPositionInViewport(positions: Vec2D[], strSvgName, extraPixelsIn = 32): boolean {
+  cullCheckPositionsInViewport(positions: Vec2D[], strSvgName, extraPixelsIn = 32): boolean {
     if (!this.doCheckIsInViewport) {
       return true;
     }

--- a/src/app/services/ui/ui.interaction.service.ts
+++ b/src/app/services/ui/ui.interaction.service.ts
@@ -217,10 +217,9 @@ export class UiInteractionService implements OnDestroy {
   }
 
 
-  private checkIsElementPositionInViewport(pos: Vec2D, strSvgName: string, extraPixelsIn = 32): ViewportOut[] {
+  private checkIsElementPositionInViewport(pos: Vec2D, strSvgName: string, extraPixels = 64): ViewportOut[] {
 
     const vp = this.getViewboxProperties(strSvgName);
-    const extraPixels = extraPixelsIn / (vp.zoomFactor * 100);
     const x0 = Number(vp.panZoomLeft) - extraPixels;
     const y0 = Number(vp.panZoomTop) - extraPixels;
     const x1 = x0 + Number(vp.panZoomWidth) + 2.0 * extraPixels;

--- a/src/app/services/ui/ui.interaction.service.ts
+++ b/src/app/services/ui/ui.interaction.service.ts
@@ -258,18 +258,25 @@ export class UiInteractionService implements OnDestroy {
       // check whether an element is inside the "Viewport"
       return true;
     }
-    if (mappedPositions.find(el => el.find( el2 => el2 === ViewportOut.LeftOutside) !== undefined) !== undefined) {
-      if (mappedPositions.find(el => el.find( el2 => el2 === ViewportOut.RightOutside) !== undefined) !== undefined) {
-        return true;
-      }
-    } else {
-      if (mappedPositions.find(el => el.find( el2 => el2 === ViewportOut.TopOutside) !== undefined) !== undefined) {
-        if (mappedPositions.find(el => el.find( el2 => el2 === ViewportOut.BottomOutside) !== undefined) !== undefined) {
-          return true;
-        }
-      }
+
+    const topOutside = mappedPositions.filter( el => el.find( el2 => el2 === ViewportOut.TopOutside) !== undefined);
+    if (topOutside.length === mappedPositions.length){
+      return false;
     }
-    return false;
+    const bottomOutside = mappedPositions.filter( el => el.find( el2 => el2 === ViewportOut.BottomOutside) !== undefined);
+    if (bottomOutside.length === mappedPositions.length){
+      return false;
+    }
+    const leftOutside = mappedPositions.filter( el => el.find( el2 => el2 === ViewportOut.LeftOutside) !== undefined);
+    if (leftOutside.length === mappedPositions.length){
+      return false;
+    }
+    const rightOutside = mappedPositions.filter( el => el.find( el2 => el2 === ViewportOut.RightOutside) !== undefined);
+    if (rightOutside.length === mappedPositions.length){
+      return false;
+    }
+
+    return true;
   }
 
   loadActiveTheme() {

--- a/src/app/view/editor-main-view/data-views/connections.view.ts
+++ b/src/app/view/editor-main-view/data-views/connections.view.ts
@@ -292,7 +292,7 @@ export class ConnectionsView {
   displayConnections(inputConnections: Connection[]) {
     const connections = inputConnections.filter((c) =>
       this.filterConnectionsToDisplay(c) &&
-      this.editorView.checkIsPositionInViewport(c.getPath())
+      this.editorView.doCullCheckPositionsInViewport(c.getPath())
     );
     const connectionsGroup = this.connectionsGroup
       .selectAll(StaticDomTags.CONNECTION_ROOT_CONTAINER_DOM_REF)

--- a/src/app/view/editor-main-view/data-views/connections.view.ts
+++ b/src/app/view/editor-main-view/data-views/connections.view.ts
@@ -291,7 +291,8 @@ export class ConnectionsView {
 
   displayConnections(inputConnections: Connection[]) {
     const connections = inputConnections.filter((c) =>
-      this.filterConnectionsToDisplay(c),
+      this.filterConnectionsToDisplay(c) &&
+      this.editorView.checkIsPositionInViewport(c.getPath())
     );
     const connectionsGroup = this.connectionsGroup
       .selectAll(StaticDomTags.CONNECTION_ROOT_CONTAINER_DOM_REF)

--- a/src/app/view/editor-main-view/data-views/editor.view.ts
+++ b/src/app/view/editor-main-view/data-views/editor.view.ts
@@ -33,7 +33,7 @@ import {CopyService} from "../../../services/data/copy.service";
 import {StreckengrafikDrawingContext} from "../../../streckengrafik/model/util/streckengrafik.drawing.context";
 
 export enum ViewportOut {
-  ElmentIsInside,
+  ElementIsInside,
   LeftOutside,
   RightOutside,
   TopOutside,

--- a/src/app/view/editor-main-view/data-views/editor.view.ts
+++ b/src/app/view/editor-main-view/data-views/editor.view.ts
@@ -32,6 +32,14 @@ import {UndoService} from "../../../services/data/undo.service";
 import {CopyService} from "../../../services/data/copy.service";
 import {StreckengrafikDrawingContext} from "../../../streckengrafik/model/util/streckengrafik.drawing.context";
 
+export enum ViewportOut {
+  ElmentIsInside,
+  LeftOutside,
+  RightOutside,
+  TopOutside,
+  BottomOutside,
+}
+
 export class EditorView implements SVGMouseControllerObserver {
   static svgName = "graphContainer";
   editorMode: EditorMode = EditorMode.NetzgrafikEditing;
@@ -442,7 +450,7 @@ export class EditorView implements SVGMouseControllerObserver {
     if (!this.isMultiSelectOn) {
       return;
     }
-    
+
     const allNodesOfInterest = this.nodeService.getNodes().filter((n: Node) => {
       this.nodeService.unselectNode(n.getId(), false);
       if (this.filterService.filterNode(n)) {
@@ -572,6 +580,7 @@ export class EditorView implements SVGMouseControllerObserver {
 
   zoomFactorChanged(newZoomFactor: number) {
     this.controller.zoomFactorChanged(newZoomFactor);
+    this.uiInteractionService.onViewportChangeUpdateRendering(true);
   }
 
   onViewboxChanged(viewboxProperties: ViewboxProperties) {
@@ -579,6 +588,14 @@ export class EditorView implements SVGMouseControllerObserver {
       EditorView.svgName,
       viewboxProperties,
     );
+    this.uiInteractionService.onViewportChangeUpdateRendering(true);
+  }
+
+  checkIsPositionInViewport(positions: Vec2D[], extraPixelsIn = 32): boolean {
+    return this.uiInteractionService.checkIsPositionInViewport(
+      positions,
+      EditorView.svgName,
+      extraPixelsIn);
   }
 
   setEditorMode(mode: EditorMode) {

--- a/src/app/view/editor-main-view/data-views/editor.view.ts
+++ b/src/app/view/editor-main-view/data-views/editor.view.ts
@@ -591,8 +591,8 @@ export class EditorView implements SVGMouseControllerObserver {
     this.uiInteractionService.onViewportChangeUpdateRendering(true);
   }
 
-  checkIsPositionInViewport(positions: Vec2D[], extraPixelsIn = 32): boolean {
-    return this.uiInteractionService.checkIsPositionInViewport(
+  doCullCheckPositionsInViewport(positions: Vec2D[], extraPixelsIn = 32): boolean {
+    return this.uiInteractionService.cullCheckPositionsInViewport(
       positions,
       EditorView.svgName,
       extraPixelsIn);

--- a/src/app/view/editor-main-view/data-views/nodes.view.ts
+++ b/src/app/view/editor-main-view/data-views/nodes.view.ts
@@ -106,6 +106,12 @@ export class NodesView {
           ),
           new Vec2D(
             n.getPositionX() + n.getNodeWidth(),
+            n.getPositionY()),
+          new Vec2D(
+            n.getPositionX(),
+            n.getPositionY() + n.getNodeHeight()),
+          new Vec2D(
+            n.getPositionX() + n.getNodeWidth(),
             n.getPositionY() + n.getNodeHeight())
         ])
     );

--- a/src/app/view/editor-main-view/data-views/nodes.view.ts
+++ b/src/app/view/editor-main-view/data-views/nodes.view.ts
@@ -98,7 +98,7 @@ export class NodesView {
   displayNodes(inputNodes: Node[]) {
     const nodes = inputNodes.filter((n) =>
       this.filterNodesToDisplay(n) &&
-      this.editorView.checkIsPositionInViewport(
+      this.editorView.doCullCheckPositionsInViewport(
         [
           new Vec2D(
             n.getPositionX(),

--- a/src/app/view/editor-main-view/data-views/nodes.view.ts
+++ b/src/app/view/editor-main-view/data-views/nodes.view.ts
@@ -96,7 +96,19 @@ export class NodesView {
   }
 
   displayNodes(inputNodes: Node[]) {
-    const nodes = inputNodes.filter((n) => this.filterNodesToDisplay(n));
+    const nodes = inputNodes.filter((n) =>
+      this.filterNodesToDisplay(n) &&
+      this.editorView.checkIsPositionInViewport(
+        [
+          new Vec2D(
+            n.getPositionX(),
+            n.getPositionY()
+          ),
+          new Vec2D(
+            n.getPositionX() + n.getNodeWidth(),
+            n.getPositionY() + n.getNodeHeight())
+        ])
+    );
 
     const group = this.nodeGroup
       .selectAll(StaticDomTags.NODE_ROOT_CONTAINER_DOM_REF)

--- a/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
@@ -1659,7 +1659,8 @@ export class TrainrunSectionsView {
 
     const filteredTrainrunSections = trainrunSections.filter(
       (trainrunSection: TrainrunSection) =>
-        this.filterTrainrunSectionToDisplay(trainrunSection),
+        this.filterTrainrunSectionToDisplay(trainrunSection) &&
+        this.editorView.checkIsPositionInViewport(trainrunSection.getPath())
     );
 
     const group = this.trainrunSectionGroup

--- a/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
@@ -1660,7 +1660,7 @@ export class TrainrunSectionsView {
     const filteredTrainrunSections = trainrunSections.filter(
       (trainrunSection: TrainrunSection) =>
         this.filterTrainrunSectionToDisplay(trainrunSection) &&
-        this.editorView.checkIsPositionInViewport(trainrunSection.getPath())
+        this.editorView.doCullCheckPositionsInViewport(trainrunSection.getPath())
     );
 
     const group = this.trainrunSectionGroup

--- a/src/app/view/editor-main-view/data-views/transitions.view.ts
+++ b/src/app/view/editor-main-view/data-views/transitions.view.ts
@@ -242,7 +242,8 @@ export class TransitionsView {
     }
 
     const transitions = inputTransitions.filter((t) =>
-      this.filtertransitionToDisplay(t, t.getTrainrun()),
+      this.filtertransitionToDisplay(t, t.getTrainrun()) &&
+      this.editorView.checkIsPositionInViewport(t.getPath())
     );
     this.createTransitions(
       transitions,

--- a/src/app/view/editor-main-view/data-views/transitions.view.ts
+++ b/src/app/view/editor-main-view/data-views/transitions.view.ts
@@ -243,7 +243,7 @@ export class TransitionsView {
 
     const transitions = inputTransitions.filter((t) =>
       this.filtertransitionToDisplay(t, t.getTrainrun()) &&
-      this.editorView.checkIsPositionInViewport(t.getPath())
+      this.editorView.doCullCheckPositionsInViewport(t.getPath())
     );
     this.createTransitions(
       transitions,

--- a/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
+++ b/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
@@ -117,6 +117,8 @@ export class EditorToolsViewComponent {
   onExportNetzgrafikSVG() {
     // option 2: save svg as svg
     // https://www.npmjs.com/package/save-svg-as-png
+    this.uiInteractionService.onViewportChangeUpdateRendering(false);
+
     const containerInfo = this.getContainertoExport();
     svg
       .svgAsDataUri(
@@ -146,6 +148,8 @@ export class EditorToolsViewComponent {
   onExportNetzgrafikPNG() {
     // option 1: save svg as png
     // https://www.npmjs.com/package/save-svg-as-png
+    this.uiInteractionService.onViewportChangeUpdateRendering(false);
+
     const containerInfo = this.getContainertoExport();
     svg.saveSvgAsPng(
       containerInfo.documentToExport,
@@ -307,10 +311,12 @@ export class EditorToolsViewComponent {
       "main-streckengrafik-container",
     );
     let param = {};
-    console.log(htmlElementToExport);
+    console.log("Try -1- (main-streckengrafik-container): ", htmlElementToExport !== null);
 
     if (htmlElementToExport === null) {
       htmlElementToExport = document.getElementById("graphContainer");
+      console.log("Try -2- (graphContainer): ", htmlElementToExport !== null);
+
       const boundingBox = this.getNetzgrafikBoundingBox();
       param = {
         encoderOptions: 1.0,

--- a/src/app/view/util/svg.mouse.controller.ts
+++ b/src/app/view/util/svg.mouse.controller.ts
@@ -76,8 +76,6 @@ export class SVGMouseController {
   }
 
   resize(width: number, height: number) {
-    const oldW = this.svgDrawingContext.attr("width");
-    const oldH = this.svgDrawingContext.attr("height");
     this.svgDrawingContext.attr("width", width);
     this.svgDrawingContext.attr("height", height);
     if (

--- a/src/app/view/util/svg.mouse.controller.ts
+++ b/src/app/view/util/svg.mouse.controller.ts
@@ -92,12 +92,9 @@ export class SVGMouseController {
       this.viewboxProperties.panZoomHeight = height;
       this.viewboxProperties.panZoomWidth = width;
     } else {
-      const dW = width - oldW;
-      const dH = height - oldH;
-      this.viewboxProperties.panZoomLeft -= dW / 2;
-      this.viewboxProperties.panZoomTop -= dH / 2;
-      this.viewboxProperties.panZoomWidth += dW;
-      this.viewboxProperties.panZoomHeight += dH;
+      this.viewboxProperties.origHeight = height;
+      this.viewboxProperties.origWidth = width;
+      this.updateZoomCenter(new Vec2D(0.5, 0.5));
     }
     this.setViewbox();
     this.svgMouseControllerObserver.zoomFactorChanged(

--- a/src/app/view/util/svg.mouse.controller.ts
+++ b/src/app/view/util/svg.mouse.controller.ts
@@ -76,6 +76,8 @@ export class SVGMouseController {
   }
 
   resize(width: number, height: number) {
+    const oldW = this.svgDrawingContext.attr("width");
+    const oldH = this.svgDrawingContext.attr("height");
     this.svgDrawingContext.attr("width", width);
     this.svgDrawingContext.attr("height", height);
     if (
@@ -89,6 +91,13 @@ export class SVGMouseController {
       this.viewboxProperties.panZoomTop = 0;
       this.viewboxProperties.panZoomHeight = height;
       this.viewboxProperties.panZoomWidth = width;
+    } else {
+      const dW = width - oldW;
+      const dH = height - oldH;
+      this.viewboxProperties.panZoomLeft -= dW / 2;
+      this.viewboxProperties.panZoomTop -= dH / 2;
+      this.viewboxProperties.panZoomWidth += dW;
+      this.viewboxProperties.panZoomHeight += dH;
     }
     this.setViewbox();
     this.svgMouseControllerObserver.zoomFactorChanged(


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->
# Description

Viewport culling is a technique used in computer graphics to improve rendering performance by only rendering objects that are visible within the viewport or rendering area of the screen.

When rendering the Netzgrafik (scene), the current implementation of the SVG graphics engine determines which objects are visible and should be rendered on the screen. This process involves checking whether each object's bounding volume (such as a bounding box or bounding sphere) intersects with the viewport or falls entirely outside of it.

Objects that are completely outside the viewport are considered to be occluded or not visible, so they are not rendered, saving computational resources. On the other hand, objects that intersect with the viewport or partially fall inside it are considered to be visible and are rendered.

Overall, viewport culling is a crucial step in the rendering pipeline to optimize rendering performance by reducing unnecessary computations and improving the efficiency of the graphics rendering process.

This feature is now available for the Netzgrafik editor in the editing mode. This can greatly improve interactivity, especially for complex Netzgrafik with many elements. 

![image](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/assets/10423646/06536448-218b-4442-a71a-40f0edacd02a)

> main changes:
> checkIsElementPositionInViewport(pos: Vec2D, strSvgName: string, extraPixels = 64): ViewportOut[] { ... }
> cullCheckPositionsInViewport(positions: Vec2D[], strSvgName, extraPixelsIn = 32): boolean { ... }

<!-- Describe the changes your PR introduces here. -->

# Issues

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.
-->

A known issue is that the frustum culling is scale-dependent. If the "camera" is far away, resulting in a large viewport, the performance gain may not be significant or sufficient.

When the scale factors are very small, it would make sense to implement a level of detail (LOD) system. This can help overcome the above address problem. When an object is too small in screen coordinates, it can be skipped or displayed with fewer details to improve performance.

> See https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/pull/105
# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] This PR contains a description of the changes I'm making
* [x] I've read the [Contribution Guidelines](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/CONTRIBUTING.md)
* [x] I've added tests for changes or features I've introduced
* [x] I documented any high-level concepts I'm introducing in `documentation/`
* [x] CI is currently green and this is ready for review

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation.
-->
