### PR TITLE
Lgr/remove pointer events empty cells

### DIFF
--- a/src/app/origin-destination/components/origin-destination.component.ts
+++ b/src/app/origin-destination/components/origin-destination.component.ts
@@ -226,6 +226,8 @@ export class OriginDestinationComponent implements OnInit, OnDestroy {
       .style("stroke-width", 4)
       .style("stroke", "none")
       .style("opacity", 0.8)
+      .style("pointer-events", (d: OriginDestination) => d.found ? "auto" : "none")
+
       .on("mouseover", mouseover)
       .on("mousemove", mousemove)
       .on("mouseleave", mouseleave);


### PR DESCRIPTION
Currently, when mouse overing empty cells, the tooltip shows this:
![image](https://github.com/user-attachments/assets/2c21d205-bc16-4b3c-8ed6-f14b0d401e36)

It gives no information and overload the interface. I suggest removing the tooltips when the cells are empty.

This PR is also a suggestion: I am not sure if we want the disable to tooltip for empty cells

Another solution would be to at least write something else than `undefined`, but I don't have any idea

@aiAdrian 