### PR TITLE
Refacto language + add navigator preferences

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -11,8 +11,8 @@
       {{ 'app.user-manual' | translate }}
     </a>
     <sbb-select
-      (selectionChange)="changeLocale($event.value)"
-      [value]="locale"
+      (selectionChange)="changeLanguage($event.value)"
+      [value]="language"
       class="language-selector"
     >
       <sbb-option value="en">🇬🇧 English</sbb-option>
@@ -35,8 +35,8 @@
   </sbb-usermenu>
   <sbb-menu #menu="sbbMenu">
     <sbb-select
-      (selectionChange)="changeLocale($event.value)"
-      [value]="locale"
+      (selectionChange)="changeLanguage($event.value)"
+      [value]="language"
       class="language-selector language-selector-menu"
       (click)="$event.stopPropagation()"
       (keydown)="$event.stopPropagation()"

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -26,7 +26,7 @@
   <sbb-menu #menu="sbbMenu">
     <sbb-select
       (selectionChange)="language = $event.value"
-      [value]="localStorageLanguage"
+      [value]="currentLanguage"
       class="language-selector language-selector-menu"
       (click)="$event.stopPropagation()"
       (keydown)="$event.stopPropagation()"

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -11,8 +11,8 @@
       {{ 'app.user-manual' | translate }}
     </a>
     <sbb-select
-      (selectionChange)="changeLanguage($event.value)"
-      [value]="language"
+      (selectionChange)="language = $event.value"
+      [value]="localStorageLanguage"
       class="language-selector"
     >
       <sbb-option value="en">🇬🇧 English</sbb-option>
@@ -35,8 +35,8 @@
   </sbb-usermenu>
   <sbb-menu #menu="sbbMenu">
     <sbb-select
-      (selectionChange)="changeLanguage($event.value)"
-      [value]="language"
+      (selectionChange)="language = $event.value"
+      [value]="localStorageLanguage"
       class="language-selector language-selector-menu"
       (click)="$event.stopPropagation()"
       (keydown)="$event.stopPropagation()"

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -10,16 +10,6 @@
     >
       {{ 'app.user-manual' | translate }}
     </a>
-    <sbb-select
-      (selectionChange)="language = $event.value"
-      [value]="localStorageLanguage"
-      class="language-selector"
-    >
-      <sbb-option value="en">🇬🇧 English</sbb-option>
-      <sbb-option value="de">🇩🇪 Deutsch</sbb-option>
-      <sbb-option value="fr">🇫🇷 Français</sbb-option>
-      <!-- <sbb-option value="it">🇮🇹 Italiano</sbb-option> -->
-    </sbb-select>
   </sbb-app-chooser-section>
   <sbb-header-environment class="noprint" *ngIf="environmentLabel">{{
     environmentLabel

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -20,7 +20,6 @@ import {NodeService} from "./services/data/node.service";
 export class AppComponent {
   readonly disableBackend = environment.disableBackend;
   readonly version = packageJson.version;
-  readonly locale = localStorage.getItem("locale");
   readonly environmentLabel = environment.label;
   readonly authenticated: Promise<unknown>;
 
@@ -64,6 +63,8 @@ export class AppComponent {
     this.language = language;
     location.reload();
   }
+
+  @Input() language: string;
 
   @Input()
   get netzgrafikDto() {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -11,6 +11,7 @@ import {NetzgrafikDto} from "./data-structures/business.data.structures";
 import {Operation} from "./models/operation.model";
 import {LabelService} from "./services/data/label.serivce";
 import {NodeService} from "./services/data/node.service";
+import {I18nService} from "./core/i18n/i18n.service";
 
 @Component({
   selector: "sbb-root",
@@ -22,6 +23,7 @@ export class AppComponent {
   readonly version = packageJson.version;
   readonly environmentLabel = environment.label;
   readonly authenticated: Promise<unknown>;
+  protected localStorageLanguage: string;
 
   projectInMenu: Observable<ProjectDto | null>;
 
@@ -45,8 +47,10 @@ export class AppComponent {
               private trainrunSectionService: TrainrunSectionService,
               private nodeService: NodeService,
               private labelService: LabelService,
+              private i18nService: I18nService,
             ) {
-    this.language = localStorage.getItem("i18nLng");
+    this.i18nService.setLanguage();
+    this.localStorageLanguage = localStorage.getItem("i18nLng");
     if (!this.disableBackend) {
       this.authenticated = authService.initialized;
     }
@@ -58,13 +62,14 @@ export class AppComponent {
     }
   }
 
-  changeLanguage(language: string) {
-    localStorage.setItem("i18nLng", language);
-    this.language = language;
-    location.reload();
+  @Input()
+  set language(value: string) {
+    if (value !== this.localStorageLanguage) {
+      localStorage.setItem("i18nLng", value);
+      this.i18nService.setLanguage();
+      this.localStorageLanguage = localStorage.getItem("i18nLng");
+    }
   }
-
-  @Input() language: string;
 
   @Input()
   get netzgrafikDto() {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -23,7 +23,7 @@ export class AppComponent {
   readonly version = packageJson.version;
   readonly environmentLabel = environment.label;
   readonly authenticated: Promise<unknown>;
-  protected currentLanguage: string;
+  protected currentLanguage: string = this.i18nService.language;
 
   projectInMenu: Observable<ProjectDto | null>;
 
@@ -49,8 +49,6 @@ export class AppComponent {
               private labelService: LabelService,
               private i18nService: I18nService,
             ) {
-    this.i18nService.setLanguage();
-    this.currentLanguage = localStorage.getItem("i18nLng");
     if (!this.disableBackend) {
       this.authenticated = authService.initialized;
     }
@@ -67,11 +65,10 @@ export class AppComponent {
     return this.currentLanguage;
   }
   
-  set language(value: string) {
-    if (value !== this.currentLanguage) {
-      localStorage.setItem("i18nLng", value);
-      this.i18nService.setLanguage();
-      this.currentLanguage = value;
+  set language(language: string) {
+    if (language !== this.currentLanguage) {
+      this.i18nService.setLanguage(language);
+      this.currentLanguage = language;
     }
   }
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -23,7 +23,7 @@ export class AppComponent {
   readonly version = packageJson.version;
   readonly environmentLabel = environment.label;
   readonly authenticated: Promise<unknown>;
-  protected localStorageLanguage: string;
+  protected currentLanguage: string;
 
   projectInMenu: Observable<ProjectDto | null>;
 
@@ -50,7 +50,7 @@ export class AppComponent {
               private i18nService: I18nService,
             ) {
     this.i18nService.setLanguage();
-    this.localStorageLanguage = localStorage.getItem("i18nLng");
+    this.currentLanguage = localStorage.getItem("i18nLng");
     if (!this.disableBackend) {
       this.authenticated = authService.initialized;
     }
@@ -63,11 +63,15 @@ export class AppComponent {
   }
 
   @Input()
+  get language() {
+    return this.currentLanguage;
+  }
+  
   set language(value: string) {
-    if (value !== this.localStorageLanguage) {
+    if (value !== this.currentLanguage) {
       localStorage.setItem("i18nLng", value);
       this.i18nService.setLanguage();
-      this.localStorageLanguage = localStorage.getItem("i18nLng");
+      this.currentLanguage = value;
     }
   }
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -47,6 +47,7 @@ export class AppComponent {
               private nodeService: NodeService,
               private labelService: LabelService,
             ) {
+    this.language = localStorage.getItem("i18nLng");
     if (!this.disableBackend) {
       this.authenticated = authService.initialized;
     }
@@ -58,8 +59,9 @@ export class AppComponent {
     }
   }
 
-  changeLocale(locale: string) {
-    localStorage.setItem("locale", locale);
+  changeLanguage(language: string) {
+    localStorage.setItem("i18nLng", language);
+    this.language = language;
     location.reload();
   }
 

--- a/src/app/core/i18n/i18n.module.ts
+++ b/src/app/core/i18n/i18n.module.ts
@@ -1,23 +1,23 @@
 import {NgModule, APP_INITIALIZER, LOCALE_ID} from "@angular/core";
 import {CommonModule} from "@angular/common";
 import {TranslatePipe} from "./translate.pipe";
-import {I18n} from "./i18n.service";
+import {I18nService} from "./i18n.service";
 
 @NgModule({
   declarations: [TranslatePipe], // Declare the pipe
   imports: [CommonModule],
   providers: [
-    I18n,
+    I18nService,
     { // Load locale data at app start-up
       provide: APP_INITIALIZER,
-      useFactory: (i18n: I18n) => () => i18n.setLocale(),
-      deps: [I18n],
+      useFactory: (i18nService: I18nService) => () => i18nService.setLanguage(),
+      deps: [I18nService],
       multi: true,
     },
     { // Set the runtime locale for the app
       provide: LOCALE_ID,
-      useFactory: (i18n: I18n) => i18n.locale,
-      deps: [I18n],
+      useFactory: (i18nService: I18nService) => i18nService.language,
+      deps: [I18nService],
     }
   ],
   exports: [TranslatePipe] // Export the pipe

--- a/src/app/core/i18n/i18n.service.ts
+++ b/src/app/core/i18n/i18n.service.ts
@@ -6,20 +6,25 @@ import {loadTranslations} from "@angular/localize";
     providedIn: "root",
   })
   export class I18n {
-    locale = "en";
     readonly allowedLocales = ["en", "fr", "de", "it"];
     translations: any = {};
-  
+    locale: string;
+
     async setLocale() {
       const userLocale = localStorage.getItem("locale");
-  
-      // If the user has a preferred language stored in LocalStorage, use it.
       if (userLocale && this.allowedLocales.includes(userLocale)) {
         this.locale = userLocale;
-      } else {
+      }
+      else {
+        const navigatorLocale = navigator.language.slice(0, 2);
+        if (this.allowedLocales.includes(navigatorLocale)) {
+          this.locale = navigatorLocale;
+        } else {
+          this.locale = "en";
+        }
         localStorage.setItem("locale", this.locale);
       }
-  
+
       // Use webpack magic string to only include required locale data
       const localeModule = await import(
         /* webpackInclude: /(en|de|fr|it)\.mjs$/ */

--- a/src/app/core/i18n/i18n.service.ts
+++ b/src/app/core/i18n/i18n.service.ts
@@ -14,8 +14,7 @@ import {loadTranslations} from "@angular/localize";
       const userLanguage = localStorage.getItem("i18nLng");
       if (userLanguage && this.allowedLanguages.includes(userLanguage)) {
         this.language = userLanguage;
-      }
-      else {
+      } else {
         const navigatorLanguage = navigator.language.slice(0, 2);
         if (this.allowedLanguages.includes(navigatorLanguage)) {
           this.language = navigatorLanguage;

--- a/src/app/core/i18n/i18n.service.ts
+++ b/src/app/core/i18n/i18n.service.ts
@@ -18,8 +18,6 @@ export class I18nService {
     if (language && this.allowedLanguages.includes(this.language)) {
       this.setLanguageToStorage(language);
       this.currentLanguage = language;
-    } else if (!this.allowedLanguages.includes(this.currentLanguage)) {
-      this.currentLanguage = this.allowedLanguages[0];
     }
 
     const languageModule = await import(
@@ -36,7 +34,8 @@ export class I18nService {
   }
 
   private getLanguageFromStorage(): string | null {
-    return localStorage.getItem("i18nLng");
+    const lang = localStorage.getItem("i18nLng");
+    return this.allowedLanguages.includes(lang) ? lang : null;
   }
 
   private detectNavigatorLanguage(): string {

--- a/src/app/core/i18n/i18n.service.ts
+++ b/src/app/core/i18n/i18n.service.ts
@@ -5,88 +5,88 @@ import {loadTranslations} from "@angular/localize";
 @Injectable({
     providedIn: "root",
   })
-  export class I18nService {
-    readonly allowedLanguages = ["en", "fr", "de", "it"];
-    translations: any = {};
-    language: string;
+export class I18nService {
+  readonly allowedLanguages = ["en", "fr", "de", "it"];
+  translations: any = {};
+  language: string;
 
-    async setLanguage() {
-      const userLanguage = localStorage.getItem("i18nLng");
-      if (userLanguage && this.allowedLanguages.includes(userLanguage)) {
-        this.language = userLanguage;
+  async setLanguage() {
+    const userLanguage = localStorage.getItem("i18nLng");
+    if (userLanguage && this.allowedLanguages.includes(userLanguage)) {
+      this.language = userLanguage;
+    } else {
+      const navigatorLanguage = navigator.language.slice(0, 2);
+      if (this.allowedLanguages.includes(navigatorLanguage)) {
+        this.language = navigatorLanguage;
       } else {
-        const navigatorLanguage = navigator.language.slice(0, 2);
-        if (this.allowedLanguages.includes(navigatorLanguage)) {
-          this.language = navigatorLanguage;
-        } else {
-          this.language = this.allowedLanguages[0];
-        }
+        this.language = this.allowedLanguages[0];
       }
+    }
 
-      // Use webpack magic string to only include required locale data
-      const languageModule = await import(
-        /* webpackInclude: /(en|de|fr|it)\.mjs$/ */
-        `/node_modules/@angular/common/locales/${this.language}.mjs`
-      );
-      registerLocaleData(languageModule.default);
-  
-      // Load translation file initially
-      await this.loadTranslations();
-    }
-  
-    async loadTranslations() {
-      const languageTranslationsModule = await import(
-        `src/assets/i18n/${this.language}.json`
-      );
-  
-      // Ensure translations are flattened if necessary
-      this.translations = this.flattenTranslations(languageTranslationsModule.default);
-  
-      // Load translations for the current language at runtime
-      loadTranslations(this.translations);
-    }
-  
-    // Helper function to flatten nested translations
-    // nested JSON :
-    // {
-    //   "app": {
-    //     "login": "Login",
-    //     "models": {...}
-    //   }
-    // }
-    // flattened JSON :
-    // {
-    //   "app.login": "Login",
-    //   "app.models...": ...,
-    //   "app.models...": ...
-    // }
-    private flattenTranslations(translations: any): any {
-      const flattenedTranslations = {};
-  
-      function flatten(obj, prefix = "") {
-        for (const key in obj) {
-          if (typeof obj[key] === "string") {
-            flattenedTranslations[prefix + key] = obj[key];
-          } else if (typeof obj[key] === "object") {
-            flatten(obj[key], prefix + key + ".");
-          }
+    // Use webpack magic string to only include required locale data
+    const languageModule = await import(
+      /* webpackInclude: /(en|de|fr|it)\.mjs$/ */
+      `/node_modules/@angular/common/locales/${this.language}.mjs`
+    );
+    registerLocaleData(languageModule.default);
+
+    // Load translation file initially
+    await this.loadTranslations();
+  }
+
+  async loadTranslations() {
+    const languageTranslationsModule = await import(
+      `src/assets/i18n/${this.language}.json`
+    );
+
+    // Ensure translations are flattened if necessary
+    this.translations = this.flattenTranslations(languageTranslationsModule.default);
+
+    // Load translations for the current language at runtime
+    loadTranslations(this.translations);
+  }
+
+  // Helper function to flatten nested translations
+  // nested JSON :
+  // {
+  //   "app": {
+  //     "login": "Login",
+  //     "models": {...}
+  //   }
+  // }
+  // flattened JSON :
+  // {
+  //   "app.login": "Login",
+  //   "app.models...": ...,
+  //   "app.models...": ...
+  // }
+  private flattenTranslations(translations: any): any {
+    const flattenedTranslations = {};
+
+    function flatten(obj, prefix = "") {
+      for (const key in obj) {
+        if (typeof obj[key] === "string") {
+          flattenedTranslations[prefix + key] = obj[key];
+        } else if (typeof obj[key] === "object") {
+          flatten(obj[key], prefix + key + ".");
         }
       }
-  
-      flatten(translations);
-      return flattenedTranslations;
     }
-  
-    // Used for the pipe and allowing parameters
-    translate(key: string, params?: any): string {
-      let translation = this.translations[key] || key;
-  
-      if (params) {
-        Object.keys(params).forEach(param => {
-          translation = translation.replace(`{$${param}}`, params[param]);
-        });
-      }
-  
-      return translation;
-    }
+
+    flatten(translations);
+    return flattenedTranslations;
   }
+
+  // Used for the pipe and allowing parameters
+  translate(key: string, params?: any): string {
+    let translation = this.translations[key] || key;
+
+    if (params) {
+      Object.keys(params).forEach(param => {
+        translation = translation.replace(`{$${param}}`, params[param]);
+      });
+    }
+
+    return translation;
+  }
+}

--- a/src/app/core/i18n/i18n.service.ts
+++ b/src/app/core/i18n/i18n.service.ts
@@ -5,46 +5,46 @@ import {loadTranslations} from "@angular/localize";
 @Injectable({
     providedIn: "root",
   })
-  export class I18n {
-    readonly allowedLocales = ["en", "fr", "de", "it"];
+  export class I18nService {
+    readonly allowedLanguages = ["en", "fr", "de", "it"];
     translations: any = {};
-    locale: string;
+    language: string;
 
-    async setLocale() {
-      const userLocale = localStorage.getItem("locale");
-      if (userLocale && this.allowedLocales.includes(userLocale)) {
-        this.locale = userLocale;
+    async setLanguage() {
+      const userLanguage = localStorage.getItem("i18nLng");
+      if (userLanguage && this.allowedLanguages.includes(userLanguage)) {
+        this.language = userLanguage;
       }
       else {
-        const navigatorLocale = navigator.language.slice(0, 2);
-        if (this.allowedLocales.includes(navigatorLocale)) {
-          this.locale = navigatorLocale;
+        const navigatorLanguage = navigator.language.slice(0, 2);
+        if (this.allowedLanguages.includes(navigatorLanguage)) {
+          this.language = navigatorLanguage;
         } else {
-          this.locale = "en";
+          this.language = this.allowedLanguages[0];
         }
-        localStorage.setItem("locale", this.locale);
+        localStorage.setItem("i18nLng", this.language);
       }
 
       // Use webpack magic string to only include required locale data
-      const localeModule = await import(
+      const languageModule = await import(
         /* webpackInclude: /(en|de|fr|it)\.mjs$/ */
-        `/node_modules/@angular/common/locales/${this.locale}.mjs`
+        `/node_modules/@angular/common/locales/${this.language}.mjs`
       );
-      registerLocaleData(localeModule.default);
+      registerLocaleData(languageModule.default);
   
       // Load translation file initially
       await this.loadTranslations();
     }
   
     async loadTranslations() {
-      const localeTranslationsModule = await import(
-        `src/assets/i18n/${this.locale}.json`
+      const languageTranslationsModule = await import(
+        `src/assets/i18n/${this.language}.json`
       );
   
       // Ensure translations are flattened if necessary
-      this.translations = this.flattenTranslations(localeTranslationsModule.default);
+      this.translations = this.flattenTranslations(languageTranslationsModule.default);
   
-      // Load translations for the current locale at runtime
+      // Load translations for the current language at runtime
       loadTranslations(this.translations);
     }
   

--- a/src/app/core/i18n/i18n.service.ts
+++ b/src/app/core/i18n/i18n.service.ts
@@ -21,7 +21,6 @@ import {loadTranslations} from "@angular/localize";
         } else {
           this.language = this.allowedLanguages[0];
         }
-        localStorage.setItem("i18nLng", this.language);
       }
 
       // Use webpack magic string to only include required locale data

--- a/src/app/core/i18n/translate.pipe.ts
+++ b/src/app/core/i18n/translate.pipe.ts
@@ -1,14 +1,14 @@
 import {Pipe, PipeTransform} from "@angular/core";
-import {I18n} from "./i18n.service";
+import {I18nService} from "./i18n.service";
 
 @Pipe({
   name: "translate",
   pure: false
 })
 export class TranslatePipe implements PipeTransform {
-  constructor(private i18n: I18n) {}
+  constructor(private i18nService: I18nService) {}
 
   transform(key: string, params?: any): string {
-    return this.i18n.translate(key, params);
+    return this.i18nService.translate(key, params);
   }
 }


### PR DESCRIPTION
# Description

- Initialize application language with navigator language if no preference (= first connection) in localStorage
- Allow to change language from the application without window reload
- Allow to change language from the outer of the application with `@Input (setter)` (in `standalone` mode especially)

# Issues

- I renamed `"locale" -> "language"` since a locale is something like `"fr-FR"` and a language `"fr"`, and we use `"fr"` as value for the language ; but i can revert these changes and bring back the `"locale"`
- Cannot use `@Input (getter)` to uniformize the code, because the getter is called at any change (including mouse move), then involving too many actions and crash the application
- (Edit: removed) Could we also remove this button ? @aiAdrian  or is it still used for demo purpose on your side ?
![image](https://github.com/user-attachments/assets/0b75d9f1-3bba-4624-9231-21c31681c091)

# Checklist

* [x] This PR contains a description of the changes I'm making
* [x] I've read the [Contribution Guidelines](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/CONTRIBUTING.md)
* [ ] I've added tests for changes or features I've introduced
* [ ] I documented any high-level concepts I'm introducing in `documentation/`
* [x] CI is currently green and this is ready for review
