### PR TITLE
fix: Combining train journeys that consist of more than one trainrun segment has been fixed.

### DIFF
--- a/src/app/services/data/trainrun.service.ts
+++ b/src/app/services/data/trainrun.service.ts
@@ -484,6 +484,13 @@ export class TrainrunService {
     trainrun1.unselect();
     trainrun2.unselect();
 
+    // Change all trainrun sections' trainrunId reference from trainrun2 to trainrun1
+    // There can be some other "unconnected" trainrun segments left; those have to be moved to
+    // trainrun1, which will "survive".
+    this.trainrunSectionService.getAllTrainrunSectionsForTrainrun(trainrun2.getId()).forEach(
+      (ts: TrainrunSection) => ts.setTrainrun(trainrun1)
+    );
+
     // remove empty trainrun
     this.deleteTrainrun(trainrun2, false);
 


### PR DESCRIPTION
While combining two trainruns the first trainrun will "survive" and the second one will be deleted. If the trainrun which will be deleted consists of more than one trainrun segment (connected paths) the reported issue will be generated.

<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->
# Description

<!-- Describe the changes your PR introduces here. -->

# Issues

https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/330

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] This PR contains a description of the changes I'm making
* [x] I've read the [Contribution Guidelines](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/CONTRIBUTING.md)
* [ ] I've added tests for changes or features I've introduced
* [ ] I documented any high-level concepts I'm introducing in `documentation/`
* [x] CI is currently green and this is ready for review

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation.
-->
