### PR TITLE
fix: use change event instead of keyup for node name change

### DIFF
--- a/src/app/view/editor-side-view/editor-node-detail-view/editor-node-detail-view.component.html
+++ b/src/app/view/editor-side-view/editor-node-detail-view/editor-node-detail-view.component.html
@@ -10,14 +10,14 @@
       <input
         sbbInput
         [ngModel]="nodeProperties.nodeBetriebspunktName"
-        (keyup)="onBetriebspunktNameChanged($event)"
+        (change)="onBetriebspunktNameChanged($event)"
       />
     </sbb-form-field>
     <sbb-form-field [label]="'app.view.editor-side-view.editor-node-detail-view.name' | translate" class="sbb-form-field-long">
       <input
         sbbInput
         [ngModel]="nodeProperties.nodeBetriebspunktFullName"
-        (keyup)="onFullNameChanged($event)"
+        (change)="onFullNameChanged($event)"
       />
     </sbb-form-field>
     <sbb-form-field [label]="'app.view.editor-side-view.editor-node-detail-view.connection-time' | translate" class="sbb-form-field-long">

--- a/src/app/view/editor-side-view/editor-node-detail-view/editor-node-detail-view.component.ts
+++ b/src/app/view/editor-side-view/editor-node-detail-view/editor-node-detail-view.component.ts
@@ -98,7 +98,6 @@ export class EditorNodeDetailViewComponent implements OnInit, OnDestroy {
       this.nodeProperties.nodeId,
       event.target.value,
     );
-    this.nodeProperties.nodeBetriebspunktName = event.target.value;
     this.uiInteractionService.updateNodeStammdaten();
   }
 
@@ -107,7 +106,6 @@ export class EditorNodeDetailViewComponent implements OnInit, OnDestroy {
       this.nodeProperties.nodeId,
       event.target.value,
     );
-    this.nodeProperties.nodeBetriebspunktFullName = event.target.value;
   }
 
   onConnectionTimeChanged() {


### PR DESCRIPTION
Fixes a few issues:

- "keyup" is not triggered when copy-pasting. So if the user right clicks and pastes a new value, the name would not get updated.
- "keyup" triggers each time a character is typed in the input field. This results in a lot of operations on each keypress.
- No need to set this.nodeProperties.nodeBetriebspunktName nor this.nodeProperties.nodeBetriebspunktFullName on keyup: this is already done automatically by [ngModel].

Note that we do loose a bit of functionality with this patch: the diagrams and sidebar headings aren't updated in real-time as the user types anymore. If this is deemed important functionality, we could use `(ngModelChange)` instead.