### PR TITLE
Don't overwrite initial DTO in standalone mode

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input, Output} from "@angular/core";
+import {Component, Input, Output, OnInit} from "@angular/core";
 import {AuthService} from "./services/auth/auth.service";
 import {TrainrunService} from "./services/data/trainrun.service";
 import {TrainrunSectionService} from "./services/data/trainrunsection.service";
@@ -13,18 +13,20 @@ import {LabelService} from "./services/data/label.service";
 import {NodeService} from "./services/data/node.service";
 import {I18nService} from "./core/i18n/i18n.service";
 import {PositionTransformationService} from "./services/util/position.transformation.service";
+import {NetzgrafikDefault} from "./sample-netzgrafik/netzgrafik.default";
 
 @Component({
   selector: "sbb-root",
   templateUrl: "./app.component.html",
   styleUrls: ["./app.component.scss"],
 })
-export class AppComponent {
+export class AppComponent implements OnInit {
   readonly disableBackend = environment.disableBackend;
   readonly version = packageJson.version;
   readonly environmentLabel = environment.label;
   readonly authenticated: Promise<unknown>;
   protected currentLanguage: string = this.i18nService.language;
+  private netzgrafikDtoIsSet = false;
 
   projectInMenu: Observable<ProjectDto | null>;
 
@@ -56,6 +58,12 @@ export class AppComponent {
     }
   }
 
+  ngOnInit() {
+    if (this.disableBackend && !this.netzgrafikDtoIsSet) {
+      this.netzgrafikDto = NetzgrafikDefault.getDefaultNetzgrafik();
+    }
+  }
+
   logout() {
     if (!this.disableBackend) {
       this.authService.logOut();
@@ -66,7 +74,7 @@ export class AppComponent {
   get language() {
     return this.currentLanguage;
   }
-  
+
   set language(language: string) {
     if (language !== this.currentLanguage) {
       this.i18nService.setLanguage(language);
@@ -80,6 +88,7 @@ export class AppComponent {
   }
 
   set netzgrafikDto(netzgrafikDto: NetzgrafikDto) {
+    this.netzgrafikDtoIsSet = true;
     this.dataService.loadNetzgrafikDto(netzgrafikDto);
   }
 

--- a/src/app/netzgrafik-application/netzgrafik-application.component.ts
+++ b/src/app/netzgrafik-application/netzgrafik-application.component.ts
@@ -12,7 +12,6 @@ import {DomSanitizer} from "@angular/platform-browser";
 import {EditorMode} from "../view/editor-menu/editor-mode";
 import {UndoService} from "../services/data/undo.service";
 import {EditorView} from "../view/editor-main-view/data-views/editor.view";
-import {NetzgrafikDefault} from "../sample-netzgrafik/netzgrafik.default";
 import {environment} from "../../environments/environment";
 import {NodeService} from "../services/data/node.service";
 
@@ -54,10 +53,9 @@ export class NetzgrafikApplicationComponent {
       .subscribe((params) => {
         uiInteractionService.setEditorMode(EditorMode.NetzgrafikEditing);
         uiInteractionService.showNetzgrafik();
-        try {
-          versionControlService.load(params.getVariantId(), true);
-        } catch (e) {
-          versionControlService.loadNetzgrafikDTO(NetzgrafikDefault.getDefaultNetzgrafik());
+        const variantId = params.tryGetVariantId();
+        if (variantId !== null) {
+          versionControlService.load(variantId, true);
         }
         uiInteractionService.setViewboxProperties(
           EditorView.svgName,


### PR DESCRIPTION
In standalone mode, the DTO might be passed as an HTML element custom attribute. The attribute can be set before NGE is inserted into the DOM like so:

    const sbbRoot = document.createElement('sbb-root');
    sbbRoot.netzgrafikDto = dto;
    document.body.appendChild(sbbRoot);

However, when using the custom attribute this way, the DTO gets overwritten with the default DTO when NetzgrafikApplicationComponent initializes.

Fix this by loading the DTO in AppComponent.ngOnInit instead, only if the user hasn't set the netzgrafikDto custom attribute.

This allows users to set an initial DTO before NGE starts up. Previously, users had to set the DTO after inserting NGE into the DOM and this caused a visible glitch: the default DTO was visible for a split second before the user-provided DTO got loaded.