### PR TITLE
issue fixed and resolution increase - speed drops but still ok

### DIFF
--- a/src/app/streckengrafik/services/sg-6-track.service.ts
+++ b/src/app/streckengrafik/services/sg-6-track.service.ts
@@ -230,8 +230,8 @@ export class Sg6TrackService implements OnDestroy {
 
   private extractSectionTracks(
     sectionsOfInterest: Map<string, any[]>,
-    distRes = 4, // Res 15s
-    timeRes = 4, // Res 15s
+    distRes = 15, // Res 4s
+    timeRes = 15, // Res 4s
   ) {
     const sectionsTracks = new Map<string, number[]>();
     for (const keyNodeId of sectionsOfInterest.keys()) {
@@ -281,7 +281,7 @@ export class Sg6TrackService implements OnDestroy {
             // the bands of "headway" - Nachbelegung (free the occupied resource just after this "band"
             for (
               let bandOffset = 0;
-              bandOffset < timeRes * headwayTime;
+              bandOffset <= timeRes * headwayTime;
               bandOffset++
             ) {
               // compute the indices to get the matrix cell's where to fill in the information

--- a/src/app/streckengrafik/services/streckengrafik.services.spec.ts
+++ b/src/app/streckengrafik/services/streckengrafik.services.spec.ts
@@ -474,12 +474,12 @@ describe("StreckengrafikServicesTests", () => {
         expect(section.getPathNode()).toBe(undefined);
 
         const trackSegments = section.trackData.sectionTrackSegments;
-        expect(trackSegments.length).toBe(12);
+        expect(trackSegments.length).toBe(13);
         const trackSegDataTracks: number[] = [
-          4, 4, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+          4, 4, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2
         ];
         const trackSegDataMinTracks: number[] = [
-          4, 3, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1,
+          4, 3, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2
         ];
         for (let idx = 0; idx < trackSegments.length; idx++) {
           expect(trackSegments[idx].nbrTracks).toBe(trackSegDataTracks[idx]);
@@ -489,7 +489,7 @@ describe("StreckengrafikServicesTests", () => {
         }
         expect(trackSegments[0].startPos).toBe(0);
         expect(trackSegments[1].startPos).toBe(trackSegments[0].endPos);
-        expect(trackSegments[11].endPos).toBe(1);
+        expect(trackSegments[12].endPos).toBe(1);
 
         expect(node.trackOccupier).toBe(true);
       });


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->
# Description
The problem has been fixed. The problem was the wrong band limiter checking against "less than" instead of "less than or equal to". To increase accuracy - 4 second grid resolution. Performance is still ok. In general scheduling only 60s (1min) is scheduled in current scenarios => so 4s is still ok.

<!-- Describe the changes your PR introduces here. -->

# Issues

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] This PR contains a description of the changes I'm making
* [x] I've read the [Contribution Guidelines](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/CONTRIBUTING.md)
* [x] I've added tests for changes or features I've introduced
* [x] I documented any high-level concepts I'm introducing in `documentation/`
* [x] CI is currently green and this is ready for review

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation.
-->
