### PR TITLE
fix: Performance - only render trainrunSection and transition element - which are required

### DIFF
--- a/documentation/DATA_MODEL_JSON.md
+++ b/documentation/DATA_MODEL_JSON.md
@@ -554,7 +554,7 @@ LinePatternRefs {
 
 ![image](https://github.com/user-attachments/assets/f12d1fe4-cb30-4d9c-95f6-bbe026eae1c0)
 
-This image illustrates the four-layer (level) approach. Start by drawing the background on layer 0, then add levels 1, 2, and 3. Choose the appropriate stroke width and stroke color. Finally, ensure that we always have level 0, which serves as the background event handling area for mouse hovering and clicks (selection). To ensure that mouse events are captured, the stroke opacity for level 0 is set to 0.001 when it is not visible. Rendering styling is controlled via trainrunsections.view.scss 
+The above image illustrates the four-layer (level) approach. Start by drawing the background on layer 0, then add levels 1, 2, and 3. Choose the appropriate stroke width and stroke color. Finally, ensure that we always have level 0, which serves as the background event handling area for mouse hovering and clicks (selection). To ensure that mouse events are captured, the stroke opacity for level 0 is set to 0.001 when it is not visible. Rendering styling is controlled via trainrunsections.view.scss 
 
 
 See also, [TrainrunSectionsView::make4LayerTrainrunSectionLines](https://github.com/search?q=repo%3ASchweizerischeBundesbahnen/netzgrafik-editor-frontend%20make4LayerTrainrunSectionLines&type=code)

--- a/documentation/DATA_MODEL_JSON.md
+++ b/documentation/DATA_MODEL_JSON.md
@@ -551,8 +551,10 @@ LinePatternRefs {
   "120", // -.-.-.  ; unique indentifier
 }
 ```
-The rendering pattern [TrainrunSectionsView::make4LayerTrainrunSectionLines](https://github.com/search?q=repo%3ASchweizerischeBundesbahnen/netzgrafik-editor-frontend%20make4LayerTrainrunSectionLines&type=code)
+This image illustrates the four-layer (level) approach. Start by drawing the background on layer 0, then add levels 1, 2, and 3. Choose the appropriate stroke width and stroke color. Finally, ensure that we always have level 0, which serves as the background event handling area for mouse hovering and clicks (selection). To ensure that mouse events are captured, the stroke opacity for level 0 is set to 0.001 when it is not visible.
 ![image](https://github.com/user-attachments/assets/f12d1fe4-cb30-4d9c-95f6-bbe026eae1c0)
+
+See also, [TrainrunSectionsView::make4LayerTrainrunSectionLines](https://github.com/search?q=repo%3ASchweizerischeBundesbahnen/netzgrafik-editor-frontend%20make4LayerTrainrunSectionLines&type=code)
 
 
 

--- a/documentation/DATA_MODEL_JSON.md
+++ b/documentation/DATA_MODEL_JSON.md
@@ -551,6 +551,9 @@ LinePatternRefs {
   "15", // four lines ; unique indentifier
 }
 ```
+The rendering pattern [TrainrunSectionsView::make4LayerTrainrunSectionLines](https://github.com/search?q=repo%3ASchweizerischeBundesbahnen/netzgrafik-editor-frontend%20make4LayerTrainrunSectionLines&type=code)
+![image](https://github.com/user-attachments/assets/b0ed81ec-a9fc-4125-9270-2874f7100338)
+
 
 </details>
 

--- a/documentation/DATA_MODEL_JSON.md
+++ b/documentation/DATA_MODEL_JSON.md
@@ -552,9 +552,10 @@ LinePatternRefs {
 }
 ```
 
-![image](https://github.com/user-attachments/assets/f12d1fe4-cb30-4d9c-95f6-bbe026eae1c0)
 
-The above image illustrates the four-layer (level) approach. Start by drawing the background on layer 0, then add levels 1, 2, and 3. Choose the appropriate stroke width and stroke color. Finally, ensure that we always have level 0, which serves as the background event handling area for mouse hovering and clicks (selection). To ensure that mouse events are captured, the stroke opacity for level 0 is set to 0.001 when it is not visible. Rendering styling is controlled via trainrunsections.view.scss 
+The following figure illustrates the four-layer (level) approach. Start by drawing the background on layer 0, then add levels 1, 2, and 3. Choose the appropriate stroke width and stroke color. Finally, ensure that we always have level 0, which serves as the background event handling area for mouse hovering and clicks (selection). To ensure that mouse events are captured, the stroke opacity for level 0 is set to 0.001 when it is not visible. Rendering styling is controlled via trainrunsections.view.scss 
+
+![image](https://github.com/user-attachments/assets/f12d1fe4-cb30-4d9c-95f6-bbe026eae1c0)
 
 
 See also, [TrainrunSectionsView::make4LayerTrainrunSectionLines](https://github.com/search?q=repo%3ASchweizerischeBundesbahnen/netzgrafik-editor-frontend%20make4LayerTrainrunSectionLines&type=code)

--- a/documentation/DATA_MODEL_JSON.md
+++ b/documentation/DATA_MODEL_JSON.md
@@ -544,15 +544,16 @@ trainrunFrequencies: Represents the frequencies at which trainruns operates.
 The defined line pattern which can be used are 
 ```
 LinePatternRefs {
-  "120", // -.-.-.  ; unique indentifier
-  "60", // ----- ; unique indentifier
-  "30", // ==== ; unique indentifier
-  "20", // three lines  ; unique indentifier
   "15", // four lines ; unique indentifier
+  "20", // three lines  ; unique indentifier
+  "30", // ==== ; unique indentifier
+  "60", // ----- ; unique indentifier
+  "120", // -.-.-.  ; unique indentifier
 }
 ```
 The rendering pattern [TrainrunSectionsView::make4LayerTrainrunSectionLines](https://github.com/search?q=repo%3ASchweizerischeBundesbahnen/netzgrafik-editor-frontend%20make4LayerTrainrunSectionLines&type=code)
-![image](https://github.com/user-attachments/assets/b0ed81ec-a9fc-4125-9270-2874f7100338)
+![image](https://github.com/user-attachments/assets/f12d1fe4-cb30-4d9c-95f6-bbe026eae1c0)
+
 
 
 </details>

--- a/documentation/DATA_MODEL_JSON.md
+++ b/documentation/DATA_MODEL_JSON.md
@@ -551,8 +551,11 @@ LinePatternRefs {
   "120", // -.-.-.  ; unique indentifier
 }
 ```
-This image illustrates the four-layer (level) approach. Start by drawing the background on layer 0, then add levels 1, 2, and 3. Choose the appropriate stroke width and stroke color. Finally, ensure that we always have level 0, which serves as the background event handling area for mouse hovering and clicks (selection). To ensure that mouse events are captured, the stroke opacity for level 0 is set to 0.001 when it is not visible.
+
 ![image](https://github.com/user-attachments/assets/f12d1fe4-cb30-4d9c-95f6-bbe026eae1c0)
+
+This image illustrates the four-layer (level) approach. Start by drawing the background on layer 0, then add levels 1, 2, and 3. Choose the appropriate stroke width and stroke color. Finally, ensure that we always have level 0, which serves as the background event handling area for mouse hovering and clicks (selection). To ensure that mouse events are captured, the stroke opacity for level 0 is set to 0.001 when it is not visible. Rendering styling is controlled via trainrunsections.view.scss 
+
 
 See also, [TrainrunSectionsView::make4LayerTrainrunSectionLines](https://github.com/search?q=repo%3ASchweizerischeBundesbahnen/netzgrafik-editor-frontend%20make4LayerTrainrunSectionLines&type=code)
 

--- a/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
@@ -2494,7 +2494,7 @@ export class TrainrunSectionsView {
     this.createTrainrunSection(
       groupLines,
       StaticDomTags.EDGE_LINE_LAYER_0,
-      [],//20, 30, 60], (background is required to "strech the hower area"
+      [LinePatternRefs.Freq30],// LinePatternRefs.Freq60], (background is required to "strech the hower area"
       selectedTrainrun,
       connectedTrainIds,
       enableEvents,

--- a/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
@@ -28,6 +28,7 @@ import {EditorMode} from "../../editor-menu/editor-mode";
 import {Transition} from "../../../models/transition.model";
 import {InformSelectedTrainrunClick} from "../../../services/data/trainrunsection.service";
 import {LevelOfDetail} from "../../../services/ui/level.of.detail.service";
+import {LinePatternRefs} from "../../../data-structures/business.data.structures";
 
 export class TrainrunSectionsView {
   trainrunSectionGroup;
@@ -1089,14 +1090,14 @@ export class TrainrunSectionsView {
   createTrainrunSection(
     groupEnter: d3.Selector,
     classRef,
-    levelFreqFilter: number[],
+    levelFreqFilter: LinePatternRefs[],
     selectedTrainrun: Trainrun,
     connectedTrainIds: any,
     enableEvents = true,
   ) {
     const trainrunSectionElements = groupEnter
       .filter((d: TrainrunSectionViewObject) => {
-        return !levelFreqFilter.includes(d.trainrunSection.getFrequency());
+        return !levelFreqFilter.includes(d.trainrunSection.getFrequencyLinePatternRef());
       })
       .append(StaticDomTags.EDGE_LINE_SVG)
       .attr(
@@ -2501,7 +2502,7 @@ export class TrainrunSectionsView {
     this.createTrainrunSection(
       groupLines,
       StaticDomTags.EDGE_LINE_LAYER_1,
-      [30],
+      [LinePatternRefs.Freq30],
       selectedTrainrun,
       connectedTrainIds,
       enableEvents,
@@ -2509,7 +2510,7 @@ export class TrainrunSectionsView {
     this.createTrainrunSection(
       groupLines,
       StaticDomTags.EDGE_LINE_LAYER_2,
-      [60, 120],
+      [LinePatternRefs.Freq60, LinePatternRefs.Freq120],
       selectedTrainrun,
       connectedTrainIds,
       enableEvents,
@@ -2517,7 +2518,7 @@ export class TrainrunSectionsView {
     this.createTrainrunSection(
       groupLines,
       StaticDomTags.EDGE_LINE_LAYER_3,
-      [60, 120],
+      [LinePatternRefs.Freq60, LinePatternRefs.Freq120],
       selectedTrainrun,
       connectedTrainIds,
       enableEvents,

--- a/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
@@ -1089,11 +1089,15 @@ export class TrainrunSectionsView {
   createTrainrunSection(
     groupEnter: d3.Selector,
     classRef,
+    levelFreqFilter: number[],
     selectedTrainrun: Trainrun,
     connectedTrainIds: any,
     enableEvents = true,
   ) {
     const trainrunSectionElements = groupEnter
+      .filter((d: TrainrunSectionViewObject) => {
+        return !levelFreqFilter.includes(d.trainrunSection.getFrequency());
+      })
       .append(StaticDomTags.EDGE_LINE_SVG)
       .attr(
         "class",
@@ -2489,6 +2493,7 @@ export class TrainrunSectionsView {
     this.createTrainrunSection(
       groupLines,
       StaticDomTags.EDGE_LINE_LAYER_0,
+      [],//20, 30, 60], (background is required to "strech the hower area"
       selectedTrainrun,
       connectedTrainIds,
       enableEvents,
@@ -2496,6 +2501,7 @@ export class TrainrunSectionsView {
     this.createTrainrunSection(
       groupLines,
       StaticDomTags.EDGE_LINE_LAYER_1,
+      [30],
       selectedTrainrun,
       connectedTrainIds,
       enableEvents,
@@ -2503,6 +2509,7 @@ export class TrainrunSectionsView {
     this.createTrainrunSection(
       groupLines,
       StaticDomTags.EDGE_LINE_LAYER_2,
+      [60, 120],
       selectedTrainrun,
       connectedTrainIds,
       enableEvents,
@@ -2510,6 +2517,7 @@ export class TrainrunSectionsView {
     this.createTrainrunSection(
       groupLines,
       StaticDomTags.EDGE_LINE_LAYER_3,
+      [60, 120],
       selectedTrainrun,
       connectedTrainIds,
       enableEvents,

--- a/src/app/view/editor-main-view/data-views/transitions.view.ts
+++ b/src/app/view/editor-main-view/data-views/transitions.view.ts
@@ -99,11 +99,15 @@ export class TransitionsView {
   static createTransitionLineLayer(
     grpEnter: d3.selector,
     classRef: string,
+    levelFreqFilter: number[],
     selectedTrainrun: Trainrun,
     connectedTrainIds: any,
     editorView: EditorView,
   ) {
     grpEnter
+      .filter((d: TransitionViewObject) => {
+        return !levelFreqFilter.includes(d.transition.getTrainrun().getFrequency());
+      })
       .append(StaticDomTags.TRANSITION_LINE_SVG)
       .attr(
         "class",
@@ -298,6 +302,7 @@ export class TransitionsView {
     TransitionsView.createTransitionLineLayer(
       grpEnter,
       StaticDomTags.TRANSITION_LINE_CLASS_0,
+      [],//20, 30, 60], (background is required to "strech the hower area"
       selectedTrainrun,
       connectedTrainIds,
       this.editorView,
@@ -305,6 +310,7 @@ export class TransitionsView {
     TransitionsView.createTransitionLineLayer(
       grpEnter,
       StaticDomTags.TRANSITION_LINE_CLASS_1,
+      [30],
       selectedTrainrun,
       connectedTrainIds,
       this.editorView,
@@ -312,6 +318,7 @@ export class TransitionsView {
     TransitionsView.createTransitionLineLayer(
       grpEnter,
       StaticDomTags.TRANSITION_LINE_CLASS_2,
+      [60, 120],
       selectedTrainrun,
       connectedTrainIds,
       this.editorView,
@@ -319,6 +326,7 @@ export class TransitionsView {
     TransitionsView.createTransitionLineLayer(
       grpEnter,
       StaticDomTags.TRANSITION_LINE_CLASS_3,
+      [60, 120],
       selectedTrainrun,
       connectedTrainIds,
       this.editorView,

--- a/src/app/view/editor-main-view/data-views/transitions.view.ts
+++ b/src/app/view/editor-main-view/data-views/transitions.view.ts
@@ -11,6 +11,7 @@ import {
 } from "./trainrunsection.previewline.view";
 import {Vec2D} from "../../../utils/vec2D";
 import {TransitionViewObject} from "./transitionViewObject";
+import {LinePatternRefs} from "../../../data-structures/business.data.structures";
 
 export class TransitionsView {
   transitionsGroup;
@@ -99,14 +100,14 @@ export class TransitionsView {
   static createTransitionLineLayer(
     grpEnter: d3.selector,
     classRef: string,
-    levelFreqFilter: number[],
+    levelFreqFilter: LinePatternRefs[],
     selectedTrainrun: Trainrun,
     connectedTrainIds: any,
     editorView: EditorView,
   ) {
     grpEnter
       .filter((d: TransitionViewObject) => {
-        return !levelFreqFilter.includes(d.transition.getTrainrun().getFrequency());
+        return !levelFreqFilter.includes(d.transition.getTrainrun().getFrequencyLinePatternRef());
       })
       .append(StaticDomTags.TRANSITION_LINE_SVG)
       .attr(
@@ -310,7 +311,7 @@ export class TransitionsView {
     TransitionsView.createTransitionLineLayer(
       grpEnter,
       StaticDomTags.TRANSITION_LINE_CLASS_1,
-      [30],
+      [LinePatternRefs.Freq30],
       selectedTrainrun,
       connectedTrainIds,
       this.editorView,
@@ -318,7 +319,7 @@ export class TransitionsView {
     TransitionsView.createTransitionLineLayer(
       grpEnter,
       StaticDomTags.TRANSITION_LINE_CLASS_2,
-      [60, 120],
+      [LinePatternRefs.Freq60, LinePatternRefs.Freq120],
       selectedTrainrun,
       connectedTrainIds,
       this.editorView,
@@ -326,7 +327,7 @@ export class TransitionsView {
     TransitionsView.createTransitionLineLayer(
       grpEnter,
       StaticDomTags.TRANSITION_LINE_CLASS_3,
-      [60, 120],
+      [LinePatternRefs.Freq60, LinePatternRefs.Freq120],
       selectedTrainrun,
       connectedTrainIds,
       this.editorView,

--- a/src/app/view/editor-main-view/data-views/transitions.view.ts
+++ b/src/app/view/editor-main-view/data-views/transitions.view.ts
@@ -303,7 +303,7 @@ export class TransitionsView {
     TransitionsView.createTransitionLineLayer(
       grpEnter,
       StaticDomTags.TRANSITION_LINE_CLASS_0,
-      [],//20, 30, 60], (background is required to "strech the hower area"
+      [LinePatternRefs.Freq30],// LinePatternRefs.Freq60], (background is required to "strech the hower area"
       selectedTrainrun,
       connectedTrainIds,
       this.editorView,


### PR DESCRIPTION


<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->
# Description
 
 Issue reported by @louisgreiner 
 
 Sarah and Yohan made a discovery about how the train run sections are rendered: for the same section, 4 HTML objects are always rendered (with the same ID, which is surprising for HTML). There is no difference between the 4 objects, except that one of them has a different opacity. Is this normal, or does it serve a special purpose? If not, could it be a potential area for performance improvement to render only one object?
 
![image](https://github.com/user-attachments/assets/37b9e3e2-80e1-4baa-9329-ba00dc835bc1)

