### PR TITLE
fix: use light theme for sbb-esta

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" class="sbb-lean">
+<html lang="en" class="sbb-lean sbb-light">
   <head>
     <meta charset="utf-8" />
     <title>Netzgrafik-Editor</title>


### PR DESCRIPTION
# Description

The automatic dark variant is broken.

# Issues

Closes: https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/156

# Checklist

* [x] This PR contains a description of the changes I'm making
* [x] I've read the [Contribution Guidelines](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/CONTRIBUTING.md)
* [ ] I've added tests for changes or features I've introduced
* [ ] I documented any high-level concepts I'm introducing in `documentation/`
* [x] CI is currently green and this is ready for review
