### PR TITLE
fix: 320 bug graphical timetable streckengrafik renders only one trainrun segement

### DIFF
--- a/documentation/CREATE_TRAINRUN.md
+++ b/documentation/CREATE_TRAINRUN.md
@@ -106,3 +106,23 @@ To switch a train from a stop to a non-stop at a node, follow these steps:
 For more details have a look into 
 - [Split/Combine two trainruns](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/documentation/Split_Combine_Trainruns.md)
 - [Merge Netzgrafik](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/documentation/Merge_Netzgrafik.md)
+
+## Special cases
+
+### Trainrun path  
+
+When creating a trainrun, the trairnun path should connect all nodes from start to destination using trainrun sections. 
+However, it can happen during the creation that not all trainrun sections have been drawn in the meantime. 
+Gaps may occur along the trainrun path where at least one trainrun section is missing. 
+These “holes” usually occur if the trainrun path has not yet been drawn completely or correctly.
+For example, a trainrun path could look like this with a "hole" in the middle, 
+
+A - B - C ---- (missing section) ---- E - F - G
+
+The trainrun section between C and E is missing here. However, these gaps can also occur if a partial cancelation is made for a train run.
+
+In each of these cases, the trainrun has at least two parts, e.g. [(A B), (A C)] and [(E F)(F G)]. 
+In this case, the trainrun is interpreted as two separate trainruns.
+The Netzgrafik has no information about whether the missing part could be closed between C - E, C - D - E or 
+another possible variant, therefore the assumption that there is an independent trainrun for each trainrun part is 
+the best assumption. This avoids many new problems. 

--- a/documentation/CREATE_TRAINRUN.md
+++ b/documentation/CREATE_TRAINRUN.md
@@ -111,6 +111,9 @@ For more details have a look into
 
 ### Trainrun path with "holes" (missing sections) 
 
+![image](https://github.com/user-attachments/assets/d87b842c-7696-4e81-aa78-75cc966b5306)
+Example Netzgrafik with missing sections (See the cargo trainrun GTwo_Part_trainrun)
+
 When creating a trainrun, the trairnun path should connect all nodes from start to destination using trainrun sections. 
 However, it can happen during the creation that not all trainrun sections have been drawn in the meantime. 
 Gaps may occur along the trainrun path where at least one trainrun section is missing. 
@@ -120,6 +123,9 @@ For example, a trainrun path could look like this with a "hole" in the middle,
 A - B - C ---- (missing section) ---- E - F - G
 
 The trainrun section between C and E is missing here. However, these gaps can also occur if a partial cancelation is made for a train run.
+
+![image](https://github.com/user-attachments/assets/5d1ef657-e421-41ff-ae57-622eee82f295)
+Graphical timetable.
 
 In each of these cases, the trainrun has at least two parts, e.g. [(A B), (A C)] and [(E F)(F G)]. 
 In this case, the trainrun is interpreted as two separate trainruns.

--- a/documentation/CREATE_TRAINRUN.md
+++ b/documentation/CREATE_TRAINRUN.md
@@ -112,7 +112,8 @@ For more details have a look into
 ### Trainrun path with "holes" (missing sections) 
 
 ![image](https://github.com/user-attachments/assets/d87b842c-7696-4e81-aa78-75cc966b5306)
-Example Netzgrafik with missing sections (See the cargo trainrun GTwo_Part_trainrun)
+*Example Netzgrafik with missing sections (See the cargo trainrun GTwo_Part_trainrun)*
+
 
 When creating a trainrun, the trairnun path should connect all nodes from start to destination using trainrun sections. 
 However, it can happen during the creation that not all trainrun sections have been drawn in the meantime. 
@@ -125,7 +126,8 @@ A - B - C ---- (missing section) ---- E - F - G
 The trainrun section between C and E is missing here. However, these gaps can also occur if a partial cancelation is made for a train run.
 
 ![image](https://github.com/user-attachments/assets/5d1ef657-e421-41ff-ae57-622eee82f295)
-Graphical timetable.
+*Graphical timetable.*
+
 
 In each of these cases, the trainrun has at least two parts, e.g. [(A B), (A C)] and [(E F)(F G)]. 
 In this case, the trainrun is interpreted as two separate trainruns.

--- a/documentation/CREATE_TRAINRUN.md
+++ b/documentation/CREATE_TRAINRUN.md
@@ -109,7 +109,7 @@ For more details have a look into
 
 ## Special cases
 
-### Trainrun path  
+### Trainrun path with "holes" (missing sections) 
 
 When creating a trainrun, the trairnun path should connect all nodes from start to destination using trainrun sections. 
 However, it can happen during the creation that not all trainrun sections have been drawn in the meantime. 

--- a/documentation/USERMANUAL.md
+++ b/documentation/USERMANUAL.md
@@ -178,3 +178,6 @@ creation of comprehensive and visually appealing network representations.
 ## Links
 - [Netzgrafik-Editor data export/import (JSON)](DATA_MODEL_JSON.md)
 - [DATA MODEL](DATA_MODEL.md)
+
+## Technical documentation 
+- [Trainrun iterator](/technical/trainrun_iterations.md)

--- a/documentation/technical/trainrun_iterations.md
+++ b/documentation/technical/trainrun_iterations.md
@@ -1,0 +1,68 @@
+# Trainrun iterator 
+
+## Sample code 
+
+https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/pull/325
+
+Iterator pattern for iterating through all trainrun parts seperatly
+ 
+```typescript
+getForwardTrainrunPartIterator(trainrunSection : TrainrunSection) {
+      // find both start nodes ( N1 - N2 - N3 - N4 ) => N1 , N2
+      const bothEndNodes =
+        this.trainrunService.getBothEndNodesFromTrainrunPart(trainrunSection);
+        
+      // get start / end node from Top/Left -> Botton / Right 
+      const startForwardNode = GeneralViewFunctions.getLeftOrTopNode(
+        bothEndNodes.endNode1,
+        bothEndNodes.endNode2,
+      );
+     
+      // get start trainrun section -> forward direction/orientation 
+      const startTrainrunSection = startForwardNode.getStartTrainrunSection(
+        trainrun.getId(),
+      );
+
+      // create forward iterator
+      const iterator: TrainrunIterator = this.trainrunService.getIterator(
+        startForwardNode,
+        startTrainrunSection,
+      );
+  return iterator;
+}
+
+
+simpleTrainrunAllPartsIterator(trainrun: Trainrun) {
+    let alltrainrunsections =
+      this.trainrunSectionService
+        .getAllTrainrunSectionsForTrainrun(trainrun.getId());
+
+    while (alltrainrunsections.length > 0) {
+      // traverse over all trainrun parts
+       const iterator= getForwardTrainrunPartIterator(alltrainrunsections[0]);
+
+      while (iterator.hasNext()) {
+        // move iterator forward
+        const currentTrainrunSectionNodePair = iterator.next();
+
+        // get data 
+        const trainrunSection = currentTrainrunSectionNodePair.trainrunSection;
+        const node = currentTrainrunSectionNodePair.node;
+
+      ...
+        user
+        defined
+        data
+        processing
+      ...
+
+        // filter all still visited trainrun sections
+        alltrainrunsections = alltrainrunsections.filter(ts =>
+          ts.getId() !== trainrunSection.getId()
+        );
+      }
+
+
+    }
+  }
+```

--- a/documentation/technical/trainrun_iterations.md
+++ b/documentation/technical/trainrun_iterations.md
@@ -4,7 +4,40 @@
 
 https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/pull/325
 
-Iterator pattern for iterating through all trainrun parts seperatly
+### Simple trainrun iterator - just one trainrun part
+To iterate starting from a node of interest with the orientation passed through the trainrun section, you can use the sample code (pattern) below. 
+The iteration will proceed along the trainrun. Be aware that this does not ensure traveling through the full train run.
+
+https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/documentation/CREATE_TRAINRUN.md#trainrun-path-with-holes-missing-sections
+
+```typescript
+ 
+  // create forward iterator
+  const iterator: TrainrunIterator = this.trainrunService.getIterator(
+    startForwardNode,
+    startTrainrunSection,
+  );
+  while (iterator.hasNext()) {
+    // move iterator forward
+    const currentTrainrunSectionNodePair = iterator.next();
+
+    // get data 
+    const trainrunSection = currentTrainrunSectionNodePair.trainrunSection;
+    const node = currentTrainrunSectionNodePair.node;
+
+  ...
+    user
+    defined
+    data
+    processing
+  ...
+ 
+  } 
+}
+```
+
+### Complete Train Run Iterator - Over All Train Run Parts
+Iterator pattern for iterating through all train run parts separately.
  
 ```typescript
 getForwardTrainrunPartIterator(trainrunSection : TrainrunSection) {
@@ -30,7 +63,6 @@ getForwardTrainrunPartIterator(trainrunSection : TrainrunSection) {
       );
   return iterator;
 }
-
 
 simpleTrainrunAllPartsIterator(trainrun: Trainrun) {
     let alltrainrunsections =

--- a/src/app/perlenkette/model/perlenkette-tests.spec.ts
+++ b/src/app/perlenkette/model/perlenkette-tests.spec.ts
@@ -3,8 +3,18 @@ import {PerlenketteSection} from "./perlenketteSection";
 
 describe("PerlenketteModelTests", () => {
   it("Perlenkette-Model - Test - PerlenketteNode - 001", () => {
-    const node = new PerlenketteNode(0, "BN", "Berm", 10, [], undefined);
+    const node = new PerlenketteNode(0,
+      "BN",
+      "Berm",
+      10,
+      [],
+      undefined,
+      false,
+      true
+    );
 
+    expect(node.isFristTrainrunPartNode()).toBe(false);
+    expect(node.isLastTrainrunPartNode()).toBe(true);
     expect(node.isPerlenketteNode()).toBe(true);
     expect(node.isPerlenketteSection()).toBe(false);
     expect(node.getPerlenketteNode()).toEqual(node);
@@ -19,8 +29,12 @@ describe("PerlenketteModelTests", () => {
       undefined,
       0,
       false,
+      false,
+      true
     );
 
+    expect(section.isFristTrainrunPartSection()).toBe(false);
+    expect(section.isLastTrainrunPartSection()).toBe(true);
     expect(section.isPerlenketteNode()).toBe(false);
     expect(section.isPerlenketteSection()).toBe(true);
     expect(section.getPerlenketteNode()).toEqual(undefined);

--- a/src/app/perlenkette/model/perlenketteNode.ts
+++ b/src/app/perlenkette/model/perlenketteNode.ts
@@ -12,7 +12,22 @@ export class PerlenketteNode implements PerlenketteItem {
     public connectionTime: number,
     public connections: PerlenketteConnection[],
     public transition: Transition,
-  ) {}
+    public fristTrainrunPartNode: boolean,
+    public lastTrainrunPartNode: boolean
+  ) {
+  }
+
+  isFristTrainrunPartNode(): boolean {
+    return this.fristTrainrunPartNode;
+  }
+
+  isLastTrainrunPartNode(): boolean {
+    return this.lastTrainrunPartNode;
+  }
+
+  setLastTrainrunPartNode(flag : boolean) {
+    this.lastTrainrunPartNode = flag;
+  }
 
   isPerlenketteNode(): boolean {
     return true;

--- a/src/app/perlenkette/model/perlenketteSection.ts
+++ b/src/app/perlenkette/model/perlenketteSection.ts
@@ -10,7 +10,22 @@ export class PerlenketteSection implements PerlenketteItem {
     public toNode: Node,
     public numberOfStops: number,
     public isBeingEdited: boolean = false,
-  ) {}
+    public fristTrainrunPartSection: boolean = false,
+    public lastTrainrunPartSection: boolean = false
+  ) {
+  }
+
+  isFristTrainrunPartSection(): boolean {
+    return this.fristTrainrunPartSection;
+  }
+
+  isLastTrainrunPartSection(): boolean {
+    return this.lastTrainrunPartSection;
+  }
+
+  setLastTrainrunPartSection(flag : boolean) {
+    this.lastTrainrunPartSection = flag;
+  }
 
   isPerlenketteNode(): boolean {
     return false;

--- a/src/app/perlenkette/perlenkette.component.html
+++ b/src/app/perlenkette/perlenkette.component.html
@@ -140,8 +140,8 @@
               [notificationIsBeingEdited]="
                 getSignalAllChildrenIsBeingEditedObservable()
               "
-              [isFirstSection]="idx === 1"
-              [isLastSection]="idx === perlenketteTrainrun.pathItems.length-2"
+              [isFirstSection]="isFirstSection(pathItem)"
+              [isLastSection]="isLastSection(pathItem)"
             >
             </sbb-perlenkette-section>
           </ng-container>

--- a/src/app/perlenkette/perlenkette.component.html
+++ b/src/app/perlenkette/perlenkette.component.html
@@ -126,6 +126,10 @@
               [isBottomNode]="idx === perlenketteTrainrun.pathItems.length-1"
             >
             </sbb-perlenkette-node>
+            <div *ngIf="doSplitTrainrun(perlenketteTrainrun.pathItems, idx)">
+              <br>
+              <br>
+            </div>
             <sbb-perlenkette-section
               *ngIf="pathItem.isPerlenketteSection()"
               [perlenketteSection]="pathItem.getPerlenketteSection()"

--- a/src/app/perlenkette/perlenkette.component.html
+++ b/src/app/perlenkette/perlenkette.component.html
@@ -94,7 +94,10 @@
             (click)="goto(pathItem)"
           >{{ pathItem.getPerlenketteNode().shortName }}</span
           >
-        </p>
+
+        <ng-container *ngIf="isLastNodeButNotVeryLast(pathItem)">
+          <span [class]="getSmallstationClassTag(pathItem)"> &#x2022; </span>
+        </ng-container>
       </div>
     </ng-container>
 

--- a/src/app/perlenkette/perlenkette.component.ts
+++ b/src/app/perlenkette/perlenkette.component.ts
@@ -250,6 +250,20 @@ export class PerlenketteComponent implements AfterContentChecked, OnDestroy {
     return false;
   }
 
+  isLastNode(item: PerlenketteItem): boolean {
+    if (item.isPerlenketteNode()) {
+      const pni = item.getPerlenketteNode();
+      return pni.isLastTrainrunPartNode();
+    }
+    return false;
+  }
+
+  isLastNodeButNotVeryLast(item: PerlenketteItem) {
+    if (this.perlenketteTrainrun.pathItems.indexOf(item) === this.perlenketteTrainrun.pathItems.length - 1) {
+      return false;
+    }
+    return this.isLastNode(item);
+  }
 
   getSignalAllChildrenIsBeingEditedObservable() {
     return this.signalAllChildrenIsBeingEditedSubject.asObservable();

--- a/src/app/perlenkette/perlenkette.component.ts
+++ b/src/app/perlenkette/perlenkette.component.ts
@@ -54,7 +54,7 @@ export class PerlenketteComponent implements AfterContentChecked, OnDestroy {
     readonly filterService: FilterService,
     private readonly uiInteractionService: UiInteractionService,
     private readonly nodeService: NodeService,
-    private versionControlService : VersionControlService,
+    private versionControlService: VersionControlService,
     private changeDetectorRef: ChangeDetectorRef,
   ) {
     this.selectedPerlenketteConnection = undefined;
@@ -215,6 +215,15 @@ export class PerlenketteComponent implements AfterContentChecked, OnDestroy {
     this.signalAllChildrenIsBeingEditedSubject.next(event);
   }
 
+  doSplitTrainrun(pathItems: PerlenketteItem[], idx: number): boolean {
+    if (idx >= pathItems.length - 1) {
+      return false;
+    }
+    const item = pathItems[idx];
+    const previousItem = pathItems[idx + 1];
+    return item.isPerlenketteNode() === previousItem.isPerlenketteNode();
+  }
+
   signalHeightChanged(height: number, pathItem: PerlenketteItem) {
     this.perlenketteRenderingElementsHeight.push([pathItem, height]);
     this.renderedElementsHeight = 0;
@@ -229,7 +238,7 @@ export class PerlenketteComponent implements AfterContentChecked, OnDestroy {
     return this.signalAllChildrenIsBeingEditedSubject.asObservable();
   }
 
-  getVariantIsWritable() : boolean {
+  getVariantIsWritable(): boolean {
     return this.versionControlService.getVariantIsWritable();
   }
 

--- a/src/app/perlenkette/perlenkette.component.ts
+++ b/src/app/perlenkette/perlenkette.component.ts
@@ -234,6 +234,23 @@ export class PerlenketteComponent implements AfterContentChecked, OnDestroy {
     });
   }
 
+  isFirstSection(item: PerlenketteItem): boolean {
+    if (item.isPerlenketteSection()) {
+      const psi = item.getPerlenketteSection();
+      return psi.isFristTrainrunPartSection();
+    }
+    return false;
+  }
+
+  isLastSection(item: PerlenketteItem): boolean {
+    if (item.isPerlenketteSection()) {
+      const psi = item.getPerlenketteSection();
+      return psi.isLastTrainrunPartSection();
+    }
+    return false;
+  }
+
+
   getSignalAllChildrenIsBeingEditedObservable() {
     return this.signalAllChildrenIsBeingEditedSubject.asObservable();
   }

--- a/src/app/perlenkette/service/load-perlenkette.service.ts
+++ b/src/app/perlenkette/service/load-perlenkette.service.ts
@@ -156,7 +156,6 @@ export class LoadPerlenketteService implements OnDestroy {
           startTrainrunSection,
         );
 
-        const visitedTrainrunSections: TrainrunSection[] = [startTrainrunSection];
         let firstSection = true;
         while (iterator.hasNext()) {
           const currentTrainrunSectionNodePair = iterator.next();
@@ -192,7 +191,10 @@ export class LoadPerlenketteService implements OnDestroy {
           );
           lastNode = node;
 
-          visitedTrainrunSections.push(currentTrainrunSectionNodePair.trainrunSection);
+          // filter all still visited trainrun sections
+          alltrainrunsections = alltrainrunsections.filter(ts =>
+            ts.getId() !== currentTrainrunSectionNodePair.trainrunSection.getId()
+          );
         }
 
         if (perlenketteItem.length > 1) {
@@ -208,10 +210,7 @@ export class LoadPerlenketteService implements OnDestroy {
           }
         }
 
-        // filter all still visited trainrun sections
-        alltrainrunsections = alltrainrunsections.filter(ts =>
-          visitedTrainrunSections.indexOf(ts) === -1
-        );
+
       }
     }
     return perlenketteItem;

--- a/src/app/services/data/trainrun.service.ts
+++ b/src/app/services/data/trainrun.service.ts
@@ -604,17 +604,15 @@ export class TrainrunService {
       const bothEndNodes =
         this.getBothEndNodesFromTrainrunPart(trainrunSection);
 
-      const startForwardNode = GeneralViewFunctions.getLeftOrTopNode(
-        bothEndNodes.endNode1,
-        bothEndNodes.endNode2,
-      );
-      const startBackwardNode =
-        bothEndNodes.endNode1.getId() === startForwardNode.getId()
-          ? bothEndNodes.endNode2
-          : bothEndNodes.endNode1;
+      const startForwardBackwardNode =
+        GeneralViewFunctions.getStartForwardAndBackwardNode(
+          bothEndNodes.endNode1,
+          bothEndNodes.endNode2,
+        );
+
       const propDataForward = this.propagateConsecutiveTimes(
-        startForwardNode,
-        startForwardNode.getStartTrainrunSection(
+        startForwardBackwardNode.startForwardNode,
+        startForwardBackwardNode.startForwardNode.getStartTrainrunSection(
           trainrunSection.getTrainrunId(),
           true
         ),
@@ -631,8 +629,8 @@ export class TrainrunService {
       offset = Math.floor(offset / 60) * 60;
 
       const propDataBackward = this.propagateConsecutiveTimes(
-        startBackwardNode,
-        startBackwardNode.getStartTrainrunSection(
+        startForwardBackwardNode.startBackwardNode,
+        startForwardBackwardNode.startBackwardNode.getStartTrainrunSection(
           trainrunSection.getTrainrunId(),
           false
         ),

--- a/src/app/services/data/trainrun.service.ts
+++ b/src/app/services/data/trainrun.service.ts
@@ -575,6 +575,18 @@ export class TrainrunService {
     this.propagateConsecutiveTimesForTrainrun(ts.getId());
   }
 
+  getBothEndNodesFromTrainrunPart(trainrunSection: TrainrunSection):
+    {
+      endNode1: Node;
+      endNode2: Node;
+    } {
+    const sourceNode = trainrunSection.getSourceNode();
+    const targetNode = trainrunSection.getTargetNode();
+    const endNode1 = this.getEndNode(sourceNode, trainrunSection);
+    const endNode2 = this.getEndNode(targetNode, trainrunSection);
+    return {endNode1, endNode2};
+  }
+
   propagateConsecutiveTimesForTrainrun(trainrunSectionId: number) {
     const inTrainrunSection =
       this.trainrunSectionService.getTrainrunSectionFromId(trainrunSectionId);
@@ -589,11 +601,8 @@ export class TrainrunService {
     while (alltrainrunsections.length > 0) {
       // propagate Consecutive Times Forward
       const trainrunSection = alltrainrunsections[0];
-      const sourceNode = trainrunSection.getSourceNode();
-      const targetNode = trainrunSection.getTargetNode();
-      const endNode1 = this.getEndNode(sourceNode, trainrunSection);
-      const endNode2 = this.getEndNode(targetNode, trainrunSection);
-      const bothEndNodes = {endNode1, endNode2};
+      const bothEndNodes =
+        this.getBothEndNodesFromTrainrunPart(trainrunSection);
 
       const startForwardNode = GeneralViewFunctions.getLeftOrTopNode(
         bothEndNodes.endNode1,
@@ -827,11 +836,7 @@ export class TrainrunService {
     const trainrunSection = trainrunSections.find(
       (trs) => trs.getTrainrunId() === trainrunId,
     );
-    const sourceNode = trainrunSection.getSourceNode();
-    const targetNode = trainrunSection.getTargetNode();
-    const endNode1 = this.getEndNode(sourceNode, trainrunSection);
-    const endNode2 = this.getEndNode(targetNode, trainrunSection);
-    return {endNode1, endNode2};
+    return this.getBothEndNodesFromTrainrunPart(trainrunSection);
   }
 
   private createNewTrainrunFromDto(trainrun: TrainrunDto): Trainrun {

--- a/src/app/services/data/trainrun.service.ts
+++ b/src/app/services/data/trainrun.service.ts
@@ -582,7 +582,10 @@ export class TrainrunService {
       return;
     }
 
-    let alltrainrunsections = this.trainrunSectionService.getAllTrainrunSectionsForTrainrun(inTrainrunSection.getTrainrunId());
+    let alltrainrunsections =
+      this.trainrunSectionService
+        .getAllTrainrunSectionsForTrainrun(inTrainrunSection.getTrainrunId());
+
     while (alltrainrunsections.length > 0) {
       // propagate Consecutive Times Forward
       const trainrunSection = alltrainrunsections[0];
@@ -629,10 +632,8 @@ export class TrainrunService {
 
       // filter all still visited trainrun sections
       alltrainrunsections = alltrainrunsections.filter(ts =>
-        propDataForward.visitedTrainrunSections.find(ts2 => ts2.getId() === ts.getId()) === undefined
-      );
-      alltrainrunsections = alltrainrunsections.filter(ts =>
-        propDataBackward.visitedTrainrunSections.find(ts2 => ts2.getId() === ts.getId()) === undefined
+        propDataForward.visitedTrainrunSections.indexOf(ts) === -1 &&
+        propDataBackward.visitedTrainrunSections.indexOf(ts) === -1
       );
     }
   }

--- a/src/app/services/util/trainrunsection.helper.ts
+++ b/src/app/services/util/trainrunsection.helper.ts
@@ -104,14 +104,14 @@ export class TrainrunsectionHelper {
   getLeftRightSections(trainrunSection: TrainrunSection) {
     const bothLastNonStopTransitNodes =
       this.trainrunService.getBothLastNonStopNodes(trainrunSection);
-    const lastLeftNode = GeneralViewFunctions.getLeftOrTopNode(
-      bothLastNonStopTransitNodes.lastNonStopNode1,
-      bothLastNonStopTransitNodes.lastNonStopNode2,
-    );
-    const lastRightNode =
-      lastLeftNode.getId() === bothLastNonStopTransitNodes.lastNonStopNode1.getId() ?
-        bothLastNonStopTransitNodes.lastNonStopNode2 :
-        bothLastNonStopTransitNodes.lastNonStopNode1;
+
+    const startForwardBackwardNode =
+      GeneralViewFunctions.getStartForwardAndBackwardNode(
+        bothLastNonStopTransitNodes.lastNonStopNode1,
+        bothLastNonStopTransitNodes.lastNonStopNode2,
+      );
+    const lastLeftNode = startForwardBackwardNode.startForwardNode;
+    const lastRightNode = startForwardBackwardNode.startBackwardNode;
 
     const towardsSource =
       this.trainrunService.getLastNonStopTrainrunSection(

--- a/src/app/streckengrafik/services/sg-1-load-trainrun-item.service.ts
+++ b/src/app/streckengrafik/services/sg-1-load-trainrun-item.service.ts
@@ -394,19 +394,15 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
     const bothEndNodes =
       this.trainrunService.getBothEndNodesFromTrainrunPart(trainrunSection);
 
-    let startForwardNode = GeneralViewFunctions.getLeftOrTopNode(
+    const startForwardBackwardNode = GeneralViewFunctions.getStartForwardAndBackwardNode(
       bothEndNodes.endNode1,
       bothEndNodes.endNode2,
     );
-    let startBackwardNode =
-      bothEndNodes.endNode1.getId() === startForwardNode.getId()
-        ? bothEndNodes.endNode2
-        : bothEndNodes.endNode1;
 
     if (onlyForward) {
       const tsg = this.trainrunSectionGroup(
         trainrun.getId(),
-        startForwardNode,
+        startForwardBackwardNode.startForwardNode,
         true
       );
       this.forwardTrainrunSectionGroup = tsg.trainrunSectionGroups;
@@ -414,21 +410,21 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
     } else {
       const extractedInfo = this.isTrainRunWayDirectionBackward(
         trainrun,
-        startForwardNode,
-        startBackwardNode,
+        startForwardBackwardNode.startForwardNode,
+        startForwardBackwardNode.startBackwardNode,
         this.forwardTrainrunSectionGroup,
       );
       visitedTrainrunSections = extractedInfo.visitedTrainrunSections;
       if (extractedInfo.check) {
-        const nextStartForwardNode = startBackwardNode;
-        const nextStartBackwardNode = startForwardNode;
-        startForwardNode = nextStartForwardNode;
-        startBackwardNode = nextStartBackwardNode;
+        const nextStartForwardNode = startForwardBackwardNode.startBackwardNode;
+        const nextStartBackwardNode = startForwardBackwardNode.startForwardNode;
+        startForwardBackwardNode.startForwardNode = nextStartForwardNode;
+        startForwardBackwardNode.startBackwardNode = nextStartBackwardNode;
       }
     }
     return {
-      startForwardNode: startForwardNode,
-      startBackwardNode: startBackwardNode,
+      startForwardNode: startForwardBackwardNode.startForwardNode,
+      startBackwardNode: startForwardBackwardNode.startBackwardNode,
       visitedTrainrunSections: visitedTrainrunSections,
     };
   }

--- a/src/app/streckengrafik/services/sg-1-load-trainrun-item.service.ts
+++ b/src/app/streckengrafik/services/sg-1-load-trainrun-item.service.ts
@@ -712,7 +712,7 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
 
             // filter all still visited trainrun sections
             alltrainrunsections = alltrainrunsections.filter(ts =>
-              loadeddata.visitedTrainrunSections.find(ts2 => ts2.getId() === ts.getId()) === undefined
+              loadeddata.visitedTrainrunSections.indexOf(ts) === -1
             );
           }
         }
@@ -986,7 +986,7 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
       false
     );
     const backwardTrainrunSectionGroups = tsgBackward.trainrunSectionGroups;
-    visitedTrainrunSections= visitedTrainrunSections.concat(tsgBackward.visitedTrainrunSections);
+    visitedTrainrunSections = visitedTrainrunSections.concat(tsgBackward.visitedTrainrunSections);
 
     const selectedPaths = this.betriebspunktNamePaths(
       selectedForwardTrainrunSectionGroups,

--- a/src/app/streckengrafik/services/sg-1-load-trainrun-item.service.ts
+++ b/src/app/streckengrafik/services/sg-1-load-trainrun-item.service.ts
@@ -700,7 +700,7 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
             .getAllTrainrunSectionsForTrainrun(trainrun.getId());
 
           // As long not all trainrun section are visited (process) continue
-          // this part of code supports partial cancelatlations, e.g. trainrun runs from
+          // this part of code supports partial cancellations, e.g., trainrun runs from
           // A - B - C [ partial canceled ] D - E
           while (alltrainrunsections.length > 0) {
             const ts: TrainrunSection = alltrainrunsections.find(ts => true);

--- a/src/app/streckengrafik/services/sg-1-load-trainrun-item.service.ts
+++ b/src/app/streckengrafik/services/sg-1-load-trainrun-item.service.ts
@@ -391,11 +391,8 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
     let visitedTrainrunSections: TrainrunSection[] = [];
     const trainrun = trainrunSection.getTrainrun();
 
-    const sourceNode = trainrunSection.getSourceNode();
-    const targetNode = trainrunSection.getTargetNode();
-    const endNode1 = this.trainrunService.getEndNode(sourceNode, trainrunSection);
-    const endNode2 = this.trainrunService.getEndNode(targetNode, trainrunSection);
-    const bothEndNodes = {endNode1, endNode2};
+    const bothEndNodes =
+      this.trainrunService.getBothEndNodesFromTrainrunPart(trainrunSection);
 
     let startForwardNode = GeneralViewFunctions.getLeftOrTopNode(
       bothEndNodes.endNode1,

--- a/src/app/streckengrafik/services/sg-1-load-trainrun-item.service.ts
+++ b/src/app/streckengrafik/services/sg-1-load-trainrun-item.service.ts
@@ -443,7 +443,7 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
     trainrunItem: TrainrunItem;
     visitedTrainrunSections: TrainrunSection[];
   } {
-    const visitedTrainrunSections: TrainrunSection[] = [];
+    let visitedTrainrunSections: TrainrunSection[] = [];
     let index = 0;
     let trainrunStartTime = 0;
     let trainrunEndTime = 0;
@@ -467,9 +467,7 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
       true
     );
     const forwardTrainrunSectionGroup = tsgForward.trainrunSectionGroups;
-    tsgForward.visitedTrainrunSections.forEach(ts => {
-      visitedTrainrunSections.push(ts);
-    });
+    visitedTrainrunSections = visitedTrainrunSections.concat(tsgForward.visitedTrainrunSections);
 
     const tsgBackward = this.trainrunSectionGroup(
       trainrun.getId(),
@@ -477,9 +475,7 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
       false
     );
     const backwardTrainrunSectionGroup = tsgBackward.trainrunSectionGroups;
-    tsgBackward.visitedTrainrunSections.forEach(ts => {
-      visitedTrainrunSections.push(ts);
-    });
+    visitedTrainrunSections = visitedTrainrunSections.concat(tsgBackward.visitedTrainrunSections);
 
     let forwardStartNode: PathNode = undefined;
     let forwardEndNode: PathNode = undefined;
@@ -974,7 +970,7 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
     check: boolean;
     visitedTrainrunSections: TrainrunSection[];
   } {
-    const visitedTrainrunSections: TrainrunSection[] = [];
+    let visitedTrainrunSections: TrainrunSection[] = [];
 
     const tsgForward = this.trainrunSectionGroup(
       trainrun.getId(),
@@ -982,9 +978,7 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
       true
     );
     const forwardTrainrunSectionGroups = tsgForward.trainrunSectionGroups;
-    tsgForward.visitedTrainrunSections.forEach(ts => {
-      visitedTrainrunSections.push(ts);
-    });
+    visitedTrainrunSections = visitedTrainrunSections.concat(tsgForward.visitedTrainrunSections);
 
     const tsgBackward = this.trainrunSectionGroup(
       trainrun.getId(),
@@ -992,9 +986,7 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
       false
     );
     const backwardTrainrunSectionGroups = tsgBackward.trainrunSectionGroups;
-    tsgBackward.visitedTrainrunSections.forEach(ts => {
-      visitedTrainrunSections.push(ts);
-    });
+    visitedTrainrunSections= visitedTrainrunSections.concat(tsgBackward.visitedTrainrunSections);
 
     const selectedPaths = this.betriebspunktNamePaths(
       selectedForwardTrainrunSectionGroups,
@@ -1024,7 +1016,10 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
         this.addStartEnde(backwardPaths),
       );
     }
-    return {check: rateForward < rateBackward, visitedTrainrunSections: visitedTrainrunSections};
+    return {
+      check: rateForward < rateBackward,
+      visitedTrainrunSections: visitedTrainrunSections
+    };
   }
 
   setDataOnlyForTestPurpose() {

--- a/src/app/streckengrafik/services/sg-1-load-trainrun-item.service.ts
+++ b/src/app/streckengrafik/services/sg-1-load-trainrun-item.service.ts
@@ -714,17 +714,6 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
             );
             trainrunItems.push(loadeddata.trainrunItem);
 
-            // debug log
-            console.log(trainrun.getTitle(), alltrainrunsections.length);
-            const path: string[] = [];
-            loadeddata.trainrunItem.pathItems.forEach(pi => {
-              if (pi.isNode()) {
-                path.push(pi.getPathNode().nodeShortName);
-              }
-            });
-            console.log(trainrun.getTitle(), loadeddata.trainrunItem);
-            console.log(trainrun.getTitle(), path);
-
             // filter all still visited trainrun sections
             alltrainrunsections = alltrainrunsections.filter(ts =>
               loadeddata.visitedTrainrunSections.find(ts2 => ts2.getId() === ts.getId()) === undefined

--- a/src/app/streckengrafik/services/sg-1-load-trainrun-item.service.ts
+++ b/src/app/streckengrafik/services/sg-1-load-trainrun-item.service.ts
@@ -714,6 +714,17 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
             );
             trainrunItems.push(loadeddata.trainrunItem);
 
+            // debug log
+            console.log(trainrun.getTitle(), alltrainrunsections.length);
+            const path: string[] = [];
+            loadeddata.trainrunItem.pathItems.forEach(pi => {
+              if (pi.isNode()) {
+                path.push(pi.getPathNode().nodeShortName);
+              }
+            });
+            console.log(trainrun.getTitle(), loadeddata.trainrunItem);
+            console.log(trainrun.getTitle(), path);
+
             // filter all still visited trainrun sections
             alltrainrunsections = alltrainrunsections.filter(ts =>
               loadeddata.visitedTrainrunSections.find(ts2 => ts2.getId() === ts.getId()) === undefined

--- a/src/app/streckengrafik/services/sg-1-load-trainrun-item.service.ts
+++ b/src/app/streckengrafik/services/sg-1-load-trainrun-item.service.ts
@@ -972,7 +972,7 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
     selectedForwardTrainrunSectionGroups: TrainrunSectionGroup[],
   ): {
     check: boolean;
-    visitedTrainrunSections: TrainrunSection[]
+    visitedTrainrunSections: TrainrunSection[];
   } {
     const visitedTrainrunSections: TrainrunSection[] = [];
 

--- a/src/app/view/util/generalViewFunctions.ts
+++ b/src/app/view/util/generalViewFunctions.ts
@@ -81,6 +81,26 @@ export class GeneralViewFunctions {
     }
   }
 
+  static getStartForwardAndBackwardNode(endNode1: Node, endNode2: Node): {
+    startForwardNode: Node;
+    startBackwardNode: Node;
+  } {
+    const startForwardNode = GeneralViewFunctions.getLeftOrTopNode(
+      endNode1,
+      endNode2,
+    );
+
+    const startBackwardNode =
+      endNode1.getId() === startForwardNode.getId()
+        ? endNode2
+        : endNode1;
+
+    return {
+      startForwardNode: startForwardNode,
+      startBackwardNode: startBackwardNode
+    };
+  }
+
   static getRightOrBottomNode(node1: Node, node2: Node): Node {
     const posNode1: Vec2D = new Vec2D(
       node1.getPositionX(),


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->
# Description

This change fixes the problem if a trainrun does not have a continuous path from the start to the destination, i.e. if sections are missing in the path that should continuously connect the nodes from the start to the end. These **holes** are artifacts that can occur during drawing if the train has not been drawn correctly or has not yet been fully drawn. So there can always be a train run that has "holes" along the path, i.e. missing train run sections along the path, e.g.
A - B - C ---- missing --- E - F - G --> also no section between C and E.

The solution to the problem - described above - is proposed in this fix: The trainrun has two parts: [(A B), (A C)] and [(E F)(F G)]. The trainrun is now interpreted as two separate train runs. The network diagram provides no information as to whether the missing part is between C - E, C - D - E, or another possible variant. Thus the best assumption we can make here is that each part of the train run can be interpreted as a single trainrun. 

(In principle, however, this should not occur in a perfect Netzgrafik.)

![image](https://github.com/user-attachments/assets/601d7cfc-fd7d-46c3-9666-abece65c71d1)
Example Netzgrafik 

![image](https://github.com/user-attachments/assets/1a6c3c44-2ee5-4401-be2f-5fac17f0dcfa)
Graphical timetable 

<!-- Describe the changes your PR introduces here. -->

# Issues fixed

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.
-->
The issue was fixed in the **graphical timetable (Streckengrafik)** within the TrainrunSection collector. All trainruns are now selected using the default iteration, which starts at the top-left end and traverses through the trainrun. Previously, if a trainrun had more than one segment the old version only collected a "random" trainrun part. This has now been fixed.

Additionally, the **cumulativeTimePropagation** for the trainrun had a similar issue, which caused other problems in the graphical timetable. This has also been resolved. Each trainrun segment is now interpreted as a single trainrun and is propagated separately.

The trainrun part issue was as well found in the **pearlsview** -  it's as well resolved.
![image](https://github.com/user-attachments/assets/4fe0e58c-984c-49e8-82e5-222de34351de)


# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] This PR contains a description of the changes I'm making
* [x] I've read the [Contribution Guidelines](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/CONTRIBUTING.md)
* [x] I've added tests for changes or features I've introduced
* [x] I documented any high-level concepts I'm introducing in `documentation/`
* [x] CI is currently green and this is ready for review

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation.
-->
