### PR TITLE
fix: Performance improvement - when paning the undoSerivce should not…

### DIFF
--- a/src/app/services/data/undo.service.ts
+++ b/src/app/services/data/undo.service.ts
@@ -66,6 +66,10 @@ export class UndoService implements OnDestroy {
     this.undoRecordingStopped = false;
   }
 
+  getUndoRecording(): boolean {
+    return this.undoRecordingStopped;
+  }
+
   private subscribeSnapshots() {
     if (this.changesSubscription !== undefined) {
       this.changesSubscription.unsubscribe();
@@ -129,7 +133,7 @@ export class UndoService implements OnDestroy {
     this.currentVariantId = variantId;
   }
 
-  public getCurrentVariantId():number{
+  public getCurrentVariantId(): number {
     return this.currentVariantId;
   }
 }

--- a/src/app/services/data/undo.service.ts
+++ b/src/app/services/data/undo.service.ts
@@ -78,13 +78,10 @@ export class UndoService implements OnDestroy {
       .getNetzgrafikChangesObservable(10)
       .pipe(takeUntil(this.destroyed$))
       .subscribe(() => {
-        if (this.undoRecordingStopped) {
-          return;
+        if (!this.undoRecordingStopped &&
+          !(this.netzgrafikIsLoading || this.undoNetzgrafikIsLoading)) {
+          this.pushCurrentVersion();
         }
-        if (this.netzgrafikIsLoading || this.undoNetzgrafikIsLoading) {
-          return;
-        }
-        this.pushCurrentVersion();
       });
   }
 

--- a/src/app/view/editor-main-view/data-views/connections.view.ts
+++ b/src/app/view/editor-main-view/data-views/connections.view.ts
@@ -297,10 +297,11 @@ export class ConnectionsView {
       this.filterConnectionsToDisplay(c)
     );
 
+    const connectionData = this.createTransitionViewObjects(connections);
     const connectionsGroup = this.connectionsGroup
       .selectAll(StaticDomTags.CONNECTION_ROOT_CONTAINER_DOM_REF)
       .data(
-        this.createTransitionViewObjects(connections),
+        connectionData,
         (c: ConnectionsViewObject) => c.key,
       );
 

--- a/src/app/view/editor-main-view/data-views/editor.view.ts
+++ b/src/app/view/editor-main-view/data-views/editor.view.ts
@@ -445,6 +445,7 @@ export class EditorView implements SVGMouseControllerObserver {
     if (this.trainrunSectionPreviewLineView.isDragging()) {
       return;
     }
+    this.undoService.pauseUndoRecording();
     this.isMultiSelectOn = true;
     this.uiInteractionService.setEditorMode(EditorMode.MultiNodeMoving);
     this.multiSelectRenderer.displayBox();
@@ -503,6 +504,8 @@ export class EditorView implements SVGMouseControllerObserver {
   }
 
   onEndMultiSelect() {
+    this.undoService.startUndoRecording();
+
     if (!this.isMultiSelectOn) {
       return;
     }

--- a/src/app/view/editor-main-view/data-views/editor.view.ts
+++ b/src/app/view/editor-main-view/data-views/editor.view.ts
@@ -137,7 +137,7 @@ export class EditorView implements SVGMouseControllerObserver {
     private positionTransformationService: PositionTransformationService
   ) {
     this.controller = controller;
-    this.svgMouseController = new SVGMouseController(EditorView.svgName, this);
+    this.svgMouseController = new SVGMouseController(EditorView.svgName, this, this.undoService);
     this.nodesView = new NodesView(this);
     this.transitionsView = new TransitionsView(this);
     this.connectionsView = new ConnectionsView(this);

--- a/src/app/view/editor-main-view/data-views/nodes.view.ts
+++ b/src/app/view/editor-main-view/data-views/nodes.view.ts
@@ -109,10 +109,11 @@ export class NodesView {
       this.filterNodesToDisplay(n)
     );
 
+    const nodeData = this.createViewNodeDataObjects(nodes);
     const group = this.nodeGroup
       .selectAll(StaticDomTags.NODE_ROOT_CONTAINER_DOM_REF)
       .data(
-        this.createViewNodeDataObjects(nodes),
+        nodeData,
         (n: NodeViewObject) => n.key,
       );
 

--- a/src/app/view/editor-main-view/data-views/notes.view.ts
+++ b/src/app/view/editor-main-view/data-views/notes.view.ts
@@ -139,10 +139,11 @@ export class NotesView {
       this.filterNotesToDisplay(n)
     );
 
+    const notesData = this.createViewNoteDataObjects(notes);
     const group = this.notesGroup
       .selectAll(StaticDomTags.NOTE_ROOT_CONTAINER_DOM_REF)
       .data(
-        this.createViewNoteDataObjects(notes),
+        notesData,
         (n: NodeViewObject) => n.key,
       );
 

--- a/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
@@ -1721,15 +1721,16 @@ export class TrainrunSectionsView {
         this.filterTrainrunSectionToDisplay(trainrunSection)
     );
 
+    const trainrunSectionData = this.createViewTrainrunSectionDataObjects(
+      this.editorView,
+      filteredTrainrunSections,
+      selectedTrainrun,
+      connectedTrainIds,
+    );
     const group = this.trainrunSectionGroup
       .selectAll(StaticDomTags.EDGE_ROOT_CONTAINER_DOM_REF)
       .data(
-        this.createViewTrainrunSectionDataObjects(
-          this.editorView,
-          filteredTrainrunSections,
-          selectedTrainrun,
-          connectedTrainIds,
-        ),
+        trainrunSectionData,
         (d: TrainrunSectionViewObject) => d.key,
       );
 

--- a/src/app/view/editor-main-view/data-views/transitions.view.ts
+++ b/src/app/view/editor-main-view/data-views/transitions.view.ts
@@ -278,15 +278,16 @@ export class TransitionsView {
       rootGroup = this.selectedTransitionsGroup;
     }
 
+    const transitionData = TransitionsView.createTransitionViewObjects(
+      this.editorView,
+      transitions,
+      selectedTrainrun,
+      connectedTrainIds,
+    );
     const transitionsGroup = rootGroup
       .selectAll(StaticDomTags.TRANSITION_ROOT_CONTAINER_DOM_REF)
       .data(
-        TransitionsView.createTransitionViewObjects(
-          this.editorView,
-          transitions,
-          selectedTrainrun,
-          connectedTrainIds,
-        ),
+        transitionData,
         (t: TransitionViewObject) => t.key,
       );
 

--- a/src/app/view/editor-main-view/editor-main-view.component.ts
+++ b/src/app/view/editor-main-view/editor-main-view.component.ts
@@ -610,27 +610,21 @@ export class EditorMainViewComponent implements AfterViewInit, OnDestroy {
       .pipe(takeUntil(this.destroyed))
       .subscribe((updatedNodes) => {
         this.editorView.nodesView.displayNodes(updatedNodes);
-        if (this.undoService.getUndoRecording()) {
-          this.editorView.postDisplayRendering();
-        }
+        this.editorView.postDisplayRendering();
       });
 
     this.nodeService.transitions
       .pipe(takeUntil(this.destroyed))
       .subscribe((updatedTransitions) => {
         this.editorView.transitionsView.displayTransitions(updatedTransitions);
-        if (this.undoService.getUndoRecording()) {
-          this.editorView.postDisplayRendering();
-        }
+        this.editorView.postDisplayRendering();
       });
 
     this.nodeService.connections
       .pipe(takeUntil(this.destroyed))
       .subscribe((updatedConnections) => {
         this.editorView.connectionsView.displayConnections(updatedConnections);
-        if (this.undoService.getUndoRecording()) {
-          this.editorView.postDisplayRendering();
-        }
+        this.editorView.postDisplayRendering();
       });
 
     this.trainrunSectionService.trainrunSections
@@ -646,9 +640,7 @@ export class EditorMainViewComponent implements AfterViewInit, OnDestroy {
       .pipe(takeUntil(this.destroyed))
       .subscribe((updatedNotes) => {
         this.editorView.notesView.displayNotes(updatedNotes);
-        if (this.undoService.getUndoRecording()) {
-          this.editorView.postDisplayRendering();
-        }
+        this.editorView.postDisplayRendering();
       });
 
     this.nodeService.nodes

--- a/src/app/view/editor-main-view/editor-main-view.component.ts
+++ b/src/app/view/editor-main-view/editor-main-view.component.ts
@@ -610,21 +610,27 @@ export class EditorMainViewComponent implements AfterViewInit, OnDestroy {
       .pipe(takeUntil(this.destroyed))
       .subscribe((updatedNodes) => {
         this.editorView.nodesView.displayNodes(updatedNodes);
-        this.editorView.postDisplayRendering();
+        if (this.undoService.getUndoRecording()) {
+          this.editorView.postDisplayRendering();
+        }
       });
 
     this.nodeService.transitions
       .pipe(takeUntil(this.destroyed))
       .subscribe((updatedTransitions) => {
         this.editorView.transitionsView.displayTransitions(updatedTransitions);
-        this.editorView.postDisplayRendering();
+        if (this.undoService.getUndoRecording()) {
+          this.editorView.postDisplayRendering();
+        }
       });
 
     this.nodeService.connections
       .pipe(takeUntil(this.destroyed))
       .subscribe((updatedConnections) => {
         this.editorView.connectionsView.displayConnections(updatedConnections);
-        this.editorView.postDisplayRendering();
+        if (this.undoService.getUndoRecording()) {
+          this.editorView.postDisplayRendering();
+        }
       });
 
     this.trainrunSectionService.trainrunSections
@@ -640,7 +646,9 @@ export class EditorMainViewComponent implements AfterViewInit, OnDestroy {
       .pipe(takeUntil(this.destroyed))
       .subscribe((updatedNotes) => {
         this.editorView.notesView.displayNotes(updatedNotes);
-        this.editorView.postDisplayRendering();
+        if (this.undoService.getUndoRecording()) {
+          this.editorView.postDisplayRendering();
+        }
       });
 
     this.nodeService.nodes

--- a/src/app/view/util/svg.mouse.controller.spec.ts
+++ b/src/app/view/util/svg.mouse.controller.spec.ts
@@ -60,6 +60,7 @@ describe("general view functions", () => {
     const svgMouseController = new SVGMouseController(
       "graphContainer",
       dummySVGMouseControllerObserver,
+      undefined
     );
     svgMouseController.init(viewboxProperties);
     const prop = svgMouseController.getViewboxProperties();
@@ -82,6 +83,7 @@ describe("general view functions", () => {
     const svgMouseController = new SVGMouseController(
       "graphContainer",
       dummySVGMouseControllerObserver,
+      undefined
     );
     svgMouseController.init(viewboxProperties);
     const prop = svgMouseController.getViewboxProperties();
@@ -104,6 +106,7 @@ describe("general view functions", () => {
     const svgMouseController = new SVGMouseController(
       "graphContainer",
       dummySVGMouseControllerObserver,
+      undefined
     );
     svgMouseController.init(viewboxProperties);
     const prop = svgMouseController.getViewboxProperties();
@@ -120,6 +123,7 @@ describe("general view functions", () => {
     const svgMouseController = new SVGMouseController(
       "graphContainer",
       dummySVGMouseControllerObserver,
+      undefined
     );
     svgMouseController.init(viewboxProperties);
     const prop = svgMouseController.getViewboxProperties();

--- a/src/app/view/util/svg.mouse.controller.ts
+++ b/src/app/view/util/svg.mouse.controller.ts
@@ -2,6 +2,7 @@ import * as d3 from "d3";
 import {Vec2D} from "../../utils/vec2D";
 import {StaticDomTags} from "../editor-main-view/data-views/static.dom.tags";
 import {ViewboxProperties} from "../../services/ui/ui.interaction.service";
+import {UndoService} from "../../services/data/undo.service";
 
 export interface SVGMouseControllerObserver {
   onEarlyReturnFromMousemove(): boolean;
@@ -38,6 +39,7 @@ export class SVGMouseController {
   constructor(
     private svgName: string,
     private svgMouseControllerObserver: SVGMouseControllerObserver,
+    private undoService: UndoService
   ) {
   }
 
@@ -438,7 +440,15 @@ export class SVGMouseController {
 
       this.viewboxProperties.panZoomLeft += delta.getX();
       this.viewboxProperties.panZoomTop += delta.getY();
-      this.setViewbox();
+
+      if (this.undoService?.getUndoRecording()) {
+        this.undoService.pauseUndoRecording();
+        this.setViewbox();
+        this.undoService.startUndoRecording();
+      } else {
+        this.setViewbox();
+      }
+
     }
 
     this.previousPanMousePosition = this.getCurrentMousePosition();

--- a/src/app/view/util/svg.mouse.controller.ts
+++ b/src/app/view/util/svg.mouse.controller.ts
@@ -193,6 +193,16 @@ export class SVGMouseController {
   }
 
   setViewbox() {
+    if (this.undoService?.getUndoRecording()) {
+      this.undoService.pauseUndoRecording();
+      this.setViewboxInternal();
+      this.undoService.startUndoRecording();
+    } else {
+      this.setViewboxInternal();
+    }
+  }
+
+  setViewboxInternal() {
     this.viewboxProperties.currentViewBox = this.makeViewboxString();
     this.svgDrawingContext.attr(
       "viewBox",
@@ -441,14 +451,7 @@ export class SVGMouseController {
       this.viewboxProperties.panZoomLeft += delta.getX();
       this.viewboxProperties.panZoomTop += delta.getY();
 
-      if (this.undoService?.getUndoRecording()) {
-        this.undoService.pauseUndoRecording();
-        this.setViewbox();
-        this.undoService.startUndoRecording();
-      } else {
-        this.setViewbox();
-      }
-
+      this.setViewbox();
     }
 
     this.previousPanMousePosition = this.getCurrentMousePosition();


### PR DESCRIPTION
… update the "undo stack"

<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->
# Description
If the user wants to pan – that is, only move the view area – the UndoService should not update the stack or check for changes – because only the view area is changed.

<!-- Describe the changes your PR introduces here. -->

# Issues

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] This PR contains a description of the changes I'm making
* [x] I've read the [Contribution Guidelines](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/CONTRIBUTING.md)
* [ ] I've added tests for changes or features I've introduced
* [ ] I documented any high-level concepts I'm introducing in `documentation/`
* [ ] CI is currently green and this is ready for review

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation.
-->
