### PR TITLE
refacto trainrun filter service for label uniqueness

### DIFF
--- a/src/app/services/data/node.service.ts
+++ b/src/app/services/data/node.service.ts
@@ -982,17 +982,17 @@ export class NodeService implements OnDestroy {
 
   changeLabels(nodeId: number, labels: string[]) {
     const node = this.getNodeFromId(nodeId);
-    const labelIds: number[] = [];
-    labels.forEach((label) => {
-      labelIds.push(
-        this.labelService.getOrCreateLabel(label, LabelRef.Node).getId(),
-      );
-    });
-    const deletetLabelIds = this.labelService.clearLabel(
+
+    // ensure uniqueness of input labels
+    const uniqueLabels = Array.from(new Set(labels));
+    const labelIds = uniqueLabels.map(label =>
+      this.labelService.getOrCreateLabel(label, LabelRef.Node).getId()
+    );
+    const deletedLabelIds = this.labelService.clearLabel(
       this.findClearedLabel(node, labelIds),
       this.makeLabelIDCounterMap(this.getNodes()),
     );
-    this.filterService.clearDeletetFilterNodeLabels(deletetLabelIds);
+    this.filterService.clearDeletetFilterNodeLabels(deletedLabelIds);
     node.setLabelIds(labelIds);
     this.nodesUpdated();
   }

--- a/src/app/services/data/note.service.ts
+++ b/src/app/services/data/note.service.ts
@@ -188,17 +188,17 @@ export class NoteService {
 
   setLabels(noteId: number, labels: string[]) {
     const note = this.getNoteFromId(noteId);
-    const labelIds: number[] = [];
-    labels.forEach((label) => {
-      labelIds.push(
-        this.labelService.getOrCreateLabel(label, LabelRef.Note).getId(),
-      );
-    });
-    const deletetLabelIds = this.labelService.clearLabel(
+
+    // ensure uniqueness of input labels
+    const uniqueLabels = Array.from(new Set(labels));
+    const labelIds = uniqueLabels.map(label =>
+      this.labelService.getOrCreateLabel(label, LabelRef.Note).getId()
+    );
+    const deletedLabelIds = this.labelService.clearLabel(
       this.findClearedLabel(note, labelIds),
       this.makeLabelIDCounterMap(this.getNotes()),
     );
-    this.filterService.clearDeletetFilterNoteLabels(deletetLabelIds);
+    this.filterService.clearDeletetFilterNoteLabels(deletedLabelIds);
     note.setLabelIds(labelIds);
     this.notesUpdated();
   }

--- a/src/app/services/data/trainrun.service.ts
+++ b/src/app/services/data/trainrun.service.ts
@@ -529,17 +529,17 @@ export class TrainrunService {
 
   setLabels(trainrunId: number, labels: string[]) {
     const trainrun = this.getTrainrunFromId(trainrunId);
-    const labelIds: number[] = [];
-    labels.forEach((label) => {
-      labelIds.push(
-        this.labelService.getOrCreateLabel(label, LabelRef.Trainrun).getId(),
-      );
-    });
-    const deletetLabelIds = this.labelService.clearLabel(
+
+    // ensure uniqueness of input labels
+    const uniqueLabels = Array.from(new Set(labels));
+    const labelIds = uniqueLabels.map(label =>
+      this.labelService.getOrCreateLabel(label, LabelRef.Trainrun).getId()
+    );
+    const deletedLabelIds = this.labelService.clearLabel(
       this.findClearedLabel(trainrun, labelIds),
       this.makeLabelIDCounterMap(this.getTrainruns()),
     );
-    this.filterService.clearDeletetFilterTrainrunLabels(deletetLabelIds);
+    this.filterService.clearDeletetFilterTrainrunLabels(deletedLabelIds);
     trainrun.setLabelIds(labelIds);
     this.trainrunsUpdated();
   }

--- a/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-filter-tab/trainrun-filter-tab.component.ts
+++ b/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-filter-tab/trainrun-filter-tab.component.ts
@@ -157,7 +157,6 @@ export class TrainrunFilterTabComponent implements OnInit, OnDestroy {
 
   // set labels only if any of it has changed
   private checkAndSetLabels() {
-    console.log(this.trainrunLabels);
     if (
       this.trainrunLabels.length !== this.initialTrainrunLabels.length ||
       !this.trainrunLabels.every((label, index) => label === this.initialTrainrunLabels[index])

--- a/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-filter-tab/trainrun-filter-tab.component.ts
+++ b/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-filter-tab/trainrun-filter-tab.component.ts
@@ -30,9 +30,11 @@ export class TrainrunFilterTabComponent implements OnInit, OnDestroy {
 
   public selectedTrainrun: Trainrun;
   public trainrunLabels: string[];
+  private initialTrainrunLabels: string[];
   trainrunLabelsAutoCompleteOptions: string[] = [];
   readonly separatorKeysCodes = [ENTER, COMMA];
   private destroyed = new Subject<void>();
+  private isLabelBeingEdited = false;
 
   constructor(
     public dataService: DataService,
@@ -76,10 +78,9 @@ export class TrainrunFilterTabComponent implements OnInit, OnDestroy {
     this.trainrunLabels = this.trainrunLabels.filter(
       (labels) => labels !== valueDelete,
     );
-    this.trainrunService.setLabels(
-      this.selectedTrainrun.getId(),
-      this.trainrunLabels,
-    );
+    this.isLabelBeingEdited = true;
+    this.checkAndSetLabels();
+    this.isLabelBeingEdited = false;
   }
 
   add(inputEvent: SbbChipInputEvent): void {
@@ -87,12 +88,10 @@ export class TrainrunFilterTabComponent implements OnInit, OnDestroy {
     if (!value) {
       return;
     }
-    console.log("add", value);
     this.trainrunLabels.push(value);
-    this.trainrunService.setLabels(
-      this.selectedTrainrun.getId(),
-      this.trainrunLabels,
-    );
+    this.isLabelBeingEdited = true;
+    this.checkAndSetLabels();
+    this.isLabelBeingEdited = false;
     inputEvent.chipInput!.clear();
   }
 
@@ -121,6 +120,8 @@ export class TrainrunFilterTabComponent implements OnInit, OnDestroy {
   }
 
   onLabelsFocusout() {
+    if (this.isLabelBeingEdited) return;
+
     const keyboardEvent = new KeyboardEvent("keydown", {
       code: "Enter",
       key: "Enter",
@@ -130,10 +131,7 @@ export class TrainrunFilterTabComponent implements OnInit, OnDestroy {
       bubbles: true,
     });
     document.getElementById("trainrunLabelsInput").dispatchEvent(keyboardEvent);
-    this.trainrunService.setLabels(
-      this.selectedTrainrun.getId(),
-      this.trainrunLabels,
-    );
+    this.checkAndSetLabels();
   }
 
   getAutoCompleteLabels(): string[] {
@@ -148,10 +146,25 @@ export class TrainrunFilterTabComponent implements OnInit, OnDestroy {
     this.trainrunLabels = this.labelService.getTextLabelsFromIds(
       this.selectedTrainrun.getLabelIds(),
     );
+    this.initialTrainrunLabels = [...this.trainrunLabels]; // initialize labels
   }
 
   private updateTrainrunLabelsAutoCompleteOptions() {
     this.trainrunLabelsAutoCompleteOptions = this.getAutoCompleteLabels();
     this.cd.detectChanges();
+  }
+
+  // set labels only if any of it has changed
+  private checkAndSetLabels() {
+    if (
+      this.trainrunLabels.length !== this.initialTrainrunLabels.length ||
+      !this.trainrunLabels.every((label, index) => label === this.initialTrainrunLabels[index])
+    ) {
+      this.trainrunService.setLabels(
+        this.selectedTrainrun.getId(),
+        this.trainrunLabels
+      );
+      this.initialTrainrunLabels = [...this.trainrunLabels];
+    }
   }
 }

--- a/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-filter-tab/trainrun-filter-tab.component.ts
+++ b/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-filter-tab/trainrun-filter-tab.component.ts
@@ -143,6 +143,7 @@ export class TrainrunFilterTabComponent implements OnInit, OnDestroy {
 
   private initializeWithCurrentSelectedTrainrun() {
     this.selectedTrainrun = this.trainrunService.getSelectedTrainrun();
+    if (this.selectedTrainrun === null) return;
     this.trainrunLabels = this.labelService.getTextLabelsFromIds(
       this.selectedTrainrun.getLabelIds(),
     );

--- a/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-filter-tab/trainrun-filter-tab.component.ts
+++ b/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-filter-tab/trainrun-filter-tab.component.ts
@@ -157,6 +157,7 @@ export class TrainrunFilterTabComponent implements OnInit, OnDestroy {
 
   // set labels only if any of it has changed
   private checkAndSetLabels() {
+    console.log(this.trainrunLabels);
     if (
       this.trainrunLabels.length !== this.initialTrainrunLabels.length ||
       !this.trainrunLabels.every((label, index) => label === this.initialTrainrunLabels[index])

--- a/src/app/view/editor-side-view/editor-node-detail-view/editor-node-detail-view.component.ts
+++ b/src/app/view/editor-side-view/editor-node-detail-view/editor-node-detail-view.component.ts
@@ -265,17 +265,17 @@ export class EditorNodeDetailViewComponent implements OnInit, OnDestroy {
     }
   }
 
-    // set labels only if any of it has changed
-    private checkAndSetLabels() {
-      if (
-        this.nodeProperties.labels.length !== this.initialNodeLabels.length ||
-        !this.nodeProperties.labels.every((label, index) => label === this.initialNodeLabels[index])
-      ) {
-        this.nodeService.changeLabels(
-          this.nodeProperties.nodeId,
-          this.nodeProperties.labels
-        );
-        this.initialNodeLabels = [...this.nodeProperties.labels];
-      }
+  // set labels only if any of it has changed
+  private checkAndSetLabels() {
+    if (
+      this.nodeProperties.labels.length !== this.initialNodeLabels.length ||
+      !this.nodeProperties.labels.every((label, index) => label === this.initialNodeLabels[index])
+    ) {
+      this.nodeService.changeLabels(
+        this.nodeProperties.nodeId,
+        this.nodeProperties.labels
+      );
+      this.initialNodeLabels = [...this.nodeProperties.labels];
     }
+  }
 }

--- a/src/app/view/editor-side-view/editor-node-detail-view/editor-node-detail-view.component.ts
+++ b/src/app/view/editor-side-view/editor-node-detail-view/editor-node-detail-view.component.ts
@@ -54,10 +54,13 @@ export class EditorNodeDetailViewComponent implements OnInit, OnDestroy {
     labels: [],
   };
 
+  private initialNodeLabels: string[];
+
   readonly separatorKeysCodes = [ENTER, COMMA];
   nodeLabelsAutoCompleteOptions: string[] = [];
 
   private destroyed = new Subject<void>();
+  private isLabelBeingEdited = false;
 
   constructor(
     private uiInteractionService: UiInteractionService,
@@ -117,10 +120,9 @@ export class EditorNodeDetailViewComponent implements OnInit, OnDestroy {
       return;
     }
     this.nodeProperties.labels.push(value);
-    this.nodeService.changeLabels(
-      this.nodeProperties.nodeId,
-      this.nodeProperties.labels,
-    );
+    this.isLabelBeingEdited = true;
+    this.checkAndSetLabels();
+    this.isLabelBeingEdited = false;
     chipInputEvent.chipInput!.clear();
   }
 
@@ -133,13 +135,14 @@ export class EditorNodeDetailViewComponent implements OnInit, OnDestroy {
     this.nodeProperties.labels = this.nodeProperties.labels.filter(
       (labels) => labels !== valueDelete,
     );
-    this.nodeService.changeLabels(
-      this.nodeProperties.nodeId,
-      this.nodeProperties.labels,
-    );
+    this.isLabelBeingEdited = true;
+    this.checkAndSetLabels();
+    this.isLabelBeingEdited = false;
   }
 
   onLabelsFocusout() {
+    if (this.isLabelBeingEdited) return;
+
     const keyboardEvent = new KeyboardEvent("keydown", {
       code: "Enter",
       key: "Enter",
@@ -149,10 +152,7 @@ export class EditorNodeDetailViewComponent implements OnInit, OnDestroy {
       bubbles: true,
     });
     document.getElementById("nodeLabelsInput").dispatchEvent(keyboardEvent);
-    this.nodeService.changeLabels(
-      this.nodeProperties.nodeId,
-      this.nodeProperties.labels,
-    );
+    this.checkAndSetLabels();
   }
 
   onCapacityChanged() {
@@ -261,6 +261,21 @@ export class EditorNodeDetailViewComponent implements OnInit, OnDestroy {
           selectedNode.getLabelIds(),
         ),
       };
+      this.initialNodeLabels = [...this.nodeProperties.labels]; // initialize labels
     }
   }
+
+    // set labels only if any of it has changed
+    private checkAndSetLabels() {
+      if (
+        this.nodeProperties.labels.length !== this.initialNodeLabels.length ||
+        !this.nodeProperties.labels.every((label, index) => label === this.initialNodeLabels[index])
+      ) {
+        this.nodeService.changeLabels(
+          this.nodeProperties.nodeId,
+          this.nodeProperties.labels
+        );
+        this.initialNodeLabels = [...this.nodeProperties.labels];
+      }
+    }
 }


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->
# Description

<!-- Describe the changes your PR introduces here. -->

When using (create, delete, focusout) the trainrun label area, the trainrun label service makes unnecessary calls.

This feature:
- test uniqueness of `labels` before calling `setLabels()`
- remove double calls when `create` a label, but also `focusout` at the same time, thus calling twice the functions

Update:  does the same refactor for node filters

# Issues

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] This PR contains a description of the changes I'm making
* [x] I've read the [Contribution Guidelines](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/CONTRIBUTING.md)
* [x] CI is currently green and this is ready for review

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation.
-->
