### PR TITLE
fix: remove undoService.pushCurrentVersion - call …

### DIFF
--- a/src/app/services/data/undo.service.ts
+++ b/src/app/services/data/undo.service.ts
@@ -92,10 +92,11 @@ export class UndoService implements OnDestroy {
   }
 
   public pushCurrentVersion(enforce = false) {
-    this.ignoreNextPushCurrentVersionCall = false;
     if (this.ignoreNextPushCurrentVersionCall && !enforce) {
+      this.ignoreNextPushCurrentVersionCall = false;
       return;
     }
+    this.ignoreNextPushCurrentVersionCall = false;
     this.internalPushCurrentVersion(enforce);
   }
 
@@ -104,6 +105,7 @@ export class UndoService implements OnDestroy {
       this.dataService.getNetzgrafikDto(),
     );
     const modified = newNetzgrafikJson !== this.currentNetzgrafikJSON;
+    console.log(modified, this.dataService.getNetzgrafikDto());
     if (modified || enforce) {
       this.changeHistoryStack.push(JSON.parse(newNetzgrafikJson));
       this.currentNetzgrafikJSON = newNetzgrafikJson;

--- a/src/app/services/data/undo.service.ts
+++ b/src/app/services/data/undo.service.ts
@@ -105,7 +105,6 @@ export class UndoService implements OnDestroy {
       this.dataService.getNetzgrafikDto(),
     );
     const modified = newNetzgrafikJson !== this.currentNetzgrafikJSON;
-    console.log(modified, this.dataService.getNetzgrafikDto());
     if (modified || enforce) {
       this.changeHistoryStack.push(JSON.parse(newNetzgrafikJson));
       this.currentNetzgrafikJSON = newNetzgrafikJson;

--- a/src/app/services/data/undo.service.ts
+++ b/src/app/services/data/undo.service.ts
@@ -93,8 +93,8 @@ export class UndoService implements OnDestroy {
 
   public pushCurrentVersion(enforce = false) {
     if (enforce) {
-      this.internalPushCurrentVersion(enforce);
       this.ignoreNextPushCurrentVersionCall = false;
+      this.internalPushCurrentVersion(enforce);
       return;
     }
     if (this.ignoreNextPushCurrentVersionCall) {

--- a/src/app/services/data/undo.service.ts
+++ b/src/app/services/data/undo.service.ts
@@ -21,6 +21,7 @@ export class UndoService implements OnDestroy {
   private undoNetzgrafikIsLoading = false;
   private currentVariantId: number = undefined;
   private undoRecordingStopped = false;
+  private ignoreNextPushCurrentVersionCall = false;
 
   constructor(
     private readonly dataService: DataService,
@@ -66,6 +67,12 @@ export class UndoService implements OnDestroy {
     this.undoRecordingStopped = false;
   }
 
+  setIgnoreNextPushCurrentVersionCall() {
+    // performance improvement: pan, ... should only be used when the data doesn't change
+    // - such as when changing the viewBox, etc. which requires a redrawing/update
+    this.ignoreNextPushCurrentVersionCall = true;
+  }
+
   private subscribeSnapshots() {
     if (this.changesSubscription !== undefined) {
       this.changesSubscription.unsubscribe();
@@ -85,6 +92,19 @@ export class UndoService implements OnDestroy {
   }
 
   public pushCurrentVersion(enforce = false) {
+    if (enforce) {
+      this.internalPushCurrentVersion(enforce);
+      this.ignoreNextPushCurrentVersionCall = false;
+      return;
+    }
+    if (this.ignoreNextPushCurrentVersionCall) {
+      this.ignoreNextPushCurrentVersionCall = false;
+      return;
+    }
+    this.internalPushCurrentVersion(enforce);
+  }
+
+  private internalPushCurrentVersion(enforce = false) {
     const newNetzgrafikJson = JSON.stringify(
       this.dataService.getNetzgrafikDto(),
     );
@@ -129,7 +149,7 @@ export class UndoService implements OnDestroy {
     this.currentVariantId = variantId;
   }
 
-  public getCurrentVariantId():number{
+  public getCurrentVariantId(): number {
     return this.currentVariantId;
   }
 }

--- a/src/app/services/data/undo.service.ts
+++ b/src/app/services/data/undo.service.ts
@@ -92,13 +92,8 @@ export class UndoService implements OnDestroy {
   }
 
   public pushCurrentVersion(enforce = false) {
-    if (enforce) {
-      this.ignoreNextPushCurrentVersionCall = false;
-      this.internalPushCurrentVersion(enforce);
-      return;
-    }
-    if (this.ignoreNextPushCurrentVersionCall) {
-      this.ignoreNextPushCurrentVersionCall = false;
+    this.ignoreNextPushCurrentVersionCall = false;
+    if (this.ignoreNextPushCurrentVersionCall && !enforce) {
       return;
     }
     this.internalPushCurrentVersion(enforce);

--- a/src/app/view/editor-main-view/data-views/editor.view.ts
+++ b/src/app/view/editor-main-view/data-views/editor.view.ts
@@ -137,7 +137,7 @@ export class EditorView implements SVGMouseControllerObserver {
     private positionTransformationService: PositionTransformationService
   ) {
     this.controller = controller;
-    this.svgMouseController = new SVGMouseController(EditorView.svgName, this);
+    this.svgMouseController = new SVGMouseController(EditorView.svgName, this, undoService);
     this.nodesView = new NodesView(this);
     this.transitionsView = new TransitionsView(this);
     this.connectionsView = new ConnectionsView(this);

--- a/src/app/view/util/svg.mouse.controller.spec.ts
+++ b/src/app/view/util/svg.mouse.controller.spec.ts
@@ -60,6 +60,7 @@ describe("general view functions", () => {
     const svgMouseController = new SVGMouseController(
       "graphContainer",
       dummySVGMouseControllerObserver,
+      undefined,
     );
     svgMouseController.init(viewboxProperties);
     const prop = svgMouseController.getViewboxProperties();
@@ -82,6 +83,7 @@ describe("general view functions", () => {
     const svgMouseController = new SVGMouseController(
       "graphContainer",
       dummySVGMouseControllerObserver,
+      undefined,
     );
     svgMouseController.init(viewboxProperties);
     const prop = svgMouseController.getViewboxProperties();
@@ -104,6 +106,7 @@ describe("general view functions", () => {
     const svgMouseController = new SVGMouseController(
       "graphContainer",
       dummySVGMouseControllerObserver,
+      undefined,
     );
     svgMouseController.init(viewboxProperties);
     const prop = svgMouseController.getViewboxProperties();
@@ -120,6 +123,7 @@ describe("general view functions", () => {
     const svgMouseController = new SVGMouseController(
       "graphContainer",
       dummySVGMouseControllerObserver,
+      undefined,
     );
     svgMouseController.init(viewboxProperties);
     const prop = svgMouseController.getViewboxProperties();

--- a/src/app/view/util/svg.mouse.controller.ts
+++ b/src/app/view/util/svg.mouse.controller.ts
@@ -131,6 +131,7 @@ export class SVGMouseController {
       );
       this.viewboxProperties.zoomFactor =
         Math.round(this.viewboxProperties.zoomFactor / 10) * 10;
+      this.temporaryDisableUndoServicePushCurrentVersion();
       this.updateZoomCenter(zoomCenter);
       this.svgMouseControllerObserver.zoomFactorChanged(
         this.viewboxProperties.zoomFactor,
@@ -155,6 +156,7 @@ export class SVGMouseController {
       );
       this.viewboxProperties.zoomFactor =
         Math.round(this.viewboxProperties.zoomFactor / 10) * 10;
+      this.temporaryDisableUndoServicePushCurrentVersion();
       this.updateZoomCenter(zoomCenter);
       this.svgMouseControllerObserver.zoomFactorChanged(
         this.viewboxProperties.zoomFactor,
@@ -167,6 +169,7 @@ export class SVGMouseController {
       return;
     }
     this.viewboxProperties.zoomFactor = 100;
+    this.temporaryDisableUndoServicePushCurrentVersion();
     this.updateZoomCenter(zoomCenter);
     this.svgMouseControllerObserver.zoomFactorChanged(
       this.viewboxProperties.zoomFactor,
@@ -193,9 +196,6 @@ export class SVGMouseController {
   }
 
   setViewbox() {
-    if (this.undoService !== undefined){
-      this.undoService.setIgnoreNextPushCurrentVersionCall();
-    }
     this.viewboxProperties.currentViewBox = this.makeViewboxString();
     this.svgDrawingContext.attr(
       "viewBox",
@@ -292,6 +292,7 @@ export class SVGMouseController {
               curPos.getY(),
             ),
           );
+          this.temporaryDisableUndoServicePushCurrentVersion();
           this.svgMouseControllerObserver.updateMultiSelect(
             topLef,
             bottomRight,
@@ -443,6 +444,7 @@ export class SVGMouseController {
 
       this.viewboxProperties.panZoomLeft += delta.getX();
       this.viewboxProperties.panZoomTop += delta.getY();
+      this.temporaryDisableUndoServicePushCurrentVersion();
       this.setViewbox();
     }
 
@@ -459,5 +461,12 @@ export class SVGMouseController {
       " " +
       this.viewboxProperties.panZoomHeight
     );
+  }
+
+  private temporaryDisableUndoServicePushCurrentVersion(){
+    // temporary disable undoService push current version
+    if (this.undoService !== undefined){
+      this.undoService.setIgnoreNextPushCurrentVersionCall();
+    }
   }
 }

--- a/src/app/view/util/svg.mouse.controller.ts
+++ b/src/app/view/util/svg.mouse.controller.ts
@@ -232,6 +232,7 @@ export class SVGMouseController {
       (d3.event.buttons === 2 && this.lastMouseEventTimeStamp === undefined)
     ) {
       this.previousMultiSelectShiftPosition = this.getCurrentMousePosition();
+      this.temporaryDisableUndoServicePushCurrentVersion();
       this.svgMouseControllerObserver.onStartMultiSelect();
     } else {
       this.previousPanMousePosition = null;

--- a/src/app/view/util/svg.mouse.controller.ts
+++ b/src/app/view/util/svg.mouse.controller.ts
@@ -2,6 +2,7 @@ import * as d3 from "d3";
 import {Vec2D} from "../../utils/vec2D";
 import {StaticDomTags} from "../editor-main-view/data-views/static.dom.tags";
 import {ViewboxProperties} from "../../services/ui/ui.interaction.service";
+import {UndoService} from "../../services/data/undo.service";
 
 export interface SVGMouseControllerObserver {
   onEarlyReturnFromMousemove(): boolean;
@@ -38,6 +39,7 @@ export class SVGMouseController {
   constructor(
     private svgName: string,
     private svgMouseControllerObserver: SVGMouseControllerObserver,
+    private undoService : UndoService
   ) {
   }
 
@@ -191,6 +193,9 @@ export class SVGMouseController {
   }
 
   setViewbox() {
+    if (this.undoService !== undefined){
+      this.undoService.setIgnoreNextPushCurrentVersionCall();
+    }
     this.viewboxProperties.currentViewBox = this.makeViewboxString();
     this.svgDrawingContext.attr(
       "viewBox",


### PR DESCRIPTION
…when the viewbox gets changed (performance improvement) for zoom/pan

<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->
# Description
Comparing a large Netzgrafik to detect changes is time-consuming. When the user pans or zooms the Netzgrafik, an update event is triggered, and the viewbox changes. The update call is required to ensure correct rendering (frustum culling). The changes to the viewbox only update the render area (visualisation). However, neither step changes the data (the Netzgrafik data). Therefore, we don't need to check whether the Netzgrafik has changed and we never push it onto the undo stack. We can just ignore this comparison (step).

These changes improve performance by temporarily disabling the check and pushing the data onto the stack (which would never be necessary without changes).