### PR TITLE
feat: add AppComponent inputs/outputs

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,9 +1,14 @@
-import {Component} from "@angular/core";
+import {Component, Input, Output} from "@angular/core";
 import {AuthService} from "./services/auth/auth.service";
+import {TrainrunService} from "./services/data/trainrun.service";
+import {TrainrunSectionService} from "./services/data/trainrunsection.service";
+import {DataService} from "./services/data/data.service";
 import {environment} from "../environments/environment";
 import packageJson from "../../package.json";
-import {Observable} from "rxjs";
+import {Observable, merge} from "rxjs";
 import {ProjectDto} from "./api/generated";
+import {NetzgrafikDto} from "./data-structures/business.data.structures";
+import {Operation} from "./models/operation.model";
 
 @Component({
   selector: "sbb-root",
@@ -33,7 +38,7 @@ export class AppComponent {
     return this.authService.claims?.email;
   }
 
-  constructor(private authService: AuthService) {
+  constructor(private authService: AuthService, private dataService: DataService, private trainrunService: TrainrunService, private trainrunSectionService: TrainrunSectionService) {
     if (!this.disableBackend) {
       this.authenticated = authService.initialized;
     }
@@ -44,4 +49,15 @@ export class AppComponent {
       this.authService.logOut();
     }
   }
+
+  @Input()
+  get netzgrafikDto() {
+    return this.dataService.getNetzgrafikDto();
+  }
+  set netzgrafikDto(netzgrafikDto: NetzgrafikDto) {
+    this.dataService.loadNetzgrafikDto(netzgrafikDto);
+  }
+
+  @Output()
+  operation: Observable<Operation> = merge(this.trainrunService.operation, this.trainrunSectionService.operation);
 }

--- a/src/app/models/operation.model.ts
+++ b/src/app/models/operation.model.ts
@@ -1,0 +1,43 @@
+import {Trainrun} from "./trainrun.model";
+import {TrainrunSection} from "./trainrunsection.model";
+
+enum OperationType {
+  create = "create",
+  update = "update",
+  delete = "delete"
+}
+
+export abstract class Operation {
+  readonly type: OperationType;
+
+  constructor(type: OperationType) {
+    this.type = type;
+  }
+}
+
+export class CreateTrainrunOperation extends Operation {
+  readonly trainrunSection: TrainrunSection;
+
+  constructor(trainrunSection: TrainrunSection) {
+    super(OperationType.create);
+    this.trainrunSection = trainrunSection;
+  }
+}
+
+export class UpdateTrainrunSectionsOperation extends Operation {
+  readonly trainrunSections: TrainrunSection[];
+
+  constructor(trainrunSections: TrainrunSection[]) {
+    super(OperationType.update);
+    this.trainrunSections = trainrunSections;
+  }
+}
+
+export class DeleteTrainrunOperation extends Operation {
+  readonly trainrun: Trainrun;
+
+  constructor(trainrun: Trainrun) {
+    super(OperationType.delete);
+    this.trainrun = trainrun;
+  }
+}

--- a/src/app/services/data/trainrun.service.ts
+++ b/src/app/services/data/trainrun.service.ts
@@ -8,7 +8,7 @@ import {
   TrainrunFrequency,
   TrainrunTimeCategory,
 } from "../../data-structures/business.data.structures";
-import {Injectable} from "@angular/core";
+import {EventEmitter, Injectable} from "@angular/core";
 import {BehaviorSubject} from "rxjs";
 import {NodeService} from "./node.service";
 import {TrainrunSectionService} from "./trainrunsection.service";
@@ -23,6 +23,7 @@ import {FilterService} from "../ui/filter.service";
 import {Transition} from "../../models/transition.model";
 import {Port} from "../../models/port.model";
 import {Connection} from "../../models/connection.model";
+import {DeleteTrainrunOperation, Operation} from "../../models/operation.model";
 
 @Injectable({
   providedIn: "root",
@@ -33,6 +34,8 @@ export class TrainrunService {
   readonly trainruns = this.trainrunsSubject.asObservable();
 
   trainrunsStore: { trainruns: Trainrun[] } = {trainruns: []}; // store the data in memory
+
+  readonly operation = new EventEmitter<Operation>();
 
   private dataService: DataService = null;
   private nodeService: NodeService = null;
@@ -180,6 +183,7 @@ export class TrainrunService {
     if (enforceUpdate) {
       this.trainrunsUpdated();
     }
+    this.operation.emit(new DeleteTrainrunOperation(trainrun));
   }
 
   getSelectedTrainrun(): Trainrun {


### PR DESCRIPTION
# Description

This is the second part of https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/pull/158, cleaned up and rebased.

Add inputs and outputs so that a custom element user can interact with NGE.

A netzgrafikDto input is introduced to get/set the data service's current DTO. A operation output is introduced to notify about DTO changes. The changes are described by a new Operation class.

The new additions have no impact on the existing behavior and can simply be ignored when unused (e.g. when NGE runs with its own backend).

cc @louisgreiner 

# Checklist

* [x] This PR contains a description of the changes I'm making
* [x] I've read the [Contribution Guidelines](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/CONTRIBUTING.md)
* [ ] I've added tests for changes or features I've introduced
* [ ] I documented any high-level concepts I'm introducing in `documentation/`
* [x] CI is currently green and this is ready for review