### PR TITLE
fix: Simplified third-party JSON import (no port alignment/path precalculation required)

### DIFF
--- a/documentation/DATA_MODEL_JSON.md
+++ b/documentation/DATA_MODEL_JSON.md
@@ -18,6 +18,14 @@ To export the current Netzgrafik use the `Export netzgrafik as JSON` button.
 #### Import 
 The exported data in JSON format can be imported again using the `Import netzgrafik as JSON` button.
 
+##### 3rd party JSON 
+If nodes have no port objects or if no TrainrunSection has a defined path element, the import process will automatically adjust, 
+respectively create the required elements. This adjustment ensures that all nodes are created first, followed by the systematic 
+insertion of each train, section by section. Inserting each section by section ensures that the Netzgrafik drawing gets well routed. 
+This streamlines the import process, making the exchange of data much more straightforward and efficient. 
+The 3rd party has to care about the nodes' position only. The TrainrunSection routing gets computed while importing, 
+thus no complex calculation must be reimplemented by the 3rd party provider.
+
 ## JSON Description (basic data structure)
 
 ```json

--- a/documentation/DATA_MODEL_JSON.md
+++ b/documentation/DATA_MODEL_JSON.md
@@ -18,7 +18,7 @@ To export the current Netzgrafik use the `Export netzgrafik as JSON` button.
 #### Import 
 The exported data in JSON format can be imported again using the `Import netzgrafik as JSON` button.
 
-##### 3rd party JSON 
+##### JSON-Based Data Import from 3rd Party Data Providers
 If nodes have no port objects or if no TrainrunSection has a defined path element, the import process will automatically adjust, 
 respectively create the required elements. This adjustment ensures that all nodes are created first, followed by the systematic 
 insertion of each train, section by section. Inserting each section by section ensures that the Netzgrafik drawing gets well routed. 


### PR DESCRIPTION

<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->
# Description

The import of JSON from third-party providers has been simplified - or allowed. If no node has a port or if all ports are empty or no TrainrunSection has a path, then the import should be adjusted so that all nodes are created and then each train is inserted section by section. This makes the import (exchange) from 3rd party more easy.

# Issues

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] This PR contains a description of the changes I'm making
* [x] I've read the [Contribution Guidelines](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/CONTRIBUTING.md)
* [x] I've added tests for changes or features I've introduced
* [x] I documented any high-level concepts I'm introducing in `documentation/`
* [x] CI is currently green and this is ready for review

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation.
-->
