### PR TITLE
od: make od nodes bold on mouseover

### DIFF
--- a/src/app/origin-destination/components/origin-destination.component.ts
+++ b/src/app/origin-destination/components/origin-destination.component.ts
@@ -120,13 +120,13 @@ export class OriginDestinationComponent implements OnInit, OnDestroy {
     graphContentGroup
       .append("g")
       .style("pointer-events", "none")
-      .style("font-size", 15)
       .attr("transform", "translate(0, -20)")
       .call(d3.axisBottom(x).tickSize(0))
       .style("user-select", "none")
       .call((g) =>
         g
           .selectAll("text")
+          .attr("data-origin-label", (d: string) => d)
           .style("text-anchor", "start")
           .attr("dx", "-0.8em")
           .attr("dy", "0.4em")
@@ -145,9 +145,13 @@ export class OriginDestinationComponent implements OnInit, OnDestroy {
     graphContentGroup
       .append("g")
       .style("pointer-events", "none")
-      .style("font-size", 14)
       .call(d3.axisLeft(y).tickSize(0))
       .style("user-select", "none")
+      .call((g) =>
+        g
+        .selectAll("text")
+        .attr("data-destination-label", (d: string) => d)
+      )
       .select(".domain")
       .remove();
 
@@ -180,6 +184,14 @@ export class OriginDestinationComponent implements OnInit, OnDestroy {
         .style("stroke", "black")
         .style("stroke-width", "2px")
         .style("opacity", 1);
+
+      // Highlight axis labels in bold when hovering over a cell
+      d3.selectAll(`[data-origin-label="${_d.origin}"]`)
+        .style("font-weight", "bold")
+        .style("font-size", "12px");
+      d3.selectAll(`[data-destination-label="${_d.destination}"]`)
+        .style("font-weight", "bold")
+        .style("font-size", "12px");
     };
 
     const totalCostTranslation = $localize`:@@app.origin-destination.tooltip.total-cost:Total cost`;
@@ -208,6 +220,14 @@ export class OriginDestinationComponent implements OnInit, OnDestroy {
     const mouseleave = function (_d) {
       tooltip.style("opacity", 0);
       d3.select(this).style("stroke", "none").style("opacity", 0.8);
+
+      // Remove boldness from the axis labels
+      d3.selectAll(`[data-origin-label="${_d.origin}"]`)
+        .style("font-weight", null)
+        .style("font-size", null);
+      d3.selectAll(`[data-destination-label="${_d.destination}"]`)
+        .style("font-weight", null)
+        .style("font-size", null);
     };
 
     // add the squares

--- a/src/app/origin-destination/components/origin-destination.component.ts
+++ b/src/app/origin-destination/components/origin-destination.component.ts
@@ -178,8 +178,8 @@ export class OriginDestinationComponent implements OnInit, OnDestroy {
       .style("pointer-events", "none");
 
     // Three function that change the tooltip when user hover / move / leave a cell
-    const mouseover = function (_d) {
-      if (_d.found) {
+    const mouseover = function (d: OriginDestination) {
+      if (d.found) {
         tooltip.style("opacity", 1);
         d3.select(this)
           .style("stroke", "black")
@@ -188,10 +188,10 @@ export class OriginDestinationComponent implements OnInit, OnDestroy {
       }
 
       // Highlight axis labels in bold when hovering over a cell
-      d3.selectAll(`[data-origin-label="${_d.origin}"]`)
+      d3.selectAll(`[data-origin-label="${d.origin}"]`)
         .style("font-weight", "bold")
         .style("font-size", "12px");
-      d3.selectAll(`[data-destination-label="${_d.destination}"]`)
+      d3.selectAll(`[data-destination-label="${d.destination}"]`)
         .style("font-weight", "bold")
         .style("font-size", "12px");
     };

--- a/src/app/origin-destination/components/origin-destination.component.ts
+++ b/src/app/origin-destination/components/origin-destination.component.ts
@@ -179,11 +179,13 @@ export class OriginDestinationComponent implements OnInit, OnDestroy {
 
     // Three function that change the tooltip when user hover / move / leave a cell
     const mouseover = function (_d) {
-      tooltip.style("opacity", 1);
-      d3.select(this)
-        .style("stroke", "black")
-        .style("stroke-width", "2px")
-        .style("opacity", 1);
+      if (_d.found) {
+        tooltip.style("opacity", 1);
+        d3.select(this)
+          .style("stroke", "black")
+          .style("stroke-width", "2px")
+          .style("opacity", 1);
+      }
 
       // Highlight axis labels in bold when hovering over a cell
       d3.selectAll(`[data-origin-label="${_d.origin}"]`)
@@ -252,7 +254,7 @@ export class OriginDestinationComponent implements OnInit, OnDestroy {
       .style("stroke-width", 4)
       .style("stroke", "none")
       .style("opacity", 0.8)
-      .style("pointer-events", (d: OriginDestination) => d.found ? "auto" : "none")
+      .style("pointer-events", "auto")
 
       .on("mouseover", mouseover)
       .on("mousemove", mousemove)


### PR DESCRIPTION
With that change, the origin and destination nodes are bold when the mouse is over a cell.

I am not sure on:
- the relevance of this enhancement
- if relevant, the font-size chosen : 12px or less/more?
- if relevant, we could also change the color of the text, or anything else that make the nodes names highlit

What do you think @aiAdrian ?