### PR TITLE
fix: 350 bug delete node or trainrunsections cause low performance

### DIFF
--- a/src/app/services/data/trainrunsection.service.ts
+++ b/src/app/services/data/trainrunsection.service.ts
@@ -814,40 +814,46 @@ export class TrainrunSectionService implements OnDestroy {
     this.operation.emit(new TrainrunOperation(OperationType.update, trainrunSection.getTrainrun()));
   }
 
-  deleteListOfTrainrunSections(trainrunSections: TrainrunSection[]) {
+  deleteListOfTrainrunSections(trainrunSections: TrainrunSection[], enforceUpdate = true) {
     trainrunSections.forEach((trainrunSection) => {
       this.deleteTrainrunSectionAndCleanupNodes(trainrunSection, false);
     });
-    this.nodeService.transitionsUpdated();
-    this.nodeService.connectionsUpdated();
-    this.trainrunService.trainrunsUpdated();
-    this.trainrunSectionsUpdated();
+    if (enforceUpdate) {
+      this.nodeService.transitionsUpdated();
+      this.nodeService.connectionsUpdated();
+      this.trainrunService.trainrunsUpdated();
+      this.trainrunSectionsUpdated();
+    }
   }
 
-  deleteAllVisibleTrainrunSections() {
+  deleteAllVisibleTrainrunSections(enforceUpdate = true) {
     const allTrainrunSections = this.trainrunSectionsStore.trainrunSections;
     allTrainrunSections.forEach((trainrunSection: TrainrunSection) => {
       if (this.filterService.filterTrainrunsection(trainrunSection)) {
         this.deleteTrainrunSectionAndCleanupNodes(trainrunSection, false);
       }
     });
-    this.nodeService.transitionsUpdated();
-    this.nodeService.connectionsUpdated();
-    this.trainrunService.trainrunsUpdated();
-    this.trainrunSectionsUpdated();
+    if (enforceUpdate){
+      this.nodeService.transitionsUpdated();
+      this.nodeService.connectionsUpdated();
+      this.trainrunService.trainrunsUpdated();
+      this.trainrunSectionsUpdated();
+    }
   }
 
-  deleteAllNonVisibleTrainrunSections() {
+  deleteAllNonVisibleTrainrunSections(enforceUpdate = true) {
     const allTrainrunSections = this.trainrunSectionsStore.trainrunSections;
     allTrainrunSections.forEach((trainrunSection: TrainrunSection) => {
       if (!this.filterService.filterTrainrunsection(trainrunSection)) {
         this.deleteTrainrunSectionAndCleanupNodes(trainrunSection, false);
       }
     });
-    this.nodeService.transitionsUpdated();
-    this.nodeService.connectionsUpdated();
-    this.trainrunService.trainrunsUpdated();
-    this.trainrunSectionsUpdated();
+    if (enforceUpdate) {
+      this.nodeService.transitionsUpdated();
+      this.nodeService.connectionsUpdated();
+      this.trainrunService.trainrunsUpdated();
+      this.trainrunSectionsUpdated();
+    }
   }
 
   deleteTrainrunSection(trainrunSectionId: number, enforceUpdate = true) {

--- a/src/app/services/data/trainrunsection.service.ts
+++ b/src/app/services/data/trainrunsection.service.ts
@@ -816,8 +816,11 @@ export class TrainrunSectionService implements OnDestroy {
 
   deleteListOfTrainrunSections(trainrunSections: TrainrunSection[]) {
     trainrunSections.forEach((trainrunSection) => {
-      this.deleteTrainrunSectionAndCleanupNodes(trainrunSection);
+      this.deleteTrainrunSectionAndCleanupNodes(trainrunSection, false);
     });
+    this.nodeService.transitionsUpdated();
+    this.nodeService.connectionsUpdated();
+    this.trainrunService.trainrunsUpdated();
     this.trainrunSectionsUpdated();
   }
 
@@ -825,9 +828,12 @@ export class TrainrunSectionService implements OnDestroy {
     const allTrainrunSections = this.trainrunSectionsStore.trainrunSections;
     allTrainrunSections.forEach((trainrunSection: TrainrunSection) => {
       if (this.filterService.filterTrainrunsection(trainrunSection)) {
-        this.deleteTrainrunSectionAndCleanupNodes(trainrunSection);
+        this.deleteTrainrunSectionAndCleanupNodes(trainrunSection, false);
       }
     });
+    this.nodeService.transitionsUpdated();
+    this.nodeService.connectionsUpdated();
+    this.trainrunService.trainrunsUpdated();
     this.trainrunSectionsUpdated();
   }
 
@@ -835,9 +841,12 @@ export class TrainrunSectionService implements OnDestroy {
     const allTrainrunSections = this.trainrunSectionsStore.trainrunSections;
     allTrainrunSections.forEach((trainrunSection: TrainrunSection) => {
       if (!this.filterService.filterTrainrunsection(trainrunSection)) {
-        this.deleteTrainrunSectionAndCleanupNodes(trainrunSection);
+        this.deleteTrainrunSectionAndCleanupNodes(trainrunSection, false);
       }
     });
+    this.nodeService.transitionsUpdated();
+    this.nodeService.connectionsUpdated();
+    this.trainrunService.trainrunsUpdated();
     this.trainrunSectionsUpdated();
   }
 


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->
# Description

<!-- Describe the changes your PR introduces here. -->
When deleting multiple nodes or trainrun sections, it's crucial that the delete loop doesn't refresh the rendering for each deleted element. The deletions should be performed all at once at the end - only one update (refresh) should be triggered. This is now implemented and improves the performance.

https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/350


# Issues

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] This PR contains a description of the changes I'm making
* [x] I've read the [Contribution Guidelines](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/CONTRIBUTING.md)
* [ ] I've added tests for changes or features I've introduced
* [ ] I documented any high-level concepts I'm introducing in `documentation/`
* [x] CI is currently green and this is ready for review

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation.
-->
