### PR TITLE
fix: warn users when having unsymmetric times

### DIFF
--- a/src/app/models/trainrunsection.model.ts
+++ b/src/app/models/trainrunsection.model.ts
@@ -201,7 +201,7 @@ export class TrainrunSection {
     return formattedText;
   }
 
-  shiftAllTimes(translateMinutes: number, mirrorSourceDeparture : boolean) {
+  shiftAllTimes(translateMinutes: number, mirrorSourceDeparture: boolean) {
     this.sourceDeparture.time += translateMinutes;
     this.targetArrival.time += translateMinutes;
     this.sourceArrival.time += translateMinutes;
@@ -503,6 +503,26 @@ export class TrainrunSection {
     };
   }
 
+  getTargetArrivalWarning() {
+    return this.targetArrival.warning;
+  }
+
+  getSourceArrivalWarning() {
+    return this.sourceArrival.warning;
+  }
+
+  getTargetDepartureWarning() {
+    return this.targetDeparture.warning;
+  }
+
+  getSourceDepartureWarning() {
+    return this.sourceDeparture.warning;
+  }
+
+  getTravelTimeWarning() {
+    return this.travelTime.warning;
+  }
+
   resetTargetArrivalWarning() {
     this.targetArrival.warning = null;
   }
@@ -639,7 +659,7 @@ export class TrainrunSection {
       resourceId: this.resourceId,
 
       specificTrainrunSectionFrequencyId:
-        this.specificTrainrunSectionFrequencyId,
+      this.specificTrainrunSectionFrequencyId,
       path: this.path,
       warnings: this.warnings,
     };

--- a/src/app/services/util/trainrunsection.validator.ts
+++ b/src/app/services/util/trainrunsection.validator.ts
@@ -38,17 +38,17 @@ export class TrainrunsectionValidator {
     const sourceSymmetricCheck = sourceSum % 60 === 0;
     if (!sourceSymmetricCheck) {
       trainrunSection.setSourceArrivalWarning($localize`:@@app.services.util.trainrunsection-validator.broken-symmetry:Broken symmetry`,
-        " " + (trainrunSection.getSourceArrival() + " + " + trainrunSection.getSourceDeparture()) + " != 60 ");
+        " " + (trainrunSection.getSourceArrival() + " + " + trainrunSection.getSourceDeparture()) + " = " + sourceSum);
       trainrunSection.setSourceDepartureWarning($localize`:@@app.services.util.trainrunsection-validator.broken-symmetry:Broken symmetry`,
-        " " + (trainrunSection.getSourceArrival() + " + " + trainrunSection.getSourceDeparture()) + " != 60 ");
+        " " + (trainrunSection.getSourceArrival() + " + " + trainrunSection.getSourceDeparture()) + " = " + sourceSum);
     }
     const targetSum = (trainrunSection.getTargetArrival() + trainrunSection.getTargetDeparture());
     const targetSymmetricCheck = targetSum % 60 === 0;
     if (!targetSymmetricCheck) {
       trainrunSection.setTargetArrivalWarning($localize`:@@app.services.util.trainrunsection-validator.broken-symmetry:Broken symmetry`,
-        " " + (trainrunSection.getTargetArrival() + " + " + trainrunSection.getTargetDeparture()) + " != 60 ");
+        " " + (trainrunSection.getTargetArrival() + " + " + trainrunSection.getTargetDeparture()) + " = " + targetSum);
       trainrunSection.setTargetDepartureWarning($localize`:@@app.services.util.trainrunsection-validator.broken-symmetry:Broken symmetry`,
-        " " + (trainrunSection.getTargetArrival() + " + " + trainrunSection.getTargetDeparture()) + " != 60 ");
+        " " + (trainrunSection.getTargetArrival() + " + " + trainrunSection.getTargetDeparture()) + " =  " + targetSum);
     }
 
 

--- a/src/app/services/util/trainrunsection.validator.ts
+++ b/src/app/services/util/trainrunsection.validator.ts
@@ -1,5 +1,4 @@
 import {TrainrunSection} from "../../models/trainrunsection.model";
-import {MathUtils} from "../../utils/math";
 
 export class TrainrunsectionValidator {
   static validateOneSection(trainrunSection: TrainrunSection) {
@@ -10,7 +9,7 @@ export class TrainrunsectionValidator {
       (trainrunSection.getSourceDeparture() + trainrunSection.getTravelTime()) %
       60;
     if (Math.abs(calculatedTargetArrivalTime - trainrunSection.getTargetArrival())
-       > 1 / 60) {
+      > 1 / 60) {
       trainrunSection.setTargetArrivalWarning(
         $localize`:@@app.services.util.trainrunsection-validator.target-arrival-not-reacheable.title:Target Arrival Warning`,
         $localize`:@@app.services.util.trainrunsection-validator.target-arrival-not-reacheable.description:Target arrival time cannot be reached`,
@@ -23,7 +22,7 @@ export class TrainrunsectionValidator {
       (trainrunSection.getTargetDeparture() + trainrunSection.getTravelTime()) %
       60;
     if (Math.abs(calculatedSourceArrivalTime - trainrunSection.getSourceArrival())
-       > 1 / 60) {
+      > 1 / 60) {
       trainrunSection.setSourceArrivalWarning(
         $localize`:@@app.services.util.trainrunsection-validator.source-arrival-not-reacheable.title:Source Arrival Warning`,
         $localize`:@@app.services.util.trainrunsection-validator.source-arrival-not-reacheable.description:Source arrival time cannot be reached`,
@@ -31,6 +30,28 @@ export class TrainrunsectionValidator {
     } else {
       trainrunSection.resetSourceArrivalWarning();
     }
+
+    // check for broken symmetry (times)
+    trainrunSection.resetSourceDepartureWarning();
+    trainrunSection.resetTargetDepartureWarning();
+    const sourceSum = (trainrunSection.getSourceArrival() + trainrunSection.getSourceDeparture());
+    const sourceSymmetricCheck = sourceSum % 60 === 0;
+    if (!sourceSymmetricCheck) {
+      trainrunSection.setSourceArrivalWarning($localize`:@@app.services.util.trainrunsection-validator.broken-symmetry:Broken symmetry`,
+        " " + (trainrunSection.getSourceArrival() + " + " + trainrunSection.getSourceDeparture()) + " != 60 ");
+      trainrunSection.setSourceDepartureWarning($localize`:@@app.services.util.trainrunsection-validator.broken-symmetry:Broken symmetry`,
+        " " + (trainrunSection.getSourceArrival() + " + " + trainrunSection.getSourceDeparture()) + " != 60 ");
+    }
+    const targetSum = (trainrunSection.getTargetArrival() + trainrunSection.getTargetDeparture());
+    const targetSymmetricCheck = targetSum % 60 === 0;
+    if (!targetSymmetricCheck) {
+      trainrunSection.setTargetArrivalWarning($localize`:@@app.services.util.trainrunsection-validator.broken-symmetry:Broken symmetry`,
+        " " + (trainrunSection.getTargetArrival() + " + " + trainrunSection.getTargetDeparture()) + " != 60 ");
+      trainrunSection.setTargetDepartureWarning($localize`:@@app.services.util.trainrunsection-validator.broken-symmetry:Broken symmetry`,
+        " " + (trainrunSection.getTargetArrival() + " + " + trainrunSection.getTargetDeparture()) + " != 60 ");
+    }
+
+
   }
 
   static validateTravelTime(trainrunSection: TrainrunSection) {

--- a/src/app/services/util/trainrunsection.validator.ts
+++ b/src/app/services/util/trainrunsection.validator.ts
@@ -6,6 +6,11 @@ export class TrainrunsectionValidator {
     trainrunSection.resetSourceDepartureWarning();
     trainrunSection.resetTargetDepartureWarning();
 
+    TrainrunsectionValidator.validateTravelTimeOneSection(trainrunSection);
+    TrainrunsectionValidator.validateUnsymmetricTimesOneSection(trainrunSection);
+  }
+
+  static validateTravelTimeOneSection(trainrunSection: TrainrunSection) {
     const calculatedTargetArrivalTime =
       (trainrunSection.getSourceDeparture() + trainrunSection.getTravelTime()) %
       60;
@@ -31,7 +36,9 @@ export class TrainrunsectionValidator {
     } else {
       trainrunSection.resetSourceArrivalWarning();
     }
+  }
 
+  static validateUnsymmetricTimesOneSection(trainrunSection: TrainrunSection) {
     // check for broken symmetry (times)
     trainrunSection.resetSourceDepartureWarning();
     trainrunSection.resetTargetDepartureWarning();
@@ -39,17 +46,17 @@ export class TrainrunsectionValidator {
     const sourceSymmetricCheck = sourceSum % 60 === 0;
     if (!sourceSymmetricCheck) {
       trainrunSection.setSourceArrivalWarning($localize`:@@app.services.util.trainrunsection-validator.broken-symmetry:Broken symmetry`,
-        " " + (trainrunSection.getSourceArrival() + " + " + trainrunSection.getSourceDeparture()) + " = " + sourceSum);
+        "" + (trainrunSection.getSourceArrival() + " + " + trainrunSection.getSourceDeparture()) + " = " + sourceSum);
       trainrunSection.setSourceDepartureWarning($localize`:@@app.services.util.trainrunsection-validator.broken-symmetry:Broken symmetry`,
-        " " + (trainrunSection.getSourceArrival() + " + " + trainrunSection.getSourceDeparture()) + " = " + sourceSum);
+        "" + (trainrunSection.getSourceArrival() + " + " + trainrunSection.getSourceDeparture()) + " = " + sourceSum);
     }
     const targetSum = MathUtils.round(trainrunSection.getTargetArrival() + trainrunSection.getTargetDeparture(), 4);
     const targetSymmetricCheck = targetSum % 60 === 0;
     if (!targetSymmetricCheck) {
       trainrunSection.setTargetArrivalWarning($localize`:@@app.services.util.trainrunsection-validator.broken-symmetry:Broken symmetry`,
-        " " + (trainrunSection.getTargetArrival() + " + " + trainrunSection.getTargetDeparture()) + " = " + targetSum);
+        "" + (trainrunSection.getTargetArrival() + " + " + trainrunSection.getTargetDeparture()) + " = " + targetSum);
       trainrunSection.setTargetDepartureWarning($localize`:@@app.services.util.trainrunsection-validator.broken-symmetry:Broken symmetry`,
-        " " + (trainrunSection.getTargetArrival() + " + " + trainrunSection.getTargetDeparture()) + " =  " + targetSum);
+        "" + (trainrunSection.getTargetArrival() + " + " + trainrunSection.getTargetDeparture()) + " =  " + targetSum);
     }
   }
 

--- a/src/app/services/util/trainrunsection.validator.ts
+++ b/src/app/services/util/trainrunsection.validator.ts
@@ -12,10 +12,8 @@ export class TrainrunsectionValidator {
 
   static validateTravelTimeOneSection(trainrunSection: TrainrunSection) {
     const calculatedTargetArrivalTime =
-      (trainrunSection.getSourceDeparture() + trainrunSection.getTravelTime()) %
-      60;
-    if (Math.abs(calculatedTargetArrivalTime - trainrunSection.getTargetArrival())
-      > 1 / 60) {
+      (trainrunSection.getSourceDeparture() + trainrunSection.getTravelTime()) % 60;
+    if (Math.abs(calculatedTargetArrivalTime - trainrunSection.getTargetArrival()) > 1 / 60) {
       trainrunSection.setTargetArrivalWarning(
         $localize`:@@app.services.util.trainrunsection-validator.target-arrival-not-reacheable.title:Target Arrival Warning`,
         $localize`:@@app.services.util.trainrunsection-validator.target-arrival-not-reacheable.description:Target arrival time cannot be reached`,
@@ -25,10 +23,8 @@ export class TrainrunsectionValidator {
     }
 
     const calculatedSourceArrivalTime =
-      (trainrunSection.getTargetDeparture() + trainrunSection.getTravelTime()) %
-      60;
-    if (Math.abs(calculatedSourceArrivalTime - trainrunSection.getSourceArrival())
-      > 1 / 60) {
+      (trainrunSection.getTargetDeparture() + trainrunSection.getTravelTime()) % 60;
+    if (Math.abs(calculatedSourceArrivalTime - trainrunSection.getSourceArrival()) > 1 / 60) {
       trainrunSection.setSourceArrivalWarning(
         $localize`:@@app.services.util.trainrunsection-validator.source-arrival-not-reacheable.title:Source Arrival Warning`,
         $localize`:@@app.services.util.trainrunsection-validator.source-arrival-not-reacheable.description:Source arrival time cannot be reached`,

--- a/src/app/services/util/trainrunsection.validator.ts
+++ b/src/app/services/util/trainrunsection.validator.ts
@@ -43,7 +43,7 @@ export class TrainrunsectionValidator {
     trainrunSection.resetSourceDepartureWarning();
     trainrunSection.resetTargetDepartureWarning();
     const sourceSum = MathUtils.round(trainrunSection.getSourceArrival() + trainrunSection.getSourceDeparture(), 4);
-    const sourceSymmetricCheck = sourceSum % 60 === 0;
+    const sourceSymmetricCheck = Math.abs(sourceSum % 60) < 1 / 60;
     if (!sourceSymmetricCheck) {
       trainrunSection.setSourceArrivalWarning($localize`:@@app.services.util.trainrunsection-validator.broken-symmetry:Broken symmetry`,
         "" + (trainrunSection.getSourceArrival() + " + " + trainrunSection.getSourceDeparture()) + " = " + sourceSum);
@@ -51,7 +51,7 @@ export class TrainrunsectionValidator {
         "" + (trainrunSection.getSourceArrival() + " + " + trainrunSection.getSourceDeparture()) + " = " + sourceSum);
     }
     const targetSum = MathUtils.round(trainrunSection.getTargetArrival() + trainrunSection.getTargetDeparture(), 4);
-    const targetSymmetricCheck = targetSum % 60 === 0;
+    const targetSymmetricCheck = Math.abs(targetSum % 60) < 1 / 60;
     if (!targetSymmetricCheck) {
       trainrunSection.setTargetArrivalWarning($localize`:@@app.services.util.trainrunsection-validator.broken-symmetry:Broken symmetry`,
         "" + (trainrunSection.getTargetArrival() + " + " + trainrunSection.getTargetDeparture()) + " = " + targetSum);

--- a/src/app/services/util/trainrunsection.validator.ts
+++ b/src/app/services/util/trainrunsection.validator.ts
@@ -1,4 +1,5 @@
 import {TrainrunSection} from "../../models/trainrunsection.model";
+import {MathUtils} from "../../utils/math";
 
 export class TrainrunsectionValidator {
   static validateOneSection(trainrunSection: TrainrunSection) {
@@ -34,7 +35,7 @@ export class TrainrunsectionValidator {
     // check for broken symmetry (times)
     trainrunSection.resetSourceDepartureWarning();
     trainrunSection.resetTargetDepartureWarning();
-    const sourceSum = (trainrunSection.getSourceArrival() + trainrunSection.getSourceDeparture());
+    const sourceSum = MathUtils.round(trainrunSection.getSourceArrival() + trainrunSection.getSourceDeparture(), 4);
     const sourceSymmetricCheck = sourceSum % 60 === 0;
     if (!sourceSymmetricCheck) {
       trainrunSection.setSourceArrivalWarning($localize`:@@app.services.util.trainrunsection-validator.broken-symmetry:Broken symmetry`,
@@ -42,7 +43,7 @@ export class TrainrunsectionValidator {
       trainrunSection.setSourceDepartureWarning($localize`:@@app.services.util.trainrunsection-validator.broken-symmetry:Broken symmetry`,
         " " + (trainrunSection.getSourceArrival() + " + " + trainrunSection.getSourceDeparture()) + " = " + sourceSum);
     }
-    const targetSum = (trainrunSection.getTargetArrival() + trainrunSection.getTargetDeparture());
+    const targetSum = MathUtils.round(trainrunSection.getTargetArrival() + trainrunSection.getTargetDeparture(), 4);
     const targetSymmetricCheck = targetSum % 60 === 0;
     if (!targetSymmetricCheck) {
       trainrunSection.setTargetArrivalWarning($localize`:@@app.services.util.trainrunsection-validator.broken-symmetry:Broken symmetry`,
@@ -50,8 +51,6 @@ export class TrainrunsectionValidator {
       trainrunSection.setTargetDepartureWarning($localize`:@@app.services.util.trainrunsection-validator.broken-symmetry:Broken symmetry`,
         " " + (trainrunSection.getTargetArrival() + " + " + trainrunSection.getTargetDeparture()) + " =  " + targetSum);
     }
-
-
   }
 
   static validateTravelTime(trainrunSection: TrainrunSection) {

--- a/src/app/services/util/transition.validator.spec.ts
+++ b/src/app/services/util/transition.validator.spec.ts
@@ -184,16 +184,16 @@ describe("TransitionValidator", () => {
       nodeHaltezeiten[
         trainrunSections.trainrunSection1.getTrainrun().getTrainrunCategory()
           .fachCategory
-      ].haltezeit;
+        ].haltezeit;
     trainrunSections.trainrunSection2.setSourceDeparture(
       trainrunSections.trainrunSection1.getSourceArrival() -
-        trainrunHaltezeit -
-        1,
+      trainrunHaltezeit -
+      1,
     );
     trainrunSections.trainrunSection2.setTargetDeparture(
       trainrunSections.trainrunSection1.getTargetArrival() -
-        trainrunHaltezeit -
-        1,
+      trainrunHaltezeit -
+      1,
     );
 
     trainrunSections.trainrunSection1.resetTargetArrivalWarning();
@@ -276,16 +276,16 @@ describe("TransitionValidator", () => {
       nodeHaltezeiten[
         trainrunSections.trainrunSection2.getTrainrun().getTrainrunCategory()
           .fachCategory
-      ].haltezeit;
+        ].haltezeit;
     trainrunSections.trainrunSection1.setSourceDeparture(
       trainrunSections.trainrunSection2.getSourceArrival() -
-        trainrunHaltezeit -
-        1,
+      trainrunHaltezeit -
+      1,
     );
     trainrunSections.trainrunSection1.setTargetDeparture(
       trainrunSections.trainrunSection2.getTargetArrival() -
-        trainrunHaltezeit -
-        1,
+      trainrunHaltezeit -
+      1,
     );
 
     trainrunSections.trainrunSection1.resetTargetArrivalWarning();
@@ -386,16 +386,16 @@ describe("TransitionValidator", () => {
       nodeHaltezeiten[
         trainrunSections.trainrunSection2.getTrainrun().getTrainrunCategory()
           .fachCategory
-      ].haltezeit;
+        ].haltezeit;
     trainrunSections.trainrunSection1.setSourceDeparture(
       trainrunSections.trainrunSection2.getSourceArrival() -
-        trainrunHaltezeit -
-        1,
+      trainrunHaltezeit -
+      1,
     );
     trainrunSections.trainrunSection1.setTargetDeparture(
       trainrunSections.trainrunSection2.getTargetArrival() -
-        trainrunHaltezeit -
-        1,
+      trainrunHaltezeit -
+      1,
     );
 
     trainrunSections.trainrunSection1.resetTargetArrivalWarning();
@@ -496,16 +496,16 @@ describe("TransitionValidator", () => {
       nodeHaltezeiten[
         trainrunSections.trainrunSection2.getTrainrun().getTrainrunCategory()
           .fachCategory
-      ].haltezeit;
+        ].haltezeit;
     trainrunSections.trainrunSection1.setSourceDeparture(
       trainrunSections.trainrunSection2.getSourceArrival() -
-        trainrunHaltezeit -
-        1,
+      trainrunHaltezeit -
+      1,
     );
     trainrunSections.trainrunSection1.setTargetDeparture(
       trainrunSections.trainrunSection2.getTargetArrival() -
-        trainrunHaltezeit -
-        1,
+      trainrunHaltezeit -
+      1,
     );
 
     trainrunSections.trainrunSection1.resetTargetArrivalWarning();
@@ -606,16 +606,16 @@ describe("TransitionValidator", () => {
       nodeHaltezeiten[
         trainrunSections.trainrunSection2.getTrainrun().getTrainrunCategory()
           .fachCategory
-      ].haltezeit;
+        ].haltezeit;
     trainrunSections.trainrunSection1.setSourceDeparture(
       trainrunSections.trainrunSection2.getSourceArrival() -
-        trainrunHaltezeit -
-        1,
+      trainrunHaltezeit -
+      1,
     );
     trainrunSections.trainrunSection2.setTargetDeparture(
       trainrunSections.trainrunSection1.getTargetArrival() -
-        trainrunHaltezeit -
-        1,
+      trainrunHaltezeit -
+      1,
     );
 
     trainrunSections.trainrunSection1.resetTargetArrivalWarning();
@@ -681,5 +681,16 @@ describe("TransitionValidator", () => {
     expect(trainrunSections.trainrunSection2.hasSourceDepartureWarning()).toBe(
       false,
     );
+  });
+
+  it("Validate Test - 007", () => {
+    dataService.loadNetzgrafikDto(
+      NetzgrafikUnitTesting.getUnitTestNetzgrafik(),
+    );
+    const ts1 = trainrunSectionService.getTrainrunSectionFromId(4);
+    ts1.setSourceDeparture((ts1.getSourceDeparture() + 1) % 60);
+    const a = ts1.getSourceArrival();
+    const b = ts1.getSourceDeparture();
+    expect(ts1.getSourceArrivalWarning().description).toBe("" + a + " + " + b + " = " + (a + b));
   });
 });

--- a/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
@@ -178,6 +178,31 @@ export class TrainrunSectionsView {
     }
   }
 
+  static getWarning(
+    trainrunSection: TrainrunSection,
+    textElement: TrainrunSectionText,
+  ): string {
+    if (!TrainrunSectionsView.hasWarning(trainrunSection, textElement)) {
+      return "";
+    }
+    switch (textElement) {
+      case TrainrunSectionText.SourceDeparture:
+        return trainrunSection.getSourceDepartureWarning().title + ":" + trainrunSection.getSourceDepartureWarning().description;
+      case TrainrunSectionText.SourceArrival:
+        return trainrunSection.getSourceArrivalWarning().title + ":" + trainrunSection.getSourceArrivalWarning().description;
+      case TrainrunSectionText.TargetDeparture:
+        return trainrunSection.getTargetDepartureWarning().title + ":" + trainrunSection.getTargetDepartureWarning().description;
+      case TrainrunSectionText.TargetArrival:
+        return trainrunSection.getTargetArrivalWarning().title + ":" + trainrunSection.getTargetArrivalWarning().description;
+      case TrainrunSectionText.TrainrunSectionTravelTime:
+        return trainrunSection.getTravelTimeWarning().title + ":" + trainrunSection.getTravelTimeWarning().description;
+      case TrainrunSectionText.TrainrunSectionName:
+      default:
+        return "";
+    }
+    return "";
+  }
+
   static getTime(
     trainrunSection: TrainrunSection,
     textElement: TrainrunSectionText,
@@ -1221,7 +1246,7 @@ export class TrainrunSectionsView {
     connectedTrainIds: any,
     atSource: boolean,
   ) {
-    if (!this.editorView.trainrunSectionPreviewLineView.getVariantIsWritable()){
+    if (!this.editorView.trainrunSectionPreviewLineView.getVariantIsWritable()) {
       return;
     }
     groupEnter
@@ -1416,6 +1441,10 @@ export class TrainrunSectionsView {
             textElement,
           );
         }
+      })
+      .append("svg:title")
+      .text((d: TrainrunSectionViewObject) => {
+        return TrainrunSectionsView.getWarning(d.trainrunSection, textElement);
       });
   }
 

--- a/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
@@ -187,15 +187,15 @@ export class TrainrunSectionsView {
     }
     switch (textElement) {
       case TrainrunSectionText.SourceDeparture:
-        return trainrunSection.getSourceDepartureWarning().title + ":" + trainrunSection.getSourceDepartureWarning().description;
+        return trainrunSection.getSourceDepartureWarning().title + ": " + trainrunSection.getSourceDepartureWarning().description;
       case TrainrunSectionText.SourceArrival:
-        return trainrunSection.getSourceArrivalWarning().title + ":" + trainrunSection.getSourceArrivalWarning().description;
+        return trainrunSection.getSourceArrivalWarning().title + ": " + trainrunSection.getSourceArrivalWarning().description;
       case TrainrunSectionText.TargetDeparture:
-        return trainrunSection.getTargetDepartureWarning().title + ":" + trainrunSection.getTargetDepartureWarning().description;
+        return trainrunSection.getTargetDepartureWarning().title + ": " + trainrunSection.getTargetDepartureWarning().description;
       case TrainrunSectionText.TargetArrival:
-        return trainrunSection.getTargetArrivalWarning().title + ":" + trainrunSection.getTargetArrivalWarning().description;
+        return trainrunSection.getTargetArrivalWarning().title + ": " + trainrunSection.getTargetArrivalWarning().description;
       case TrainrunSectionText.TrainrunSectionTravelTime:
-        return trainrunSection.getTravelTimeWarning().title + ":" + trainrunSection.getTravelTimeWarning().description;
+        return trainrunSection.getTravelTimeWarning().title + ": " + trainrunSection.getTravelTimeWarning().description;
       case TrainrunSectionText.TrainrunSectionName:
       default:
         return "";

--- a/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
@@ -1339,21 +1339,21 @@ export class TrainrunSectionsView {
       );
   }
 
-  createTrainrunSectionElement(
+  private createInternTrainrunSectionElementFilteringWarningElements(
     groupEnter: d3.Selector,
     selectedTrainrun: Trainrun,
     connectedTrainIds: any,
     textElement: TrainrunSectionText,
-    enableEvents = true
+    enableEvents = true,
+    hasWarning = true
   ) {
-
     const atSource =
       textElement === TrainrunSectionText.SourceArrival ||
       textElement === TrainrunSectionText.SourceDeparture;
     const isArrival =
       textElement === TrainrunSectionText.SourceArrival ||
       textElement === TrainrunSectionText.TargetArrival;
-    groupEnter
+    const renderingObjects = groupEnter
       .filter(
         (d: TrainrunSectionViewObject) =>
           this.filterTrainrunsectionAtNode(d.trainrunSection, atSource) &&
@@ -1361,7 +1361,8 @@ export class TrainrunSectionsView {
             d.trainrunSection,
             atSource,
             isArrival,
-          ),
+          ) &&
+          TrainrunSectionsView.hasWarning(d.trainrunSection, textElement) === hasWarning
       )
       .append(StaticDomTags.EDGE_LINE_TEXT_SVG)
       .attr("class", (d: TrainrunSectionViewObject) =>
@@ -1441,11 +1442,33 @@ export class TrainrunSectionsView {
             textElement,
           );
         }
-      })
-      .append("svg:title")
-      .text((d: TrainrunSectionViewObject) => {
-        return TrainrunSectionsView.getWarning(d.trainrunSection, textElement);
       });
+
+    if (hasWarning) {
+      renderingObjects
+        .append("svg:title")
+        .text((d: TrainrunSectionViewObject) => {
+          return TrainrunSectionsView.getWarning(d.trainrunSection, textElement);
+        });
+    }
+  }
+
+  createTrainrunSectionElement(
+    groupEnter: d3.Selector,
+    selectedTrainrun: Trainrun,
+    connectedTrainIds: any,
+    textElement: TrainrunSectionText,
+    enableEvents = true
+  ) {
+    // pass(1) : render all elements without warnings
+    this.createInternTrainrunSectionElementFilteringWarningElements(
+      groupEnter, selectedTrainrun, connectedTrainIds, textElement, enableEvents, false
+    );
+    // pass(2) : render all elements with warnings
+    //           especially <svg:title>warning_msg</svg:title>
+    this.createInternTrainrunSectionElementFilteringWarningElements(
+      groupEnter, selectedTrainrun, connectedTrainIds, textElement, enableEvents, true
+    );
   }
 
   createTrainrunSectionGotoInfoElement(

--- a/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
+++ b/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
@@ -29,6 +29,7 @@ import {
   computeShortestPaths,
   topoSort
 } from "../util/origin-destination-graph";
+import {TrainrunsectionValidator} from "../../services/util/trainrunsection.validator";
 
 @Component({
   selector: "sbb-editor-tools-view-component",
@@ -629,6 +630,12 @@ export class EditorToolsViewComponent {
 
     // step(4) Recalc/propagte consecutive times
     this.trainrunService.propagateInitialConsecutiveTimes();
+
+    // step(5) Validate all trainrun sections
+    this.trainrunSectionService.getTrainrunSections().forEach((ts) => {
+      TrainrunsectionValidator.validateOneSection(ts);
+      TrainrunsectionValidator.validateTravelTime(ts);
+    });
   }
 
   private processNetzgrafikJSON(netzgrafikDto: NetzgrafikDto) {

--- a/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
+++ b/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
@@ -628,7 +628,7 @@ export class EditorToolsViewComponent {
       });
     });
 
-    // step(4) Recalc/propagte consecutive times
+    // step(4) Recalc/propagate consecutive times
     this.trainrunService.propagateInitialConsecutiveTimes();
 
     // step(5) Validate all trainrun sections

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -86,6 +86,7 @@
           }
         },
         "trainrunsection-validator": {
+          "broken-symmetry": "Symmetrie gebrochen",
           "target-arrival-not-reacheable": {
             "title": "Ziel Ankunft Warnung",
             "description": "Zielankunftszeit kann nicht erreicht werden"

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -86,6 +86,7 @@
           }
         },
         "trainrunsection-validator": {
+          "broken-symmetry": "Broken symmetry",
           "target-arrival-not-reacheable": {
             "title": "Target Arrival Warning",
             "description": "Target arrival time cannot be reached"

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -89,7 +89,7 @@
           "broken-symmetry": "Symétrie brisée",
           "target-arrival-not-reacheable": {
             "title": "Avertissement d'arrivée à destination",
-            "description": "L'heure d'arrivée à la destination ne peut être atteinte"
+            "description": "L'heure d'arrivée à destination ne peut être atteinte"
           },
           "source-arrival-not-reacheable": {
             "title": "Avertissement d'arrivée à l'origine",
@@ -110,12 +110,12 @@
             "description": "L'heure de départ à l'origine ne peut être atteinte"
           },
           "target-arrival-not-reacheable": {
-            "title": "Avertissement d'arrivée à la destination",
-            "description": "L'heure d'arrivée à la destination ne peut être atteinte"
+            "title": "Avertissement d'arrivée à destination",
+            "description": "L'heure d'arrivée à destination ne peut être atteinte"
           },
           "target-departure-not-reacheable": {
-            "title": "Avertissement de départ à la destination",
-            "description": "L'heure de départ à la destination ne peut être atteinte"
+            "title": "Avertissement de départ à destination",
+            "description": "L'heure de départ à destination ne peut être atteinte"
           }
         }
       }

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -86,6 +86,7 @@
           }
         },
         "trainrunsection-validator": {
+          "broken-symmetry": "Symétrie brisée",
           "target-arrival-not-reacheable": {
             "title": "Avertissement d'arrivée à la destination",
             "description": "L'heure d'arrivée à la destination ne peut être atteinte"

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -88,7 +88,7 @@
         "trainrunsection-validator": {
           "broken-symmetry": "Symétrie brisée",
           "target-arrival-not-reacheable": {
-            "title": "Avertissement d'arrivée à la destination",
+            "title": "Avertissement d'arrivée à destination",
             "description": "L'heure d'arrivée à la destination ne peut être atteinte"
           },
           "source-arrival-not-reacheable": {

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -86,6 +86,7 @@
           }
         },
         "trainrunsection-validator": {
+          "broken-symmetry": "Broken symmetry",
           "target-arrival-not-reacheable": {
             "title": "Target Arrival Warning",
             "description": "Target arrival time cannot be reached"


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->
# Description

<!-- Describe the changes your PR introduces here. -->
Add warning for unsymmetric times. Those times can be imported when importing Netzgrafik from 3rd parties

Previously, the system did not warn users about the presence of unsymmetric times. This commit adds functionality to detect and alert users when unsymmetric times exists.

2nd part of the fix is that the user will have a tooltip (svg:titel) show warning message when hovering over the element.

# Issues

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] This PR contains a description of the changes I'm making
* [x] I've read the [Contribution Guidelines](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/CONTRIBUTING.md)
* [x] I've added tests for changes or features I've introduced
* [ ] I documented any high-level concepts I'm introducing in `documentation/`
* [x] CI is currently green and this is ready for review

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation.
-->
