### PR TITLE
feat: publish package on NPM

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -54,3 +54,20 @@ jobs:
         with:
           name: build
           path: dist/netzgrafik-frontend/
+
+  build-standalone:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+      - run: npm clean-install
+      - run: npm run build:standalone
+      - name: Store build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-standalone
+          path: dist/netzgrafik-frontend/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,3 +38,22 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  release-npm-package:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm clean-install
+      - run: npm run build:standalone
+      - run: npm pkg delete dependencies optionalDependencies devDependencies
+      - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
   },
   "name": "netzgrafik-frontend",
   "version": "2.5.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend.git"
+  },
   "files": [
     "dist/*"
   ],


### PR DESCRIPTION
# Description

This is the last part of https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/pull/158.

Add two new CI tasks: one to build the standalone variant on push, and another one to publish an NPM package on release.

The latter requires setting up a `NPM_TOKEN` secret in the GitHub repository settings.

All dependencies are removed before publication because the published package is completely standalone: all of the dependencies are bundled in `dist/`.

Add the "repository" field in package.json: it's a requirement for the `npm publish --provenance` flag.

# Checklist

* [x] This PR contains a description of the changes I'm making
* [x] I've read the [Contribution Guidelines](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/CONTRIBUTING.md)
* [ ] I've added tests for changes or features I've introduced
* [ ] I documented any high-level concepts I'm introducing in `documentation/`
* [ ] CI is currently green and this is ready for review