### PR TITLE
fix: remove variante read/write button from standalone env

### DIFF
--- a/src/app/view/editor-menu/editor-menu.component.html
+++ b/src/app/view/editor-menu/editor-menu.component.html
@@ -1,5 +1,5 @@
 <div class="editorMenuGripLayout">
-  <div class="NodeNetzgrafikVariante">
+  <div class="NodeNetzgrafikVariante" *ngIf="!disableBackend">
     <div class="LabelNetzgrafik">
       <div class="LabelNetzgrafikVariante" title="{{ label$ | async }}">
         {{ label$ | async }}


### PR DESCRIPTION
# Description

As this box is always "read-only", we can just remove it, to make the UI clearer

From:
![image](https://github.com/user-attachments/assets/a67bd013-d758-421f-a937-6519680c9e20)

To:
![image](https://github.com/user-attachments/assets/3804730a-041e-4bc6-8887-fc79983b6d1c)

# Issues

# Checklist

* [x] This PR contains a description of the changes I'm making
* [x] I've read the [Contribution Guidelines](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/CONTRIBUTING.md)
* [ ] I've added tests for changes or features I've introduced
* [ ] I documented any high-level concepts I'm introducing in `documentation/`
* [x] CI is currently green and this is ready for review