### PR TITLE
The menubar has a visual "thick" separator in between variant/project name and the filter symbol is resolved

### DIFF
--- a/src/app/view/editor-menu/editor-menu.component.scss
+++ b/src/app/view/editor-menu/editor-menu.component.scss
@@ -504,6 +504,7 @@ button {
 
 div.LabelNetzgrafik{
   background: var(--sbb-header-lean-background-color);
+  border-right: none
 }
 
 div.NodeZoomValue{


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->
# Description

The issue is fixed. 
 
![image](https://github.com/user-attachments/assets/0bca52f9-5d99-467f-866a-82c2d4bc6623)

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] This PR contains a description of the changes I'm making
* [x] I've read the [Contribution Guidelines](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/CONTRIBUTING.md)
* [x] I've added tests for changes or features I've introduced
* [x] I documented any high-level concepts I'm introducing in `documentation/`
* [x] CI is currently green and this is ready for review

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation.
-->
