### PR TITLE
fix: disable environment header in standalone mode

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -21,7 +21,7 @@
       <!-- <sbb-option value="it">🇮🇹 Italiano</sbb-option> -->
     </sbb-select>
   </sbb-app-chooser-section>
-  <sbb-header-environment class="noprint">{{
+  <sbb-header-environment class="noprint" *ngIf="environmentLabel">{{
     environmentLabel
   }}</sbb-header-environment>
   <sbb-usermenu

--- a/src/environments/environment.model.ts
+++ b/src/environments/environment.model.ts
@@ -2,7 +2,7 @@ import {AuthConfig} from "angular-oauth2-oidc";
 
 export interface Environment {
   production: boolean;
-  label: string;
+  label?: string;
   backendUrl?: string;
   authConfig?: AuthConfig;
   disableBackend: boolean;

--- a/src/environments/environment.standalone.ts
+++ b/src/environments/environment.standalone.ts
@@ -2,7 +2,6 @@ import {Environment} from "./environment.model";
 
 export const environment: Environment = {
   production: true,
-  label: "standalone",
   disableBackend: true,
   customElement: true,
 };


### PR DESCRIPTION
According to the [sbb-angular docs][1], the sbb-header-environment component should be disabled in production. Do so in standalone mode.

Without this, a ribbon with a "standalone" text is displayed in the top-left corner.

![out](https://github.com/user-attachments/assets/06378e88-6cab-4c82-a224-b90990179d26)

[1]: https://github.com/sbb-design-systems/sbb-angular/blob/main/src/angular/header-lean/header-lean.md#environment