### PR TITLE
Addition of Prettier for Code Formatting and integration into CI

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,19 +1,11 @@
 {
   "root": true,
-  "ignorePatterns": [
-    "projects/**/*",
-    "src/app/api/generated/**/*"
-  ],
+  "ignorePatterns": ["projects/**/*", "src/app/api/generated/**/*"],
   "overrides": [
     {
-      "files": [
-        "*.ts"
-      ],
+      "files": ["*.ts"],
       "parserOptions": {
-        "project": [
-          "tsconfig.json",
-          "e2e/tsconfig.json"
-        ],
+        "project": ["tsconfig.json", "e2e/tsconfig.json"],
         "createDefaultProgram": true
       },
       "extends": [
@@ -24,9 +16,7 @@
         "plugin:rxjs/recommended",
         "prettier"
       ],
-      "plugins": [
-        "deprecation"
-      ],
+      "plugins": ["deprecation"],
       "rules": {
         "@angular-eslint/directive-selector": [
           "error",
@@ -50,9 +40,7 @@
         "@typescript-eslint/no-empty-function": [
           "off",
           {
-            "allow": [
-              "private-constructors"
-            ]
+            "allow": ["private-constructors"]
           }
         ],
         "@typescript-eslint/no-explicit-any": "off",
@@ -77,9 +65,7 @@
             "allowTemplateLiterals": false
           }
         ],
-        "@typescript-eslint/semi": [
-          "error"
-        ],
+        "@typescript-eslint/semi": ["error"],
         "deprecation/deprecation": "warn",
         "consistent-return": "error",
         "eqeqeq": "error",
@@ -93,12 +79,8 @@
       }
     },
     {
-      "files": [
-        "*.html"
-      ],
-      "extends": [
-        "plugin:@angular-eslint/template/recommended"
-      ],
+      "files": ["*.html"],
+      "extends": ["plugin:@angular-eslint/template/recommended"],
       "rules": {}
     }
   ]

--- a/.github/ISSUE_TEMPLATE/1-bug.yaml
+++ b/.github/ISSUE_TEMPLATE/1-bug.yaml
@@ -30,11 +30,11 @@ body:
     attributes:
       label: Bug type
       options:
-        - 'Functionality'
-        - 'Accessibility'
-        - 'Performance'
-        - 'Security vulnerability'
-        - 'Other'
+        - "Functionality"
+        - "Accessibility"
+        - "Performance"
+        - "Security vulnerability"
+        - "Other"
     validations:
       required: true
   - type: input
@@ -67,9 +67,9 @@ body:
     attributes:
       label: Input mode
       options:
-        - 'Mouse/Keyboard'
-        - 'Touch'
-        - 'Other'
+        - "Mouse/Keyboard"
+        - "Touch"
+        - "Other"
     validations:
       required: false
   - type: input

--- a/.github/ISSUE_TEMPLATE/2-feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yaml
@@ -1,7 +1,7 @@
 name: Feature request or enhancement
 description: Request for a new component or enhancement of a component
 title: "[Feature request]: "
-labels: ['type: enhancement']
+labels: ["type: enhancement"]
 assignees:
   - octocat
 body:
@@ -25,8 +25,8 @@ body:
     attributes:
       label: Request type
       options:
-        - 'Request for a new component'
-        - 'Request for enhancement of a component'
+        - "Request for a new component"
+        - "Request for enhancement of a component"
     validations:
       required: true
   - type: textarea

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,7 @@
     Thank you for your contribution. Please use this template to help guide
     you towards preparing a PR that fullfills our merge requirements.
 -->
+
 # Description
 
 <!-- Describe the changes your PR introduces here. -->
@@ -21,11 +22,11 @@
     be prepared to add more items.
 -->
 
-* [ ] This PR contains a description of the changes I'm making
-* [ ] I've read the [Contribution Guidelines](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/CONTRIBUTING.md)
-* [ ] I've added tests for changes or features I've introduced
-* [ ] I documented any high-level concepts I'm introducing in `documentation/`
-* [ ] CI is currently green and this is ready for review
+- [ ] This PR contains a description of the changes I'm making
+- [ ] I've read the [Contribution Guidelines](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/CONTRIBUTING.md)
+- [ ] I've added tests for changes or features I've introduced
+- [ ] I documented any high-level concepts I'm introducing in `documentation/`
+- [ ] CI is currently green and this is ready for review
 
 <!--
     Please open PRs as Draft while you make CI green and/or finalise

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -15,6 +15,18 @@ permissions:
   packages: write
 
 jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+      - run: npm clean-install
+      - name: Check code formatting
+        run: npx prettier --check .
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,8 +21,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
+          node-version-file: ".nvmrc"
+          cache: "npm"
       - run: npm clean-install
       - run: npm run lint
 
@@ -33,8 +33,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
+          node-version-file: ".nvmrc"
+          cache: "npm"
       - run: npm clean-install
       - run: npm test
 
@@ -45,8 +45,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
+          node-version-file: ".nvmrc"
+          cache: "npm"
       - run: npm clean-install
       - run: npm run build
       - name: Store build artifacts
@@ -62,8 +62,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
+          node-version-file: ".nvmrc"
+          cache: "npm"
       - run: npm clean-install
       - run: npm run build:standalone
       - name: Store build artifacts
@@ -79,8 +79,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
+          node-version-file: ".nvmrc"
+          cache: "npm"
       - run: npm clean-install
       - run: npm run build:standalonedemo
       - name: Store build artifacts

--- a/.github/workflows/deploy-standalone-github.yml
+++ b/.github/workflows/deploy-standalone-github.yml
@@ -2,7 +2,7 @@ name: Deploy static content to GitHub Pages
 
 on:
   push:
-    branches: ['main']
+    branches: ["main"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -15,7 +15,7 @@ permissions:
 
 # Allow one concurrent deployment
 concurrency:
-  group: 'pages'
+  group: "pages"
   cancel-in-progress: true
 
 jobs:
@@ -25,8 +25,8 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-    - id: build-publish
-      uses: bitovi/github-actions-angular-to-github-pages@v1.0.0
-      with:
-        path: dist/netzgrafik-frontend
-        build_command: npm run build:standalonedemo -- --base-href=netzgrafik-frontend
+      - id: build-publish
+        uses: bitovi/github-actions-angular-to-github-pages@v1.0.0
+        with:
+          path: dist/netzgrafik-frontend
+          build_command: npm run build:standalonedemo -- --base-href=netzgrafik-frontend

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -68,9 +68,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
-          registry-url: 'https://registry.npmjs.org'
+          node-version-file: ".nvmrc"
+          cache: "npm"
+          registry-url: "https://registry.npmjs.org"
       - run: npm clean-install
       - run: npm run build:standalone
       - run: npm pkg delete dependencies optionalDependencies devDependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,481 +2,416 @@
 
 ## [2.9.29](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/netzgrafik-frontend-v2.9.28...netzgrafik-frontend-v2.9.29) (2025-05-13)
 
-
 ### Bug Fixes
 
-* updateTrainrunCategory,      updateTrainrunTimeCategory and     … ([#457](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/457)) ([ee9a0b7](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/ee9a0b7aecdc256784de0b128d5f322c9f2f295e))
+- updateTrainrunCategory, updateTrainrunTimeCategory and … ([#457](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/457)) ([ee9a0b7](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/ee9a0b7aecdc256784de0b128d5f322c9f2f295e))
 
 ## [2.9.28](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/netzgrafik-frontend-v2.9.27...netzgrafik-frontend-v2.9.28) (2025-05-12)
 
-
 ### Bug Fixes
 
-* toggle temporay disable ([#455](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/455)) ([bdede87](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/bdede8730099a92669d4a741a229f8cdd56582cc))
+- toggle temporay disable ([#455](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/455)) ([bdede87](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/bdede8730099a92669d4a741a229f8cdd56582cc))
 
 ## [2.9.27](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/netzgrafik-frontend-v2.9.26...netzgrafik-frontend-v2.9.27) (2025-05-12)
 
-
 ### Bug Fixes
 
-* check was missing - the filtering should only be reset when a filter is active and the filtering is not temporary switched off ([#451](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/451)) ([1551417](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/1551417d79c3184db82593d84d6ac62f8c7eff95))
+- check was missing - the filtering should only be reset when a filter is active and the filtering is not temporary switched off ([#451](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/451)) ([1551417](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/1551417d79c3184db82593d84d6ac62f8c7eff95))
 
 ## [2.9.26](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/netzgrafik-frontend-v2.9.25...netzgrafik-frontend-v2.9.26) (2025-05-09)
 
-
 ### Bug Fixes
 
-* Performance - only render trainrunSection and transition element - which are required ([#444](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/444)) ([4d2ba01](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/4d2ba01c3edfa556aa33ddc2f3eeb58a0c7c1476))
+- Performance - only render trainrunSection and transition element - which are required ([#444](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/444)) ([4d2ba01](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/4d2ba01c3edfa556aa33ddc2f3eeb58a0c7c1476))
 
 ## [2.9.25](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/netzgrafik-frontend-v2.9.24...netzgrafik-frontend-v2.9.25) (2025-05-08)
 
-
 ### Bug Fixes
 
-* remove undoService.pushCurrentVersion - call … ([#445](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/445)) ([8ba733d](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/8ba733dd668a2cc546b41ccfc2c24ac7515e80f0))
+- remove undoService.pushCurrentVersion - call … ([#445](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/445)) ([8ba733d](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/8ba733dd668a2cc546b41ccfc2c24ac7515e80f0))
 
 ## [2.9.24](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/netzgrafik-frontend-v2.9.23...netzgrafik-frontend-v2.9.24) (2025-04-09)
 
-
 ### Bug Fixes
 
-* reset main view after netzgrafikDto import ([c0e2d02](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/c0e2d0202e96d1097362b519e274e74c862213be))
+- reset main view after netzgrafikDto import ([c0e2d02](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/c0e2d0202e96d1097362b519e274e74c862213be))
 
 ## [2.9.23](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/netzgrafik-frontend-v2.9.22...netzgrafik-frontend-v2.9.23) (2025-04-03)
 
-
 ### Bug Fixes
 
-* changed filtering oder and add cull for notes ([#429](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/429)) ([b863cda](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/b863cda2554e49c5fa6da4d4d53d1a10042eb1e4))
+- changed filtering oder and add cull for notes ([#429](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/429)) ([b863cda](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/b863cda2554e49c5fa6da4d4d53d1a10042eb1e4))
 
 ## [2.9.22](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/netzgrafik-frontend-v2.9.21...netzgrafik-frontend-v2.9.22) (2025-04-01)
 
-
 ### Bug Fixes
 
-* The performance gets improved for big Netzgrafik ([#427](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/427)) ([bb00a4d](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/bb00a4d54cded069132d1bbf5b1e7e754af97288))
+- The performance gets improved for big Netzgrafik ([#427](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/427)) ([bb00a4d](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/bb00a4d54cded069132d1bbf5b1e7e754af97288))
 
 ## [2.9.21](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/netzgrafik-frontend-v2.9.20...netzgrafik-frontend-v2.9.21) (2025-01-28)
 
-
 ### Bug Fixes
 
-* aemit operations for position transformation service ([#400](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/400)) ([a7dae9e](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/a7dae9ef2f71e32238c3015d1ae4165dfd0d7bf8))
+- aemit operations for position transformation service ([#400](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/400)) ([a7dae9e](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/a7dae9ef2f71e32238c3015d1ae4165dfd0d7bf8))
 
 ## [2.9.20](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/netzgrafik-frontend-v2.9.19...netzgrafik-frontend-v2.9.20) (2025-01-15)
 
-
 ### Bug Fixes
 
-* fix trains going back in OD matrix ([#395](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/395)) ([173986c](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/173986c8b3e140327d45d44d983310709a3541d0))
+- fix trains going back in OD matrix ([#395](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/395)) ([173986c](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/173986c8b3e140327d45d44d983310709a3541d0))
 
 ## [2.9.19](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/netzgrafik-frontend-v2.9.18...netzgrafik-frontend-v2.9.19) (2024-12-18)
 
-
 ### Bug Fixes
 
-* typo 'Serivce' -&gt; 'Service' ([#392](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/392)) ([1d6b811](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/1d6b81110c662d3ca1fc01207eb7ab9974b2b9fe))
+- typo 'Serivce' -&gt; 'Service' ([#392](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/392)) ([1d6b811](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/1d6b81110c662d3ca1fc01207eb7ab9974b2b9fe))
 
 ## [2.9.18](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/netzgrafik-frontend-v2.9.17...netzgrafik-frontend-v2.9.18) (2024-12-17)
 
-
 ### Bug Fixes
 
-* 260 feature request align selected nodes all at once ([#390](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/390)) ([af03ac9](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/af03ac956543103e9f0604dda75ed498fa6af94d))
+- 260 feature request align selected nodes all at once ([#390](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/390)) ([af03ac9](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/af03ac956543103e9f0604dda75ed498fa6af94d))
 
 ## [2.9.17](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/netzgrafik-frontend-v2.9.16...netzgrafik-frontend-v2.9.17) (2024-12-12)
 
-
 ### Bug Fixes
 
-* multi-nodes scaling ctrl + mouse wheel ([#386](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/386)) ([f393f4a](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/f393f4add7e0ae05f63d6a20762d3efc266fb0ed))
+- multi-nodes scaling ctrl + mouse wheel ([#386](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/386)) ([f393f4a](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/f393f4add7e0ae05f63d6a20762d3efc266fb0ed))
 
 ## [2.9.16](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/netzgrafik-frontend-v2.9.15...netzgrafik-frontend-v2.9.16) (2024-12-12)
 
-
 ### Bug Fixes
 
-* issue fixed and two other methods refactored to same code structure as the getTrainrunFrequency method ([#383](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/383)) ([e864528](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/e864528c3ce6c993edc4eec5e047836cee21c9b4))
+- issue fixed and two other methods refactored to same code structure as the getTrainrunFrequency method ([#383](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/383)) ([e864528](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/e864528c3ce6c993edc4eec5e047836cee21c9b4))
 
 ## [2.9.15](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/netzgrafik-frontend-v2.9.14...netzgrafik-frontend-v2.9.15) (2024-12-11)
 
-
 ### Bug Fixes
 
-* issue fixed ([#380](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/380)) ([0bbff36](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/0bbff3671cf1d404ae3fa8236be61ca69805f951))
+- issue fixed ([#380](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/380)) ([0bbff36](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/0bbff3671cf1d404ae3fa8236be61ca69805f951))
 
 ## [2.9.14](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/netzgrafik-frontend-v2.9.13...netzgrafik-frontend-v2.9.14) (2024-12-11)
 
-
 ### Bug Fixes
 
-* if the ctrl + mouse wheel lets scale the netzgrafik or multi-selected nodes (local scale) ([#376](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/376)) ([de55afe](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/de55afe8b1101615c43906c807989be62d84485d))
+- if the ctrl + mouse wheel lets scale the netzgrafik or multi-selected nodes (local scale) ([#376](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/376)) ([de55afe](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/de55afe8b1101615c43906c807989be62d84485d))
 
 ## [2.9.13](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/netzgrafik-frontend-v2.9.12...netzgrafik-frontend-v2.9.13) (2024-12-10)
 
-
 ### Bug Fixes
 
-* import 3rd party performance ([#373](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/373)) ([5b0ecdc](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/5b0ecdc5c9650ed28968871fc9398a65f113962f))
+- import 3rd party performance ([#373](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/373)) ([5b0ecdc](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/5b0ecdc5c9650ed28968871fc9398a65f113962f))
 
 ## [2.9.12](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/netzgrafik-frontend-v2.9.11...netzgrafik-frontend-v2.9.12) (2024-12-05)
 
-
 ### Bug Fixes
 
-* build broken! ([#371](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/371)) ([04f9a2f](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/04f9a2fab45b987e352a75f71616e7e1a02a34ac))
+- build broken! ([#371](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/371)) ([04f9a2f](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/04f9a2fab45b987e352a75f71616e7e1a02a34ac))
 
 ## [2.9.11](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/netzgrafik-frontend-v2.9.10...netzgrafik-frontend-v2.9.11) (2024-11-28)
 
-
 ### Bug Fixes
 
-* correct connections-&gt;transfers naming for O/D matrix ([#365](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/365)) ([454c201](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/454c201abf3228dacecb8685f80545ef13eea554))
-* documentation for 3rd party import ([#367](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/367)) ([53ee469](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/53ee469b7cbba5042530d6436f1dbfaa447a1285))
+- correct connections-&gt;transfers naming for O/D matrix ([#365](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/365)) ([454c201](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/454c201abf3228dacecb8685f80545ef13eea554))
+- documentation for 3rd party import ([#367](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/367)) ([53ee469](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/53ee469b7cbba5042530d6436f1dbfaa447a1285))
 
 ## [2.9.10](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/netzgrafik-frontend-v2.9.9...netzgrafik-frontend-v2.9.10) (2024-11-22)
 
-
 ### Bug Fixes
 
-* warn users when having unsymmetric times ([#359](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/359)) ([9923567](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/992356722772db594e48a1f7aa8511b904a62c79))
+- warn users when having unsymmetric times ([#359](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/359)) ([9923567](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/992356722772db594e48a1f7aa8511b904a62c79))
 
 ## [2.9.9](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/netzgrafik-frontend-v2.9.8...netzgrafik-frontend-v2.9.9) (2024-11-14)
 
-
 ### Bug Fixes
 
-* performance opt / refactored ([#356](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/356)) ([f939df6](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/f939df6640159e868802de80f12a40469bf8d943))
+- performance opt / refactored ([#356](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/356)) ([f939df6](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/f939df6640159e868802de80f12a40469bf8d943))
 
 ## [2.9.8](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/netzgrafik-frontend-v2.9.7...netzgrafik-frontend-v2.9.8) (2024-11-14)
 
-
 ### Bug Fixes
 
-* performance issue fixed (part 2) ([#354](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/354)) ([c8eb613](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/c8eb61364b7cf5ab8d41a2a04eba3e9d35c46562))
+- performance issue fixed (part 2) ([#354](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/354)) ([c8eb613](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/c8eb61364b7cf5ab8d41a2a04eba3e9d35c46562))
 
 ## [2.9.7](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/netzgrafik-frontend-v2.9.6...netzgrafik-frontend-v2.9.7) (2024-11-14)
 
-
 ### Bug Fixes
 
-* 350 bug delete node or trainrunsections cause low performance ([#351](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/351)) ([72f8599](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/72f859920ac425668356fcb095f2ef49f019421f))
+- 350 bug delete node or trainrunsections cause low performance ([#351](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/351)) ([72f8599](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/72f859920ac425668356fcb095f2ef49f019421f))
 
 ## [2.9.6](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/netzgrafik-frontend-v2.9.5...netzgrafik-frontend-v2.9.6) (2024-11-13)
 
-
 ### Bug Fixes
 
-* 346 bug importing 3rd party json misses detecting non stop transitions ([#347](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/347)) ([9d71b4a](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/9d71b4aa9608eaec4d50f7f13178693305ea4a3c))
+- 346 bug importing 3rd party json misses detecting non stop transitions ([#347](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/347)) ([9d71b4a](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/9d71b4aa9608eaec4d50f7f13178693305ea4a3c))
 
 ## [2.9.5](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/netzgrafik-frontend-v2.9.4...netzgrafik-frontend-v2.9.5) (2024-11-11)
 
-
 ### Bug Fixes
 
-* CSV base data export  ([#343](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/343)) ([2d75f2d](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/2d75f2da23d63a87638bac8ba3f1551f54054b9c))
-* Simplified third-party JSON import (no port alignment/path precalculation required) ([#341](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/341)) ([d7d1776](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/d7d1776e7bb9fd4872821d315f9a81a8c2313c4d))
+- CSV base data export ([#343](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/343)) ([2d75f2d](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/2d75f2da23d63a87638bac8ba3f1551f54054b9c))
+- Simplified third-party JSON import (no port alignment/path precalculation required) ([#341](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/341)) ([d7d1776](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/d7d1776e7bb9fd4872821d315f9a81a8c2313c4d))
 
 ## [2.9.4](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/netzgrafik-frontend-v2.9.3...netzgrafik-frontend-v2.9.4) (2024-11-06)
 
-
 ### Bug Fixes
 
-* 334 bug archived read mode allows to move nodes but not persisted ([#336](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/336)) ([6275ae1](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/6275ae17929fbf564b7419896ad11946b90c20b1))
+- 334 bug archived read mode allows to move nodes but not persisted ([#336](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/336)) ([6275ae1](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/6275ae17929fbf564b7419896ad11946b90c20b1))
 
 ## [2.9.3](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/netzgrafik-frontend-v2.9.2...netzgrafik-frontend-v2.9.3) (2024-11-05)
 
-
 ### Bug Fixes
 
-* fix O/D Matrix for trainrun 0 ([#337](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/337)) ([28a6d3a](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/28a6d3ae56c436a40e06eed54a3bbc117b97bdb7))
+- fix O/D Matrix for trainrun 0 ([#337](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/337)) ([28a6d3a](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/28a6d3ae56c436a40e06eed54a3bbc117b97bdb7))
 
 ## [2.9.2](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/netzgrafik-frontend-v2.9.1...netzgrafik-frontend-v2.9.2) (2024-11-04)
 
-
 ### Bug Fixes
 
-* While combining two trainruns the first trainrun will "survive" and the second one will be deleted. If the trainrun which will be deleted consists of more than one trainrun segment (connected paths) the reported issue will be generated. (Test added) ([c55388b](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/c55388b2d58efd788d64f745560c4b37c5d227e9))
+- While combining two trainruns the first trainrun will "survive" and the second one will be deleted. If the trainrun which will be deleted consists of more than one trainrun segment (connected paths) the reported issue will be generated. (Test added) ([c55388b](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/c55388b2d58efd788d64f745560c4b37c5d227e9))
 
 ## [2.9.1](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/netzgrafik-frontend-v2.9.0...netzgrafik-frontend-v2.9.1) (2024-10-28)
 
-
 ### Bug Fixes
 
-* 320 bug graphical timetable streckengrafik renders only one trainrun segement ([#325](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/325)) ([790f53b](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/790f53b7f7493cc7204719643dd368eccad89d16))
+- 320 bug graphical timetable streckengrafik renders only one trainrun segement ([#325](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/325)) ([790f53b](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/790f53b7f7493cc7204719643dd368eccad89d16))
 
 ## [2.9.0](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/netzgrafik-frontend-v2.8.0...netzgrafik-frontend-v2.9.0) (2024-10-24)
 
-
 ### Features
 
-* migrate originDestination connectionPenalty to netzgrafikDto ([#314](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/314)) ([ce3f90d](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/ce3f90d73784fabb49f29ac3625b142ceaa4134f))
-* optimize originDestination graph ([#316](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/316)) ([83895a1](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/83895a153bcbc83cbbb692f48b8df196a56a9467))
-
+- migrate originDestination connectionPenalty to netzgrafikDto ([#314](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/314)) ([ce3f90d](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/ce3f90d73784fabb49f29ac3625b142ceaa4134f))
+- optimize originDestination graph ([#316](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/316)) ([83895a1](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/83895a153bcbc83cbbb692f48b8df196a56a9467))
 
 ### Bug Fixes
 
-* fix O/D Matrix for unordered trainruns ([#321](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/321)) ([3d9644f](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/3d9644fbe94ea0a11a5403b798ea5634481166fa))
+- fix O/D Matrix for unordered trainruns ([#321](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/321)) ([3d9644f](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/3d9644fbe94ea0a11a5403b798ea5634481166fa))
 
 ## [2.8.0](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/netzgrafik-frontend-v2.7.17...netzgrafik-frontend-v2.8.0) (2024-10-10)
 
-
 ### Features
 
-* Implement Origin/Destination matrix ([#301](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/301)) ([383c99d](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/383c99d9e2081c1587bf36aa71dcb7ee6e73c7d9))
+- Implement Origin/Destination matrix ([#301](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/301)) ([383c99d](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/383c99d9e2081c1587bf36aa71dcb7ee6e73c7d9))
 
 ## [2.7.17](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/netzgrafik-frontend-v2.7.16...netzgrafik-frontend-v2.7.17) (2024-10-03)
 
-
 ### Bug Fixes
 
-* Documentation enhanced and standalone application deployed to github pages ([#304](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/304)) ([bee16d2](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/bee16d216a980bb32fdd0e6427d90c775bcd4292))
+- Documentation enhanced and standalone application deployed to github pages ([#304](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/304)) ([bee16d2](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/bee16d216a980bb32fdd0e6427d90c775bcd4292))
 
 ## [2.7.16](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/netzgrafik-frontend-v2.7.15...netzgrafik-frontend-v2.7.16) (2024-09-26)
 
-
 ### Bug Fixes
 
-* some translations ([#299](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/299)) ([c29c93f](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/c29c93f2e48fb294484d31e7238da637620c6e43))
+- some translations ([#299](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/299)) ([c29c93f](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/c29c93f2e48fb294484d31e7238da637620c6e43))
 
 ## [2.7.15](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/netzgrafik-frontend-v2.7.14...netzgrafik-frontend-v2.7.15) (2024-09-19)
 
-
 ### Bug Fixes
 
-* doc: Split_Combine_Trainruns.md grammar ([#293](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/293)) ([ae64d44](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/ae64d446ca979db5b95601dbd414a3c9d6e6419f))
-* doc: STANDALONE.md grammar ([#292](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/292)) ([22f4f87](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/22f4f87074faa9b9a06a7b482ffb9a0d7312303d))
-* doc: USERMANUAL.md spelling grammar punctuation ([#294](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/294)) ([6a402c8](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/6a402c87322bac3daedadf7bc359c2875f7b31c1))
+- doc: Split_Combine_Trainruns.md grammar ([#293](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/293)) ([ae64d44](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/ae64d446ca979db5b95601dbd414a3c9d6e6419f))
+- doc: STANDALONE.md grammar ([#292](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/292)) ([22f4f87](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/22f4f87074faa9b9a06a7b482ffb9a0d7312303d))
+- doc: USERMANUAL.md spelling grammar punctuation ([#294](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/294)) ([6a402c8](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/6a402c87322bac3daedadf7bc359c2875f7b31c1))
 
 ## [2.7.14](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/netzgrafik-frontend-v2.7.13...netzgrafik-frontend-v2.7.14) (2024-09-16)
 
-
 ### Bug Fixes
 
-* doc: DATA_MODEL_JSON.md, spelling ([#276](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/276)) ([f504f0d](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/f504f0d40a4269fb4ab5a47ce6797e43c1564d32))
-* doc: Graphic_Timetable.md, spelling, grammar ([#277](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/277)) ([853b80f](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/853b80fa30b4e2119a919787f2b22bd4f4ac2600))
+- doc: DATA_MODEL_JSON.md, spelling ([#276](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/276)) ([f504f0d](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/f504f0d40a4269fb4ab5a47ce6797e43c1564d32))
+- doc: Graphic_Timetable.md, spelling, grammar ([#277](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/277)) ([853b80f](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/853b80fa30b4e2119a919787f2b22bd4f4ac2600))
 
 ## [2.7.13](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/netzgrafik-frontend-v2.7.12...netzgrafik-frontend-v2.7.13) (2024-08-29)
 
-
 ### Bug Fixes
 
-* Bug archived read only mode variants are editable even tho not persisted ([#257](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/257)) ([9472a89](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/9472a89c445e3473877e7fe80add5f5e3cc37863))
+- Bug archived read only mode variants are editable even tho not persisted ([#257](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/257)) ([9472a89](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/9472a89c445e3473877e7fe80add5f5e3cc37863))
 
 ## [2.7.12](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/netzgrafik-frontend-v2.7.11...netzgrafik-frontend-v2.7.12) (2024-08-29)
 
-
 ### Bug Fixes
 
-* Technical improvement: replace hard-coded styles with CSS class for sbb-icon-sidebar-container. This improves maintainability and reusability of styles. ([#273](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/273)) ([b505d03](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/b505d03f4296809fe5e53c7ad216ca006bb234cc))
+- Technical improvement: replace hard-coded styles with CSS class for sbb-icon-sidebar-container. This improves maintainability and reusability of styles. ([#273](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/273)) ([b505d03](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/b505d03f4296809fe5e53c7ad216ca006bb234cc))
 
 ## [2.7.11](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/netzgrafik-frontend-v2.7.10...netzgrafik-frontend-v2.7.11) (2024-08-28)
 
-
 ### Bug Fixes
 
-* doc: CREATE_TRAINRUN.md, spelling, grammar ([#267](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/267)) ([a9e1747](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/a9e1747f7b9dcdb4c5cee2a3e52be7426b526ad4))
+- doc: CREATE_TRAINRUN.md, spelling, grammar ([#267](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/267)) ([a9e1747](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/a9e1747f7b9dcdb4c5cee2a3e52be7426b526ad4))
 
 ## [2.7.10](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/netzgrafik-frontend-v2.7.9...netzgrafik-frontend-v2.7.10) (2024-08-26)
 
-
 ### Bug Fixes
 
-* Update de.json, en.jason, spelling ([#259](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/259)) ([a166d83](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/a166d83a4689864410715949da01df04524e3d26))
+- Update de.json, en.jason, spelling ([#259](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/259)) ([a166d83](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/a166d83a4689864410715949da01df04524e3d26))
 
 ## [2.7.9](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/netzgrafik-frontend-v2.7.8...netzgrafik-frontend-v2.7.9) (2024-08-26)
 
-
 ### Bug Fixes
 
-* doc: CREATE_NODES.md, spelling ([#264](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/264)) ([30cf1d7](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/30cf1d73dda29cb153fd04354c2ec1bb912b1758))
+- doc: CREATE_NODES.md, spelling ([#264](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/264)) ([30cf1d7](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/30cf1d73dda29cb153fd04354c2ec1bb912b1758))
 
 ## [2.7.8](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/netzgrafik-frontend-v2.7.7...netzgrafik-frontend-v2.7.8) (2024-08-24)
 
-
 ### Bug Fixes
 
-* doc: Update CREATE_FILTERS.md, spelling ([#258](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/258)) ([e0eb559](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/e0eb5592b3e0a9cd25f74ffacfe411b4f73d1369))
+- doc: Update CREATE_FILTERS.md, spelling ([#258](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/258)) ([e0eb559](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/e0eb5592b3e0a9cd25f74ffacfe411b4f73d1369))
 
 ## [2.7.7](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/netzgrafik-frontend-v2.7.6...netzgrafik-frontend-v2.7.7) (2024-08-20)
 
 ### Bug Fixes
-* Long email addresses cause incorrect formatting of the left sidebar change history ([#243](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/243)) ([dd0fda5](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/dd0fda51f8ada14e340ae6e821e153aeac42ad7a))
-* Viewport Not Centering on Bounding Box When Reloading/Opening Netzgrafik ([#244](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/244)) ([9e5e2fd](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/9e5e2fdf85ff2c8eec9a568c2af656744f0d69af))
-* Translation is not working for variant when archived ([#249](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/249)) ([e313580](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/e3135804cf93a47a35162ab82554507d9e8b3403))
-* The menubar has a visual "thick" separator in between variant/project name and the filter symbol ([#252](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/252)) ([3496d0a](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/3496d0a2dcb7b960d14c49e15abcfd2034f65d99))
+
+- Long email addresses cause incorrect formatting of the left sidebar change history ([#243](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/243)) ([dd0fda5](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/dd0fda51f8ada14e340ae6e821e153aeac42ad7a))
+- Viewport Not Centering on Bounding Box When Reloading/Opening Netzgrafik ([#244](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/244)) ([9e5e2fd](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/9e5e2fdf85ff2c8eec9a568c2af656744f0d69af))
+- Translation is not working for variant when archived ([#249](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/249)) ([e313580](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/e3135804cf93a47a35162ab82554507d9e8b3403))
+- The menubar has a visual "thick" separator in between variant/project name and the filter symbol ([#252](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/252)) ([3496d0a](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/3496d0a2dcb7b960d14c49e15abcfd2034f65d99))
 
 ## [2.7.6](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/netzgrafik-frontend-v2.7.5...netzgrafik-frontend-v2.7.6) (2024-08-19)
 
-
 ### Bug Fixes
 
-* use change event instead of keyup for node name change ([#248](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/248)) ([1e1177b](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/1e1177b3f382f10e36deb8f9080b6c58522a43bc))
+- use change event instead of keyup for node name change ([#248](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/248)) ([1e1177b](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/1e1177b3f382f10e36deb8f9080b6c58522a43bc))
 
 ## [2.7.5](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/netzgrafik-frontend-v2.7.4...netzgrafik-frontend-v2.7.5) (2024-08-08)
 
-
 ### Features
 
-* add AppComponent inputs/outputs ([#166](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/166)) ([9d2c6ee](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/9d2c6eee74f94912b68ec8b3375dc53e21a5ecdc))
-* introduce standalone mode ([#162](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/162)) ([cc4c56b](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/cc4c56b25aa2d978ebd70fbf34dc129f36b776b2))
-* **pr-template:** add pull request template ([89b4d61](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/89b4d61954382c45ffd20ac54137d1faf2f0c5f9))
-* publish package on NPM ([#172](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/172)) ([1692d55](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/1692d5561f8e1fd8b00a60b673b7567d81d83aef))
-
+- add AppComponent inputs/outputs ([#166](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/166)) ([9d2c6ee](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/9d2c6eee74f94912b68ec8b3375dc53e21a5ecdc))
+- introduce standalone mode ([#162](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/162)) ([cc4c56b](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/cc4c56b25aa2d978ebd70fbf34dc129f36b776b2))
+- **pr-template:** add pull request template ([89b4d61](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/89b4d61954382c45ffd20ac54137d1faf2f0c5f9))
+- publish package on NPM ([#172](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/172)) ([1692d55](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/1692d5561f8e1fd8b00a60b673b7567d81d83aef))
 
 ### Bug Fixes
 
-* align theme color picker with buttons ([#198](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/198)) ([e3a8798](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/e3a87989ea28a04a4a0bb9cee825825bb1b97d7b))
-* disable environment header in standalone mode ([#230](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/230)) ([e25887e](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/e25887eb11ab36ce84756e92344bc63cdeb9b1a4))
-* disable links section in node sidebar ([2554094](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/255409410aa2552dfc1155bf89e7afce78dc17bc))
-* disable notes in filter sidebar in standalone mode ([#211](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/211)) ([df335ef](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/df335ef9aede8c47064655f3dbcc5723c2a89f1a))
-* enable output hashing by default ([#174](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/174)) ([8ac67b8](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/8ac67b807db1e0fc418d4bacddabfabcb80620f4))
-* issue I. + typo ([#72](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/72)) ([deb7cd1](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/deb7cd1514a320ca14d53bdd26cdbdeff6005c79))
-* use light theme for sbb-esta ([#176](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/176)) ([89aaae0](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/89aaae004170b59649b0856f14de1d31e86a6e18))
-
+- align theme color picker with buttons ([#198](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/198)) ([e3a8798](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/e3a87989ea28a04a4a0bb9cee825825bb1b97d7b))
+- disable environment header in standalone mode ([#230](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/230)) ([e25887e](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/e25887eb11ab36ce84756e92344bc63cdeb9b1a4))
+- disable links section in node sidebar ([2554094](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/255409410aa2552dfc1155bf89e7afce78dc17bc))
+- disable notes in filter sidebar in standalone mode ([#211](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/211)) ([df335ef](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/df335ef9aede8c47064655f3dbcc5723c2a89f1a))
+- enable output hashing by default ([#174](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/174)) ([8ac67b8](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/8ac67b807db1e0fc418d4bacddabfabcb80620f4))
+- issue I. + typo ([#72](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/72)) ([deb7cd1](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/deb7cd1514a320ca14d53bdd26cdbdeff6005c79))
+- use light theme for sbb-esta ([#176](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/176)) ([89aaae0](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/89aaae004170b59649b0856f14de1d31e86a6e18))
 
 ### Miscellaneous Chores
 
-* release 2.5.0 ([00e6836](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/00e68365b1401d0af211cf6f9cd3184ed61fa102))
-* release 2.7.3 ([f06b8ff](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/f06b8ff117a30c4ed0a2084c6a75dfd4e72d254b))
-* release 2.7.3 ([484e008](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/484e0081b69b59c0f41857bab66ac8b024d95e86))
-* release 2.7.5 ([f69edec](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/f69edecca48480cd1f4483cd8d9b655ef7cfd512))
+- release 2.5.0 ([00e6836](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/00e68365b1401d0af211cf6f9cd3184ed61fa102))
+- release 2.7.3 ([f06b8ff](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/f06b8ff117a30c4ed0a2084c6a75dfd4e72d254b))
+- release 2.7.3 ([484e008](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/484e0081b69b59c0f41857bab66ac8b024d95e86))
+- release 2.7.5 ([f69edec](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/f69edecca48480cd1f4483cd8d9b655ef7cfd512))
 
 ## [2.7.4](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/v2.7.3...v2.7.4) (2024-08-08)
 
-
 ### Bug Fixes
 
-* disable environment header in standalone mode ([#230](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/230)) ([e25887e](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/e25887eb11ab36ce84756e92344bc63cdeb9b1a4))
+- disable environment header in standalone mode ([#230](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/230)) ([e25887e](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/e25887eb11ab36ce84756e92344bc63cdeb9b1a4))
 
 ## [2.7.3](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/v2.7.2...v2.7.3) (2024-08-06)
 
-
 ### Features
 
-* add AppComponent inputs/outputs ([#166](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/166)) ([9d2c6ee](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/9d2c6eee74f94912b68ec8b3375dc53e21a5ecdc))
-* introduce standalone mode ([#162](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/162)) ([cc4c56b](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/cc4c56b25aa2d978ebd70fbf34dc129f36b776b2))
-* **pr-template:** add pull request template ([89b4d61](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/89b4d61954382c45ffd20ac54137d1faf2f0c5f9))
-* publish package on NPM ([#172](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/172)) ([1692d55](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/1692d5561f8e1fd8b00a60b673b7567d81d83aef))
-
+- add AppComponent inputs/outputs ([#166](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/166)) ([9d2c6ee](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/9d2c6eee74f94912b68ec8b3375dc53e21a5ecdc))
+- introduce standalone mode ([#162](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/162)) ([cc4c56b](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/cc4c56b25aa2d978ebd70fbf34dc129f36b776b2))
+- **pr-template:** add pull request template ([89b4d61](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/89b4d61954382c45ffd20ac54137d1faf2f0c5f9))
+- publish package on NPM ([#172](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/172)) ([1692d55](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/1692d5561f8e1fd8b00a60b673b7567d81d83aef))
 
 ### Bug Fixes
 
-* align theme color picker with buttons ([#198](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/198)) ([e3a8798](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/e3a87989ea28a04a4a0bb9cee825825bb1b97d7b))
-* disable links section in node sidebar ([2554094](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/255409410aa2552dfc1155bf89e7afce78dc17bc))
-* disable notes in filter sidebar in standalone mode ([#211](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/211)) ([df335ef](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/df335ef9aede8c47064655f3dbcc5723c2a89f1a))
-* enable output hashing by default ([#174](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/174)) ([8ac67b8](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/8ac67b807db1e0fc418d4bacddabfabcb80620f4))
-* issue I. + typo ([#72](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/72)) ([deb7cd1](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/deb7cd1514a320ca14d53bdd26cdbdeff6005c79))
-* use light theme for sbb-esta ([#176](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/176)) ([89aaae0](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/89aaae004170b59649b0856f14de1d31e86a6e18))
-
+- align theme color picker with buttons ([#198](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/198)) ([e3a8798](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/e3a87989ea28a04a4a0bb9cee825825bb1b97d7b))
+- disable links section in node sidebar ([2554094](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/255409410aa2552dfc1155bf89e7afce78dc17bc))
+- disable notes in filter sidebar in standalone mode ([#211](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/211)) ([df335ef](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/df335ef9aede8c47064655f3dbcc5723c2a89f1a))
+- enable output hashing by default ([#174](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/174)) ([8ac67b8](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/8ac67b807db1e0fc418d4bacddabfabcb80620f4))
+- issue I. + typo ([#72](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/72)) ([deb7cd1](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/deb7cd1514a320ca14d53bdd26cdbdeff6005c79))
+- use light theme for sbb-esta ([#176](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/176)) ([89aaae0](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/89aaae004170b59649b0856f14de1d31e86a6e18))
 
 ### Miscellaneous Chores
 
-* release 2.5.0 ([00e6836](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/00e68365b1401d0af211cf6f9cd3184ed61fa102))
-* release 2.7.3 ([f06b8ff](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/f06b8ff117a30c4ed0a2084c6a75dfd4e72d254b))
-* release 2.7.3 ([484e008](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/484e0081b69b59c0f41857bab66ac8b024d95e86))
+- release 2.5.0 ([00e6836](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/00e68365b1401d0af211cf6f9cd3184ed61fa102))
+- release 2.7.3 ([f06b8ff](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/f06b8ff117a30c4ed0a2084c6a75dfd4e72d254b))
+- release 2.7.3 ([484e008](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/484e0081b69b59c0f41857bab66ac8b024d95e86))
 
 ## [2.7.2](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/netzgrafik-frontend-v2.7.2...netzgrafik-frontend-v2.7.2) (2024-08-06)
 
-
 ### Bug Fixes
 
-* disable notes in filter sidebar in standalone mode ([#211](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/211)) ([df335ef](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/df335ef9aede8c47064655f3dbcc5723c2a89f1a))
+- disable notes in filter sidebar in standalone mode ([#211](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/211)) ([df335ef](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/df335ef9aede8c47064655f3dbcc5723c2a89f1a))
 
 ## [2.7.2](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/netzgrafik-frontend-v2.7.2...netzgrafik-frontend-v2.7.2) (2024-08-06)
 
-
 ### Bug Fixes
 
-* disable notes in filter sidebar in standalone mode ([#211](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/211)) ([df335ef](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/df335ef9aede8c47064655f3dbcc5723c2a89f1a))
+- disable notes in filter sidebar in standalone mode ([#211](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/211)) ([df335ef](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/df335ef9aede8c47064655f3dbcc5723c2a89f1a))
 
 ## 2.7.2 (2024-08-06)
 
-
 ### Features
 
-* add AppComponent inputs/outputs ([#166](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/166)) ([9d2c6ee](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/9d2c6eee74f94912b68ec8b3375dc53e21a5ecdc))
-* introduce standalone mode ([#162](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/162)) ([cc4c56b](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/cc4c56b25aa2d978ebd70fbf34dc129f36b776b2))
-* **pr-template:** add pull request template ([89b4d61](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/89b4d61954382c45ffd20ac54137d1faf2f0c5f9))
-* publish package on NPM ([#172](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/172)) ([1692d55](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/1692d5561f8e1fd8b00a60b673b7567d81d83aef))
-
+- add AppComponent inputs/outputs ([#166](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/166)) ([9d2c6ee](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/9d2c6eee74f94912b68ec8b3375dc53e21a5ecdc))
+- introduce standalone mode ([#162](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/162)) ([cc4c56b](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/cc4c56b25aa2d978ebd70fbf34dc129f36b776b2))
+- **pr-template:** add pull request template ([89b4d61](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/89b4d61954382c45ffd20ac54137d1faf2f0c5f9))
+- publish package on NPM ([#172](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/172)) ([1692d55](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/1692d5561f8e1fd8b00a60b673b7567d81d83aef))
 
 ### Bug Fixes
 
-* align theme color picker with buttons ([#198](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/198)) ([e3a8798](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/e3a87989ea28a04a4a0bb9cee825825bb1b97d7b))
-* enable output hashing by default ([#174](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/174)) ([8ac67b8](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/8ac67b807db1e0fc418d4bacddabfabcb80620f4))
-* issue I. + typo ([#72](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/72)) ([deb7cd1](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/deb7cd1514a320ca14d53bdd26cdbdeff6005c79))
-* use light theme for sbb-esta ([#176](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/176)) ([89aaae0](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/89aaae004170b59649b0856f14de1d31e86a6e18))
-
+- align theme color picker with buttons ([#198](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/198)) ([e3a8798](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/e3a87989ea28a04a4a0bb9cee825825bb1b97d7b))
+- enable output hashing by default ([#174](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/174)) ([8ac67b8](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/8ac67b807db1e0fc418d4bacddabfabcb80620f4))
+- issue I. + typo ([#72](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/72)) ([deb7cd1](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/deb7cd1514a320ca14d53bdd26cdbdeff6005c79))
+- use light theme for sbb-esta ([#176](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/176)) ([89aaae0](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/89aaae004170b59649b0856f14de1d31e86a6e18))
 
 ### Miscellaneous Chores
 
-* release 2.5.0 ([00e6836](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/00e68365b1401d0af211cf6f9cd3184ed61fa102))
+- release 2.5.0 ([00e6836](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/00e68365b1401d0af211cf6f9cd3184ed61fa102))
 
 ## 2.7.1 Manually edited version number (preparation automatic release building)
 
-
 ### Bug Fixes
 
-* align theme color picker with buttons ([#198](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/198)) ([e3a8798](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/e3a87989ea28a04a4a0bb9cee825825bb1b97d7b))
+- align theme color picker with buttons ([#198](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/198)) ([e3a8798](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/e3a87989ea28a04a4a0bb9cee825825bb1b97d7b))
 
 ## [2.6.0](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/v2.5.0...v2.6.0) (2024-07-22)
 
-
 ### Features
 
-* add AppComponent inputs/outputs ([#166](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/166)) ([9d2c6ee](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/9d2c6eee74f94912b68ec8b3375dc53e21a5ecdc))
-* introduce standalone mode ([#162](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/162)) ([cc4c56b](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/cc4c56b25aa2d978ebd70fbf34dc129f36b776b2))
-* publish package on NPM ([#172](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/172)) ([1692d55](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/1692d5561f8e1fd8b00a60b673b7567d81d83aef))
-
+- add AppComponent inputs/outputs ([#166](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/166)) ([9d2c6ee](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/9d2c6eee74f94912b68ec8b3375dc53e21a5ecdc))
+- introduce standalone mode ([#162](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/162)) ([cc4c56b](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/cc4c56b25aa2d978ebd70fbf34dc129f36b776b2))
+- publish package on NPM ([#172](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/172)) ([1692d55](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/1692d5561f8e1fd8b00a60b673b7567d81d83aef))
 
 ### Bug Fixes
 
-* enable output hashing by default ([#174](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/174)) ([8ac67b8](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/8ac67b807db1e0fc418d4bacddabfabcb80620f4))
-* use light theme for sbb-esta ([#176](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/176)) ([89aaae0](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/89aaae004170b59649b0856f14de1d31e86a6e18))
+- enable output hashing by default ([#174](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/174)) ([8ac67b8](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/8ac67b807db1e0fc418d4bacddabfabcb80620f4))
+- use light theme for sbb-esta ([#176](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/176)) ([89aaae0](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/89aaae004170b59649b0856f14de1d31e86a6e18))
 
 ## [2.5.0](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/v2.5.0...v2.5.0) (2024-04-22)
 
-
 ### Features
 
-* **pr-template:** add pull request template ([89b4d61](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/89b4d61954382c45ffd20ac54137d1faf2f0c5f9))
-
+- **pr-template:** add pull request template ([89b4d61](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/89b4d61954382c45ffd20ac54137d1faf2f0c5f9))
 
 ### Bug Fixes
 
-* issue I. + typo ([#72](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/72)) ([deb7cd1](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/deb7cd1514a320ca14d53bdd26cdbdeff6005c79))
-
+- issue I. + typo ([#72](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/72)) ([deb7cd1](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/deb7cd1514a320ca14d53bdd26cdbdeff6005c79))
 
 ### Miscellaneous Chores
 
-* release 2.5.0 ([00e6836](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/00e68365b1401d0af211cf6f9cd3184ed61fa102))
+- release 2.5.0 ([00e6836](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/00e68365b1401d0af211cf6f9cd3184ed61fa102))
 
 ## [2.5.0](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/v2.5.0...v2.5.0) (2024-04-22)
 
-
 ### Features
 
-* **pr-template:** add pull request template ([89b4d61](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/89b4d61954382c45ffd20ac54137d1faf2f0c5f9))
-
+- **pr-template:** add pull request template ([89b4d61](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/89b4d61954382c45ffd20ac54137d1faf2f0c5f9))
 
 ### Bug Fixes
 
-* issue I. + typo ([#72](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/72)) ([deb7cd1](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/deb7cd1514a320ca14d53bdd26cdbdeff6005c79))
-
+- issue I. + typo ([#72](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/72)) ([deb7cd1](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/deb7cd1514a320ca14d53bdd26cdbdeff6005c79))
 
 ### Miscellaneous Chores
 
-* release 2.5.0 ([00e6836](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/00e68365b1401d0af211cf6f9cd3184ed61fa102))
+- release 2.5.0 ([00e6836](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/00e68365b1401d0af211cf6f9cd3184ed61fa102))
 
 ## [2.5.0](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/compare/v2.4.0...v2.5.0) (2024-04-15)
 
-
 ### Features
 
-* **pr-template:** add pull request template ([89b4d61](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/89b4d61954382c45ffd20ac54137d1faf2f0c5f9))
-
+- **pr-template:** add pull request template ([89b4d61](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/89b4d61954382c45ffd20ac54137d1faf2f0c5f9))
 
 ### Bug Fixes
 
-* issue I. + typo ([#72](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/72)) ([deb7cd1](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/deb7cd1514a320ca14d53bdd26cdbdeff6005c79))
+- issue I. + typo ([#72](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/72)) ([deb7cd1](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/commit/deb7cd1514a320ca14d53bdd26cdbdeff6005c79))

--- a/CI.md
+++ b/CI.md
@@ -8,12 +8,11 @@ It maintains [Release PRs](https://github.com/googleapis/release-please?tab=read
 We use [Manifest Driven release-please](https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md).
 It uses source-controlled files containing
 
-* releaser specific configuration ([release-please-config.json](release-please-config.json))
-* package version tracking ([.release-please-manifest.json](.release-please-manifest.json)).
+- releaser specific configuration ([release-please-config.json](release-please-config.json))
+- package version tracking ([.release-please-manifest.json](.release-please-manifest.json)).
 
 See [release-please CLI documentation](https://github.com/googleapis/release-please/blob/main/docs/cli.md) for more details.
 
 ### FAQ
 
-* [How do I change the version number?](https://github.com/googleapis/release-please?tab=readme-ov-file#how-do-i-change-the-version-number)
-
+- [How do I change the version number?](https://github.com/googleapis/release-please?tab=readme-ov-file#how-do-i-change-the-version-number)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -17,23 +17,23 @@ diverse, inclusive, and healthy community.
 Examples of behavior that contributes to a positive environment for our
 community include:
 
-* Demonstrating empathy and kindness toward other people
-* Being respectful of differing opinions, viewpoints, and experiences
-* Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes,
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
   and learning from the experience
-* Focusing on what is best not just for us as individuals, but for the overall
+- Focusing on what is best not just for us as individuals, but for the overall
   community
 
 Examples of unacceptable behavior include:
 
-* The use of sexualized language or imagery, and sexual attention or advances of
+- The use of sexualized language or imagery, and sexual attention or advances of
   any kind
-* Trolling, insulting or derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or email address,
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
   without their explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
+- Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
 ## Enforcement Responsibilities

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-We appreciate all kinds of contributions. The following is a set of guidelines for contributing to this repository on GitHub. 
+We appreciate all kinds of contributions. The following is a set of guidelines for contributing to this repository on GitHub.
 These are mostly guidelines, not rules. Use your best judgment, and feel free to propose changes to this document in a pull request.
 
 By submitting a contribution to this repository you agree that you do this under the [license](LICENSE) of the repository and certify that you have all the rights to do so.
@@ -12,29 +12,33 @@ By submitting a contribution to this repository you agree that you do this under
 [I just have a question!](#i-just-have-a-question)
 
 [What should I know before I get started?](#what-should-i-know-before-i-get-started)
-* [Tools and Packages](#tools-and-packages)
-* [Design Decisions](#design-decisions)
+
+- [Tools and Packages](#tools-and-packages)
+- [Design Decisions](#design-decisions)
 
 [How Can I Contribute?](#how-can-i-contribute)
-* [Issues and Bugs](#issue)
-* [Feature Requests](#feature)
-* [Pull Requests Guidelines](#submit-pr)
-* [Your First Code Contribution](#your-first-code-contribution)
-* [Coding Rules](#rules)
-* [Commit Message Guidelines](#commit)
+
+- [Issues and Bugs](#issue)
+- [Feature Requests](#feature)
+- [Pull Requests Guidelines](#submit-pr)
+- [Your First Code Contribution](#your-first-code-contribution)
+- [Coding Rules](#rules)
+- [Commit Message Guidelines](#commit)
 
 <a id="code-of-conduct"></a>
+
 ## Code of Conduct
 
-This project and everyone participating in it is governed by the [Code of Conduct](CODE_OF_CONDUCT.md). 
+This project and everyone participating in it is governed by the [Code of Conduct](CODE_OF_CONDUCT.md).
 By participating, you are expected to uphold this code.
 
 <a id="i-just-have-a-question"></a>
+
 ## I just have a question!
 
 Please ask the questions in the discussions page.
 
-* [Github Discussions, the official message board](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/discussions)
+- [Github Discussions, the official message board](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/discussions)
 
 ## <a id="what-should-i-know-before-i-get-started"></a> What should I know before I get started?
 
@@ -58,19 +62,18 @@ diagnose the problem. Screenshots are also helpful.
 
 You can help the team even more and [submit a Pull Request](#submit-pr) with a fix.
 
-
 ## <a id="feature"></a> Want a Feature?
 
-You can *request* a new feature by [submitting an issue](#submit-issue)
+You can _request_ a new feature by [submitting an issue](#submit-issue)
 to our [GitHub Repository](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/new).
-If you would like to *implement* a new feature, please submit an issue with
+If you would like to _implement_ a new feature, please submit an issue with
 a proposal for your work first, to be sure that we can use it.
 Please consider what kind of change it is:
 
-* For a **Major Feature**, first open an issue and outline your proposal so that it can be
+- For a **Major Feature**, first open an issue and outline your proposal so that it can be
   discussed. This will also allow us to better coordinate our efforts, prevent duplication of work,
   and help you to craft the change so that it is successfully accepted into the project.
-* **Small Features** can be crafted and directly [submitted as a Pull Request](#submit-pr).
+- **Small Features** can be crafted and directly [submitted as a Pull Request](#submit-pr).
 
 ### <a id="submit-issue"></a> Submitting an Issue
 
@@ -78,16 +81,16 @@ If your issue appears to be a bug, and hasn't been reported, open a new issue.
 Providing the following information will increase the
 chances of your issue being dealt with quickly:
 
-* **Overview of the Issue** - if an error is being thrown a non-minified stack trace helps
-* **Toolchain and Environment Details** - which versions of libraries, toolchain, platform etc 
-* **Motivation for or Use Case** - explain what are you trying to do and why the current behavior
+- **Overview of the Issue** - if an error is being thrown a non-minified stack trace helps
+- **Toolchain and Environment Details** - which versions of libraries, toolchain, platform etc
+- **Motivation for or Use Case** - explain what are you trying to do and why the current behavior
   is a bug for you
-* **Browsers and Operating System** - is this a problem with all browsers?
-* **Reproduce the Error** - provide a live example (using StackBlitz or similar) or a unambiguous set of steps
-* **Screenshots** - myybe screenshots can help the team
+- **Browsers and Operating System** - is this a problem with all browsers?
+- **Reproduce the Error** - provide a live example (using StackBlitz or similar) or a unambiguous set of steps
+- **Screenshots** - myybe screenshots can help the team
   triage issues far more quickly than a text description.
-* **Related Issues** - has a similar issue been reported before?
-* **Suggest a Fix** - if you can't fix the bug yourself, perhaps you can point to what might be
+- **Related Issues** - has a similar issue been reported before?
+- **Suggest a Fix** - if you can't fix the bug yourself, perhaps you can point to what might be
   causing the problem (line of code or commit)
 
 You can file new issues by providing the above information [here](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/new).
@@ -96,45 +99,47 @@ You can file new issues by providing the above information [here](https://github
 
 Before you submit your Pull Request (PR) consider the following guidelines:
 
-* Make your changes in a new git branch:
+- Make your changes in a new git branch:
 
-     ```shell
-     git checkout -b my-fix-branch main
-     ```
+  ```shell
+  git checkout -b my-fix-branch main
+  ```
 
-* Create your patch, **including appropriate test cases**.
-* Follow our [Coding Rules](#rules).
-* Test your changes with our supported browsers and screen readers.
-* Run tests and ensure that all tests pass.
-* Commit your changes using a descriptive commit message that follows our
+- Create your patch, **including appropriate test cases**.
+- Follow our [Coding Rules](#rules).
+- Test your changes with our supported browsers and screen readers.
+- Run tests and ensure that all tests pass.
+- Commit your changes using a descriptive commit message that follows our
   [commit message conventions](#commit). Adherence to these conventions
   is necessary because release notes are automatically generated from these messages.
 
   ```shell
   git commit -a
   ```
+
   Note: the optional commit `-a` command line option will automatically "add" and "rm" edited files.
-* Push your branch to GitHub:
+
+- Push your branch to GitHub:
 
   ```shell
   git push my-fork my-fix-branch
   ```
 
-* In GitHub, send a pull request to `sbb-your-project:main`.
+- In GitHub, send a pull request to `sbb-your-project:main`.
   The PR title and message should as well conform to the [commit message conventions](#commit).
 
 ## <a id="rules"></a> Coding Rules
 
 To ensure consistency throughout the source code, keep these rules in mind as you are working:
 
-* All features or bug fixes **must be tested** by one or more specs (unit-tests).
-* All public API methods **must be documented**.
-* Also see [CODING_STANDARDS](./CODING_STANDARDS.md)
+- All features or bug fixes **must be tested** by one or more specs (unit-tests).
+- All public API methods **must be documented**.
+- Also see [CODING_STANDARDS](./CODING_STANDARDS.md)
 
 ## <a id="commit"></a> Commit Message Guidelines
 
 This project uses [Conventional Commits](https://www.conventionalcommits.org/) to generate the changelog.
-As an example, please refer to: https://github.com/sbb-design-systems/sbb-angular 
+As an example, please refer to: https://github.com/sbb-design-systems/sbb-angular
 
 <a id="your-first-code-contribution"></a>
 
@@ -144,18 +149,18 @@ The project is using [Release please](https://github.com/googleapis/release-plea
 
 The most important prefixes you should have in mind are:
 
-* `fix:` which represents bug fixes, and correlates to a [SemVer](https://semver.org/)
+- `fix:` which represents bug fixes, and correlates to a [SemVer](https://semver.org/)
   patch.
-* `feat:` which represents a new feature, and correlates to a SemVer minor.
-* `feat!:`,  or `fix!:`, `refactor!:`, etc., which represent a breaking change
+- `feat:` which represents a new feature, and correlates to a SemVer minor.
+- `feat!:`, or `fix!:`, `refactor!:`, etc., which represent a breaking change
   (indicated by the `!`) and will result in a SemVer major.
-  
+
 ## Your First Code Contribution
 
 Unsure where to begin contributing to Atom? You can start by looking through these `beginner` and `help-wanted` issues:
 
-* [Beginner issues][beginner] - issues which should only require a few lines of code, and a test or two.
-* [Help wanted issues][help-wanted] - issues which should be a bit more involved than `beginner` issues.
+- [Beginner issues][beginner] - issues which should only require a few lines of code, and a test or two.
+- [Help wanted issues][help-wanted] - issues which should be a bit more involved than `beginner` issues.
 
 ## Attribution
 

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -43,14 +43,14 @@ gantt
         Martin Sojka - Railway Network Developer --- From ideation to product   :  2020-04-01, 2024-02-01
         Corelia Reichen - Railway Network Developer                             :, 2020-04-01, 2023-04-01
         Christian Baumberger - Software development                             :, 2020-04-01, 2022-11-01
-    
-    section Ideation 
+
+    section Ideation
         Erik Nygren                                :done, 2020-02-15, 2022-03-01
         Christian Eichenberger                     :done, 2020-02-15, 2020-05-01
-    
-    section UX 
+
+    section UX
         Tim Schoch - UX Design & Concept           :, 2020-04-01, 2020-12-01
-        Sibylle Trenck                             :done, 2020-03-01, 2020-06-01 
+        Sibylle Trenck                             :done, 2020-03-01, 2020-06-01
 
     section Software Developer
         Samuel Ueltschi                            :done, 2021-08-01, 2021-11-01
@@ -62,12 +62,12 @@ gantt
 
     section UX (Usability Test)
         Dina Dändliker                             :done, 2022-10-01, 2023-01-01
-        Simona Manetsch                            :done, 2022-10-01, 2023-01-01  
-    
+        Simona Manetsch                            :done, 2022-10-01, 2023-01-01
+
     section OpenSource
         Mahalia Stephan                            :done, 2023-06-01, 2024-02-01
         Peter Keller                               :done, 2023-06-01, 2024-02-01
-        
+
     section Milesstone
         Open Source                                :milestone, 2024-04-10, 2024-04-10
         2.0.0                                      :milestone, 2023-12-20, 2023-12-20

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -38,4 +38,5 @@ Information disclosed in connection with any Project activity, including but not
 Amendments to this governance policy may be made by affirmative vote of 2/3 of all Maintainers, with approval by the Technical Committee.
 
 ---
+
 Based on [GitHub's Minimum Viable Governance (MVG)](https://github.com/github/MVG). Licensed under the [CC-BY 4.0 License](https://creativecommons.org/licenses/by/4.0/).

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,10 +2,11 @@
 
 This document lists the Maintainers of the Project. Maintainers may be added once approved by the existing maintainers as described in the [Governance document](./GOVERNANCE.md). By adding your name to this list you are agreeing to abide by the Project governance documents and to abide by all of the Organization's policies, including the [code of conduct](./CODE_OF_CONDUCT.md). If you are participating because of your affiliation with another organization (designated below), you represent that you have the authority to bind that organization to these policies.
 
-| **NAME** | **Organization** |
-| -------- | ---------------- |
-| Martin Sojka | SBB AG |
-| Adrian Egli | SBB AG |
+| **NAME**     | **Organization** |
+| ------------ | ---------------- |
+| Martin Sojka | SBB AG           |
+| Adrian Egli  | SBB AG           |
 
 ---
+
 Based on [GitHub's Minimum Viable Governance (MVG)](https://github.com/github/MVG). Licensed under the [CC-BY 4.0 License](https://creativecommons.org/licenses/by/4.0/).

--- a/README.md
+++ b/README.md
@@ -216,9 +216,29 @@ echo "use flake" >> .envrc && direnv allow
 
 See [official direnv documentation](https://direnv.net/) for more information.
 
+### Linting
+
+```sh
+# to fix the eventual lint issues
+npm run lint
+
+# to check that the code is correctly linted
+npm run lint:fix
+```
+
+### Formatting
+
+```sh
+# to check that the code is correctly formatted
+npm run format:check
+
+# to format the code according to Prettier rules
+npm run format
+```
+
 ### Testing
 
-```
+```sh
 # just run the test once
 npm run test
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,7 +10,7 @@ and outlines more general ideas.
 
 - Origin-Destination-Matrix: Travel time matrix for different routes / visualisation & analytics. (https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/126)
 - Check conformity of business rules
-- Comparision of variants 
+- Comparision of variants
 - Merge different variants: [more Info](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/documentation/Merge_Netzgrafik.md).
 
 ### Long-term goals on the roadmap:

--- a/angular.json
+++ b/angular.json
@@ -22,10 +22,7 @@
             "main": "src/main.ts",
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.app.json",
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
+            "assets": ["src/favicon.ico", "src/assets"],
             "styles": [
               "src/styles.scss",
               "node_modules/@sbb-esta/angular/typography.css"
@@ -38,10 +35,7 @@
             "sourceMap": true,
             "optimization": false,
             "namedChunks": true,
-            "allowedCommonJsDependencies": [
-              "papaparse",
-              "save-svg-as-png"
-            ]
+            "allowedCommonJsDependencies": ["papaparse", "save-svg-as-png"]
           },
           "configurations": {
             "production": {
@@ -98,7 +92,7 @@
                   "with": "src/environments/environment.standalonedemo.ts"
                 }
               ]
-            },
+            }
           },
           "defaultConfiguration": ""
         },
@@ -141,10 +135,7 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.spec.json",
             "karmaConfig": "karma.conf.js",
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
+            "assets": ["src/favicon.ico", "src/assets"],
             "styles": [
               "src/styles.scss",
               "node_modules/@sbb-esta/angular/typography.css"
@@ -158,20 +149,14 @@
               "sourceMap": false,
               "progress": false,
               "watch": false,
-              "reporters": [
-                "dots",
-                "sonarqube"
-              ]
+              "reporters": ["dots", "sonarqube"]
             }
           }
         },
         "lint": {
           "builder": "@angular-eslint/builder:lint",
           "options": {
-            "lintFilePatterns": [
-              "src/**/*.ts",
-              "src/**/*.html"
-            ]
+            "lintFilePatterns": ["src/**/*.ts", "src/**/*.html"]
           }
         },
         "e2e": {

--- a/api-docs.json
+++ b/api-docs.json
@@ -18,9 +18,7 @@
   "paths": {
     "/v1/variants/{variantId}/unarchive": {
       "put": {
-        "tags": [
-          "variant-controller"
-        ],
+        "tags": ["variant-controller"],
         "operationId": "unarchiveVariant",
         "parameters": [
           {
@@ -41,9 +39,7 @@
     },
     "/v1/variants/{variantId}/snapshots/asNewest": {
       "put": {
-        "tags": [
-          "variant-controller"
-        ],
+        "tags": ["variant-controller"],
         "operationId": "raiseSnapshotsToNewestReleaseVersion",
         "parameters": [
           {
@@ -64,9 +60,7 @@
     },
     "/v1/variants/{variantId}/archive": {
       "put": {
-        "tags": [
-          "variant-controller"
-        ],
+        "tags": ["variant-controller"],
         "operationId": "archiveVariant",
         "parameters": [
           {
@@ -87,9 +81,7 @@
     },
     "/v1/projects/{id}": {
       "put": {
-        "tags": [
-          "project-controller"
-        ],
+        "tags": ["project-controller"],
         "operationId": "updateProject",
         "parameters": [
           {
@@ -120,9 +112,7 @@
     },
     "/v1/projects/{id}/unarchive": {
       "put": {
-        "tags": [
-          "project-controller"
-        ],
+        "tags": ["project-controller"],
         "operationId": "unarchiveProject",
         "parameters": [
           {
@@ -143,9 +133,7 @@
     },
     "/v1/projects/{id}/archive": {
       "put": {
-        "tags": [
-          "project-controller"
-        ],
+        "tags": ["project-controller"],
         "operationId": "archiveProject",
         "parameters": [
           {
@@ -166,9 +154,7 @@
     },
     "/v1/versions/{versionId}/variant/new": {
       "post": {
-        "tags": [
-          "variant-controller"
-        ],
+        "tags": ["variant-controller"],
         "operationId": "createVariantFromVersion",
         "parameters": [
           {
@@ -207,9 +193,7 @@
     },
     "/v1/versions/{versionId}/restore": {
       "post": {
-        "tags": [
-          "version-controller"
-        ],
+        "tags": ["version-controller"],
         "operationId": "restoreVersion",
         "parameters": [
           {
@@ -238,9 +222,7 @@
     },
     "/v1/versions/{snapshotVersionId}/release": {
       "post": {
-        "tags": [
-          "version-controller"
-        ],
+        "tags": ["version-controller"],
         "operationId": "createReleaseVersion",
         "parameters": [
           {
@@ -279,9 +261,7 @@
     },
     "/v1/versions/{baseVersionId}/snapshot": {
       "post": {
-        "tags": [
-          "version-controller"
-        ],
+        "tags": ["version-controller"],
         "operationId": "createSnapshotVersion",
         "parameters": [
           {
@@ -320,9 +300,7 @@
     },
     "/v1/projects": {
       "get": {
-        "tags": [
-          "project-controller"
-        ],
+        "tags": ["project-controller"],
         "operationId": "getAllProjects",
         "responses": {
           "200": {
@@ -341,9 +319,7 @@
         }
       },
       "post": {
-        "tags": [
-          "project-controller"
-        ],
+        "tags": ["project-controller"],
         "operationId": "createProject",
         "requestBody": {
           "content": {
@@ -372,9 +348,7 @@
     },
     "/v1/projects/{projectId}/variants": {
       "post": {
-        "tags": [
-          "variant-controller"
-        ],
+        "tags": ["variant-controller"],
         "operationId": "createVariant",
         "parameters": [
           {
@@ -413,9 +387,7 @@
     },
     "/v1/versions/{versionId}": {
       "get": {
-        "tags": [
-          "version-controller"
-        ],
+        "tags": ["version-controller"],
         "operationId": "getVersion",
         "parameters": [
           {
@@ -443,9 +415,7 @@
     },
     "/v1/versions/{versionId}/model": {
       "get": {
-        "tags": [
-          "version-controller"
-        ],
+        "tags": ["version-controller"],
         "operationId": "getVersionModel",
         "parameters": [
           {
@@ -473,9 +443,7 @@
     },
     "/v1/variants/{variantId}": {
       "get": {
-        "tags": [
-          "variant-controller"
-        ],
+        "tags": ["variant-controller"],
         "operationId": "getVariant",
         "parameters": [
           {
@@ -501,9 +469,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "variant-controller"
-        ],
+        "tags": ["variant-controller"],
         "operationId": "deleteVariant",
         "parameters": [
           {
@@ -531,9 +497,7 @@
     },
     "/v1/projects/{projectId}": {
       "get": {
-        "tags": [
-          "project-controller"
-        ],
+        "tags": ["project-controller"],
         "operationId": "getProject",
         "parameters": [
           {
@@ -559,9 +523,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "project-controller"
-        ],
+        "tags": ["project-controller"],
         "operationId": "deleteProject",
         "parameters": [
           {
@@ -582,9 +544,7 @@
     },
     "/v1/variants/{variantId}/snapshots": {
       "delete": {
-        "tags": [
-          "variant-controller"
-        ],
+        "tags": ["variant-controller"],
         "operationId": "dropSnapshots",
         "parameters": [
           {
@@ -640,9 +600,7 @@
         }
       },
       "VariantCreateFromVersionDto": {
-        "required": [
-          "name"
-        ],
+        "required": ["name"],
         "type": "object",
         "properties": {
           "name": {
@@ -651,9 +609,7 @@
         }
       },
       "VersionCreateReleaseDto": {
-        "required": [
-          "comment"
-        ],
+        "required": ["comment"],
         "type": "object",
         "properties": {
           "comment": {
@@ -662,11 +618,7 @@
         }
       },
       "VersionCreateSnapshotDto": {
-        "required": [
-          "comment",
-          "model",
-          "name"
-        ],
+        "required": ["comment", "model", "name"],
         "type": "object",
         "properties": {
           "name": {
@@ -681,10 +633,7 @@
         }
       },
       "VariantCreateDto": {
-        "required": [
-          "initialModel",
-          "initialName"
-        ],
+        "required": ["initialModel", "initialName"],
         "type": "object",
         "properties": {
           "initialModel": {
@@ -784,11 +733,7 @@
         }
       },
       "ProjectSummaryDto": {
-        "required": [
-          "id",
-          "isArchived",
-          "name"
-        ],
+        "required": ["id", "isArchived", "name"],
         "type": "object",
         "properties": {
           "id": {

--- a/documentation/AdvancedEditingShortcuts.md
+++ b/documentation/AdvancedEditingShortcuts.md
@@ -11,7 +11,7 @@ easier to manage and edit complex network structures.
 ### Short-cuts
 
 |                                                     Keyboard                                                     |                                                                                            description                                                                                             |
-|:----------------------------------------------------------------------------------------------------------------:|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
+| :--------------------------------------------------------------------------------------------------------------: | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
 |                                                                                                                  |                                                                                                                                                                                                    |
 |                                                     `delete`                                                     |                                                                          Delete nodes, comments, and selected trainruns.                                                                           |
 |                                              `ctrl`+`d` / `insert`                                               |                                   Duplicate nodes, comments, and selected trainruns (if multiple nodes are selected, trains including nodes will be duplicated).                                   |
@@ -27,27 +27,29 @@ easier to manage and edit complex network structures.
 |                                                    `Arrow up`                                                    |                                                                           Aligns objects along their top edges (nodes).                                                                            |
 |                                                  `Arrow right`                                                   |                                                                          Aligns objects along their right edges (nodes).                                                                           |
 |                                                   `Arrow down`                                                   |                                                                          Aligns objects along their bottom edges (nodes).                                                                          |
+
 ---
 
-### Scale Netzgrafik 
-When you press `Ctrl` and use the `mouse wheel`, the netzgrafik gets scaled. This feature can be used when the nodes are spatially too close together. 
+### Scale Netzgrafik
+
+When you press `Ctrl` and use the `mouse wheel`, the netzgrafik gets scaled. This feature can be used when the nodes are spatially too close together.
 
 When you have selected multiple nodes with `right mouse button pressed and move`, then only the multi-selected nodes get scaled around their center of mass.
- 
+
 [CTRL_WHEEL_FULL_DEMO.webm](https://github.com/user-attachments/assets/1799626a-5e36-46f7-bdeb-f61e43bdbc9d)
 
 ---
 
 ### Duplicate
 
-To duplicate one or many elements - use `shift` + `left` mouse button pressed* to select several
+To duplicate one or many elements - use `shift` + `left` mouse button pressed\* to select several
 elements and press `ctrl`+`d`.
 
 If more than one node is selected, all train sections that are
 connected to two selected nodes are also duplicated. If further notes are selected, the notes are
 duplicated in the same way as the nodes.
 
-> If in the menu the *Knoten-Positionierungswerkzeug* is activated, you can *multi-select* nodes and
+> If in the menu the _Knoten-Positionierungswerkzeug_ is activated, you can _multi-select_ nodes and
 > notes by clicking. If you use `shift` + `right mouse button pressed`
 
 #### Duplicate trainrun
@@ -59,7 +61,7 @@ To duplicate a train in the project, follow these steps:
   it. This action will create an identical copy of the selected train.
 
   > There are alternative editing path to process duplication: Use the copy-paste idea: Select the
-  train und press `ctrl`+`c` then `ctrl`+`v`
+  > train und press `ctrl`+`c` then `ctrl`+`v`
 
 - Edit the train name: Click on the train name with the left mouse button, and a dialog window will
   open, allowing you to edit the train's details. Make the necessary changes to the train name or
@@ -95,7 +97,7 @@ To delete a train in the project, follow these steps:
   it. This action will create an identical copy of the selected train.
 
   > There are alternative editing path to process duplication: Use the copy-paste idea: Select
-  the train and press `ctrl`+`c` then `ctrl`+`v`.
+  > the train and press `ctrl`+`c` then `ctrl`+`v`.
 
 #### Delete nodes
 

--- a/documentation/CREATE_CONNECTIONS.md
+++ b/documentation/CREATE_CONNECTIONS.md
@@ -8,6 +8,7 @@ Connections can be easily created by following these steps:
 - Instead of re-routing the trainrun, you can use the pin (circle) to connect the trainrun to another
   trainrun. To create the connection, drag and drop the pin where the trainrun is aligned to node
   to another trainrun pin in the same node.
+
   > When dragging within a node, the line will appear dashed, and small circles will indicate all
   > possible connections (pins).
 

--- a/documentation/CREATE_FILTERS.md
+++ b/documentation/CREATE_FILTERS.md
@@ -115,4 +115,4 @@ Show/hide connections
 ### Saved filters
 
 The function for saving filters makes it possible to save filter settings so that they can be used
-again quickly. These saved filters are stored within the respective project variant. 
+again quickly. These saved filters are stored within the respective project variant.

--- a/documentation/CREATE_NODES.md
+++ b/documentation/CREATE_NODES.md
@@ -25,11 +25,11 @@ so that the layout comes directly from the import.
 <summary>Import CSV interface description
 </summary>
 
-|                  |                      BP                      |                     Bahnhof                      |   Kategorie    |    Region     |              Fahrgastwechselzeit_IPV               |               Fahrgastwechselzeit_A                |               Fahrgastwechselzeit_B                |               Fahrgastwechselzeit_C                |               Fahrgastwechselzeit_D                |      ZAZ      |           Umsteigezeit           |              Labels              |         X         |          Y          |                            Erstellen                            |
-|:----------------:|:--------------------------------------------:|:------------------------------------------------:|:--------------:|:-------------:|:--------------------------------------------------:|:--------------------------------------------------:|:--------------------------------------------------:|:--------------------------------------------------:|:--------------------------------------------------:|:-------------:|:--------------------------------:|:--------------------------------:|:-----------------:|:-------------------:|:---------------------------------------------------------------:|
-|     Datatype     |                    string                    |                      string                      |     string     |   nummeric    |                      nummeric                      |                      nummeric                      |                      nummeric                      |                      nummeric                      |                      nummeric                      |   nummeric    |             nummeric             |             nummeric             |     nummeric      |      nummeric       |                          'JA' or empty                          |
+|                  |                      BP                      |                     Bahnhof                      |   Kategorie    |    Region     |              Fahrgastwechselzeit_IPV               |               Fahrgastwechselzeit_A                |               Fahrgastwechselzeit_B                |               Fahrgastwechselzeit_C                |               Fahrgastwechselzeit_D                |      ZAZ      |           Umsteigezeit           |              Labels               |         X         |          Y          |                            Erstellen                            |
+| :--------------: | :------------------------------------------: | :----------------------------------------------: | :------------: | :-----------: | :------------------------------------------------: | :------------------------------------------------: | :------------------------------------------------: | :------------------------------------------------: | :------------------------------------------------: | :-----------: | :------------------------------: | :-------------------------------: | :---------------: | :-----------------: | :-------------------------------------------------------------: |
+|     Datatype     |                    string                    |                      string                      |     string     |   nummeric    |                      nummeric                      |                      nummeric                      |                      nummeric                      |                      nummeric                      |                      nummeric                      |   nummeric    |             nummeric             |             nummeric              |     nummeric      |      nummeric       |                          'JA' or empty                          |
 |   Description    |                      id                      |                    full name                     | category label | region number | if <= 0 -> non stop, otherwise > default stop time | if <= 0 -> non stop, otherwise > default stop time | if <= 0 -> non stop, otherwise > default stop time | if <= 0 -> non stop, otherwise > default stop time | if <= 0 -> non stop, otherwise > default stop time | no implemened | min. connectiontime - Default: 2 | comma separated filterable labels | vertical position | horizontal position | if 'JA' missing nodes gets created, otherwise just updated (ID) |
-| More information | this is a unique identifier <br/>(non-empty) | full name of the station (node) <br/>(non-empty) | empty allowed  | empty allowed |                   empty allowed                    |                   empty allowed                    |                   empty allowed                    |                   empty allowed                    |                   empty allowed                    | empty allowed |          empty allowed           |          empty allowed           |   empty allowed   |    empty allowed    |                          empty allowed                          |
+| More information | this is a unique identifier <br/>(non-empty) | full name of the station (node) <br/>(non-empty) | empty allowed  | empty allowed |                   empty allowed                    |                   empty allowed                    |                   empty allowed                    |                   empty allowed                    |                   empty allowed                    | empty allowed |          empty allowed           |           empty allowed           |   empty allowed   |    empty allowed    |                          empty allowed                          |
 
 **category label:** If the node gets created or updated the category labels gets added as filterable
 label. The label template ist "Kategorie:" + value. Comma separated values allows to add more than
@@ -46,7 +46,7 @@ region label.
 </summary>
 
 | BP   | Bahnhof           | Region | Kategorie | Fahrgastwechselzeit_IPV | Fahrgastwechselzeit_A | Fahrgastwechselzeit_B | Fahrgastwechselzeit_C | Fahrgastwechselzeit_D | Umsteigezeit | ZAZ | Labels | Erstellen | X            | Y            |
-|------|-------------------|--------|-----------|-------------------------|-----------------------|-----------------------|-----------------------|-----------------------|--------------|-----|--------|-----------|--------------|--------------|
+| ---- | ----------------- | ------ | --------- | ----------------------- | --------------------- | --------------------- | --------------------- | --------------------- | ------------ | --- | ------ | --------- | ------------ | ------------ |
 | AA   | Aarau             | Mitte  | 2         | 2                       | 2                     | 2                     | 2                     | 2                     | 4            | 0.2 | SBB    | JA        | -209.4991625 | -427.021373  |
 | GD   | Arth-Goldau       | Sud    | 2         | 2                       | 2                     | 2                     | 2                     | 2                     | 4            |     |        | JA        | 951.9866035  | 758.834056   |
 | BEL  | Bellinzona        | Sud    | 2         | 2                       | 2                     | 2                     | 2                     | 2                     | 4            |     |        | JA        | 2121.053433  | 3728.103892  |
@@ -70,6 +70,7 @@ region label.
 | ZFH  | Zürich Flughafen  | Ost    | 2         | 3                       | 3                     | 3                     | 3                     | 3                     | 4            |     |        | JA        | 962.4904855  | -647.2111605 |
 
 [Demo base data CSV file](29-01-2024-004-Stammdaten_importieren.csv)
+
 </details>
 
 ### Move nodes
@@ -112,6 +113,7 @@ are the same, they are further sorted according to the order of the drawing - fi
 aligned.
 
 > **Sorting heuristic**
+>
 > - Position Alignment (Top > Bottom > Left > Right)
 > - Left - Right | Top - Down
 > - Category short name (predefined order)

--- a/documentation/CREATE_PROJECT.md
+++ b/documentation/CREATE_PROJECT.md
@@ -18,22 +18,25 @@ description. Now you have created a first project that can contain multiple vari
 [29-01-2024-001-Create_new_project.webm](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/assets/2674075/4e34d3a2-5291-4193-ac88-5e522f6223f7)
 
 #### Share a project
-Users can share their projects with other employees and assign different access rights. There are two options: 
+
+Users can share their projects with other employees and assign different access rights. There are two options:
+
 - write access
 - read access.
 
-#### With write access, 
-... the employee with whom the project is shared can edit the project, make changes to it, or delete it, including creating, deleting, and archiving variants.
-  
+#### With write access,
 
-#### With read access, 
+... the employee with whom the project is shared can edit the project, make changes to it, or delete it, including creating, deleting, and archiving variants.
+
+#### With read access,
+
 ... the employee can only view and read the project, but cannot make any changes to it (cannot save).
 
 The choice between write access and read access depends on the desired level of collaboration and contribution from the employees to the project.
 
 #### Example
-![image](https://github.com/user-attachments/assets/cc925325-1925-4256-a654-3216c13412d5)
 
+![image](https://github.com/user-attachments/assets/cc925325-1925-4256-a654-3216c13412d5)
 
 ### Create a new Variant within a project
 
@@ -77,14 +80,14 @@ The data model for the basic concept of Project/Variants includes the following 
 
 - **Version:** This entity represents a version within a variant. Versions are used to store the
   change history and preserve intermediate changes during the creative process. They allow users to
-  restore any previous version if needed.  
+  restore any previous version if needed.
 
 The relationship between the entities is as follows:
 
 ```mermaid
 erDiagram
     Project o|--|{ Variant : has
-    Variant o|--|{ Version : has 
+    Variant o|--|{ Version : has
 ```
 
 A user has to publish a version of a variant when he is ready with editing/creating the variant.
@@ -143,7 +146,7 @@ Step-by-step example
 </summary>
 
 | Version | Snapshot version | Author |                                              Comments                                              |
-|:-------:|:----------------:|:------:|:--------------------------------------------------------------------------------------------------:|
+| :-----: | :--------------: | :----: | :------------------------------------------------------------------------------------------------: |
 |    -    |        1         |  u123  |       Initial empty network diagram that is automatically created when creating the variant.       |
 |    -    |        2         |  u123  |                                  First modification by user u123.                                  |
 |    -    |        3         |  u123  |                                 Second modification by user u123.                                  |

--- a/documentation/CREATE_TRAINRUN.md
+++ b/documentation/CREATE_TRAINRUN.md
@@ -15,8 +15,10 @@ information about the newly created trainrun, such as trainrun category and name
 the window or press `ESC` to close the dialog window.
 
 > - If you like to (re)open the dialog windows just click on the trainrun name in the editor or
+
     click any number (time). The dialog window is displayed again with the clicked data input field
     in focus.
+
 > - If you click on the trainrun - it gets selected and you can modify it.
 > - Click for a second time the Perlenkette gets opened.
 
@@ -40,23 +42,23 @@ To create a new train or adding new trainrun section to an existing trainrun, pr
 > **Note:** Importantly, you don't have to select a train route to create a new trainrun -
 > otherwise, you modify the selected trainrun
 
-
 ##### Travel time estimator (Default)
+
 The application has a travel time pre-setting or heuristic implemented which
-allows for an automated determination of travel times when drawing a new section. 
+allows for an automated determination of travel times when drawing a new section.
 Currently, following different heuristics are available:
 
-- The **default method** (heuristic) assumes a constant travel time per section, with a default setting of 1 minute per section. 
-This means that regardless of the distance or other factors, each section has a fixed travel time of 1 minute. 
-This heuristic can be helpful as it generates obviously unusable travel times, prompting the user to address the travel time. The 
-1 minute is very clear that this time has to be manually adapted. 
+- The **default method** (heuristic) assumes a constant travel time per section, with a default setting of 1 minute per section.
+  This means that regardless of the distance or other factors, each section has a fixed travel time of 1 minute.
+  This heuristic can be helpful as it generates obviously unusable travel times, prompting the user to address the travel time. The
+  1 minute is very clear that this time has to be manually adapted.
 
-- A more complex method (heuristic) can be set to **derive the travel time from existing ones**. The travel time heuristic 
-searches for other trains of the same category on the section. If there are other trains, the longest travel
-time is adopted for the newly inserted section. If not, the heuristic searches for other trains, regardless of their category. 
-If other trains are found, the maximum travel time is used; otherwise, the default is set to 1 minute.
+- A more complex method (heuristic) can be set to **derive the travel time from existing ones**. The travel time heuristic
+  searches for other trains of the same category on the section. If there are other trains, the longest travel
+  time is adopted for the newly inserted section. If not, the heuristic searches for other trains, regardless of their category.
+  If other trains are found, the maximum travel time is used; otherwise, the default is set to 1 minute.
 
-The heuristic can be adjusted under Settings - Editor - Travel Time Pre-setting (heuristic). 
+The heuristic can be adjusted under Settings - Editor - Travel Time Pre-setting (heuristic).
 The setting is user-specific and is stored in the user's profile (browser).
 
 ### Rerouting trainrun sections
@@ -73,8 +75,8 @@ To reroute a train, follow these steps:
   the hexagon button, and both train sections will move together. Drag the sections to a different
   node to reroute them.
   > If you drag the hexagon button outside the node it generates an intermediate stop if there was a
-  stopping transition or it just removed the non-stop transition. For both cases it reroutes the
-  trainrun by removing the node alignment where the hexagon/transition was.
+  > stopping transition or it just removed the non-stop transition. For both cases it reroutes the
+  > trainrun by removing the node alignment where the hexagon/transition was.
 
 [2024-1-25-Rerouting_extend_remove_trainrunsections-001.webm](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/assets/2674075/d697594c-57a8-4159-b44f-8a9f804f297f)
 
@@ -103,34 +105,33 @@ To switch a train from a stop to a non-stop at a node, follow these steps:
 
 ### Split / Combine two trainruns and merge Netzgrafik
 
-For more details have a look into 
+For more details have a look into
+
 - [Split/Combine two trainruns](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/documentation/Split_Combine_Trainruns.md)
 - [Merge Netzgrafik](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/documentation/Merge_Netzgrafik.md)
 
 ## Special cases
 
-### Trainrun path with "holes" (missing sections) 
+### Trainrun path with "holes" (missing sections)
 
 ![image](https://github.com/user-attachments/assets/d87b842c-7696-4e81-aa78-75cc966b5306)
-*Example Netzgrafik with missing sections (See the cargo trainrun GTwo_Part_trainrun)*
+_Example Netzgrafik with missing sections (See the cargo trainrun GTwo_Part_trainrun)_
 
-
-When creating a trainrun, the trairnun path should connect all nodes from start to destination using trainrun sections. 
-However, it can happen during the creation that not all trainrun sections have been drawn in the meantime. 
-Gaps may occur along the trainrun path where at least one trainrun section is missing. 
+When creating a trainrun, the trairnun path should connect all nodes from start to destination using trainrun sections.
+However, it can happen during the creation that not all trainrun sections have been drawn in the meantime.
+Gaps may occur along the trainrun path where at least one trainrun section is missing.
 These “holes” usually occur if the trainrun path has not yet been drawn completely or correctly.
-For example, a trainrun path could look like this with a "hole" in the middle, 
+For example, a trainrun path could look like this with a "hole" in the middle,
 
 A - B - C ---- (missing section) ---- E - F - G
 
 The trainrun section between C and E is missing here. However, these gaps can also occur if a partial cancelation is made for a train run.
 
 ![image](https://github.com/user-attachments/assets/5d1ef657-e421-41ff-ae57-622eee82f295)
-*Graphical timetable.*
+_Graphical timetable._
 
-
-In each of these cases, the trainrun has at least two parts, e.g. [(A B), (A C)] and [(E F)(F G)]. 
+In each of these cases, the trainrun has at least two parts, e.g. [(A B), (A C)] and [(E F)(F G)].
 In this case, the trainrun is interpreted as two separate trainruns.
-The Netzgrafik has no information about whether the missing part could be closed between C - E, C - D - E or 
-another possible variant, therefore the assumption that there is an independent trainrun for each trainrun part is 
-the best assumption. This avoids many new problems. 
+The Netzgrafik has no information about whether the missing part could be closed between C - E, C - D - E or
+another possible variant, therefore the assumption that there is an independent trainrun for each trainrun part is
+the best assumption. This avoids many new problems.

--- a/documentation/DATA_MODEL.md
+++ b/documentation/DATA_MODEL.md
@@ -1,7 +1,7 @@
 ## Data model
 
-The data model consists of the following key elements: ***trainrun***, ***trainrun section***,
-***transition***, ***trainrun connection***, ***port*** and ***node***.
+The data model consists of the following key elements: **_trainrun_**, **_trainrun section_**,
+**_transition_**, **_trainrun connection_**, **_port_** and **_node_**.
 
 ![Data model](./images/DataMoel_Sketch_KeyElement_001.jpg)
 
@@ -25,11 +25,11 @@ coordinated to ensure a smooth connection between them.
 In addition, a trainrun has references to behaviour-related abstractions such as
 category, frequency and time category, which define the behaviour of a trainrun.
 
-- ***Category*** specifies the type of trainrun, e.g. a regional train, an intercity train or a
+- **_Category_** specifies the type of trainrun, e.g. a regional train, an intercity train or a
   goods train.
-- ***Frequency*** defines the frequency with which the trainrun is carried out, e.g. 1/4h, 1/2h
+- **_Frequency_** defines the frequency with which the trainrun is carried out, e.g. 1/4h, 1/2h
   or every hour.
-- ***TimeCategory*** defines the time categorisation of the trainrun, e.g. peak times or
+- **_TimeCategory_** defines the time categorisation of the trainrun, e.g. peak times or
   off-peak times or occasional.
 
 By combining the nodes and trainrun sections in this data model, we can create a representation of
@@ -43,25 +43,24 @@ trainrun routes and schedules.
 
 ![image](https://github.com/user-attachments/assets/21fdb029-2a59-468a-ac93-11cf702536bd)
 
-
 Thus, the data model, consisting of TrainrunSection and nodes, forms a network of edges and nodes,
 similar to an undirected graph. The TrainrunSections represent the connections between the nodes and
 enable the representation and analysis of complex relationships in the model.
 
-- ***TrainrunSection*** corresponds to the edges between nodes in an undirected graph.
-- ***Nodes*** represent the points in the graph, allowing the connection of trainrun section .
-- A *pin* represents a ***port*** (point) in the graph where a trainrun section is connected to a
+- **_TrainrunSection_** corresponds to the edges between nodes in an undirected graph.
+- **_Nodes_** represent the points in the graph, allowing the connection of trainrun section .
+- A _pin_ represents a **_port_** (point) in the graph where a trainrun section is connected to a
   node.
-- The ***transition*** extends the graph within the node. A transition corresponds to an edge that
+- The **_transition_** extends the graph within the node. A transition corresponds to an edge that
   connects two pins within the node, thereby connecting two trainrun section.
 - If two trainruns should make a connection at a station, this can be defined using a
-  ***connection***. The trainrun connection links two pins, each have to be associated with a
+  **_connection_**. The trainrun connection links two pins, each have to be associated with a
   different train.
 
 Together, these elements form an undirected graph consisting of edges (TrainrunSections,
 Transitions) and nodes (Ports).
 
-The last key element is the ***trainrun***. The trainrun consists of an ordered sequence of
+The last key element is the **_trainrun_**. The trainrun consists of an ordered sequence of
 trainrun sections and transitions. This ordered sequence defines the route of the trainrun and
 establishes a direction in the undirected graph. This direction corresponds to the exact path of the
 train.
@@ -71,12 +70,12 @@ classDiagram
     Node *-- Port
     Node *-- Transition
     Node *-- Connection
-    
+
     Trainrun *-- TrainrunSection
     TrainrunSection --* Port
-    
+
     Transition -- Port
-    Connection -- Port 
+    Connection -- Port
 
     class Node {
            betriebspunktName : string
@@ -103,7 +102,7 @@ classDiagram
     }
 
     class Port {
-           ... 
+           ...
            trainrunSection : TrainrunSection
     }
 
@@ -121,10 +120,10 @@ classDiagram
 ```
 
 ##### Data structure
-More specific information about the business and technical data can be referenced in the data 
-[structure definitions](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/tree/main/src/app/data-structures) 
-within the source code.
 
+More specific information about the business and technical data can be referenced in the data
+[structure definitions](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/tree/main/src/app/data-structures)
+within the source code.
 
 ##### Ports alignment
 
@@ -147,10 +146,10 @@ representation of the lines, ensuring clarity and ease of understanding.
 
 ```typescript
 export enum PortAlignment {
-    Top,    // 0
-    Bottom, // 1
-    Left,   // 2
-    Right   // 3
+  Top, // 0
+  Bottom, // 1
+  Left, // 2
+  Right, // 3
 }
 ```
 
@@ -162,7 +161,7 @@ details [VisAVisPortPlacement.placePortsOnSourceAndTargetNode(srcNode, targetNod
 The sorting heuristics description can be found in
 the [chapter](./CREATE_NODES.md#MultipleTrainruns), it is
 worth taking a look there before diving into the source
-code [Node.sortPorts()](./../src/app/models/node.model.ts#:~:text=sortPorts()%20{) for detailed information.
+code [Node.sortPorts()](<./../src/app/models/node.model.ts#:~:text=sortPorts()%20{>) for detailed information.
 
 ##### Pre-computed paths
 
@@ -181,28 +180,28 @@ More details can be found in the source code:
 
 - [Node.computeTransitionRouting()](./../src/app/models/node.model.ts#:~:text=computeTransitionRouting)
 - [Node.computeConnectionRouting()](./../src/app/models/node.model.ts#:~:text=computeConnectionRouting)
-- [TrainrunSection.routeEdgeAndPlaceText()](./../src/app/models/trainrunsection.model.ts#:~:text=routeEdgeAndPlaceText()%20{)
-- [TrainrunSectionService.initializeTrainrunSectionRouting()](./../src/app/services/data/trainrunsection.service.ts#:~:text=initializeTrainrunSectionRouting()%20{)
+- [TrainrunSection.routeEdgeAndPlaceText()](<./../src/app/models/trainrunsection.model.ts#:~:text=routeEdgeAndPlaceText()%20{>)
+- [TrainrunSectionService.initializeTrainrunSectionRouting()](<./../src/app/services/data/trainrunsection.service.ts#:~:text=initializeTrainrunSectionRouting()%20{>)
 
 ---
 
 ### Iterate through all train run sections (forward/backward)
+
 To understand how the trainrun iteration has to work, please take another look at this illustration:
 ![image](https://github.com/user-attachments/assets/21fdb029-2a59-468a-ac93-11cf702536bd)
 
-#### General 
+#### General
 
 The [TrainrunIterator](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/d170955ecc466bfa9c10071927c63199eb7a86f7/src/app/services/util/trainrun.iterator.ts#L12) operates over a structure that can be conceptualized as an undirected acyclic graph (DAG), where each trainrun is a connected component.
-
-
 
 ##### Structure
 
 - **TrainrunSection:** Each section has a source and a target node, analogous to an edge in a graph. The trainrun section is not directly connected to a node. It's connected via a port.
-- **Node:** Nodes manage connections through ports, ports are effectively acting as a vertex within the graph. 
-- **Transition:** Transitions connect two train sections within a node with the help of ports. They can be interpreted as edges in the graph. 
+- **Node:** Nodes manage connections through ports, ports are effectively acting as a vertex within the graph.
+- **Transition:** Transitions connect two train sections within a node with the help of ports. They can be interpreted as edges in the graph.
 
 ##### Traversal
+
 To initiate traversal, it is important to specify a location (node) where the traversal begins. To determine the traversal direction a trainrun section is required. The trainrun section must be connected to the node. Otherwise the traversal will fail. With the help of the trainrun section the traversal method determines the travel direction. Therefore, a tuple consisting of a node and a trainrun section is needed for each traversal. This tuple determines the directed edge in the directed graph. Each edge in a directed graph points to another node. For example, if the given node is the source node, the iterator moves towards the target node; if the node is the target node, the iterator moves towards the source node. This can be defined very simply using the tuple.
 
 Upon reaching a node, the transition is the object that determines the transition from the input port to the output port within the node. This is important to correctly determine the transition from the incoming trainrun section to the continuing trainrun section. Therefore, to continue traversing through the next section, a transition is needed. Once no transitions are available, the traversal stops. At that point, either the target node of the trainrun or, conversely, the starting node is found.
@@ -214,20 +213,24 @@ The TrainrunIterator can effectively traverse through the trainrun sections by u
 The TrainrunIterator is a concept aimed at iterating through the sections of a trainrun, similar to how one navigates through the edges of a graph. Here is a detailed description of how this iterator works and how it can be used:
 
 ##### Structure of the Trainrun
+
 - **Graph**: The entire graph is generally an undirected acyclic graph (DAG). Each trainrun (segment) represents a connected component.
 
 ##### Traversal Logic
+
 - **Starting Point**: Iteration begins with a given node and a specific trainrun section.
 - **Section Connection**: The iterator moves through connected sections by utilizing the source and target nodes of each section.
 - **Transitions**: When a transition is reached, the next connected section is followed through the corresponding port.
 - **End of Traversal**: Iteration ends when no further sections or transitions are available.
 
 ##### Example Application
+
 - **Initialization**: The iterator is initialized with a start node ID and a specific trainrun section.
 - **Forward Traversal**: The iterator moves from section to section by navigating from one node to the next. During traversal, the source and target nodes of the sections are used to determine the path.
 - **Backward Traversal**: To traverse in the opposite direction, the iterator can be re-initialized with the end node ID of the current traversal and the corresponding trainrun section. This reverses the path and allows a return to the starting point.
 
 ##### Detailed Steps
+
 1. **Start with a Node ID and a Trainrun Section**: The iterator begins with a defined node ID and a specific trainrun section. This represents the starting point.
 2. **Section-wise Traversal**: The iterator traverses the sections by using the connections between the nodes. It moves from the source node to the target node of a section.
 3. **Handling Transitions**: When a transition within a node is reached, the iterator follows the transition to the next connected section.
@@ -240,7 +243,5 @@ If functionality should be initiated by providing a port ID, this could be a fur
 ---
 
 ### Links
+
 [Netzgrafik-Editor data export/import (JSON)](DATA_MODEL_JSON.md)
-
- 
-

--- a/documentation/DATA_MODEL_JSON.md
+++ b/documentation/DATA_MODEL_JSON.md
@@ -1,35 +1,40 @@
-## Netzgrafik-Editor data export/import (JSON) 
-The complete data export can be used for data exchange between different network graphics/variants, merging network graphics, or for user-specific customization, 
+## Netzgrafik-Editor data export/import (JSON)
+
+The complete data export can be used for data exchange between different network graphics/variants, merging network graphics, or for user-specific customization,
 including metadata such as colors and train categories, among others.
 
-By exporting or importing data in JSON format, information can be efficiently and flexibly exchanged or connected between 
-different systems or applications. JSON format is a widely used format for exchanging structured data and allows for easy 
-integration and processing of information in third-party applications. Additionally, it provides a readable and easily 
+By exporting or importing data in JSON format, information can be efficiently and flexibly exchanged or connected between
+different systems or applications. JSON format is a widely used format for exchanging structured data and allows for easy
+integration and processing of information in third-party applications. Additionally, it provides a readable and easily
 understandable representation of data, which facilitates manual editing.
 
 [DATA MODEL](DATA_MODEL.md)
 
-## Export/Import 
+## Export/Import
+
 ![image](https://github.com/user-attachments/assets/df46327d-5a00-4510-ab8f-563292ce81f8)
 
-#### Export  
+#### Export
+
 To export the current Netzgrafik use the `Export netzgrafik as JSON` button.
 
-#### Import 
+#### Import
+
 The exported data in JSON format can be imported again using the `Import netzgrafik as JSON` button.
 
 ##### JSON-Based Data Import from 3rd Party Data Providers
-If nodes have no port objects or if no TrainrunSection has a defined path element, the import process will automatically adjust, 
-respectively create the required elements. This adjustment ensures that all nodes are created first, followed by the systematic 
-insertion of each train, section by section. Inserting each section by section ensures that the Netzgrafik drawing gets well routed. 
-This streamlines the import process, making the exchange of data much more straightforward and efficient. 
-The 3rd party has only to care about the nodes' position and ensure the trainrun sections are temporally sorted. The TrainrunSection routing gets computed while importing, 
+
+If nodes have no port objects or if no TrainrunSection has a defined path element, the import process will automatically adjust,
+respectively create the required elements. This adjustment ensures that all nodes are created first, followed by the systematic
+insertion of each train, section by section. Inserting each section by section ensures that the Netzgrafik drawing gets well routed.
+This streamlines the import process, making the exchange of data much more straightforward and efficient.
+The 3rd party has only to care about the nodes' position and ensure the trainrun sections are temporally sorted. The TrainrunSection routing gets computed while importing,
 thus no complex calculation must be reimplemented by the 3rd party provider.
 
-
 ###### Detection of Third-Party Data
+
 The function [detectNetzgrafikJSON3rdParty](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/src/app/view/editor-tools-view-component/editor-tools-view.component.ts#L580) checks if the imported data comes from a third party and if it needs to be adjusted accordingly.
-    
+
 ```typescript
 private detectNetzgrafikJSON3rdParty(netzgrafikDto: NetzgrafikDto): boolean {
     return netzgrafikDto.nodes.find((n: NodeDto) =>
@@ -44,15 +49,16 @@ private detectNetzgrafikJSON3rdParty(netzgrafikDto: NetzgrafikDto): boolean {
         ts.path?.path?.length === 0
       ) !== undefined;
   }
-  ```
+```
+
 The function performs the following checks:
+
 - Whether there are nodes without port objects.
 - Whether all nodes have empty port lists.
 - Whether there are trainrun sections without a defined path.
-If any of these conditions are met, the import process is adjusted to automatically create the necessary elements.
+  If any of these conditions are met, the import process is adjusted to automatically create the necessary elements.
 
 The JSON-based data import from third parties into the net graphic system is designed to simplify the process and ensure that all required elements are correctly created and inserted. This ensures efficient and error-free data transfer.
-
 
 ## JSON Description (basic data structure)
 
@@ -73,7 +79,7 @@ The JSON-based data import from third parties into the net graphic system is des
 - **nodes**: Represents the nodes in the Netzgrafik.
 - **trainrunsections**: Contains the sections of trainruns.
 - **trainruns**: Represents the trainruns in the Netzgrafik.
-- **resources**: Contains an abstraction for resources related to the Netzgrafik (between nodes - edges) *not yet implemented*.
+- **resources**: Contains an abstraction for resources related to the Netzgrafik (between nodes - edges) _not yet implemented_.
 - **metadata**: Stores metadata information such as colors, train categories, etc.
 - **freeFloatingTexts**: Contains any freely placed texts in the Netzgrafik, notes.
 - **labels**: Represents labels associated with nodes or trainruns.
@@ -86,7 +92,7 @@ See also [DATA_MODEL.md : business orientated description](https://github.com/Sc
 
 ---
 
-### nodes 
+### nodes
 
 ```json
 "nodes": [
@@ -114,7 +120,7 @@ See also [DATA_MODEL.md : business orientated description](https://github.com/Sc
         "trainrunSectionId": 2,
         "positionIndex": 1,
         "positionAlignment": 0
-      }, 
+      },
     ],
     "transitions": [
       {
@@ -128,7 +134,7 @@ See also [DATA_MODEL.md : business orientated description](https://github.com/Sc
       {
         "id": 0,
         "port1Id": 2,
-        "port2Id": 1, 
+        "port2Id": 1,
       }
     ],
     "resourceId": 2,
@@ -141,6 +147,7 @@ See also [DATA_MODEL.md : business orientated description](https://github.com/Sc
   },
 ]
 ```
+
 - **id**: Technical identifier (key), must be unique : numeric
 - **betriebspunktName**: Operation control point (OCP) : string
 - **fullName**: The full name of the operation control point : string
@@ -155,29 +162,27 @@ See also [DATA_MODEL.md : business orientated description](https://github.com/Sc
 - **trainrunCategoryHaltezeiten** : The stop time if the trainrun of product [A, B, C, D or IPV] have to do per default : trainrunCategoryHaltezeiten
 - **symmetryAxis** : Deprecated : null
 - **warnings**: If the business logic needs to notify the user about issues, a warning can be used in JSON format : Warning
-- **labelIds**: Filterable labels assigned to the node are stored in this array of label identifiers : Array of numeric 
-
+- **labelIds**: Filterable labels assigned to the node are stored in this array of label identifiers : Array of numeric
 
 <details>
 <summary>
 More details about ports
 </summary>
 
-    
-  ```json
-  {
-    "id": 0,
-    "trainrunSectionId": 0,
-    "positionIndex": 0,
-    "positionAlignment": 1
-  }
-  ```
+```json
+{
+  "id": 0,
+  "trainrunSectionId": 0,
+  "positionIndex": 0,
+  "positionAlignment": 1
+}
+```
 
-  - **id**: Technical identifier (key), must be unique : numeric
-  - **trainrunSectionId**: Reference to the trainrunsection assigned to the port : numeric
-  - **positionIndex**: Position index within the port alignment sorting: numeric
-  - **positionAlignment**: [Position aligment](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/documentation/DATA_MODEL.md#ports-alignment) - reference [0, 1, 2, 3] : numeric 
- 
+- **id**: Technical identifier (key), must be unique : numeric
+- **trainrunSectionId**: Reference to the trainrunsection assigned to the port : numeric
+- **positionIndex**: Position index within the port alignment sorting: numeric
+- **positionAlignment**: [Position aligment](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/documentation/DATA_MODEL.md#ports-alignment) - reference [0, 1, 2, 3] : numeric
+
 </details>
 
 <details>
@@ -185,21 +190,20 @@ More details about ports
 More details about transitions
 </summary>
 
-    
-  ```json
-  {
-    "id": 0,
-    "port1Id": 0,
-    "port2Id": 1,
-    "isNonStopTransit": true
-  }
-  ```
+```json
+{
+  "id": 0,
+  "port1Id": 0,
+  "port2Id": 1,
+  "isNonStopTransit": true
+}
+```
 
-  - **id**: Technical identifier (key), must be unique : numeric
-  - **port1Id**: Reference to the port from which the transition starts (port must be a member of the node) : numeric
-  - **port2Id**: Reference to the port to which the transition ends  (port must be a member of the node): numeric
-  - **isNonStopTransit**: If set to true the train will not stop at this node, otherwise (default) the trains stops : boolean
- 
+- **id**: Technical identifier (key), must be unique : numeric
+- **port1Id**: Reference to the port from which the transition starts (port must be a member of the node) : numeric
+- **port2Id**: Reference to the port to which the transition ends (port must be a member of the node): numeric
+- **isNonStopTransit**: If set to true the train will not stop at this node, otherwise (default) the trains stops : boolean
+
 </details>
 
 <details>
@@ -207,19 +211,18 @@ More details about transitions
 More details about connections
 </summary>
 
-    
-  ```json
-  {
-    "id": 0,
-    "port1Id": 0,
-    "port2Id": 1, 
-  }
-  ```
+```json
+{
+  "id": 0,
+  "port1Id": 0,
+  "port2Id": 1
+}
+```
 
-  - **id**: Technical identifier (key), must be unique : numeric
-  - **port1Id**: Reference to the port from which train made a connection to another (port must be a member of the node) : numeric
-  - **port2Id**: Reference to the port to which train made the connection to  (port must be a member of the node): numeric 
- 
+- **id**: Technical identifier (key), must be unique : numeric
+- **port1Id**: Reference to the port from which train made a connection to another (port must be a member of the node) : numeric
+- **port2Id**: Reference to the port to which train made the connection to (port must be a member of the node): numeric
+
 </details>
 
 <details>
@@ -227,47 +230,45 @@ More details about connections
 More details about trainrunCategoryHaltezeiten
 </summary>
 
-    
-  ```json
-  "trainrunCategoryHaltezeiten": {
-    "HaltezeitA": {
-      "no_halt": false,
-      "haltezeit": 2
-    },
-    "HaltezeitB": {
-      "no_halt": false,
-      "haltezeit": 2
-    },
-    "HaltezeitC": {
-      "no_halt": false,
-      "haltezeit": 1
-    },
-    "HaltezeitD": {
-      "no_halt": false,
-      "haltezeit": 1
-    },
-    "HaltezeitIPV": {
-      "no_halt": false,
-      "haltezeit": 3
-    },
-    "HaltezeitUncategorized": {
-      "no_halt": true,
-      "haltezeit": 0
-    }
+```json
+"trainrunCategoryHaltezeiten": {
+  "HaltezeitA": {
+    "no_halt": false,
+    "haltezeit": 2
   },
-  ```
+  "HaltezeitB": {
+    "no_halt": false,
+    "haltezeit": 2
+  },
+  "HaltezeitC": {
+    "no_halt": false,
+    "haltezeit": 1
+  },
+  "HaltezeitD": {
+    "no_halt": false,
+    "haltezeit": 1
+  },
+  "HaltezeitIPV": {
+    "no_halt": false,
+    "haltezeit": 3
+  },
+  "HaltezeitUncategorized": {
+    "no_halt": true,
+    "haltezeit": 0
+  }
+},
+```
 
-  - **id**: Technical identifier (key), must be unique : numeric
-  - **port1Id**: Reference to the port from which the transition starts (port must be a member of the node) : numeric
-  - **port1Id**: Reference to the port to which the transition ends  (port must be a member of the node): numeric
-  - **isNonStopTransit**: If set to true the train will not stop at this node, otherwise (default) the trains stops : boolean
- 
+- **id**: Technical identifier (key), must be unique : numeric
+- **port1Id**: Reference to the port from which the transition starts (port must be a member of the node) : numeric
+- **port1Id**: Reference to the port to which the transition ends (port must be a member of the node): numeric
+- **isNonStopTransit**: If set to true the train will not stop at this node, otherwise (default) the trains stops : boolean
+
 </details>
-    
 
 ---
 
-### trainrunsections 
+### trainrunsections
 
 ```json
 "trainrunSections": [
@@ -298,21 +299,22 @@ More details about trainrunCategoryHaltezeiten
 - **id**: Technical identifier (key), must be unique : numeric
 - **sourceNodeId**: Reference to the node : numeric
 - **sourcePortId**: Reference to the [node:port](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/documentation/DATA_MODEL.md#ports-alignment) : numeric
-- **targetNodeId**: Reference to the node : numeric 
-- **targetPortId**: Reference to the [node:port](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/documentation/DATA_MODEL.md#ports-alignment) : numeric 
-- **travelTime**: The travel time and lock information : [TimeLock ](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/documentation/DATA_MODEL_JSON.md#timelock) 
+- **targetNodeId**: Reference to the node : numeric
+- **targetPortId**: Reference to the [node:port](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/documentation/DATA_MODEL.md#ports-alignment) : numeric
+- **travelTime**: The travel time and lock information : [TimeLock ](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/documentation/DATA_MODEL_JSON.md#timelock)
 - **sourceDeparture**: The departure time at source node in minute and lock information : [TimeLock ](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/documentation/DATA_MODEL_JSON.md#timelock)
-- **sourceArrival**: The arrival time at source node in minute and lock information : [TimeLock ](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/documentation/DATA_MODEL_JSON.md#timelock) 
-- **targetDeparture**: The departure time at target node in minute and lock information : [TimeLock ](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/documentation/DATA_MODEL_JSON.md#timelock) 
-- **targetArrival**: The arrival time at source node in minute and lock information : [TimeLock ](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/documentation/DATA_MODEL_JSON.md#timelock) 
-- **numberOfStops**: The number of intermediate stops: numeric 
+- **sourceArrival**: The arrival time at source node in minute and lock information : [TimeLock ](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/documentation/DATA_MODEL_JSON.md#timelock)
+- **targetDeparture**: The departure time at target node in minute and lock information : [TimeLock ](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/documentation/DATA_MODEL_JSON.md#timelock)
+- **targetArrival**: The arrival time at source node in minute and lock information : [TimeLock ](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/documentation/DATA_MODEL_JSON.md#timelock)
+- **numberOfStops**: The number of intermediate stops: numeric
 - **trainrunId**: Reference to the trainrunId : numeric
 - **resourceId**: Reference to the resourceId : numeric
 - **specificTrainrunSectionFrequencyId**: Reference to the trainrun section frequency (not used)
-- **path**: SVG path (coordinate) how to render the trainrun, cached : Path 
+- **path**: SVG path (coordinate) how to render the trainrun, cached : Path
 - **warnings**: If the business logic needs to notify the user about issues, a warning can be used in JSON format : Warning
 
 #### TimeLock
+
 The timelock data stores information about the time (e.g., travel time, departure time, or arrival time) and can be accompanied by a lock indicator. The lock indicator is set to "true" if it should not be changed during transmission, and "false" if the time can be modified. Additionally, the timeFormatter can be configured, and when the Netzgrafik-Editor renders the time, it will be formatted according to the rules specified by the timeFormatter.
 
 <details>
@@ -320,68 +322,67 @@ The timelock data stores information about the time (e.g., travel time, departur
 More details about TimeLock
 </summary>
 
-    
-  ```json 
-  {
-    "lock": true,
-    "time": 15,
-    "warning": null,
-    "timeFormatter": null,
-    "consecutiveTime": 1
-  }
-  ```
+```json
+{
+  "lock": true,
+  "time": 15,
+  "warning": null,
+  "timeFormatter": null,
+  "consecutiveTime": 1
+}
+```
 
-  - **lock**: Indicate whether the time is lock or not : boolean
-  - **time**: The time in minutes : numeric 
-  - **warning**: If the business logic needs to notify the user about issues, a warning can be used in JSON format : Warning
-  - **timeFormatter**: If not null - the Netzgrafik-Editor renders the time, it will be formatted according to the rules specified by the timeFormatter
-  - **consecutiveTime**: The consecutive time in minutes - for travel time this will be ignored : numeric
+- **lock**: Indicate whether the time is lock or not : boolean
+- **time**: The time in minutes : numeric
+- **warning**: If the business logic needs to notify the user about issues, a warning can be used in JSON format : Warning
+- **timeFormatter**: If not null - the Netzgrafik-Editor renders the time, it will be formatted according to the rules specified by the timeFormatter
+- **consecutiveTime**: The consecutive time in minutes - for travel time this will be ignored : numeric
 
+#### timeFormatter
 
-  #### timeFormatter
-  ```json 
-    "timeFormatter": {
-      "colorRef": null,
-      "htmlStyle": "font-size: 10px;",
-      "textWidth": 60,
-      "stylePattern": "{{consecutiveTime}}.format(HH:mm) ➤"
-    },
-  ```
+```json
+  "timeFormatter": {
+    "colorRef": null,
+    "htmlStyle": "font-size: 10px;",
+    "textWidth": 60,
+    "stylePattern": "{{consecutiveTime}}.format(HH:mm) ➤"
+  },
+```
 
-  ```typescript
-  export interface TimeFormatter {
-    /*
-      stylePattern : free text or special data access pattern or in any combination.
-      supported special data access pattern [
-      '{{consecutiveTime}}.format(HH:mm:ss)',
-      '{{consecutiveTime}}.format(HH:mm)',
-      '{{consecutiveTime}}',
-      '{{time}}.format(HH:mm:ss)',
-      '{{time}}.format(HH:mm)',
-      '{{time}}'
-      ]
-    */
-    colorRef: ColorRefType;
-    stylePattern: string;
-    textWidth: number; // default 20
-    htmlStyle: string; // default '' - example 'font-size: 16px'- should not be used for coloring !!!
-  }
-  
-  // TimeFormatter erweitert TimeLockDto (Zeitfelder) auf TrassenSection
-  export interface TimeLockDto {
-    time: number;
-    consecutiveTime: number;
-    lock: boolean;
-    warning: WarningDto;
-    timeFormatter: TimeFormatter; // undefined or object
-  }
-  ```
+```typescript
+export interface TimeFormatter {
+  /*
+    stylePattern : free text or special data access pattern or in any combination.
+    supported special data access pattern [
+    '{{consecutiveTime}}.format(HH:mm:ss)',
+    '{{consecutiveTime}}.format(HH:mm)',
+    '{{consecutiveTime}}',
+    '{{time}}.format(HH:mm:ss)',
+    '{{time}}.format(HH:mm)',
+    '{{time}}'
+    ]
+  */
+  colorRef: ColorRefType;
+  stylePattern: string;
+  textWidth: number; // default 20
+  htmlStyle: string; // default '' - example 'font-size: 16px'- should not be used for coloring !!!
+}
+
+// TimeFormatter erweitert TimeLockDto (Zeitfelder) auf TrassenSection
+export interface TimeLockDto {
+  time: number;
+  consecutiveTime: number;
+  lock: boolean;
+  warning: WarningDto;
+  timeFormatter: TimeFormatter; // undefined or object
+}
+```
 
 </details>
 
 ---
 
-### trainrun 
+### trainrun
 
 ```json
   "trainruns": [
@@ -395,19 +396,17 @@ More details about TimeLock
     }
   ],
 ```
+
 - **id**: Technical identifier (key), must be unique : numeric
 - **name**: The name of the trainrun : string
 - **categoryId**: Reference to the [trainrunCategories](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/documentation/DATA_MODEL_JSON.md#metadata) : numeric
 - **frequencyId**: Reference to the [trainrunFrequencies](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/documentation/DATA_MODEL_JSON.md#metadata) : numeric
-- **trainrunTimeCategoryId**: Reference to the [trainrunTimeCategories](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/documentation/DATA_MODEL_JSON.md#metadata) : numeric 
+- **trainrunTimeCategoryId**: Reference to the [trainrunTimeCategories](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/documentation/DATA_MODEL_JSON.md#metadata) : numeric
 - **labelIds**: Filterable labels assigned to the node are stored in this array of label identifiers : Array of integer
-
-
 
 ---
 
-### metadata 
-
+### metadata
 
 ```json
 "metadata": {
@@ -419,12 +418,10 @@ More details about TimeLock
 }
 ```
 
-
 <details>
 <summary>
 netzgrafikColors: Represents the user defined colors which can be used in the Netzgrafik.
 </summary>
-  
 
 ```json
 "netzgrafikColors": [
@@ -445,33 +442,32 @@ netzgrafikColors: Represents the user defined colors which can be used in the Ne
 
 - **id**: Technical identifier (key), must be unique : numeric
 - **colorRef**: Must be unique : string
-- **color**:  HTML color (HEX) used when a trainrun is rendered : string
+- **color**: HTML color (HEX) used when a trainrun is rendered : string
 - **colorFocus**: HTML color (HEX) used when a trainrun is rendered as focused : string
 - **colorMuted**: HTML color (HEX) used when a trainrun is rendered as muted : string
-- **colorRelated**: HTML color (HEX) used when a trainrun is rendered as related to another : string 
+- **colorRelated**: HTML color (HEX) used when a trainrun is rendered as related to another : string
 - **colorDarkMode**: HTML color (HEX) used when a trainrun is rendered (dark mode) : string
 - **colorDarkModeFocus**: HTML color (HEX) used when a trainrun is rendered as focused (dark mode) : string
 - **colorDarkModeMuted**: HTML color (HEX) used when a trainrun is rendered as muted (dark mode) : string
 - **colorDarkModeRelated**: HTML color (HEX) used when a trainrun is rendered as related to another (dark mode) : string
 
-The Netzgrafik Editor has some default implemented colors with unique predefined colorRefs. Each colorRef must be unique (key). 
+The Netzgrafik Editor has some default implemented colors with unique predefined colorRefs. Each colorRef must be unique (key).
 Therefore, those predefined colorRefs cannot be used for a user-specific netzgrafikColors declaration. The predefined colors are:
+
 ```
 defaults: ColorRefType[] = ["EC", "IC", "IR", "RE", "S", "G", "GEX"]
 ```
-For more detail have a look into the 
+
+For more detail have a look into the
 [netzgrafikColoring.service.ts](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/src/app/services/data/netzgrafikColoring.service.ts#L473) and also [src/app/models/netzgrafikColor.model.ts](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/src/app/models/netzgrafikColor.model.ts)
 
-
 </details>
-
 
 <details>
 <summary>
 trainrunCategories: Contains the categories of train runs.
 </summary>
 
-  
 ```JSON
    "trainrunCategories": [
       {
@@ -490,25 +486,21 @@ trainrunCategories: Contains the categories of train runs.
 ```
 
 - **id**: Technical identifier (key), must be unique : numeric
-- **name**: The full name of the trainrun categories : string 
-- **order**: The full position (sorting) of the trainrun categories in the list and as well used for the rendering order (heuristic) of the trainruns sorting : numeric 
+- **name**: The full name of the trainrun categories : string
+- **order**: The full position (sorting) of the trainrun categories in the list and as well used for the rendering order (heuristic) of the trainruns sorting : numeric
 - **colorRef**: Reference to a colorRef : netzgrafikColors.colorRef : string
 - **shortName**: The short name of the trainrun categories. This is rendered in the Netzgrafik as prefix to the trainrun name : string
 - **fachCategory**: Reference to the fachCategory : string
-- **sectionHeadway**: Temporal distance (headway) in minute, when a train is traveling through a section : numeric 
-- **nodeHeadwayStop**: Temporal distance (headway) in minute, when a train is stopping at a node (station) : numeric 
-- **nodeHeadwayNonStop**: Temporal distance (headway) in minute, when a train is not stopping at a node (station) : numeric 
-  
-
+- **sectionHeadway**: Temporal distance (headway) in minute, when a train is traveling through a section : numeric
+- **nodeHeadwayStop**: Temporal distance (headway) in minute, when a train is stopping at a node (station) : numeric
+- **nodeHeadwayNonStop**: Temporal distance (headway) in minute, when a train is not stopping at a node (station) : numeric
 
 </details>
-
 
 <details>
 <summary>
 trainrunFrequencies: Represents the frequencies at which trainruns operates.
 </summary>
-
 
 ```json
 "trainrunFrequencies": [
@@ -534,14 +526,15 @@ trainrunFrequencies: Represents the frequencies at which trainruns operates.
 ```
 
 - **id**: Technical identifier (key), must be unique : numeric
-- **name**:  The full name of the trainrun frequency : string
+- **name**: The full name of the trainrun frequency : string
 - **order**: The rendering order in the list : numeric
 - **offset**: Frequency offset in minute - when the frequency start after midnight, e.g. 2h frequency can start at midnight (00:00 / even) or at (01:00 / odd) : numeric
 - **frequency**: Frequency in minute : numeric
 - **shortName**: Short name : string
 - **linePatternRef**: Reference to the line rendering pattern: 1, 2, 3, 4 lines and as well used for dotted, ... : string
 
-The defined line pattern which can be used are 
+The defined line pattern which can be used are
+
 ```
 LinePatternRefs {
   "15", // four lines ; unique indentifier
@@ -552,28 +545,21 @@ LinePatternRefs {
 }
 ```
 
-
-The following figure illustrates the four-layer (level) approach. Start by drawing the background on layer 0, then add levels 1, 2, and 3. Choose the appropriate stroke width and stroke color. Finally, ensure that we always have level 0, which serves as the background event handling area for mouse hovering and clicks (selection). To ensure that mouse events are captured, the stroke opacity for level 0 is set to 0.001 when it is not visible. Rendering styling is controlled via trainrunsections.view.scss 
+The following figure illustrates the four-layer (level) approach. Start by drawing the background on layer 0, then add levels 1, 2, and 3. Choose the appropriate stroke width and stroke color. Finally, ensure that we always have level 0, which serves as the background event handling area for mouse hovering and clicks (selection). To ensure that mouse events are captured, the stroke opacity for level 0 is set to 0.001 when it is not visible. Rendering styling is controlled via trainrunsections.view.scss
 
 ![image](https://github.com/user-attachments/assets/f12d1fe4-cb30-4d9c-95f6-bbe026eae1c0)
 
-
 See also, [TrainrunSectionsView::make4LayerTrainrunSectionLines](https://github.com/search?q=repo%3ASchweizerischeBundesbahnen/netzgrafik-editor-frontend%20make4LayerTrainrunSectionLines&type=code)
 
-See also, 
+See also,
 ![image](https://github.com/user-attachments/assets/4f6c0bb7-aba0-4aab-a7ae-ebce421705ce)
 
-
-
 </details>
-
 
 <details>
 <summary>
 trainrunTimeCategories: Contains the time categories for trainruns, such as all weekdays, only weekend and so on.
 </summary>
-
-
 
 ```json
 "trainrunTimeCategories": [
@@ -624,15 +610,15 @@ trainrunTimeCategories: Contains the time categories for trainruns, such as all 
 ```
 
 - **id**: Technical identifier (key), must be unique : numeric
-- **name**:  The full name of the trainrun time category : string
+- **name**: The full name of the trainrun time category : string
 - **order**: The rendering order in the list : numeric
 - **weekday**: Weekdays when the trainrun is operated / Monday = 1, Tuesday = 2, ... , Sunday = 7 : array numeric
 - **shortName** : Short name : string
 - **linePatternRef**: Line pattern how to render the trainrun time category
 - **dayTimeInterval**: can be empty : dayTimeIntervalElement - JSON
 
+The defined line pattern which can be used are
 
-The defined line pattern which can be used are 
 ```
 LinePatternRefs {
   TimeCat7_24 = "7/24", // . . . ; unique indentifier
@@ -642,16 +628,18 @@ LinePatternRefs {
 ```
 
 Define the dayTimeIntervalElement
+
 ```json
 {
   "to": 1140,
   "from": 960
 }
 ```
+
 - **from** : interval starts at time (include), in minute : numeric
 - **to** : interval ends at time (include), in minute : numeric
 
-See also, 
+See also,
 ![image](https://github.com/user-attachments/assets/4f6c0bb7-aba0-4aab-a7ae-ebce421705ce)
 
 </details>
@@ -661,7 +649,6 @@ See also,
 analyticsSettings: Contains settings for analytics features, such as originDestination matrix.
 </summary>
 
-  
 ```JSON
 "analyticsSettings": {
     "originDestinationSettings": {
@@ -671,12 +658,11 @@ analyticsSettings: Contains settings for analytics features, such as originDesti
 ```
 
 - **connectionPenalty**: Cost to add for each connection, in minute : numeric
-  
-
 
 </details>
 
---- 
+---
+
 ### freeFloatingTexts
 
 ```JSON
@@ -695,14 +681,14 @@ analyticsSettings: Contains settings for analytics features, such as originDesti
   }
 ],
 ```
+
 - **id**: Technical identifier (key), must be unique : numeric
 - **x**: The X position - where the node is placed in the editor (map / horizontal position) : numeric
 - **y**: The Y position - where the node is placed in the editor (map / vertical position) : numeric
 - **width**: The width of the text box : numeric
-- **height**: The height of the text box : numeric  
+- **height**: The height of the text box : numeric
 - **title**: The title of the node (freeFloatingTexts) : string
 - **text**: The text (description) of the node : string
 - **backgroundColor**: HTML color as HEX for the background: string
 - **textColor**: HTML color as HEX for the text: string
 - **labelIds**: Filterable labels assigned to the node are stored in this array of label identifiers : Array of integer
-

--- a/documentation/Graphic_Timetable.md
+++ b/documentation/Graphic_Timetable.md
@@ -2,7 +2,7 @@
 
 ![Overview_Streckengrafik_Screenshot_002](./images/Overview_Streckengrafik_Screenshot_002.png)
 
-The graphic timetable (Streckengraphik) is a ***distance-time diagram***. This diagram is a
+The graphic timetable (Streckengraphik) is a **_distance-time diagram_**. This diagram is a
 representation which shows the relationship between the distance travelled and the time taken. The
 diagram shows the course of train journeys along a route corridor.
 
@@ -30,12 +30,11 @@ conflicts or temporal overlaps between different trainruns. The diagram is a use
 analyzing route progress and timetables, identifying potential conflicts, and developing alternative
 solutions to ensure smooth train operations.
 
-
 ### Show graphic timetable (Streckengrafik)
+
 A corridor is required for the graphic timetable (Streckengrafik). The corridor determines the distance axis in the time-distance diagram (graphic timetable).
 
 There are two ways to determine this corridor: Firstly, a train can be selected, and its route forms the corridor. Alternatively, the corridor can be determined by selecting several nodes using the multiple selection tool.
-
 
 #### Use a trainrun's route (path) as corridor (distance/path)
 
@@ -48,6 +47,7 @@ To generate the graphic timetable user must follow this steps:
 [2024-01-25-Project_Along_Trainrun_Streckengrafik.webm](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/assets/2674075/212abe60-6cba-4ac9-96b9-93e923022b75)
 
 #### Use user defined corridor (distance/path)
+
 The following describes how the user can define a custom corridor so that the graphical timetable is displayed along this path:
 
 - Select at least two nodes using the multi-node selection tool.
@@ -55,7 +55,6 @@ The following describes how the user can define a custom corridor so that the gr
 - The Streckengrafik will automatically project along the user-defined corridor, providing a visual representation of the timetable data along the selected nodes.
 
 [MultiNodeSelection-Graphical-Timetable-Corridor-2024-6-4.webm](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/assets/10423646/2002c9ce-fb05-4dab-b9ad-7bf36bc96c48)
-
 
 ### Built-in analytics
 
@@ -85,6 +84,7 @@ for each trainrun category). If the minimum turnaround time is not reached, anot
 must be used and the other one must wait until the next departure. This ends in an additional track.
 This additional requirement is implemented for each trainrun start and end nodes. This makes the
 track occupier more realistic, but also more complex.
+
 <details>
 <summary>
 Example

--- a/documentation/Merge_Netzgrafik.md
+++ b/documentation/Merge_Netzgrafik.md
@@ -1,4 +1,3 @@
-
 ### Merge two independent Netzgrafik
 
 To merge two Netzgrafik, you can use the split/combine technique. For example, if you have a Netzgrafik for the eastern part of Switzerland and one for the western part, you can merge the western into the eastern part by using copy-paste and trainrun combine techniques. First, copy the western part (all trains that need to be integrated into the eastern part). Then, insert the copied trainruns and nodes into the eastern part. After inserting, the resulting Netzgrafik will have all trainruns included, but the eastern and western parts of the trainruns are not yet combined. The eastern and western trainrun parts are still independent trainruns. Now, use the combine method to connect the trainruns. Once all trainruns are combined, the resulting Netzgrafik will be the merged one.
@@ -9,9 +8,9 @@ To merge two independent Netzgrafik, you can follow these steps:
 - Determine the trains and nodes that you want to combine.
 - (Optional) Create a new variant.
 - Copy the necessary elements from one Netzgrafik and paste them into the other Netzgrafik.
-- As long as complete trainruns are copied, i.e. including all trainrun sections from start to destination, there is no need to merge trainruns. If the Netzgrafiks to be merged consists of regions (or partial corridors) 
+- As long as complete trainruns are copied, i.e. including all trainrun sections from start to destination, there is no need to merge trainruns. If the Netzgrafiks to be merged consists of regions (or partial corridors)
   or just trainrun sections that actually represent partial trainrun, these must be merged manually using the [combine function](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/documentation/Split_Combine_Trainruns.md#combine-two-trainruns) at the nodes where the parts of the trainrun meet.
- 
+
 By following these steps, you can successfully merge two independent Netzgrafik.
 
 [Merge_East_West_Trainruns.webm](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/assets/10423646/74277415-b522-4dc3-b2da-2f93e7fb5411)

--- a/documentation/ORIGIN_DESTINATION_MATRIX.md
+++ b/documentation/ORIGIN_DESTINATION_MATRIX.md
@@ -15,8 +15,9 @@ The Origin Destination Matrix will only use visible trainruns to compute paths.
 ## Results
 
 There are two ways to visualize the results:
-* From the export menu (left), the results can be exported as a CSV file.
-* From the tool bar (bottom), the results can be displayed in the Origin Destination Matrix view.
+
+- From the export menu (left), the results can be exported as a CSV file.
+- From the tool bar (bottom), the results can be displayed in the Origin Destination Matrix view.
 
 The Origin Destination Matrix view computes the results once (when opened). It allows to color the matrix based on a chosen palette and a field (right). It also displays a chosen field (bottom left).
 

--- a/documentation/Split_Combine_Trainruns.md
+++ b/documentation/Split_Combine_Trainruns.md
@@ -1,19 +1,17 @@
-### Split / Combine two trainruns 
+### Split / Combine two trainruns
 
-#### Split two trainruns 
+#### Split two trainruns
 
 To split a train into two separate ones, you first have to select the train. Then you navigate to the node where you like to split the trainrun. Inside the node
 the trainrun has to have a transition. Press **CTRL key** and click with the mouse the "stop / non-stop toggle button". The trainrun gets split into two trains.
 
 [chrome-capture-2024-3-27.webm](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/assets/10423646/8acabf0e-fdb1-445b-af40-1ec4b6875c0c)
 
-
-#### Combine two trainruns 
+#### Combine two trainruns
 
 To combine two trainruns, you have to select one of the two trains. Then you have to navigate to the node where the trainrun ends (or starts). Now you can draw
-the new transition similar to creating a connection - but you have to press **CTRL key** and it must be held pressed as long as you are drawing a new transition. 
+the new transition similar to creating a connection - but you have to press **CTRL key** and it must be held pressed as long as you are drawing a new transition.
 Once you finish drawing the new transition, both trains will be combined to one single trainrun.
-Please have as well a look into [Create Connections](CREATE_CONNECTIONS.md). 
+Please have as well a look into [Create Connections](CREATE_CONNECTIONS.md).
 
 [chrome-capture-2024-3-27 (1).webm](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/assets/10423646/526408d6-0d22-4cf7-ada7-9f45442aab8e)
-

--- a/documentation/USERMANUAL.md
+++ b/documentation/USERMANUAL.md
@@ -3,7 +3,7 @@
 ## Table Of Contents
 
 - **General**
-  - [Introduction](#Introduction) 
+  - [Introduction](#Introduction)
   - [Project/Variant](#CreateNewProjectVariant)
 - **Creating/editing Netzgrafik**
   - [Nodes](#Nodes)
@@ -15,9 +15,9 @@
   - [Filters](#Filter)
 - **Views**
   - [Graphic timetable (Streckengrafik)](#Streckengrafik)
-  - [Perlenkette](#Perlenkette)  
+  - [Perlenkette](#Perlenkette)
 - **Advanced User Interaction**
-  - [Advanced editing short-cuts](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/documentation/AdvancedEditingShortcuts.md) 
+  - [Advanced editing short-cuts](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/documentation/AdvancedEditingShortcuts.md)
 - [Links](#Links)
 
 Additional information can be found under the provided [links](#Links).
@@ -61,13 +61,15 @@ Key Features
    function that improves further processing with third parties.
 
 ---
+
 <a id="CreateNewProjectVariant"></a>
 
 ## Project/Variant
+
 The container in which the planning work takes place is a project. Projects have a name and can be described. User authorisations for writing and reading are assigned at project level. Variants can be created within the projects, each of which contains a Netzgrafik (network graphic). Variants can be compared within a project.
 For more details and to create your first Netzgrafik have a look into [create a new project](CREATE_PROJECT.md).
- 
-<!--- 
+
+<!---
 
 ### Copy all visible elements
 
@@ -83,9 +85,11 @@ For more details and to create your first Netzgrafik have a look into [create a 
 --->
 
 ---
+
 <a id="Nodes"></a>
 
 ## Nodes
+
 The nodes represent the specific locations, such as stations or stops, where a trainrun can have different actions or events associated with it. These nodes serve as key points in the trainrun's route, determining where it stops, passes through, or starts and ends ([see data model](DATA_MODEL.md)).
 
 For more details have a look into [create and modify nodes](CREATE_NODES.md).
@@ -93,6 +97,7 @@ For more details have a look into [create and modify nodes](CREATE_NODES.md).
 <a id="Trains"></a>
 
 ## Trainruns
+
 A trainrun consists of one or more trainrun sections. The trainrun section represents a specific segment or portion of a trainrun that connects two nodes. It encapsulates all the relevant information related to that particular section, including temporal details like departure and arrival times. Additionally, it also stores the journey time, which indicates the duration it takes for the train to run to move from one node to another.
 
 A trainrun has references to behaviour-related abstractions such as
@@ -101,7 +106,7 @@ category (e.g., a regional train, an intercity train or a goods train), frequenc
 For more details have a look into [create and modify trainrun](CREATE_TRAINRUN.md).
 
 - [Split / Combine two trainruns](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/documentation/CREATE_TRAINRUN.md#split--combine-two-trainruns)
-- [Merge two independent Netzgrafik](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/documentation/CREATE_TRAINRUN.md#merge-two-indepandant-netzgrafik) 
+- [Merge two independent Netzgrafik](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/documentation/CREATE_TRAINRUN.md#merge-two-indepandant-netzgrafik)
 
 <a id="Connections"></a>
 
@@ -111,8 +116,8 @@ For more details have a look into [create and modify trainrun](CREATE_TRAINRUN.m
 
 For more details have a look into [create and modify connections](CREATE_CONNECTIONS.md).
 
-
 ---
+
 <a id="Filter"></a>
 
 ## Filters
@@ -120,6 +125,7 @@ For more details have a look into [create and modify connections](CREATE_CONNECT
 For more details have a look into [create and modify filters](CREATE_FILTERS.md).
 
 ---
+
 <a id="Streckengrafik"></a>
 
 ## Graphic timetable (Streckengrafik)
@@ -128,8 +134,8 @@ For more details have a look into [create and modify filters](CREATE_FILTERS.md)
 
 For more details have a look into [graphic timetable](Graphic_Timetable.md).
 
-
 ---
+
 <a id="Perlenkette"></a>
 
 ## Perlenkette
@@ -155,15 +161,18 @@ displaying the train's route as a vertical chain of nodes and trainrunsections.
 [2024-1-25_DeleteConnections-Perlenkette-Show_Connections.webm](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/assets/2674075/d272fc58-3f31-4427-aacf-cc3c50c03905)
 
 ### Change the time locks
-The time can be locked so that no propagation (automated update) will be done. Just click on the lock icon and the lock state switches: On to off or vice-versa. 
 
-### Toggle: show all locks / or only closed (default) 
+The time can be locked so that no propagation (automated update) will be done. Just click on the lock icon and the lock state switches: On to off or vice-versa.
+
+### Toggle: show all locks / or only closed (default)
+
 In the Perlenkette view, you can click on the eye icon in the bottom left corner
-to display all locks. By default, only the locks that are closed are shown. This is 
-visually visible with the disabled eye icon. When you click on the icon then the disabled 
+to display all locks. By default, only the locks that are closed are shown. This is
+visually visible with the disabled eye icon. When you click on the icon then the disabled
 eye icon switches to the visible eye icon - or vice-versa. Visible eye means all locks are visible.
 
 ---
+
 <a id="Conclusion"></a>
 
 ## Conclusion
@@ -171,13 +180,15 @@ eye icon switches to the visible eye icon - or vice-versa. Visible eye means all
 By following the instructions in this document, users can effectively create and facilitate the
 creation of comprehensive and visually appealing network representations.
 
-
 ---
+
 <a id="Links"></a>
 
 ## Links
+
 - [Netzgrafik-Editor data export/import (JSON)](DATA_MODEL_JSON.md)
 - [DATA MODEL](DATA_MODEL.md)
 
-## Technical documentation 
+## Technical documentation
+
 - [Trainrun iterator](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/documentation/technical/trainrun_iterations.md)

--- a/documentation/technical/trainrun_iterations.md
+++ b/documentation/technical/trainrun_iterations.md
@@ -1,15 +1,16 @@
-# Trainrun iterator 
+# Trainrun iterator
 
-## Sample code 
+## Sample code
 
 https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/pull/325
 
 ### Simple trainrun iterator - just one trainrun part
-To iterate starting from a node of interest with the orientation passed through the trainrun section, you can use the sample code (pattern) below. 
+
+To iterate starting from a node of interest with the orientation passed through the trainrun section, you can use the sample code (pattern) below.
 The iteration will proceed along the trainrun. Be aware that this does not ensure traveling through the full train run.
 
 ```typescript
- 
+
   // create forward iterator
   const iterator: TrainrunIterator = this.trainrunService.getIterator(
     startForwardNode,
@@ -19,7 +20,7 @@ The iteration will proceed along the trainrun. Be aware that this does not ensur
     // move iterator forward
     const currentTrainrunSectionNodePair = iterator.next();
 
-    // get data 
+    // get data
     const trainrunSection = currentTrainrunSectionNodePair.trainrunSection;
     const node = currentTrainrunSectionNodePair.node;
 
@@ -29,16 +30,17 @@ The iteration will proceed along the trainrun. Be aware that this does not ensur
     data
     processing
   ...
- 
-  } 
+
+  }
 }
 ```
 
 ### Complete Train Run Iterator - Over All Train Run Parts
+
 Iterator pattern for iterating through all train run parts separately.
 
 ![image](https://github.com/user-attachments/assets/d87b842c-7696-4e81-aa78-75cc966b5306)
-*Example Netzgrafik with missing sections (See the cargo trainrun GTwo_Part_trainrun)*
+_Example Netzgrafik with missing sections (See the cargo trainrun GTwo_Part_trainrun)_
 
 [See also](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/documentation/CREATE_TRAINRUN.md#special-cases)
 
@@ -47,14 +49,14 @@ getForwardTrainrunPartIterator(trainrunSection : TrainrunSection) {
       // find both start nodes ( N1 - N2 - N3 - N4 ) => N1 , N2
       const bothEndNodes =
         this.trainrunService.getBothEndNodesFromTrainrunPart(trainrunSection);
-        
-      // get start / end node from Top/Left -> Botton / Right 
+
+      // get start / end node from Top/Left -> Botton / Right
       const startForwardNode = GeneralViewFunctions.getLeftOrTopNode(
         bothEndNodes.endNode1,
         bothEndNodes.endNode2,
       );
-     
-      // get start trainrun section -> forward direction/orientation 
+
+      // get start trainrun section -> forward direction/orientation
       const startTrainrunSection = startForwardNode.getStartTrainrunSection(
         trainrun.getId(),
       );
@@ -80,7 +82,7 @@ simpleTrainrunAllPartsIterator(trainrun: Trainrun) {
         // move iterator forward
         const currentTrainrunSectionNodePair = iterator.next();
 
-        // get data 
+        // get data
         const trainrunSection = currentTrainrunSectionNodePair.trainrunSection;
         const node = currentTrainrunSectionNodePair.node;
 

--- a/e2e/protractor.browserstack.conf.js
+++ b/e2e/protractor.browserstack.conf.js
@@ -2,30 +2,28 @@
 // Protractor configuration file, see link for more information
 // https://github.com/angular/protractor/blob/master/lib/config.ts
 
-const { SpecReporter } = require('jasmine-spec-reporter');
-const browserstack = require('browserstack-local');
+const {SpecReporter} = require("jasmine-spec-reporter");
+const browserstack = require("browserstack-local");
 
 /**
  * @type { import("protractor").Config }
  */
 exports.config = {
   allScriptsTimeout: 11000,
-  specs: [
-    './src/**/*.e2e-spec.ts'
-  ],
+  specs: ["./src/**/*.e2e-spec.ts"],
   capabilities: {
-    'build': 'protractor-browserstack',
-    'browserName': 'chrome',
-    'browserstack.local': true,
-    'browserstack.debug': 'true',
-    'browserstack.user': process.env.BROWSERSTACK_USERNAME,
-    'browserstack.key': process.env.BROWSERSTACK_ACCESS_KEY
+    build: "protractor-browserstack",
+    browserName: "chrome",
+    "browserstack.local": true,
+    "browserstack.debug": "true",
+    "browserstack.user": process.env.BROWSERSTACK_USERNAME,
+    "browserstack.key": process.env.BROWSERSTACK_ACCESS_KEY,
   },
-  framework: 'jasmine',
+  framework: "jasmine",
   jasmineNodeOpts: {
     showColors: true,
     defaultTimeoutInterval: 30000,
-    print: function() {}
+    print: function () {},
   },
 
   // Code to start browserstack local before start of test
@@ -33,31 +31,36 @@ exports.config = {
     console.log("Connecting local");
     return new Promise(function (resolve, reject) {
       exports.bs_local = new browserstack.Local();
-      exports.bs_local.start({
-        key: process.env.BROWSERSTACK_ACCESS_KEY
-      }, function (error) {
-        if (error) {
-          return reject(error);
-        }
+      exports.bs_local.start(
+        {
+          key: process.env.BROWSERSTACK_ACCESS_KEY,
+        },
+        function (error) {
+          if (error) {
+            return reject(error);
+          }
 
-        console.log('Connected to browserstack. Now testing...');
-        resolve();
-      });
+          console.log("Connected to browserstack. Now testing...");
+          resolve();
+        },
+      );
     });
   },
 
   // Code to stop browserstack local after end of test
   afterLaunch: function () {
     return new Promise(function (resolve) {
-      console.log('Stopping browserstack-local connection');
+      console.log("Stopping browserstack-local connection");
       exports.bs_local.stop(resolve);
     });
   },
 
   onPrepare() {
-    require('ts-node').register({
-      project: require('path').join(__dirname, './tsconfig.json')
+    require("ts-node").register({
+      project: require("path").join(__dirname, "./tsconfig.json"),
     });
-    jasmine.getEnv().addReporter(new SpecReporter({ spec: { displayStacktrace: true } }));
-  }
+    jasmine
+      .getEnv()
+      .addReporter(new SpecReporter({spec: {displayStacktrace: true}}));
+  },
 };

--- a/e2e/protractor.conf.js
+++ b/e2e/protractor.conf.js
@@ -2,31 +2,31 @@
 // Protractor configuration file, see link for more information
 // https://github.com/angular/protractor/blob/master/lib/config.ts
 
-const { SpecReporter } = require('jasmine-spec-reporter');
+const {SpecReporter} = require("jasmine-spec-reporter");
 
 /**
  * @type { import("protractor").Config }
  */
 exports.config = {
   allScriptsTimeout: 11000,
-  specs: [
-    './src/**/*.e2e-spec.ts'
-  ],
+  specs: ["./src/**/*.e2e-spec.ts"],
   capabilities: {
-    'browserName': 'chrome'
+    browserName: "chrome",
   },
   directConnect: true,
-  baseUrl: 'http://localhost:4200/',
-  framework: 'jasmine',
+  baseUrl: "http://localhost:4200/",
+  framework: "jasmine",
   jasmineNodeOpts: {
     showColors: true,
     defaultTimeoutInterval: 30000,
-    print: function() {}
+    print: function () {},
   },
   onPrepare() {
-    require('ts-node').register({
-      project: require('path').join(__dirname, './tsconfig.json')
+    require("ts-node").register({
+      project: require("path").join(__dirname, "./tsconfig.json"),
     });
-    jasmine.getEnv().addReporter(new SpecReporter({ spec: { displayStacktrace: true } }));
-  }
+    jasmine
+      .getEnv()
+      .addReporter(new SpecReporter({spec: {displayStacktrace: true}}));
+  },
 };

--- a/e2e/protractor.puppeteer.conf.js
+++ b/e2e/protractor.puppeteer.conf.js
@@ -2,36 +2,36 @@
 // Protractor configuration file, see link for more information
 // https://github.com/angular/protractor/blob/master/lib/config.ts
 
-const { SpecReporter } = require('jasmine-spec-reporter');
-const puppeteer = require('puppeteer');
+const {SpecReporter} = require("jasmine-spec-reporter");
+const puppeteer = require("puppeteer");
 
 /**
  * @type { import("protractor").Config }
  */
 exports.config = {
   allScriptsTimeout: 11000,
-  specs: [
-    './src/**/*.e2e-spec.ts'
-  ],
+  specs: ["./src/**/*.e2e-spec.ts"],
   capabilities: {
-    'browserName': 'chrome',
+    browserName: "chrome",
     chromeOptions: {
-      args: ['--headless'],
+      args: ["--headless"],
       binary: puppeteer.executablePath(),
-    }
+    },
   },
   directConnect: true,
-  baseUrl: 'http://localhost:4200/',
-  framework: 'jasmine',
+  baseUrl: "http://localhost:4200/",
+  framework: "jasmine",
   jasmineNodeOpts: {
     showColors: true,
     defaultTimeoutInterval: 30000,
-    print: function() {}
+    print: function () {},
   },
   onPrepare() {
-    require('ts-node').register({
-      project: require('path').join(__dirname, './tsconfig.json')
+    require("ts-node").register({
+      project: require("path").join(__dirname, "./tsconfig.json"),
     });
-    jasmine.getEnv().addReporter(new SpecReporter({ spec: { displayStacktrace: true } }));
-  }
+    jasmine
+      .getEnv()
+      .addReporter(new SpecReporter({spec: {displayStacktrace: true}}));
+  },
 };

--- a/e2e/src/app.e2e-spec.ts
+++ b/e2e/src/app.e2e-spec.ts
@@ -1,23 +1,25 @@
-import { AppPage } from './app.po';
-import { browser, logging } from 'protractor';
+import {AppPage} from "./app.po";
+import {browser, logging} from "protractor";
 
-describe('workspace-project App', () => {
+describe("workspace-project App", () => {
   let page: AppPage;
 
   beforeEach(() => {
     page = new AppPage();
   });
 
-  it('should display welcome message', () => {
+  it("should display welcome message", () => {
     page.navigateTo();
-    expect(page.getTitleText()).toEqual('Welcome to esta-cloud-angular!');
+    expect(page.getTitleText()).toEqual("Welcome to esta-cloud-angular!");
   });
 
   afterEach(async () => {
     // Assert that there are no errors emitted from the browser
     const logs = await browser.manage().logs().get(logging.Type.BROWSER);
-    expect(logs).not.toContain(jasmine.objectContaining({
-      level: logging.Level.SEVERE,
-    } as logging.Entry));
+    expect(logs).not.toContain(
+      jasmine.objectContaining({
+        level: logging.Level.SEVERE,
+      } as logging.Entry),
+    );
   });
 });

--- a/e2e/src/app.po.ts
+++ b/e2e/src/app.po.ts
@@ -1,4 +1,4 @@
-import { browser, by, element } from 'protractor';
+import {browser, by, element} from "protractor";
 
 export class AppPage {
   navigateTo() {
@@ -6,6 +6,6 @@ export class AppPage {
   }
 
   getTitleText() {
-    return element(by.css('sbb-root h1')).getText() as Promise<string>;
+    return element(by.css("sbb-root h1")).getText() as Promise<string>;
   }
 }

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -4,10 +4,6 @@
     "outDir": "../out-tsc/e2e",
     "module": "commonjs",
     "target": "es2018",
-    "types": [
-      "jasmine",
-      "jasminewd2",
-      "node"
-    ]
+    "types": ["jasmine", "jasminewd2", "node"]
   }
 }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -2,52 +2,55 @@
 // https://karma-runner.github.io/1.0/config/configuration-file.html
 
 if (process.env.BUILD_NUMBER) {
-  process.env.CHROME_BIN = require('puppeteer').executablePath();
+  process.env.CHROME_BIN = require("puppeteer").executablePath();
 }
 
 module.exports = function (config) {
   config.set({
-    basePath: '',
-    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    basePath: "",
+    frameworks: ["jasmine", "@angular-devkit/build-angular"],
     plugins: [
-      require('karma-jasmine'),
-      require('karma-chrome-launcher'),
-      require('karma-browserstack-launcher'),
-      require('karma-jasmine-html-reporter'),
-      require('karma-sonarqube-reporter'),
-      require('karma-coverage'),
-      require('@angular-devkit/build-angular/plugins/karma')
+      require("karma-jasmine"),
+      require("karma-chrome-launcher"),
+      require("karma-browserstack-launcher"),
+      require("karma-jasmine-html-reporter"),
+      require("karma-sonarqube-reporter"),
+      require("karma-coverage"),
+      require("@angular-devkit/build-angular/plugins/karma"),
     ],
     client: {
-      clearContext: false // leave Jasmine Spec Runner output visible in browser
+      clearContext: false, // leave Jasmine Spec Runner output visible in browser
     },
     sonarqubeReporter: {
-      basePath: require('path').join(__dirname, './src'),
-      outputFolder: require('path').join(__dirname, './coverage/netzgrafik-frontend'),
-      reportName: () => 'sonarqube.xml'
+      basePath: require("path").join(__dirname, "./src"),
+      outputFolder: require("path").join(
+        __dirname,
+        "./coverage/netzgrafik-frontend",
+      ),
+      reportName: () => "sonarqube.xml",
     },
     coverageIstanbulReporter: {
-      dir: require('path').join(__dirname, './coverage/netzgrafik-frontend'),
-      reports: ['html', 'lcovonly', 'cobertura'],
-      fixWebpackSourcePaths: true
+      dir: require("path").join(__dirname, "./coverage/netzgrafik-frontend"),
+      reports: ["html", "lcovonly", "cobertura"],
+      fixWebpackSourcePaths: true,
     },
-    reporters: ['progress', 'kjhtml'],
+    reporters: ["progress", "kjhtml"],
     port: 9876,
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['Chrome'],
+    browsers: ["Chrome"],
     customLaunchers: {
       // See https://www.browserstack.com/automate/capabilities
       // To use these browsers add the key to angular.json under test => browsers
       // (Look for ChromeHeadless for an example)
       BsChrome: {
-        base: 'BrowserStack',
-        browser: 'chrome',
-        os: 'OS X'
-      }
+        base: "BrowserStack",
+        browser: "chrome",
+        os: "OS X",
+      },
     },
     singleRun: false,
-    restartOnFileChange: true
+    restartOnFileChange: true,
   });
 };

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "build:standalone": "ng build --configuration=standalone",
     "build:standalonedemo": "ng build --configuration=standalonedemo",
     "test": "ng test -c ci",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "lint": "ng lint",
     "lint:fix": "ng lint --fix",
     "e2e": "ng e2e",

--- a/src/app/api/generated/README.md
+++ b/src/app/api/generated/README.md
@@ -3,6 +3,7 @@
 ### Building
 
 To install the required dependencies and to build the typescript sources run:
+
 ```
 npm install
 npm run build
@@ -10,7 +11,7 @@ npm run build
 
 ### publishing
 
-First build the package then run ```npm publish dist``` (don't forget to specify the `dist` folder!)
+First build the package then run `npm publish dist` (don't forget to specify the `dist` folder!)
 
 ### consuming
 
@@ -33,24 +34,24 @@ _It's important to take the tgz file, otherwise you'll get trouble with links on
 _using `npm link`:_
 
 In PATH_TO_GENERATED_PACKAGE/dist:
+
 ```
 npm link
 ```
 
 In your project:
+
 ```
-npm link 
+npm link
 ```
 
-__Note for Windows users:__ The Angular CLI has troubles to use linked npm packages.
+**Note for Windows users:** The Angular CLI has troubles to use linked npm packages.
 Please refer to this issue https://github.com/angular/angular-cli/issues/8284 for a solution / workaround.
 Published packages are not effected by this issue.
-
 
 #### General usage
 
 In your Angular project:
-
 
 ```
 // without configuring providers
@@ -128,9 +129,11 @@ Note: The ApiModule is restricted to being instantiated once app wide.
 This is to ensure that all services are treated as singletons.
 
 #### Using multiple OpenAPI files / APIs / ApiModules
+
 In order to use multiple `ApiModules` generated from different OpenAPI files,
 you can create an alias name when importing the modules
 in order to avoid naming conflicts:
+
 ```
 import { ApiModule } from 'my-api-path';
 import { ApiModule as OtherApiModule } from 'my-other-api-path';
@@ -150,9 +153,9 @@ export class AppModule {
 }
 ```
 
-
 ### Set service base path
-If different than the generated base path, during app bootstrap, you can provide the base path to your service. 
+
+If different than the generated base path, during app bootstrap, you can provide the base path to your service.
 
 ```
 import { BASE_PATH } from '';
@@ -161,6 +164,7 @@ bootstrap(AppComponent, [
     { provide: BASE_PATH, useValue: 'https://your-web-service.com' },
 ]);
 ```
+
 or
 
 ```
@@ -175,8 +179,8 @@ import { BASE_PATH } from '';
 export class AppModule {}
 ```
 
-
 #### Using @angular/cli
+
 First extend your `src/environments/*.ts` files by adding the corresponding base path:
 
 ```
@@ -187,6 +191,7 @@ export const environment = {
 ```
 
 In the src/app/app.module.ts:
+
 ```
 import { BASE_PATH } from '';
 import { environment } from '../environments/environment';
@@ -200,4 +205,4 @@ import { environment } from '../environments/environment';
   bootstrap: [ AppComponent ]
 })
 export class AppModule { }
-```  
+```

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -24,7 +24,9 @@ const routes: Routes = [
   {
     path: "404",
     component: ErrorViewComponent,
-    data: {error: $localize`:@@app-routing.module.path.404:The page you were looking for was not found.`},
+    data: {
+      error: $localize`:@@app-routing.module.path.404:The page you were looking for was not found.`,
+    },
   },
   {
     path: "401",
@@ -36,20 +38,23 @@ const routes: Routes = [
   {
     path: "403",
     component: ErrorViewComponent,
-    data: {error: $localize`:@@app-routing.module.path.403:You are not authorized to perform this action.`},
+    data: {
+      error: $localize`:@@app-routing.module.path.403:You are not authorized to perform this action.`,
+    },
   },
   {
     path: "409",
     component: ErrorViewComponent,
     data: {
-      error:
-        $localize`:@@app-routing.module.path.409:There was a conflict while executing your action, please try again.`,
+      error: $localize`:@@app-routing.module.path.409:There was a conflict while executing your action, please try again.`,
     },
   },
   {
     path: "error",
     component: ErrorViewComponent,
-    data: {error: $localize`:@@app-routing.module.path.error:An error has occurred.`},
+    data: {
+      error: $localize`:@@app-routing.module.path.error:An error has occurred.`,
+    },
   },
   {path: "**", redirectTo: "/404"},
 ];

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,14 +1,18 @@
 <sbb-header-lean
   label="Netzgrafik-Editor"
-  [subtitle]="'app.version' | translate:{ 'version': version }"
+  [subtitle]="'app.version' | translate: {version: version}"
   class="sbb-header-fixed-columns noprint"
 >
-  <sbb-app-chooser-section [label]="'app.user-guide' | translate" class="noprint">
-    <a href="https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/documentation/USERMANUAL.md"
+  <sbb-app-chooser-section
+    [label]="'app.user-guide' | translate"
+    class="noprint"
+  >
+    <a
+      href="https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/documentation/USERMANUAL.md"
       class="nav-element"
       target="_blank"
     >
-      {{ 'app.user-manual' | translate }}
+      {{ "app.user-manual" | translate }}
     </a>
   </sbb-app-chooser-section>
   <sbb-header-environment class="noprint" *ngIf="environmentLabel">{{
@@ -36,10 +40,10 @@
       <sbb-option value="fr">🇫🇷 Français</sbb-option>
       <!-- <sbb-option value="it">🇮🇹 Italiano</sbb-option> -->
     </sbb-select>
-    <hr>
+    <hr />
     <button sbb-menu-item (click)="logout()">
       <sbb-icon svgIcon="exit-small" class="sbb-icon-fit"></sbb-icon>
-      <span>{{ 'app.logout' | translate }}</span>
+      <span>{{ "app.logout" | translate }}</span>
     </button>
   </sbb-menu>
 </sbb-header-lean>
@@ -50,10 +54,9 @@
 <ng-template #loading>
   <ng-container *ngIf="!disableBackend">
     <sbb-loading-indicator mode="big"></sbb-loading-indicator>
-    <div class="login-message">{{ 'app.login' | translate }}</div>
+    <div class="login-message">{{ "app.login" | translate }}</div>
   </ng-container>
   <ng-container *ngIf="disableBackend">
     <sbb-netzgrafik-editor></sbb-netzgrafik-editor>
   </ng-container>
 </ng-template>
-

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -63,16 +63,14 @@ sbb-loading-indicator {
   }
 }
 
-
 // firefox fix
-::ng-deep input[type=number]::-webkit-outer-spin-button,
-input[type=number]::-webkit-inner-spin-button {
+::ng-deep input[type="number"]::-webkit-outer-spin-button,
+input[type="number"]::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
 
-::ng-deep
-input[type=number] {
+::ng-deep input[type="number"] {
   -moz-appearance: textfield;
 }
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -45,16 +45,17 @@ export class AppComponent implements OnInit {
     return this.authService.claims?.email;
   }
 
-  constructor(private authService: AuthService,
-              private dataService: DataService,
-              private uiInteractionService: UiInteractionService,
-              private trainrunService: TrainrunService,
-              private trainrunSectionService: TrainrunSectionService,
-              private nodeService: NodeService,
-              private positionTransformationService: PositionTransformationService,
-              private labelService: LabelService,
-              private i18nService: I18nService,
-            ) {
+  constructor(
+    private authService: AuthService,
+    private dataService: DataService,
+    private uiInteractionService: UiInteractionService,
+    private trainrunService: TrainrunService,
+    private trainrunSectionService: TrainrunSectionService,
+    private nodeService: NodeService,
+    private positionTransformationService: PositionTransformationService,
+    private labelService: LabelService,
+    private i18nService: I18nService,
+  ) {
     if (!this.disableBackend) {
       this.authenticated = authService.initialized;
     }

--- a/src/app/core/i18n/i18n.module.ts
+++ b/src/app/core/i18n/i18n.module.ts
@@ -8,18 +8,20 @@ import {I18nService} from "./i18n.service";
   imports: [CommonModule],
   providers: [
     I18nService,
-    { // Load locale data at app start-up
+    {
+      // Load locale data at app start-up
       provide: APP_INITIALIZER,
       useFactory: (i18nService: I18nService) => () => i18nService.setLanguage(),
       deps: [I18nService],
       multi: true,
     },
-    { // Set the runtime locale for the app
+    {
+      // Set the runtime locale for the app
       provide: LOCALE_ID,
       useFactory: (i18nService: I18nService) => i18nService.language,
       deps: [I18nService],
-    }
+    },
   ],
-  exports: [TranslatePipe] // Export the pipe
+  exports: [TranslatePipe], // Export the pipe
 })
-export class I18nModule { }
+export class I18nModule {}

--- a/src/app/core/i18n/i18n.service.ts
+++ b/src/app/core/i18n/i18n.service.ts
@@ -3,11 +3,12 @@ import {registerLocaleData} from "@angular/common";
 import {loadTranslations} from "@angular/localize";
 
 @Injectable({
-    providedIn: "root",
-  })
+  providedIn: "root",
+})
 export class I18nService {
   readonly allowedLanguages = ["en", "fr", "de", "it"];
-  private currentLanguage: string = this.getLanguageFromStorage() || this.detectNavigatorLanguage();
+  private currentLanguage: string =
+    this.getLanguageFromStorage() || this.detectNavigatorLanguage();
   translations: any = {};
 
   get language(): string {
@@ -40,7 +41,9 @@ export class I18nService {
 
   private detectNavigatorLanguage(): string {
     const navigatorLanguage = navigator.language.slice(0, 2);
-    return this.allowedLanguages.includes(navigatorLanguage) ? navigatorLanguage : this.allowedLanguages[0];
+    return this.allowedLanguages.includes(navigatorLanguage)
+      ? navigatorLanguage
+      : this.allowedLanguages[0];
   }
 
   async loadTranslations() {
@@ -48,7 +51,9 @@ export class I18nService {
       `src/assets/i18n/${this.language}.json`
     );
 
-    this.translations = this.flattenTranslations(languageTranslationsModule.default);
+    this.translations = this.flattenTranslations(
+      languageTranslationsModule.default,
+    );
     loadTranslations(this.translations);
   }
 
@@ -88,7 +93,7 @@ export class I18nService {
     let translation = this.translations[key] || key;
 
     if (params) {
-      Object.keys(params).forEach(param => {
+      Object.keys(params).forEach((param) => {
         translation = translation.replace(`{$${param}}`, params[param]);
       });
     }

--- a/src/app/core/i18n/translate.pipe.ts
+++ b/src/app/core/i18n/translate.pipe.ts
@@ -3,7 +3,7 @@ import {I18nService} from "./i18n.service";
 
 @Pipe({
   name: "translate",
-  pure: false
+  pure: false,
 })
 export class TranslatePipe implements PipeTransform {
   constructor(private i18nService: I18nService) {}

--- a/src/app/data-structures/business.data.structures.ts
+++ b/src/app/data-structures/business.data.structures.ts
@@ -153,7 +153,6 @@ export interface LabelDto {
   labelRef: LabelRef; // label ref - declares the label group - used for double check - deprecate???
 }
 
-
 /**
  * Represents a filterable LabelGroup - in general one group per LabelRef are avaible, but user can
  * add more and algine labels to the right groups (right means = LabelRef must correspond to the
@@ -284,7 +283,7 @@ export interface ResourceDto {
  * Represents the filter settings, which can be stored.
  */
 export interface FilterSettingDto {
-  id: number;  // unique indentifier
+  id: number; // unique indentifier
   name: string; // name
   description: string; // description
   filterNodeLabels: number[]; // labels to filter out (labels only of type - LabelRef: node)

--- a/src/app/models/node.model.ts
+++ b/src/app/models/node.model.ts
@@ -420,7 +420,10 @@ export class Node {
     );
   }
 
-  getStartTrainrunSection(trainrunId: number, returnForwardStartNode = true): TrainrunSection {
+  getStartTrainrunSection(
+    trainrunId: number,
+    returnForwardStartNode = true,
+  ): TrainrunSection {
     const portsForTrainrun = this.ports.filter(
       (port) => port.getTrainrunSection().getTrainrunId() === trainrunId,
     );
@@ -435,13 +438,16 @@ export class Node {
             transition.getPortId2() === port.getId(),
         ) === undefined,
     );
-    if (portsWithNoTransition === undefined || portsWithNoTransition.length === 0) {
+    if (
+      portsWithNoTransition === undefined ||
+      portsWithNoTransition.length === 0
+    ) {
       return undefined;
     }
     // Does the system has one or more ports found (with no transitions -> Start/Ending Ports)?
     // If no return first found otherwise check whether there is the forward (start node) of
     // interest - or the backward (end node)
-    if (portsWithNoTransition.length === 1 || returnForwardStartNode ){
+    if (portsWithNoTransition.length === 1 || returnForwardStartNode) {
       // forward
       return portsWithNoTransition[0].getTrainrunSection();
     }
@@ -558,7 +564,7 @@ export class Node {
     port2: Port,
     trainrun: Trainrun,
     isNonStop = false,
-  ) : Transition {
+  ): Transition {
     const transition: Transition = new Transition();
     transition.setPort1Id(port1.getId());
     transition.setPort2Id(port2.getId());
@@ -634,8 +640,7 @@ export class Node {
 
   removeTransitionFromId(t: Transition) {
     this.transitions = this.transitions.filter(
-      (transition) =>
-        transition.getId() !== t.getId()
+      (transition) => transition.getId() !== t.getId(),
     );
   }
 

--- a/src/app/models/trainrunsection.model.spec.ts
+++ b/src/app/models/trainrunsection.model.spec.ts
@@ -630,6 +630,4 @@ describe("TrainrunSection Model Test", () => {
     expect(ts.getSourceArrival()).toBe(11);
     expect(ts.getTravelTime()).toBe(10);
   });
-
-
 });

--- a/src/app/models/trainrunsection.model.ts
+++ b/src/app/models/trainrunsection.model.ts
@@ -185,11 +185,31 @@ export class TrainrunSection {
     timeDate.setSeconds(((time.time + offset + 24 * 60) % 60) * 60);
 
     const patterns = {
-      "{{consecutiveTime}}.format(HH:mm:ss)": formatDate(consecutiveTimeDate.toISOString(), "HH:mm:ss", "en-US", "UTC"),
-      "{{consecutiveTime}}.format(HH:mm)": formatDate(consecutiveTimeDate.toISOString(), "HH:mm", "en-US", "UTC"),
+      "{{consecutiveTime}}.format(HH:mm:ss)": formatDate(
+        consecutiveTimeDate.toISOString(),
+        "HH:mm:ss",
+        "en-US",
+        "UTC",
+      ),
+      "{{consecutiveTime}}.format(HH:mm)": formatDate(
+        consecutiveTimeDate.toISOString(),
+        "HH:mm",
+        "en-US",
+        "UTC",
+      ),
       "{{consecutiveTime}}": "" + time.consecutiveTime,
-      "{{time}}.format(HH:mm:ss)": formatDate(timeDate.toISOString(), "HH:mm:ss", "en-US", "UTC"),
-      "{{time}}.format(HH:mm)": formatDate(timeDate.toISOString(), "HH:mm", "en-US", "UTC"),
+      "{{time}}.format(HH:mm:ss)": formatDate(
+        timeDate.toISOString(),
+        "HH:mm:ss",
+        "en-US",
+        "UTC",
+      ),
+      "{{time}}.format(HH:mm)": formatDate(
+        timeDate.toISOString(),
+        "HH:mm",
+        "en-US",
+        "UTC",
+      ),
       "{{time}}": "" + ((time.time + offset + 24 * 60) % 60),
     };
 
@@ -659,7 +679,7 @@ export class TrainrunSection {
       resourceId: this.resourceId,
 
       specificTrainrunSectionFrequencyId:
-      this.specificTrainrunSectionFrequencyId,
+        this.specificTrainrunSectionFrequencyId,
       path: this.path,
       warnings: this.warnings,
     };

--- a/src/app/netzgrafik-application/netzgrafik-application.component.html
+++ b/src/app/netzgrafik-application/netzgrafik-application.component.html
@@ -1,7 +1,8 @@
 <sbb-icon-sidebar-container [class]="getSidebarClassTag()">
-  <sbb-icon-sidebar [(expanded)]="expanded" >
+  <sbb-icon-sidebar [(expanded)]="expanded">
     <!--<a sbbIconSidebarItem label="Varianten" (click)="onVariantenClicked()" class="sbb-active">-->
-    <a *ngIf="!disableBackend"
+    <a
+      *ngIf="!disableBackend"
       sbbIconSidebarItem
       [label]="'app.netzgrafik-application.variants' | translate"
       [class]="getVariantsActivatedTag()"

--- a/src/app/netzgrafik-application/netzgrafik-application.component.ts
+++ b/src/app/netzgrafik-application/netzgrafik-application.component.ts
@@ -59,7 +59,8 @@ export class NetzgrafikApplicationComponent {
         }
         uiInteractionService.setViewboxProperties(
           EditorView.svgName,
-          uiInteractionService.getDefaultViewProperties());
+          uiInteractionService.getDefaultViewProperties(),
+        );
       });
   }
 
@@ -106,7 +107,9 @@ export class NetzgrafikApplicationComponent {
   }
 
   getEditStyle() {
-    if (this.uiInteractionService.getEditorMode() === EditorMode.MultiNodeMoving) {
+    if (
+      this.uiInteractionService.getEditorMode() === EditorMode.MultiNodeMoving
+    ) {
       if (this.nodeService.getSelectedNodes().length > 0) {
         return this.sanitizer.bypassSecurityTrustStyle("color:red");
       }

--- a/src/app/perlenkette/model/perlenkette-tests.spec.ts
+++ b/src/app/perlenkette/model/perlenkette-tests.spec.ts
@@ -3,14 +3,15 @@ import {PerlenketteSection} from "./perlenketteSection";
 
 describe("PerlenketteModelTests", () => {
   it("Perlenkette-Model - Test - PerlenketteNode - 001", () => {
-    const node = new PerlenketteNode(0,
+    const node = new PerlenketteNode(
+      0,
       "BN",
       "Berm",
       10,
       [],
       undefined,
       false,
-      true
+      true,
     );
 
     expect(node.isFristTrainrunPartNode()).toBe(false);
@@ -30,7 +31,7 @@ describe("PerlenketteModelTests", () => {
       0,
       false,
       false,
-      true
+      true,
     );
 
     expect(section.isFristTrainrunPartSection()).toBe(false);

--- a/src/app/perlenkette/model/perlenketteNode.ts
+++ b/src/app/perlenkette/model/perlenketteNode.ts
@@ -13,9 +13,8 @@ export class PerlenketteNode implements PerlenketteItem {
     public connections: PerlenketteConnection[],
     public transition: Transition,
     public fristTrainrunPartNode: boolean,
-    public lastTrainrunPartNode: boolean
-  ) {
-  }
+    public lastTrainrunPartNode: boolean,
+  ) {}
 
   isFristTrainrunPartNode(): boolean {
     return this.fristTrainrunPartNode;
@@ -25,7 +24,7 @@ export class PerlenketteNode implements PerlenketteItem {
     return this.lastTrainrunPartNode;
   }
 
-  setLastTrainrunPartNode(flag : boolean) {
+  setLastTrainrunPartNode(flag: boolean) {
     this.lastTrainrunPartNode = flag;
   }
 

--- a/src/app/perlenkette/model/perlenketteSection.ts
+++ b/src/app/perlenkette/model/perlenketteSection.ts
@@ -11,9 +11,8 @@ export class PerlenketteSection implements PerlenketteItem {
     public numberOfStops: number,
     public isBeingEdited: boolean = false,
     public fristTrainrunPartSection: boolean = false,
-    public lastTrainrunPartSection: boolean = false
-  ) {
-  }
+    public lastTrainrunPartSection: boolean = false,
+  ) {}
 
   isFristTrainrunPartSection(): boolean {
     return this.fristTrainrunPartSection;
@@ -23,7 +22,7 @@ export class PerlenketteSection implements PerlenketteItem {
     return this.lastTrainrunPartSection;
   }
 
-  setLastTrainrunPartSection(flag : boolean) {
+  setLastTrainrunPartSection(flag: boolean) {
     this.lastTrainrunPartSection = flag;
   }
 

--- a/src/app/perlenkette/perlenkette-node/perlenkette-node.component.html
+++ b/src/app/perlenkette/perlenkette-node/perlenkette-node.component.html
@@ -1,5 +1,7 @@
-<div class="node-container" (click)="disableSectionView($event)"
-     [class.readonly]="!getVariantIsWritable()"
+<div
+  class="node-container"
+  (click)="disableSectionView($event)"
+  [class.readonly]="!getVariantIsWritable()"
 >
   <svg
     display="block"
@@ -159,7 +161,7 @@
               "
               dominant-baseline="text-after-edge"
               class="edge_text station start layer0"
-              style=" stroke-width: 6px;"
+              style="stroke-width: 6px"
               (click)="selectConnection(connection)"
               [ngClass]="[
                 getTextNameOrTimeClassTag(connection, connectionGrpKey, 0)
@@ -192,7 +194,7 @@
               dominant-baseline="text-after-edge"
               class="edge_text station end layer0"
               (click)="selectConnection(connection)"
-              style=" stroke-width: 6px;"
+              style="stroke-width: 6px"
               [ngClass]="[
                 getTextNameOrTimeClassTag(connection, connectionGrpKey, 1)
               ]"
@@ -224,7 +226,7 @@
               dominant-baseline="text-after-edge"
               class="edge_text end station layer0"
               (click)="selectConnection(connection)"
-              style=" stroke-width: 6px;"
+              style="stroke-width: 6px"
               [ngClass]="[
                 getTextTerminalStationlassTag(connection, connectionGrpKey, 0)
               ]"
@@ -255,7 +257,7 @@
               dominant-baseline="text-after-edge"
               class="edge_text start station layer0"
               (click)="selectConnection(connection)"
-              style=" stroke-width: 6px;"
+              style="stroke-width: 6px"
               [ngClass]="[
                 getTextTerminalStationlassTag(connection, connectionGrpKey, 1)
               ]"

--- a/src/app/perlenkette/perlenkette-node/perlenkette-node.component.scss
+++ b/src/app/perlenkette/perlenkette-node/perlenkette-node.component.scss
@@ -73,7 +73,7 @@ text.edge_text.middle {
 }
 
 text.edge_text.station.layer0 {
-  stroke: var(--NODE_DOCKABLE)
+  stroke: var(--NODE_DOCKABLE);
 }
 
 path.SepConnectionLine {

--- a/src/app/perlenkette/perlenkette-node/perlenkette-node.component.ts
+++ b/src/app/perlenkette/perlenkette-node/perlenkette-node.component.ts
@@ -38,16 +38,15 @@ export class PerlenketteNodeComponent implements OnInit {
     public trainrunService: TrainrunService,
     readonly filterService: FilterService,
     readonly uiInteractionService: UiInteractionService,
-    readonly versionControlService : VersionControlService,
-  ) {
-  }
+    readonly versionControlService: VersionControlService,
+  ) {}
 
   ngOnInit() {
     this.isExpanded = true;
     this.calculateHeightConnectionSurplus();
   }
 
-  getVariantIsWritable() : boolean {
+  getVariantIsWritable(): boolean {
     return this.versionControlService.getVariantIsWritable();
   }
 
@@ -272,8 +271,10 @@ export class PerlenketteNodeComponent implements OnInit {
   getPathClassTag(connection: PerlenketteConnection = undefined): string {
     if (connection === undefined) {
       const lineTag =
-        " Freq_" + this.perlenketteTrainrun.frequency +
-        " LinePatternRef_" + this.perlenketteTrainrun.trainrunTimeCategory.linePatternRef;
+        " Freq_" +
+        this.perlenketteTrainrun.frequency +
+        " LinePatternRef_" +
+        this.perlenketteTrainrun.trainrunTimeCategory.linePatternRef;
       return "UI_DIALOG " + this.getColoringClassTag() + lineTag;
     }
 
@@ -282,9 +283,16 @@ export class PerlenketteNodeComponent implements OnInit {
       selected_tag = " " + StaticDomTags.TAG_SELECTED;
     }
     const lineTag =
-      " Freq_" + connection.frequency +
-      " LinePatternRef_" + connection.connectedTrainrun.getTimeCategoryLinePatternRef();
-    return "UI_DIALOG " + selected_tag + this.getColoringClassTag(connection) + lineTag;
+      " Freq_" +
+      connection.frequency +
+      " LinePatternRef_" +
+      connection.connectedTrainrun.getTimeCategoryLinePatternRef();
+    return (
+      "UI_DIALOG " +
+      selected_tag +
+      this.getColoringClassTag(connection) +
+      lineTag
+    );
   }
 
   getConnectedTrainEdgeLineTransform(
@@ -363,15 +371,15 @@ export class PerlenketteNodeComponent implements OnInit {
         item
           .getPerlenketteNode()
           .connections.forEach((connection: PerlenketteConnection) => {
-          const name = connection.categoryShortName + "" + connection.title;
-          maxTrainrunNameLen = Math.max(
-            3 + connection.terminalStationBackward.length,
-            Math.max(
-              3 + connection.terminalStation.length,
-              Math.max(name.length, maxTrainrunNameLen),
-            ),
-          );
-        });
+            const name = connection.categoryShortName + "" + connection.title;
+            maxTrainrunNameLen = Math.max(
+              3 + connection.terminalStationBackward.length,
+              Math.max(
+                3 + connection.terminalStation.length,
+                Math.max(name.length, maxTrainrunNameLen),
+              ),
+            );
+          });
       }
     });
 

--- a/src/app/perlenkette/perlenkette-section/perlenkette-section.component.html
+++ b/src/app/perlenkette/perlenkette-section/perlenkette-section.component.html
@@ -108,7 +108,7 @@
           y="1"
           width="12"
           height="22"
-          style="cursor: pointer; fill: var(--sbb-header-lean-background-color);"
+          style="cursor: pointer; fill: var(--sbb-header-lean-background-color)"
           (click)="switchSectionViewToggleLock($event, 'leftDepartureTime')"
         ></rect>
         <path
@@ -120,10 +120,13 @@
         />
       </g>
       <g
-        [attr.transform]="stationNumberArray.length > 0 ?
-                             (stationNumberArray.length > 5 ?
-                                  'translate(155, 82)' : 'translate(142, 82)')
-                             : 'translate(125, 82)'"
+        [attr.transform]="
+          stationNumberArray.length > 0
+            ? stationNumberArray.length > 5
+              ? 'translate(155, 82)'
+              : 'translate(142, 82)'
+            : 'translate(125, 82)'
+        "
         *ngIf="showTravelTime() && showTravelTimeLock()"
       >
         <rect
@@ -131,7 +134,7 @@
           y="1"
           width="12"
           height="22"
-          style="cursor: pointer; fill: var(--sbb-header-lean-background-color);"
+          style="cursor: pointer; fill: var(--sbb-header-lean-background-color)"
           (click)="switchSectionViewToggleLock($event, 'travelTime')"
         ></rect>
         <path
@@ -145,14 +148,14 @@
 
       <g
         transform="translate(125, 152)"
-        *ngIf="showRightDepartureTime()  && showRightLock()"
+        *ngIf="showRightDepartureTime() && showRightLock()"
       >
         <rect
           x="6"
           y="1"
           width="12"
           height="22"
-          style="cursor: pointer; fill: var(--sbb-header-lean-background-color);"
+          style="cursor: pointer; fill: var(--sbb-header-lean-background-color)"
           (click)="switchSectionViewToggleLock($event, 'rightDepartureTime')"
         ></rect>
         <path
@@ -577,12 +580,15 @@
         <foreignObject height="192px" width="45px">
           <div class="propagationButtonContainer">
             <button
-              [class]="isFirstSection===true ? 'disabled' : ''"
+              [class]="isFirstSection === true ? 'disabled' : ''"
               class="FunctionButton Rotation90"
               tabindex="-1"
               mode="icon"
               (click)="onPropagateTimeLeft($event)"
-              [title]="'app.perlenkette.perlenkette-section.propagate-times-upwards' | translate"
+              [title]="
+                'app.perlenkette.perlenkette-section.propagate-times-upwards'
+                  | translate
+              "
             >
               <div>
                 <sbb-icon
@@ -594,12 +600,15 @@
               </div>
             </button>
             <button
-              [class]="isLastSection===true ? 'disabled' : ''"
+              [class]="isLastSection === true ? 'disabled' : ''"
               class="FunctionButton Rotation90"
               tabindex="-1"
               mode="icon"
               (click)="onPropagateTimeRight($event)"
-              [title]="'app.perlenkette.perlenkette-section.propagate-times-backwards' | translate"
+              [title]="
+                'app.perlenkette.perlenkette-section.propagate-times-backwards'
+                  | translate
+              "
             >
               <div>
                 <sbb-icon

--- a/src/app/perlenkette/perlenkette-section/perlenkette-section.component.scss
+++ b/src/app/perlenkette/perlenkette-section/perlenkette-section.component.scss
@@ -11,11 +11,9 @@ svg {
   overflow: visible;
 }
 
-
 .readonly {
   pointer-events: none;
 }
-
 
 .start_text {
   text-anchor: start !important;

--- a/src/app/perlenkette/perlenkette-section/perlenkette-section.component.ts
+++ b/src/app/perlenkette/perlenkette-section/perlenkette-section.component.ts
@@ -57,7 +57,8 @@ export interface LeftAndRightLockStructure {
   providers: [TrainrunSectionTimesService],
 })
 export class PerlenketteSectionComponent
-  implements OnInit, AfterContentInit, OnDestroy {
+  implements OnInit, AfterContentInit, OnDestroy
+{
   @Input() perlenketteSection: PerlenketteSection;
   @Input() perlenketteTrainrun: PerlenketteTrainrun;
 
@@ -106,7 +107,7 @@ export class PerlenketteSectionComponent
     public trainrunSectionTimesService: TrainrunSectionTimesService,
     readonly filterService: FilterService,
     private loadPerlenketteService: LoadPerlenketteService,
-    private versionControlService: VersionControlService
+    private versionControlService: VersionControlService,
   ) {
     this.trainrunSectionHelper = new TrainrunsectionHelper(
       this.trainrunService,
@@ -212,12 +213,12 @@ export class PerlenketteSectionComponent
       "UI_DIALOG " +
       " ColorRef_" +
       this.perlenketteTrainrun.colorRef +
-      (noLinePatterns ? " " :
-        " Freq_" +
-        this.perlenketteTrainrun.frequency +
-        " LinePatternRef_" +
-        this.perlenketteTrainrun.trainrunTimeCategory.linePatternRef
-      )
+      (noLinePatterns
+        ? " "
+        : " Freq_" +
+          this.perlenketteTrainrun.frequency +
+          " LinePatternRef_" +
+          this.perlenketteTrainrun.trainrunTimeCategory.linePatternRef)
     );
   }
 
@@ -232,7 +233,6 @@ export class PerlenketteSectionComponent
     event.stopPropagation();
     this.handleSwitchSection(fieldKey);
   }
-
 
   switchSectionViewToggleLock(event: MouseEvent, fieldKey: string) {
     event.stopPropagation();
@@ -249,7 +249,6 @@ export class PerlenketteSectionComponent
       this.onButtonNodeRightLock(event);
       return;
     }
-
   }
 
   handleSwitchSection(fieldKey: string) {
@@ -628,14 +627,20 @@ export class PerlenketteSectionComponent
     ) {
       return (
         "" +
-        this.roundTime(this.trainrunSectionTimesService.getTimeStructure().travelTime) +
+        this.roundTime(
+          this.trainrunSectionTimesService.getTimeStructure().travelTime,
+        ) +
         "' (" +
         this.roundTime(this.trainrunSection.getTravelTime()) +
         "')"
       );
     }
     return (
-      "" + this.roundTime(this.trainrunSectionTimesService.getTimeStructure().travelTime) + "'"
+      "" +
+      this.roundTime(
+        this.trainrunSectionTimesService.getTimeStructure().travelTime,
+      ) +
+      "'"
     );
   }
 
@@ -958,7 +963,6 @@ export class PerlenketteSectionComponent
       return this.lockStructure.leftLock;
     }
     return this.lockStructure.rightLock;
-
   }
 
   getTargetLock(): boolean {
@@ -1092,8 +1096,10 @@ export class PerlenketteSectionComponent
   }
 
   getLockCloseSvgPath(): string {
-    return "M12 4a2 2 0 0 0-2 2v3h4V6a2 2 0 0 0-2-2Zm3 5V6a3 3 0 0 0-6 0v3H6v11h12V9h-3Zm-2.5 " +
-      "4v4h-1v-4h1ZM7 19v-9h10v9H7Z";
+    return (
+      "M12 4a2 2 0 0 0-2 2v3h4V6a2 2 0 0 0-2-2Zm3 5V6a3 3 0 0 0-6 0v3H6v11h12V9h-3Zm-2.5 " +
+      "4v4h-1v-4h1ZM7 19v-9h10v9H7Z"
+    );
   }
 
   getLockSvgPath(isClosed: boolean) {
@@ -1137,17 +1143,21 @@ export class PerlenketteSectionComponent
     const sourceId = this.trainrunSection.getSourceNodeId();
     const fromId = this.perlenketteSection.fromNode.getId();
     if (sourceId === fromId) {
-      this.lockStructure.leftLock = this.trainrunSection.getSourceDepartureLock();
+      this.lockStructure.leftLock =
+        this.trainrunSection.getSourceDepartureLock();
     } else {
       this.lockStructure.leftLock = this.trainrunSection.getTargetArrivalLock();
     }
     const targetId = this.trainrunSection.getTargetNodeId();
     const toId = this.perlenketteSection.toNode.getId();
     if (targetId === toId) {
-      this.lockStructure.rightLock = this.trainrunSection.getTargetArrivalLock();
+      this.lockStructure.rightLock =
+        this.trainrunSection.getTargetArrivalLock();
     } else {
-      this.lockStructure.rightLock = this.trainrunSection.getSourceDepartureLock();
+      this.lockStructure.rightLock =
+        this.trainrunSection.getSourceDepartureLock();
     }
-    this.lockStructure.travelTimeLock = this.trainrunSection.getTravelTimeLock();
+    this.lockStructure.travelTimeLock =
+      this.trainrunSection.getTravelTimeLock();
   }
 }

--- a/src/app/perlenkette/perlenkette.component.html
+++ b/src/app/perlenkette/perlenkette.component.html
@@ -1,12 +1,31 @@
 <div (click)="disableSectionView()">
-
   <div>
-    <div [attr.style]="'pointer-events: none; margin: 0px; position: absolute; padding-left: '+(contentWidth-55)+'px; padding-top: '+(contentHeight-40)+'px;'">
+    <div
+      [attr.style]="
+        'pointer-events: none; margin: 0px; position: absolute; padding-left: ' +
+        (contentWidth - 55) +
+        'px; padding-top: ' +
+        (contentHeight - 40) +
+        'px;'
+      "
+    >
       <ng-container *ngIf="!getShowAllLockStates()">
-        <sbb-icon class="ToggleAllEyesButton" svgIcon="eye-disabled-small" style="pointer-events:auto;" (mouseup)="toggleShowAllLockStates()" [title]="'app.perlenkette.show-only-closed-locks' | translate"></sbb-icon>
+        <sbb-icon
+          class="ToggleAllEyesButton"
+          svgIcon="eye-disabled-small"
+          style="pointer-events: auto"
+          (mouseup)="toggleShowAllLockStates()"
+          [title]="'app.perlenkette.show-only-closed-locks' | translate"
+        ></sbb-icon>
       </ng-container>
       <ng-container *ngIf="getShowAllLockStates()">
-        <sbb-icon class="ToggleAllEyesButton" svgIcon="eye-small" style="pointer-events:auto;" (mouseup)="toggleShowAllLockStates()" [title]="'app.perlenkette.show-all-locks' | translate"></sbb-icon>
+        <sbb-icon
+          class="ToggleAllEyesButton"
+          svgIcon="eye-small"
+          style="pointer-events: auto"
+          (mouseup)="toggleShowAllLockStates()"
+          [title]="'app.perlenkette.show-all-locks' | translate"
+        ></sbb-icon>
       </ng-container>
     </div>
   </div>
@@ -25,7 +44,7 @@
               (click)="trainrunNameClicked($event)"
             >
               <span class="trainname"
-              >{{ perlenketteTrainrun.categoryShortName
+                >{{ perlenketteTrainrun.categoryShortName
                 }}{{ perlenketteTrainrun.title }}</span
               >
             </p>
@@ -34,12 +53,12 @@
               <span class="station" (click)="trainrunNameClicked($event)">{{
                 perlenketteTrainrun.pathItems.at(0).getPerlenketteNode()
                   .fullName
-                }}</span>
+              }}</span>
               <span class="arrow">-</span>
               <span class="station" (click)="trainrunNameClicked($event)">{{
                 perlenketteTrainrun.pathItems.at(-1).getPerlenketteNode()
                   .fullName
-                }}</span>
+              }}</span>
             </p>
           </ng-container>
 
@@ -48,12 +67,12 @@
               <span class="station" (click)="scrollFirst($event)">{{
                 perlenketteTrainrun.pathItems.at(0).getPerlenketteNode()
                   .fullName
-                }}</span>
+              }}</span>
               <span class="arrow">-</span>
               <span class="station" (click)="scrollLast($event)">{{
                 perlenketteTrainrun.pathItems.at(-1).getPerlenketteNode()
                   .fullName
-                }}</span>
+              }}</span>
             </p>
           </ng-container>
         </div>
@@ -92,12 +111,13 @@
           <span
             [class]="getSmallstationClassTag(pathItem)"
             (click)="goto(pathItem)"
-          >{{ pathItem.getPerlenketteNode().shortName }}</span
+            >{{ pathItem.getPerlenketteNode().shortName }}</span
           >
 
-        <ng-container *ngIf="isLastNodeButNotVeryLast(pathItem)">
-          <span [class]="getSmallstationClassTag(pathItem)"> &#x2022; </span>
-        </ng-container>
+          <ng-container *ngIf="isLastNodeButNotVeryLast(pathItem)">
+            <span [class]="getSmallstationClassTag(pathItem)"> &#x2022; </span>
+          </ng-container>
+        </p>
       </div>
     </ng-container>
 
@@ -118,7 +138,9 @@
         [attr.width]="contentWidth"
       >
         <div class="drawing-container" #drawingContainer>
-          <ng-container *ngFor="let pathItem of perlenketteTrainrun.pathItems; index as idx">
+          <ng-container
+            *ngFor="let pathItem of perlenketteTrainrun.pathItems; index as idx"
+          >
             <sbb-perlenkette-node
               *ngIf="pathItem.isPerlenketteNode()"
               [perlenketteTrainrun]="perlenketteTrainrun"
@@ -126,13 +148,12 @@
               (signalHeightChanged)="signalHeightChanged($event, pathItem)"
               [perlenketteNode]="pathItem.getPerlenketteNode()"
               [isTopNode]="idx === 0"
-              [isBottomNode]="idx === perlenketteTrainrun.pathItems.length-1"
-            >
-            </sbb-perlenkette-node>
-            <div *ngIf="doSplitTrainrun(perlenketteTrainrun.pathItems, idx)">
-              <br>
-              <br>
-            </div>
+              [isBottomNode]="idx === perlenketteTrainrun.pathItems.length - 1"
+            ></sbb-perlenkette-node>
+            <div
+              *ngIf="doSplitTrainrun(perlenketteTrainrun.pathItems, idx)"
+              class="split-line"
+            ></div>
             <sbb-perlenkette-section
               *ngIf="pathItem.isPerlenketteSection()"
               [perlenketteSection]="pathItem.getPerlenketteSection()"
@@ -145,8 +166,7 @@
               "
               [isFirstSection]="isFirstSection(pathItem)"
               [isLastSection]="isLastSection(pathItem)"
-            >
-            </sbb-perlenkette-section>
+            ></sbb-perlenkette-section>
           </ng-container>
         </div>
       </foreignObject>

--- a/src/app/perlenkette/perlenkette.component.scss
+++ b/src/app/perlenkette/perlenkette.component.scss
@@ -129,5 +129,5 @@ span.smallstation:hover {
 
 .ToggleAllEyesButton:hover {
   stroke: var(--COLOR_Edit);
-  stroke-width: .5px;
+  stroke-width: 0.5px;
 }

--- a/src/app/perlenkette/perlenkette.component.ts
+++ b/src/app/perlenkette/perlenkette.component.ts
@@ -116,7 +116,7 @@ export class PerlenketteComponent implements AfterContentChecked, OnDestroy {
           ) {
             if (
               pathItem.getPerlenketteSection().trainrunSectionId ===
-              originalPathItem.getPerlenketteSection().trainrunSectionId &&
+                originalPathItem.getPerlenketteSection().trainrunSectionId &&
               originalPathItem.getPerlenketteSection().isBeingEdited
             ) {
               pathItem.getPerlenketteSection().isBeingEdited =
@@ -259,7 +259,10 @@ export class PerlenketteComponent implements AfterContentChecked, OnDestroy {
   }
 
   isLastNodeButNotVeryLast(item: PerlenketteItem) {
-    if (this.perlenketteTrainrun.pathItems.indexOf(item) === this.perlenketteTrainrun.pathItems.length - 1) {
+    if (
+      this.perlenketteTrainrun.pathItems.indexOf(item) ===
+      this.perlenketteTrainrun.pathItems.length - 1
+    ) {
       return false;
     }
     return this.isLastNode(item);

--- a/src/app/perlenkette/service/load-perlenkette.service.ts
+++ b/src/app/perlenkette/service/load-perlenkette.service.ts
@@ -117,16 +117,17 @@ export class LoadPerlenketteService implements OnDestroy {
     const perlenketteItem: PerlenketteItem[] = [];
 
     let allTrainrunSections =
-      this.trainrunSectionService
-        .getAllTrainrunSectionsForTrainrun(trainrun.getId());
+      this.trainrunSectionService.getAllTrainrunSectionsForTrainrun(
+        trainrun.getId(),
+      );
 
     while (allTrainrunSections.length > 0) {
       // traverse over all trainrun parts
       const trainrunSection = allTrainrunSections[0];
 
       // filter all still visited trainrun sections
-      allTrainrunSections = allTrainrunSections.filter(ts =>
-        ts.getId() !== trainrunSection.getId()
+      allTrainrunSections = allTrainrunSections.filter(
+        (ts) => ts.getId() !== trainrunSection.getId(),
       );
 
       const bothEndNodes =
@@ -165,7 +166,8 @@ export class LoadPerlenketteService implements OnDestroy {
         let firstSection = true;
         while (iterator.hasNext()) {
           const currentTrainrunSectionNodePair = iterator.next();
-          const trainrunSection = currentTrainrunSectionNodePair.trainrunSection;
+          const trainrunSection =
+            currentTrainrunSectionNodePair.trainrunSection;
           const node = currentTrainrunSectionNodePair.node;
           // Section X
           perlenketteItem.push(
@@ -177,7 +179,7 @@ export class LoadPerlenketteService implements OnDestroy {
               trainrunSection.getNumberOfStops(),
               false,
               firstSection,
-              false
+              false,
             ),
           );
           firstSection = false;
@@ -192,14 +194,16 @@ export class LoadPerlenketteService implements OnDestroy {
               this.getPerlenketteConnections(trainrun, node),
               node.getTransition(trainrunSection.getId()),
               false,
-              false
+              false,
             ),
           );
           lastNode = node;
 
           // filter all still visited trainrun sections
-          allTrainrunSections = allTrainrunSections.filter(ts =>
-            ts.getId() !== currentTrainrunSectionNodePair.trainrunSection.getId()
+          allTrainrunSections = allTrainrunSections.filter(
+            (ts) =>
+              ts.getId() !==
+              currentTrainrunSectionNodePair.trainrunSection.getId(),
           );
         }
 
@@ -215,8 +219,6 @@ export class LoadPerlenketteService implements OnDestroy {
             pn.setLastTrainrunPartNode(true);
           }
         }
-
-
       }
     }
     return perlenketteItem;
@@ -241,7 +243,11 @@ export class LoadPerlenketteService implements OnDestroy {
         }
 
         // filter connection
-        if (!this.filterService.filterTrainrun(port2.getTrainrunSection().getTrainrun())) {
+        if (
+          !this.filterService.filterTrainrun(
+            port2.getTrainrunSection().getTrainrun(),
+          )
+        ) {
           return;
         }
 
@@ -296,7 +302,6 @@ export class LoadPerlenketteService implements OnDestroy {
           );
         }
 
-
         // calculate real connection time
         const arrivalTime = node.getArrivalTime(port1.getTrainrunSection());
         let departureTime = node.getDepartureTime(port2.getTrainrunSection());
@@ -305,15 +310,22 @@ export class LoadPerlenketteService implements OnDestroy {
         }
         let remainingTime = 24 * 3600;
         for (let freqOff1 = 0; freqOff1 < 8; freqOff1 += 1) {
-          const freq1 = freqOff1 * port1.getTrainrunSection().getTrainrun().getFrequency();
+          const freq1 =
+            freqOff1 * port1.getTrainrunSection().getTrainrun().getFrequency();
           for (let freqOff2 = 0; freqOff2 < 8; freqOff2 += 1) {
-            const freq2 = freqOff2 * port2.getTrainrunSection().getTrainrun().getFrequency();
-            const d = departureTime +
+            const freq2 =
+              freqOff2 *
+              port2.getTrainrunSection().getTrainrun().getFrequency();
+            const d =
+              departureTime +
               freq2 +
-              port2.getTrainrunSection().getTrainrun().getTrainrunFrequency().offset;
-            const a = arrivalTime +
+              port2.getTrainrunSection().getTrainrun().getTrainrunFrequency()
+                .offset;
+            const a =
+              arrivalTime +
               freq1 +
-              port1.getTrainrunSection().getTrainrun().getTrainrunFrequency().offset;
+              port1.getTrainrunSection().getTrainrun().getTrainrunFrequency()
+                .offset;
             const delta = d - a;
             if (delta >= node.getConnectionTime()) {
               remainingTime = Math.min(remainingTime, delta);

--- a/src/app/sample-netzgrafik/DEMO_Netz-Angebot.json
+++ b/src/app/sample-netzgrafik/DEMO_Netz-Angebot.json
@@ -27126,15 +27126,7 @@
         "shortName": "7/24",
         "name": "verkehrt uneingeschränkt",
         "dayTimeInterval": [],
-        "weekday": [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7
-        ],
+        "weekday": [1, 2, 3, 4, 5, 6, 7],
         "linePatternRef": "7/24"
       },
       {
@@ -27152,15 +27144,7 @@
             "to": 1140
           }
         ],
-        "weekday": [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7
-        ],
+        "weekday": [1, 2, 3, 4, 5, 6, 7],
         "linePatternRef": "HVZ"
       },
       {
@@ -27175,6 +27159,6 @@
     ]
   },
   "freeFloatingTexts": [],
-  "labels" : [],
-  "labelGroups" : []
+  "labels": [],
+  "labelGroups": []
 }

--- a/src/app/sample-netzgrafik/Demo_LZ_netzgrafik.json
+++ b/src/app/sample-netzgrafik/Demo_LZ_netzgrafik.json
@@ -1,1 +1,5583 @@
-{"nodes":[{"id":133,"betriebspunktName":"MADI","fullName":"Madiswil ","positionX":192,"positionY":864,"ports":[{"id":597,"trainrunSectionId":281,"positionIndex":0,"positionAlignment":0},{"id":593,"trainrunSectionId":279,"positionIndex":1,"positionAlignment":0},{"id":596,"trainrunSectionId":280,"positionIndex":0,"positionAlignment":1},{"id":592,"trainrunSectionId":278,"positionIndex":1,"positionAlignment":1}],"transitions":[{"id":183,"port1Id":593,"port2Id":592,"isNonStopTransit":false},{"id":185,"port1Id":597,"port2Id":596,"isNonStopTransit":false}],"connections":[],"resourceId":162,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":134,"betriebspunktName":"WSAU","fullName":"Willisau","positionX":544,"positionY":1952,"ports":[{"id":522,"trainrunSectionId":243,"positionIndex":0,"positionAlignment":1},{"id":527,"trainrunSectionId":246,"positionIndex":1,"positionAlignment":1},{"id":524,"trainrunSectionId":244,"positionIndex":2,"positionAlignment":1},{"id":518,"trainrunSectionId":241,"positionIndex":0,"positionAlignment":2},{"id":515,"trainrunSectionId":240,"positionIndex":1,"positionAlignment":2}],"transitions":[{"id":150,"port1Id":522,"port2Id":518,"isNonStopTransit":false},{"id":151,"port1Id":527,"port2Id":515,"isNonStopTransit":false}],"connections":[],"resourceId":163,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":135,"betriebspunktName":"ZG","fullName":"Zug","positionX":1888,"positionY":1984,"ports":[{"id":507,"trainrunSectionId":236,"positionIndex":0,"positionAlignment":0},{"id":509,"trainrunSectionId":237,"positionIndex":1,"positionAlignment":0},{"id":582,"trainrunSectionId":273,"positionIndex":0,"positionAlignment":1},{"id":578,"trainrunSectionId":271,"positionIndex":1,"positionAlignment":1}],"transitions":[{"id":174,"port1Id":509,"port2Id":578,"isNonStopTransit":false},{"id":177,"port1Id":507,"port2Id":582,"isNonStopTransit":false}],"connections":[],"resourceId":164,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":136,"betriebspunktName":"BAA","fullName":"Baar","positionX":1920,"positionY":1632,"ports":[{"id":505,"trainrunSectionId":235,"positionIndex":0,"positionAlignment":0},{"id":508,"trainrunSectionId":236,"positionIndex":0,"positionAlignment":1},{"id":510,"trainrunSectionId":237,"positionIndex":1,"positionAlignment":1}],"transitions":[{"id":147,"port1Id":505,"port2Id":508,"isNonStopTransit":true}],"connections":[],"resourceId":165,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":137,"betriebspunktName":"LZ","fullName":"Luzern","positionX":1152,"positionY":2272,"ports":[{"id":542,"trainrunSectionId":253,"positionIndex":0,"positionAlignment":0},{"id":540,"trainrunSectionId":252,"positionIndex":1,"positionAlignment":0},{"id":538,"trainrunSectionId":251,"positionIndex":2,"positionAlignment":0},{"id":536,"trainrunSectionId":250,"positionIndex":3,"positionAlignment":0},{"id":532,"trainrunSectionId":248,"positionIndex":0,"positionAlignment":2},{"id":530,"trainrunSectionId":247,"positionIndex":1,"positionAlignment":2},{"id":544,"trainrunSectionId":254,"positionIndex":0,"positionAlignment":3},{"id":548,"trainrunSectionId":256,"positionIndex":1,"positionAlignment":3},{"id":550,"trainrunSectionId":257,"positionIndex":2,"positionAlignment":3},{"id":546,"trainrunSectionId":255,"positionIndex":3,"positionAlignment":3}],"transitions":[{"id":155,"port1Id":542,"port2Id":544,"isNonStopTransit":false},{"id":156,"port1Id":536,"port2Id":550,"isNonStopTransit":false}],"connections":[],"resourceId":166,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":138,"betriebspunktName":"WH","fullName":"Wolhusen","positionX":576,"positionY":2272,"ports":[{"id":521,"trainrunSectionId":243,"positionIndex":0,"positionAlignment":0},{"id":528,"trainrunSectionId":246,"positionIndex":1,"positionAlignment":0},{"id":523,"trainrunSectionId":244,"positionIndex":2,"positionAlignment":0},{"id":525,"trainrunSectionId":245,"positionIndex":0,"positionAlignment":2},{"id":520,"trainrunSectionId":242,"positionIndex":1,"positionAlignment":2},{"id":531,"trainrunSectionId":248,"positionIndex":0,"positionAlignment":3},{"id":529,"trainrunSectionId":247,"positionIndex":1,"positionAlignment":3}],"transitions":[{"id":149,"port1Id":521,"port2Id":520,"isNonStopTransit":false},{"id":152,"port1Id":523,"port2Id":529,"isNonStopTransit":false},{"id":153,"port1Id":525,"port2Id":531,"isNonStopTransit":false}],"connections":[],"resourceId":167,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":139,"betriebspunktName":"LABE","fullName":"Langnau i.E.","positionX":32,"positionY":2272,"ports":[{"id":526,"trainrunSectionId":245,"positionIndex":0,"positionAlignment":3},{"id":519,"trainrunSectionId":242,"positionIndex":1,"positionAlignment":3}],"transitions":[],"connections":[],"resourceId":168,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":140,"betriebspunktName":"RK","fullName":"Rotkreuz ","positionX":1504,"positionY":2272,"ports":[{"id":543,"trainrunSectionId":254,"positionIndex":0,"positionAlignment":2},{"id":547,"trainrunSectionId":256,"positionIndex":1,"positionAlignment":2},{"id":549,"trainrunSectionId":257,"positionIndex":2,"positionAlignment":2},{"id":545,"trainrunSectionId":255,"positionIndex":3,"positionAlignment":2},{"id":579,"trainrunSectionId":272,"positionIndex":0,"positionAlignment":3},{"id":575,"trainrunSectionId":270,"positionIndex":1,"positionAlignment":3},{"id":587,"trainrunSectionId":276,"positionIndex":2,"positionAlignment":3},{"id":583,"trainrunSectionId":274,"positionIndex":3,"positionAlignment":3}],"transitions":[{"id":172,"port1Id":549,"port2Id":575,"isNonStopTransit":false},{"id":175,"port1Id":547,"port2Id":579,"isNonStopTransit":true},{"id":178,"port1Id":545,"port2Id":583,"isNonStopTransit":false},{"id":180,"port1Id":543,"port2Id":587,"isNonStopTransit":true}],"connections":[],"resourceId":169,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":141,"betriebspunktName":"ZF","fullName":"Zofingen","positionX":992,"positionY":672,"ports":[{"id":472,"trainrunSectionId":218,"positionIndex":0,"positionAlignment":0},{"id":511,"trainrunSectionId":238,"positionIndex":1,"positionAlignment":0},{"id":473,"trainrunSectionId":219,"positionIndex":2,"positionAlignment":0},{"id":477,"trainrunSectionId":221,"positionIndex":0,"positionAlignment":1},{"id":691,"trainrunSectionId":415,"positionIndex":1,"positionAlignment":1},{"id":513,"trainrunSectionId":239,"positionIndex":2,"positionAlignment":1},{"id":534,"trainrunSectionId":249,"positionIndex":3,"positionAlignment":1},{"id":479,"trainrunSectionId":222,"positionIndex":0,"positionAlignment":2}],"transitions":[{"id":137,"port1Id":472,"port2Id":477,"isNonStopTransit":true},{"id":148,"port1Id":511,"port2Id":513,"isNonStopTransit":false},{"id":154,"port1Id":473,"port2Id":534,"isNonStopTransit":false},{"id":188,"port1Id":691,"port2Id":479,"isNonStopTransit":false}],"connections":[],"resourceId":170,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":142,"betriebspunktName":"LTH","fullName":"Langenthal","positionX":192,"positionY":352,"ports":[{"id":598,"trainrunSectionId":281,"positionIndex":0,"positionAlignment":1},{"id":594,"trainrunSectionId":279,"positionIndex":1,"positionAlignment":1},{"id":503,"trainrunSectionId":234,"positionIndex":0,"positionAlignment":2},{"id":491,"trainrunSectionId":228,"positionIndex":1,"positionAlignment":2},{"id":501,"trainrunSectionId":233,"positionIndex":0,"positionAlignment":3},{"id":499,"trainrunSectionId":232,"positionIndex":1,"positionAlignment":3},{"id":601,"trainrunSectionId":283,"positionIndex":2,"positionAlignment":3},{"id":599,"trainrunSectionId":282,"positionIndex":3,"positionAlignment":3}],"transitions":[{"id":144,"port1Id":491,"port2Id":499,"isNonStopTransit":false},{"id":146,"port1Id":503,"port2Id":501,"isNonStopTransit":false},{"id":186,"port1Id":594,"port2Id":599,"isNonStopTransit":false},{"id":187,"port1Id":598,"port2Id":601,"isNonStopTransit":false}],"connections":[],"resourceId":171,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":143,"betriebspunktName":"RTR","fullName":"Rothrist","positionX":192,"positionY":160,"ports":[{"id":497,"trainrunSectionId":231,"positionIndex":0,"positionAlignment":2},{"id":487,"trainrunSectionId":226,"positionIndex":1,"positionAlignment":2},{"id":481,"trainrunSectionId":223,"positionIndex":2,"positionAlignment":2},{"id":496,"trainrunSectionId":230,"positionIndex":0,"positionAlignment":3},{"id":486,"trainrunSectionId":225,"positionIndex":1,"positionAlignment":3},{"id":480,"trainrunSectionId":222,"positionIndex":2,"positionAlignment":3}],"transitions":[{"id":139,"port1Id":481,"port2Id":480,"isNonStopTransit":true},{"id":141,"port1Id":487,"port2Id":486,"isNonStopTransit":true},{"id":143,"port1Id":497,"port2Id":496,"isNonStopTransit":true}],"connections":[],"resourceId":172,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":144,"betriebspunktName":"BN","fullName":"Bern","positionX":-672,"positionY":160,"ports":[{"id":498,"trainrunSectionId":231,"positionIndex":0,"positionAlignment":3},{"id":488,"trainrunSectionId":226,"positionIndex":1,"positionAlignment":3},{"id":482,"trainrunSectionId":223,"positionIndex":2,"positionAlignment":3},{"id":504,"trainrunSectionId":234,"positionIndex":3,"positionAlignment":3},{"id":492,"trainrunSectionId":228,"positionIndex":4,"positionAlignment":3}],"transitions":[],"connections":[],"resourceId":173,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":145,"betriebspunktName":"ZUE","fullName":"Zuerich","positionX":1920,"positionY":160,"ports":[{"id":506,"trainrunSectionId":235,"positionIndex":0,"positionAlignment":1},{"id":493,"trainrunSectionId":229,"positionIndex":0,"positionAlignment":2},{"id":484,"trainrunSectionId":224,"positionIndex":1,"positionAlignment":2},{"id":489,"trainrunSectionId":227,"positionIndex":2,"positionAlignment":2}],"transitions":[],"connections":[],"resourceId":174,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":146,"betriebspunktName":"CHAM","fullName":"Cham","positionX":1888,"positionY":2208,"ports":[{"id":581,"trainrunSectionId":273,"positionIndex":0,"positionAlignment":0},{"id":577,"trainrunSectionId":271,"positionIndex":1,"positionAlignment":0},{"id":580,"trainrunSectionId":272,"positionIndex":0,"positionAlignment":2},{"id":576,"trainrunSectionId":270,"positionIndex":1,"positionAlignment":2}],"transitions":[{"id":173,"port1Id":577,"port2Id":576,"isNonStopTransit":false},{"id":176,"port1Id":581,"port2Id":580,"isNonStopTransit":true}],"connections":[],"resourceId":175,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":147,"betriebspunktName":"IM","fullName":"Immensee","positionX":1888,"positionY":2336,"ports":[{"id":588,"trainrunSectionId":276,"positionIndex":0,"positionAlignment":2},{"id":584,"trainrunSectionId":274,"positionIndex":1,"positionAlignment":2},{"id":589,"trainrunSectionId":277,"positionIndex":0,"positionAlignment":3},{"id":585,"trainrunSectionId":275,"positionIndex":1,"positionAlignment":3}],"transitions":[{"id":179,"port1Id":584,"port2Id":585,"isNonStopTransit":false},{"id":181,"port1Id":588,"port2Id":589,"isNonStopTransit":false}],"connections":[],"resourceId":176,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":148,"betriebspunktName":"HWIL","fullName":"Huttwil","positionX":192,"positionY":1920,"ports":[{"id":595,"trainrunSectionId":280,"positionIndex":0,"positionAlignment":0},{"id":591,"trainrunSectionId":278,"positionIndex":1,"positionAlignment":0},{"id":517,"trainrunSectionId":241,"positionIndex":0,"positionAlignment":3},{"id":516,"trainrunSectionId":240,"positionIndex":1,"positionAlignment":3}],"transitions":[{"id":182,"port1Id":591,"port2Id":516,"isNonStopTransit":false},{"id":184,"port1Id":595,"port2Id":517,"isNonStopTransit":false}],"connections":[],"resourceId":177,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":149,"betriebspunktName":"EBR","fullName":"Emmenbrücke ","positionX":1088,"positionY":1984,"ports":[{"id":571,"trainrunSectionId":268,"positionIndex":0,"positionAlignment":0},{"id":567,"trainrunSectionId":266,"positionIndex":1,"positionAlignment":0},{"id":563,"trainrunSectionId":264,"positionIndex":2,"positionAlignment":0},{"id":559,"trainrunSectionId":262,"positionIndex":3,"positionAlignment":0},{"id":541,"trainrunSectionId":253,"positionIndex":0,"positionAlignment":1},{"id":539,"trainrunSectionId":252,"positionIndex":1,"positionAlignment":1},{"id":537,"trainrunSectionId":251,"positionIndex":2,"positionAlignment":1},{"id":535,"trainrunSectionId":250,"positionIndex":3,"positionAlignment":1}],"transitions":[{"id":161,"port1Id":559,"port2Id":535,"isNonStopTransit":false},{"id":163,"port1Id":563,"port2Id":537,"isNonStopTransit":false},{"id":166,"port1Id":567,"port2Id":539,"isNonStopTransit":true},{"id":169,"port1Id":571,"port2Id":541,"isNonStopTransit":true}],"connections":[],"resourceId":178,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":150,"betriebspunktName":"GEAP","fullName":"Genf Flughafen","positionX":-864,"positionY":192,"ports":[],"transitions":[],"connections":[],"resourceId":179,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":151,"betriebspunktName":"IO","fullName":"Interlaken Ost","positionX":-800,"positionY":416,"ports":[],"transitions":[],"connections":[],"resourceId":180,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":152,"betriebspunktName":"BI","fullName":"Biel","positionX":-512,"positionY":64,"ports":[],"transitions":[],"connections":[],"resourceId":181,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":153,"betriebspunktName":"SG","fullName":"St. Gallen","positionX":2752,"positionY":256,"ports":[],"transitions":[],"connections":[],"resourceId":182,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":154,"betriebspunktName":"GD","fullName":"Goldau","positionX":2368,"positionY":2336,"ports":[{"id":603,"trainrunSectionId":284,"positionIndex":0,"positionAlignment":1},{"id":590,"trainrunSectionId":277,"positionIndex":0,"positionAlignment":2},{"id":586,"trainrunSectionId":275,"positionIndex":1,"positionAlignment":2}],"transitions":[],"connections":[],"resourceId":183,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":155,"betriebspunktName":"Milano","fullName":"Neuer Knoten","positionX":2528,"positionY":2560,"ports":[{"id":604,"trainrunSectionId":284,"positionIndex":0,"positionAlignment":0}],"transitions":[],"connections":[],"resourceId":184,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":156,"betriebspunktName":"CH","fullName":"Chur","positionX":2816,"positionY":2016,"ports":[],"transitions":[],"connections":[],"resourceId":185,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":157,"betriebspunktName":"OL","fullName":"Olten","positionX":992,"positionY":160,"ports":[{"id":471,"trainrunSectionId":218,"positionIndex":0,"positionAlignment":1},{"id":512,"trainrunSectionId":238,"positionIndex":1,"positionAlignment":1},{"id":474,"trainrunSectionId":219,"positionIndex":2,"positionAlignment":1},{"id":495,"trainrunSectionId":230,"positionIndex":0,"positionAlignment":2},{"id":485,"trainrunSectionId":225,"positionIndex":1,"positionAlignment":2},{"id":502,"trainrunSectionId":233,"positionIndex":2,"positionAlignment":2},{"id":500,"trainrunSectionId":232,"positionIndex":3,"positionAlignment":2},{"id":602,"trainrunSectionId":283,"positionIndex":4,"positionAlignment":2},{"id":600,"trainrunSectionId":282,"positionIndex":5,"positionAlignment":2},{"id":494,"trainrunSectionId":229,"positionIndex":0,"positionAlignment":3},{"id":483,"trainrunSectionId":224,"positionIndex":1,"positionAlignment":3},{"id":490,"trainrunSectionId":227,"positionIndex":2,"positionAlignment":3}],"transitions":[{"id":140,"port1Id":485,"port2Id":483,"isNonStopTransit":false},{"id":142,"port1Id":495,"port2Id":494,"isNonStopTransit":false},{"id":145,"port1Id":500,"port2Id":490,"isNonStopTransit":false}],"connections":[],"resourceId":186,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":158,"betriebspunktName":"BS","fullName":"Basel","positionX":992,"positionY":-64,"ports":[],"transitions":[],"connections":[],"resourceId":187,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":159,"betriebspunktName":"REID","fullName":"Reiden","positionX":992,"positionY":992,"ports":[{"id":478,"trainrunSectionId":221,"positionIndex":0,"positionAlignment":0},{"id":692,"trainrunSectionId":415,"positionIndex":1,"positionAlignment":0},{"id":514,"trainrunSectionId":239,"positionIndex":2,"positionAlignment":0},{"id":533,"trainrunSectionId":249,"positionIndex":3,"positionAlignment":0},{"id":551,"trainrunSectionId":258,"positionIndex":0,"positionAlignment":1},{"id":553,"trainrunSectionId":259,"positionIndex":1,"positionAlignment":1},{"id":555,"trainrunSectionId":260,"positionIndex":2,"positionAlignment":1},{"id":557,"trainrunSectionId":261,"positionIndex":3,"positionAlignment":1}],"transitions":[{"id":157,"port1Id":551,"port2Id":478,"isNonStopTransit":true},{"id":159,"port1Id":555,"port2Id":514,"isNonStopTransit":false},{"id":160,"port1Id":557,"port2Id":533,"isNonStopTransit":false},{"id":189,"port1Id":692,"port2Id":553,"isNonStopTransit":false}],"connections":[],"resourceId":188,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":160,"betriebspunktName":"SEM","fullName":"Sempach-Neuenkirch","positionX":1088,"positionY":1696,"ports":[{"id":573,"trainrunSectionId":269,"positionIndex":0,"positionAlignment":0},{"id":569,"trainrunSectionId":267,"positionIndex":1,"positionAlignment":0},{"id":565,"trainrunSectionId":265,"positionIndex":2,"positionAlignment":0},{"id":561,"trainrunSectionId":263,"positionIndex":3,"positionAlignment":0},{"id":572,"trainrunSectionId":268,"positionIndex":0,"positionAlignment":1},{"id":568,"trainrunSectionId":266,"positionIndex":1,"positionAlignment":1},{"id":564,"trainrunSectionId":264,"positionIndex":2,"positionAlignment":1},{"id":560,"trainrunSectionId":262,"positionIndex":3,"positionAlignment":1}],"transitions":[{"id":162,"port1Id":560,"port2Id":561,"isNonStopTransit":false},{"id":164,"port1Id":564,"port2Id":565,"isNonStopTransit":false},{"id":167,"port1Id":568,"port2Id":569,"isNonStopTransit":true},{"id":170,"port1Id":572,"port2Id":573,"isNonStopTransit":true}],"connections":[],"resourceId":189,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":161,"betriebspunktName":"SS","fullName":"Sursee","positionX":992,"positionY":1312,"ports":[{"id":552,"trainrunSectionId":258,"positionIndex":0,"positionAlignment":0},{"id":554,"trainrunSectionId":259,"positionIndex":1,"positionAlignment":0},{"id":556,"trainrunSectionId":260,"positionIndex":2,"positionAlignment":0},{"id":558,"trainrunSectionId":261,"positionIndex":3,"positionAlignment":0},{"id":574,"trainrunSectionId":269,"positionIndex":0,"positionAlignment":1},{"id":570,"trainrunSectionId":267,"positionIndex":1,"positionAlignment":1},{"id":566,"trainrunSectionId":265,"positionIndex":2,"positionAlignment":1},{"id":562,"trainrunSectionId":263,"positionIndex":3,"positionAlignment":1}],"transitions":[{"id":165,"port1Id":556,"port2Id":566,"isNonStopTransit":false},{"id":168,"port1Id":554,"port2Id":570,"isNonStopTransit":false},{"id":171,"port1Id":552,"port2Id":574,"isNonStopTransit":true}],"connections":[{"id":11,"port1Id":558,"port2Id":566},{"id":12,"port1Id":562,"port2Id":556},{"id":13,"port1Id":554,"port2Id":566}],"resourceId":190,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]}],"trainrunSections":[{"id":218,"sourceNodeId":157,"sourcePortId":471,"targetNodeId":141,"targetPortId":472,"travelTime":{"lock":false,"time":30,"warning":null},"sourceDeparture":{"lock":false,"time":46,"warning":null,"consecutiveTime":46},"sourceArrival":{"lock":false,"time":14,"warning":null,"consecutiveTime":314},"targetDeparture":{"lock":false,"time":44,"warning":null,"consecutiveTime":284},"targetArrival":{"lock":false,"time":16,"warning":null,"consecutiveTime":76},"numberOfStops":0,"trainrunId":84,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1008,"y":382},{"x":1008,"y":446},{"x":1008,"y":606},{"x":1008,"y":670}],"textPositions":{"0":{"x":996,"y":400},"1":{"x":1020,"y":428},"2":{"x":1020,"y":652},"3":{"x":996,"y":624},"4":{"x":996,"y":526},"5":{"x":996,"y":526},"6":{"x":1020,"y":526}}},"warnings":null},{"id":219,"sourceNodeId":141,"sourcePortId":473,"targetNodeId":157,"targetPortId":474,"travelTime":{"lock":false,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":40,"warning":null,"consecutiveTime":40},"sourceArrival":{"lock":false,"time":20,"warning":null,"consecutiveTime":20},"targetDeparture":{"lock":false,"time":10,"warning":null,"consecutiveTime":10},"targetArrival":{"lock":false,"time":50,"warning":null,"consecutiveTime":50},"numberOfStops":0,"trainrunId":86,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1072,"y":670},{"x":1072,"y":606},{"x":1072,"y":446},{"x":1072,"y":382}],"textPositions":{"0":{"x":1084,"y":652},"1":{"x":1060,"y":624},"2":{"x":1060,"y":400},"3":{"x":1084,"y":428},"4":{"x":1060,"y":526},"5":{"x":1060,"y":526},"6":{"x":1084,"y":526}}},"warnings":null},{"id":221,"sourceNodeId":141,"sourcePortId":477,"targetNodeId":159,"targetPortId":478,"travelTime":{"lock":false,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":16,"warning":null,"consecutiveTime":76},"sourceArrival":{"lock":false,"time":44,"warning":null,"consecutiveTime":284},"targetDeparture":{"lock":false,"time":34,"warning":null,"consecutiveTime":274},"targetArrival":{"lock":false,"time":26,"warning":null,"consecutiveTime":86},"numberOfStops":0,"trainrunId":84,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1008,"y":738},{"x":1008,"y":802},{"x":1008,"y":926},{"x":1008,"y":990}],"textPositions":{"0":{"x":996,"y":756},"1":{"x":1020,"y":784},"2":{"x":1020,"y":972},"3":{"x":996,"y":944},"4":{"x":996,"y":864},"5":{"x":996,"y":864},"6":{"x":1020,"y":864}}},"warnings":null},{"id":222,"sourceNodeId":141,"sourcePortId":479,"targetNodeId":143,"targetPortId":480,"travelTime":{"lock":false,"time":6,"warning":null},"sourceDeparture":{"lock":false,"time":33,"warning":null,"consecutiveTime":153},"sourceArrival":{"lock":false,"time":27,"warning":null,"consecutiveTime":27},"targetDeparture":{"lock":false,"time":21,"warning":null,"consecutiveTime":21},"targetArrival":{"lock":false,"time":39,"warning":null,"consecutiveTime":159},"numberOfStops":0,"trainrunId":87,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":990,"y":688},{"x":926,"y":688},{"x":354,"y":240},{"x":290,"y":240}],"textPositions":{"0":{"x":972,"y":676},"1":{"x":944,"y":700},"2":{"x":308,"y":252},"3":{"x":336,"y":228},"4":{"x":640,"y":452},"5":{"x":640,"y":452},"6":{"x":640,"y":476}}},"warnings":null},{"id":223,"sourceNodeId":143,"sourcePortId":481,"targetNodeId":144,"targetPortId":482,"travelTime":{"lock":false,"time":21,"warning":null},"sourceDeparture":{"lock":false,"time":39,"warning":null,"consecutiveTime":159},"sourceArrival":{"lock":false,"time":21,"warning":null,"consecutiveTime":21},"targetDeparture":{"lock":true,"time":0,"warning":null,"consecutiveTime":0},"targetArrival":{"lock":true,"time":0,"warning":null,"consecutiveTime":180},"numberOfStops":0,"trainrunId":87,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":190,"y":240},{"x":126,"y":240},{"x":-510,"y":240},{"x":-574,"y":240}],"textPositions":{"0":{"x":172,"y":228},"1":{"x":144,"y":252},"2":{"x":-556,"y":252},"3":{"x":-528,"y":228},"4":{"x":-192,"y":228},"5":{"x":-192,"y":228},"6":{"x":-192,"y":252}}},"warnings":null},{"id":224,"sourceNodeId":157,"sourcePortId":483,"targetNodeId":145,"targetPortId":484,"travelTime":{"lock":false,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":31,"warning":null,"consecutiveTime":91},"sourceArrival":{"lock":false,"time":29,"warning":null,"consecutiveTime":89},"targetDeparture":{"lock":false,"time":19,"warning":null,"consecutiveTime":79},"targetArrival":{"lock":false,"time":41,"warning":null,"consecutiveTime":101},"numberOfStops":0,"trainrunId":83,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1090,"y":208},{"x":1154,"y":208},{"x":1854,"y":208},{"x":1918,"y":208}],"textPositions":{"0":{"x":1108,"y":220},"1":{"x":1136,"y":196},"2":{"x":1900,"y":196},"3":{"x":1872,"y":220},"4":{"x":1504,"y":196},"5":{"x":1504,"y":196},"6":{"x":1504,"y":220}}},"warnings":null},{"id":225,"sourceNodeId":157,"sourcePortId":485,"targetNodeId":143,"targetPortId":486,"travelTime":{"lock":false,"time":20,"warning":null},"sourceDeparture":{"lock":false,"time":31,"warning":null,"consecutiveTime":91},"sourceArrival":{"lock":false,"time":29,"warning":null,"consecutiveTime":89},"targetDeparture":{"lock":false,"time":9,"warning":null,"consecutiveTime":69},"targetArrival":{"lock":false,"time":51,"warning":null,"consecutiveTime":111},"numberOfStops":0,"trainrunId":83,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":990,"y":208},{"x":926,"y":208},{"x":354,"y":208},{"x":290,"y":208}],"textPositions":{"0":{"x":972,"y":196},"1":{"x":944,"y":220},"2":{"x":308,"y":220},"3":{"x":336,"y":196},"4":{"x":640,"y":196},"5":{"x":640,"y":196},"6":{"x":640,"y":220}}},"warnings":null},{"id":226,"sourceNodeId":143,"sourcePortId":487,"targetNodeId":144,"targetPortId":488,"travelTime":{"lock":false,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":51,"warning":null,"consecutiveTime":111},"sourceArrival":{"lock":false,"time":9,"warning":null,"consecutiveTime":69},"targetDeparture":{"lock":false,"time":59,"warning":null,"consecutiveTime":59},"targetArrival":{"lock":false,"time":1,"warning":null,"consecutiveTime":121},"numberOfStops":0,"trainrunId":83,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":190,"y":208},{"x":126,"y":208},{"x":-510,"y":208},{"x":-574,"y":208}],"textPositions":{"0":{"x":172,"y":196},"1":{"x":144,"y":220},"2":{"x":-556,"y":220},"3":{"x":-528,"y":196},"4":{"x":-192,"y":196},"5":{"x":-192,"y":196},"6":{"x":-192,"y":220}}},"warnings":null},{"id":227,"sourceNodeId":145,"sourcePortId":489,"targetNodeId":157,"targetPortId":490,"travelTime":{"lock":false,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":32,"warning":null,"consecutiveTime":152},"sourceArrival":{"lock":false,"time":28,"warning":null,"consecutiveTime":148},"targetDeparture":{"lock":false,"time":18,"warning":null,"consecutiveTime":138},"targetArrival":{"lock":false,"time":42,"warning":null,"consecutiveTime":162},"numberOfStops":0,"trainrunId":88,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1918,"y":240},{"x":1854,"y":240},{"x":1154,"y":240},{"x":1090,"y":240}],"textPositions":{"0":{"x":1900,"y":228},"1":{"x":1872,"y":252},"2":{"x":1108,"y":252},"3":{"x":1136,"y":228},"4":{"x":1504,"y":228},"5":{"x":1504,"y":228},"6":{"x":1504,"y":252}}},"warnings":null},{"id":228,"sourceNodeId":142,"sourcePortId":491,"targetNodeId":144,"targetPortId":492,"travelTime":{"lock":false,"time":78,"warning":null},"sourceDeparture":{"lock":false,"time":56,"warning":null,"consecutiveTime":176},"sourceArrival":{"lock":false,"time":4,"warning":null,"consecutiveTime":124},"targetDeparture":{"lock":false,"time":46,"warning":null,"consecutiveTime":46},"targetArrival":{"lock":false,"time":14,"warning":null,"consecutiveTime":254},"numberOfStops":0,"trainrunId":88,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":190,"y":400},{"x":126,"y":400},{"x":-510,"y":304},{"x":-574,"y":304}],"textPositions":{"0":{"x":172,"y":388},"1":{"x":144,"y":412},"2":{"x":-556,"y":316},"3":{"x":-528,"y":292},"4":{"x":-192,"y":340},"5":{"x":-192,"y":340},"6":{"x":-192,"y":364}}},"warnings":null},{"id":229,"sourceNodeId":145,"sourcePortId":493,"targetNodeId":157,"targetPortId":494,"travelTime":{"lock":false,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":19,"warning":null,"consecutiveTime":19},"sourceArrival":{"lock":false,"time":41,"warning":null,"consecutiveTime":41},"targetDeparture":{"lock":false,"time":31,"warning":null,"consecutiveTime":31},"targetArrival":{"lock":false,"time":29,"warning":null,"consecutiveTime":29},"numberOfStops":0,"trainrunId":90,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1918,"y":176},{"x":1854,"y":176},{"x":1154,"y":176},{"x":1090,"y":176}],"textPositions":{"0":{"x":1900,"y":164},"1":{"x":1872,"y":188},"2":{"x":1108,"y":188},"3":{"x":1136,"y":164},"4":{"x":1504,"y":164},"5":{"x":1504,"y":164},"6":{"x":1504,"y":188}}},"warnings":null},{"id":230,"sourceNodeId":157,"sourcePortId":495,"targetNodeId":143,"targetPortId":496,"travelTime":{"lock":false,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":31,"warning":null,"consecutiveTime":31},"sourceArrival":{"lock":false,"time":29,"warning":null,"consecutiveTime":29},"targetDeparture":{"lock":false,"time":19,"warning":null,"consecutiveTime":19},"targetArrival":{"lock":false,"time":41,"warning":null,"consecutiveTime":41},"numberOfStops":0,"trainrunId":90,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":990,"y":176},{"x":926,"y":176},{"x":354,"y":176},{"x":290,"y":176}],"textPositions":{"0":{"x":972,"y":164},"1":{"x":944,"y":188},"2":{"x":308,"y":188},"3":{"x":336,"y":164},"4":{"x":640,"y":164},"5":{"x":640,"y":164},"6":{"x":640,"y":188}}},"warnings":null},{"id":231,"sourceNodeId":143,"sourcePortId":497,"targetNodeId":144,"targetPortId":498,"travelTime":{"lock":false,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":41,"warning":null,"consecutiveTime":41},"sourceArrival":{"lock":false,"time":19,"warning":null,"consecutiveTime":19},"targetDeparture":{"lock":false,"time":9,"warning":null,"consecutiveTime":9},"targetArrival":{"lock":false,"time":51,"warning":null,"consecutiveTime":51},"numberOfStops":0,"trainrunId":90,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":190,"y":176},{"x":126,"y":176},{"x":-510,"y":176},{"x":-574,"y":176}],"textPositions":{"0":{"x":172,"y":164},"1":{"x":144,"y":188},"2":{"x":-556,"y":188},"3":{"x":-528,"y":164},"4":{"x":-192,"y":164},"5":{"x":-192,"y":164},"6":{"x":-192,"y":188}}},"warnings":null},{"id":232,"sourceNodeId":142,"sourcePortId":499,"targetNodeId":157,"targetPortId":500,"travelTime":{"lock":false,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":6,"warning":null,"consecutiveTime":126},"sourceArrival":{"lock":false,"time":54,"warning":null,"consecutiveTime":174},"targetDeparture":{"lock":false,"time":44,"warning":null,"consecutiveTime":164},"targetArrival":{"lock":false,"time":16,"warning":null,"consecutiveTime":136},"numberOfStops":0,"trainrunId":88,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":290,"y":400},{"x":354,"y":400},{"x":926,"y":272},{"x":990,"y":272}],"textPositions":{"0":{"x":308,"y":412},"1":{"x":336,"y":388},"2":{"x":972,"y":260},"3":{"x":944,"y":284},"4":{"x":640,"y":324},"5":{"x":640,"y":324},"6":{"x":640,"y":348}}},"warnings":null},{"id":233,"sourceNodeId":142,"sourcePortId":501,"targetNodeId":157,"targetPortId":502,"travelTime":{"lock":false,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":22,"warning":null,"consecutiveTime":22},"sourceArrival":{"lock":false,"time":38,"warning":null,"consecutiveTime":38},"targetDeparture":{"lock":false,"time":28,"warning":null,"consecutiveTime":28},"targetArrival":{"lock":false,"time":32,"warning":null,"consecutiveTime":32},"numberOfStops":0,"trainrunId":89,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":290,"y":368},{"x":354,"y":368},{"x":926,"y":240},{"x":990,"y":240}],"textPositions":{"0":{"x":308,"y":380},"1":{"x":336,"y":356},"2":{"x":972,"y":228},"3":{"x":944,"y":252},"4":{"x":640,"y":292},"5":{"x":640,"y":292},"6":{"x":640,"y":316}}},"warnings":null},{"id":234,"sourceNodeId":142,"sourcePortId":503,"targetNodeId":144,"targetPortId":504,"travelTime":{"lock":false,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":40,"warning":null,"consecutiveTime":40},"sourceArrival":{"lock":false,"time":20,"warning":null,"consecutiveTime":20},"targetDeparture":{"lock":false,"time":10,"warning":null,"consecutiveTime":10},"targetArrival":{"lock":false,"time":50,"warning":null,"consecutiveTime":50},"numberOfStops":0,"trainrunId":89,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":190,"y":368},{"x":126,"y":368},{"x":-510,"y":272},{"x":-574,"y":272}],"textPositions":{"0":{"x":172,"y":356},"1":{"x":144,"y":380},"2":{"x":-556,"y":284},"3":{"x":-528,"y":260},"4":{"x":-192,"y":308},"5":{"x":-192,"y":308},"6":{"x":-192,"y":332}}},"warnings":null},{"id":235,"sourceNodeId":136,"sourcePortId":505,"targetNodeId":145,"targetPortId":506,"travelTime":{"lock":false,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":52,"warning":null,"consecutiveTime":112},"sourceArrival":{"lock":false,"time":8,"warning":null,"consecutiveTime":68},"targetDeparture":{"lock":false,"time":58,"warning":null,"consecutiveTime":58},"targetArrival":{"lock":false,"time":2,"warning":null,"consecutiveTime":122},"numberOfStops":0,"trainrunId":85,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1936,"y":1630},{"x":1936,"y":1566},{"x":1936,"y":350},{"x":1936,"y":286}],"textPositions":{"0":{"x":1948,"y":1612},"1":{"x":1924,"y":1584},"2":{"x":1924,"y":304},"3":{"x":1948,"y":332},"4":{"x":1924,"y":958},"5":{"x":1924,"y":958},"6":{"x":1948,"y":958}}},"warnings":null},{"id":236,"sourceNodeId":135,"sourcePortId":507,"targetNodeId":136,"targetPortId":508,"travelTime":{"lock":false,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":42,"warning":null,"consecutiveTime":102},"sourceArrival":{"lock":false,"time":18,"warning":null,"consecutiveTime":78},"targetDeparture":{"lock":false,"time":8,"warning":null,"consecutiveTime":68},"targetArrival":{"lock":false,"time":52,"warning":null,"consecutiveTime":112},"numberOfStops":0,"trainrunId":85,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1904,"y":1982},{"x":1904,"y":1918},{"x":1936,"y":1762},{"x":1936,"y":1698}],"textPositions":{"0":{"x":1916,"y":1964},"1":{"x":1892,"y":1936},"2":{"x":1924,"y":1716},"3":{"x":1948,"y":1744},"4":{"x":1908,"y":1840},"5":{"x":1908,"y":1840},"6":{"x":1932,"y":1840}}},"warnings":null},{"id":237,"sourceNodeId":135,"sourcePortId":509,"targetNodeId":136,"targetPortId":510,"travelTime":{"lock":false,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":23,"warning":null,"consecutiveTime":83},"sourceArrival":{"lock":false,"time":37,"warning":null,"consecutiveTime":97},"targetDeparture":{"lock":false,"time":27,"warning":null,"consecutiveTime":87},"targetArrival":{"lock":false,"time":33,"warning":null,"consecutiveTime":93},"numberOfStops":0,"trainrunId":91,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1936,"y":1982},{"x":1936,"y":1918},{"x":1968,"y":1762},{"x":1968,"y":1698}],"textPositions":{"0":{"x":1948,"y":1964},"1":{"x":1924,"y":1936},"2":{"x":1956,"y":1716},"3":{"x":1980,"y":1744},"4":{"x":1940,"y":1840},"5":{"x":1940,"y":1840},"6":{"x":1964,"y":1840}}},"warnings":null},{"id":238,"sourceNodeId":141,"sourcePortId":511,"targetNodeId":157,"targetPortId":512,"travelTime":{"lock":false,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":40,"warning":null,"consecutiveTime":160},"sourceArrival":{"lock":false,"time":20,"warning":null,"consecutiveTime":20},"targetDeparture":{"lock":false,"time":10,"warning":null,"consecutiveTime":10},"targetArrival":{"lock":false,"time":50,"warning":null,"consecutiveTime":170},"numberOfStops":0,"trainrunId":93,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1040,"y":670},{"x":1040,"y":606},{"x":1040,"y":446},{"x":1040,"y":382}],"textPositions":{"0":{"x":1052,"y":652},"1":{"x":1028,"y":624},"2":{"x":1028,"y":400},"3":{"x":1052,"y":428},"4":{"x":1028,"y":526},"5":{"x":1028,"y":526},"6":{"x":1052,"y":526}}},"warnings":null},{"id":239,"sourceNodeId":141,"sourcePortId":513,"targetNodeId":159,"targetPortId":514,"travelTime":{"lock":false,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":21.5,"warning":null,"consecutiveTime":21.5},"sourceArrival":{"lock":false,"time":38.5,"warning":null,"consecutiveTime":158.5},"targetDeparture":{"lock":false,"time":28.5,"warning":null,"consecutiveTime":148.5},"targetArrival":{"lock":false,"time":31.5,"warning":null,"consecutiveTime":31.5},"numberOfStops":0,"trainrunId":93,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1072,"y":738},{"x":1072,"y":802},{"x":1072,"y":926},{"x":1072,"y":990}],"textPositions":{"0":{"x":1060,"y":756},"1":{"x":1084,"y":784},"2":{"x":1084,"y":972},"3":{"x":1060,"y":944},"4":{"x":1060,"y":864},"5":{"x":1060,"y":864},"6":{"x":1084,"y":864}}},"warnings":null},{"id":240,"sourceNodeId":134,"sourcePortId":515,"targetNodeId":148,"targetPortId":516,"travelTime":{"lock":false,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":33,"warning":null,"consecutiveTime":93},"sourceArrival":{"lock":false,"time":27,"warning":null,"consecutiveTime":87},"targetDeparture":{"lock":false,"time":17,"warning":null,"consecutiveTime":77},"targetArrival":{"lock":false,"time":43,"warning":null,"consecutiveTime":103},"numberOfStops":3,"trainrunId":94,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":542,"y":2000},{"x":478,"y":2000},{"x":354,"y":1968},{"x":290,"y":1968}],"textPositions":{"0":{"x":524,"y":1988},"1":{"x":496,"y":2012},"2":{"x":308,"y":1980},"3":{"x":336,"y":1956},"4":{"x":416,"y":1972},"5":{"x":416,"y":1972},"6":{"x":416,"y":1996}}},"warnings":null},{"id":241,"sourceNodeId":148,"sourcePortId":517,"targetNodeId":134,"targetPortId":518,"travelTime":{"lock":false,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":37,"warning":null,"consecutiveTime":37},"sourceArrival":{"lock":false,"time":23,"warning":null,"consecutiveTime":143},"targetDeparture":{"lock":false,"time":13,"warning":null,"consecutiveTime":133},"targetArrival":{"lock":false,"time":47,"warning":null,"consecutiveTime":47},"numberOfStops":2,"trainrunId":95,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":290,"y":1936},{"x":354,"y":1936},{"x":478,"y":1968},{"x":542,"y":1968}],"textPositions":{"0":{"x":308,"y":1948},"1":{"x":336,"y":1924},"2":{"x":524,"y":1956},"3":{"x":496,"y":1980},"4":{"x":416,"y":1940},"5":{"x":416,"y":1940},"6":{"x":416,"y":1964}}},"warnings":null},{"id":242,"sourceNodeId":139,"sourcePortId":519,"targetNodeId":138,"targetPortId":520,"travelTime":{"lock":false,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":51,"warning":null,"consecutiveTime":111},"sourceArrival":{"lock":false,"time":9,"warning":null,"consecutiveTime":69},"targetDeparture":{"lock":false,"time":59,"warning":null,"consecutiveTime":59},"targetArrival":{"lock":false,"time":1,"warning":null,"consecutiveTime":121},"numberOfStops":4,"trainrunId":95,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":130,"y":2320},{"x":194,"y":2320},{"x":510,"y":2320},{"x":574,"y":2320}],"textPositions":{"0":{"x":148,"y":2332},"1":{"x":176,"y":2308},"2":{"x":556,"y":2308},"3":{"x":528,"y":2332},"4":{"x":352,"y":2308},"5":{"x":352,"y":2308},"6":{"x":352,"y":2332}}},"warnings":null},{"id":243,"sourceNodeId":138,"sourcePortId":521,"targetNodeId":134,"targetPortId":522,"travelTime":{"lock":false,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":2,"warning":null,"consecutiveTime":122},"sourceArrival":{"lock":false,"time":58,"warning":null,"consecutiveTime":58},"targetDeparture":{"lock":false,"time":48,"warning":null,"consecutiveTime":48},"targetArrival":{"lock":false,"time":12,"warning":null,"consecutiveTime":132},"numberOfStops":1,"trainrunId":95,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":592,"y":2270},{"x":592,"y":2206},{"x":560,"y":2110},{"x":560,"y":2046}],"textPositions":{"0":{"x":604,"y":2252},"1":{"x":580,"y":2224},"2":{"x":548,"y":2064},"3":{"x":572,"y":2092},"4":{"x":588,"y":2158},"5":{"x":588,"y":2158},"6":{"x":564,"y":2158}}},"warnings":null},{"id":244,"sourceNodeId":138,"sourcePortId":523,"targetNodeId":134,"targetPortId":524,"travelTime":{"lock":false,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":40,"warning":null,"consecutiveTime":40},"sourceArrival":{"lock":false,"time":20,"warning":null,"consecutiveTime":20},"targetDeparture":{"lock":false,"time":10,"warning":null,"consecutiveTime":10},"targetArrival":{"lock":false,"time":50,"warning":null,"consecutiveTime":50},"numberOfStops":2,"trainrunId":96,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":656,"y":2270},{"x":656,"y":2206},{"x":624,"y":2110},{"x":624,"y":2046}],"textPositions":{"0":{"x":668,"y":2252},"1":{"x":644,"y":2224},"2":{"x":612,"y":2064},"3":{"x":636,"y":2092},"4":{"x":652,"y":2158},"5":{"x":652,"y":2158},"6":{"x":628,"y":2158}}},"warnings":null},{"id":245,"sourceNodeId":138,"sourcePortId":525,"targetNodeId":139,"targetPortId":526,"travelTime":{"lock":false,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":20,"warning":null,"consecutiveTime":20},"sourceArrival":{"lock":false,"time":40,"warning":null,"consecutiveTime":40},"targetDeparture":{"lock":false,"time":30,"warning":null,"consecutiveTime":30},"targetArrival":{"lock":false,"time":30,"warning":null,"consecutiveTime":30},"numberOfStops":5,"trainrunId":97,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":574,"y":2288},{"x":510,"y":2288},{"x":194,"y":2288},{"x":130,"y":2288}],"textPositions":{"0":{"x":556,"y":2276},"1":{"x":528,"y":2300},"2":{"x":148,"y":2300},"3":{"x":176,"y":2276},"4":{"x":352,"y":2276},"5":{"x":352,"y":2276},"6":{"x":352,"y":2300}}},"warnings":null},{"id":246,"sourceNodeId":134,"sourcePortId":527,"targetNodeId":138,"targetPortId":528,"travelTime":{"lock":false,"time":20,"warning":null},"sourceDeparture":{"lock":false,"time":28,"warning":null,"consecutiveTime":88},"sourceArrival":{"lock":false,"time":32,"warning":null,"consecutiveTime":92},"targetDeparture":{"lock":false,"time":12,"warning":null,"consecutiveTime":72},"targetArrival":{"lock":false,"time":48,"warning":null,"consecutiveTime":108},"numberOfStops":2,"trainrunId":94,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":592,"y":2046},{"x":592,"y":2110},{"x":624,"y":2206},{"x":624,"y":2270}],"textPositions":{"0":{"x":580,"y":2064},"1":{"x":604,"y":2092},"2":{"x":636,"y":2252},"3":{"x":612,"y":2224},"4":{"x":620,"y":2158},"5":{"x":620,"y":2158},"6":{"x":596,"y":2158}}},"warnings":null},{"id":247,"sourceNodeId":138,"sourcePortId":529,"targetNodeId":137,"targetPortId":530,"travelTime":{"lock":false,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":21,"warning":null,"consecutiveTime":21},"sourceArrival":{"lock":false,"time":39,"warning":null,"consecutiveTime":39},"targetDeparture":{"lock":false,"time":29,"warning":null,"consecutiveTime":29},"targetArrival":{"lock":false,"time":31,"warning":null,"consecutiveTime":31},"numberOfStops":4,"trainrunId":96,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":674,"y":2320},{"x":738,"y":2320},{"x":1086,"y":2320},{"x":1150,"y":2320}],"textPositions":{"0":{"x":692,"y":2332},"1":{"x":720,"y":2308},"2":{"x":1132,"y":2308},"3":{"x":1104,"y":2332},"4":{"x":912,"y":2308},"5":{"x":912,"y":2308},"6":{"x":912,"y":2332}}},"warnings":null},{"id":248,"sourceNodeId":138,"sourcePortId":531,"targetNodeId":137,"targetPortId":532,"travelTime":{"lock":false,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":41.5,"warning":null,"consecutiveTime":41.5},"sourceArrival":{"lock":false,"time":18.5,"warning":null,"consecutiveTime":18.5},"targetDeparture":{"lock":false,"time":8.5,"warning":null,"consecutiveTime":8.5},"targetArrival":{"lock":false,"time":51.5,"warning":null,"consecutiveTime":51.5},"numberOfStops":2,"trainrunId":97,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":674,"y":2288},{"x":738,"y":2288},{"x":1086,"y":2288},{"x":1150,"y":2288}],"textPositions":{"0":{"x":692,"y":2300},"1":{"x":720,"y":2276},"2":{"x":1132,"y":2276},"3":{"x":1104,"y":2300},"4":{"x":912,"y":2276},"5":{"x":912,"y":2276},"6":{"x":912,"y":2300}}},"warnings":null},{"id":249,"sourceNodeId":159,"sourcePortId":533,"targetNodeId":141,"targetPortId":534,"travelTime":{"lock":false,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":29,"warning":null,"consecutiveTime":29},"sourceArrival":{"lock":false,"time":31,"warning":null,"consecutiveTime":31},"targetDeparture":{"lock":false,"time":21,"warning":null,"consecutiveTime":21},"targetArrival":{"lock":false,"time":39,"warning":null,"consecutiveTime":39},"numberOfStops":1,"trainrunId":86,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1104,"y":990},{"x":1104,"y":926},{"x":1104,"y":802},{"x":1104,"y":738}],"textPositions":{"0":{"x":1116,"y":972},"1":{"x":1092,"y":944},"2":{"x":1092,"y":756},"3":{"x":1116,"y":784},"4":{"x":1092,"y":864},"5":{"x":1092,"y":864},"6":{"x":1116,"y":864}}},"warnings":null},{"id":250,"sourceNodeId":149,"sourcePortId":535,"targetNodeId":137,"targetPortId":536,"travelTime":{"lock":false,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":39,"warning":null,"consecutiveTime":39},"sourceArrival":{"lock":false,"time":21,"warning":null,"consecutiveTime":141},"targetDeparture":{"lock":false,"time":11,"warning":null,"consecutiveTime":131},"targetArrival":{"lock":false,"time":49,"warning":null,"consecutiveTime":49},"numberOfStops":0,"trainrunId":91,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1200,"y":2050},{"x":1200,"y":2114},{"x":1264,"y":2206},{"x":1264,"y":2270}],"textPositions":{"0":{"x":1188,"y":2068},"1":{"x":1212,"y":2096},"2":{"x":1276,"y":2252},"3":{"x":1252,"y":2224},"4":{"x":1244,"y":2160},"5":{"x":1244,"y":2160},"6":{"x":1220,"y":2160}}},"warnings":null},{"id":251,"sourceNodeId":149,"sourcePortId":537,"targetNodeId":137,"targetPortId":538,"travelTime":{"lock":false,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":7.5,"warning":null,"consecutiveTime":67.5},"sourceArrival":{"lock":false,"time":52.5,"warning":null,"consecutiveTime":112.5},"targetDeparture":{"lock":false,"time":42.5,"warning":null,"consecutiveTime":102.5},"targetArrival":{"lock":false,"time":17.5,"warning":null,"consecutiveTime":77.5},"numberOfStops":0,"trainrunId":93,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1168,"y":2050},{"x":1168,"y":2114},{"x":1232,"y":2206},{"x":1232,"y":2270}],"textPositions":{"0":{"x":1156,"y":2068},"1":{"x":1180,"y":2096},"2":{"x":1244,"y":2252},"3":{"x":1220,"y":2224},"4":{"x":1212,"y":2160},"5":{"x":1212,"y":2160},"6":{"x":1188,"y":2160}}},"warnings":null},{"id":252,"sourceNodeId":149,"sourcePortId":539,"targetNodeId":137,"targetPortId":540,"travelTime":{"lock":false,"time":5,"warning":null},"sourceDeparture":{"lock":false,"time":56,"warning":null,"consecutiveTime":56},"sourceArrival":{"lock":false,"time":4,"warning":null,"consecutiveTime":124},"targetDeparture":{"lock":false,"time":59,"warning":null,"consecutiveTime":119},"targetArrival":{"lock":false,"time":1,"warning":null,"consecutiveTime":61},"numberOfStops":0,"trainrunId":87,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1136,"y":2050},{"x":1136,"y":2114},{"x":1200,"y":2206},{"x":1200,"y":2270}],"textPositions":{"0":{"x":1124,"y":2068},"1":{"x":1148,"y":2096},"2":{"x":1212,"y":2252},"3":{"x":1188,"y":2224},"4":{"x":1180,"y":2160},"5":{"x":1180,"y":2160},"6":{"x":1156,"y":2160}}},"warnings":null},{"id":253,"sourceNodeId":149,"sourcePortId":541,"targetNodeId":137,"targetPortId":542,"travelTime":{"lock":false,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":56,"warning":null,"consecutiveTime":116},"sourceArrival":{"lock":false,"time":4,"warning":null,"consecutiveTime":244},"targetDeparture":{"lock":false,"time":54,"warning":null,"consecutiveTime":234},"targetArrival":{"lock":false,"time":6,"warning":null,"consecutiveTime":126},"numberOfStops":0,"trainrunId":84,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1104,"y":2050},{"x":1104,"y":2114},{"x":1168,"y":2206},{"x":1168,"y":2270}],"textPositions":{"0":{"x":1092,"y":2068},"1":{"x":1116,"y":2096},"2":{"x":1180,"y":2252},"3":{"x":1156,"y":2224},"4":{"x":1148,"y":2160},"5":{"x":1148,"y":2160},"6":{"x":1124,"y":2160}}},"warnings":null},{"id":254,"sourceNodeId":140,"sourcePortId":543,"targetNodeId":137,"targetPortId":544,"travelTime":{"lock":false,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":42,"warning":null,"consecutiveTime":222},"sourceArrival":{"lock":false,"time":18,"warning":null,"consecutiveTime":138},"targetDeparture":{"lock":false,"time":8,"warning":null,"consecutiveTime":128},"targetArrival":{"lock":false,"time":52,"warning":null,"consecutiveTime":232},"numberOfStops":0,"trainrunId":84,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1502,"y":2288},{"x":1438,"y":2288},{"x":1346,"y":2288},{"x":1282,"y":2288}],"textPositions":{"0":{"x":1484,"y":2276},"1":{"x":1456,"y":2300},"2":{"x":1300,"y":2300},"3":{"x":1328,"y":2276},"4":{"x":1392,"y":2276},"5":{"x":1392,"y":2276},"6":{"x":1392,"y":2300}}},"warnings":null},{"id":255,"sourceNodeId":140,"sourcePortId":545,"targetNodeId":137,"targetPortId":546,"travelTime":{"lock":false,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":40,"warning":null,"consecutiveTime":40},"sourceArrival":{"lock":false,"time":20,"warning":null,"consecutiveTime":20},"targetDeparture":{"lock":false,"time":10,"warning":null,"consecutiveTime":10},"targetArrival":{"lock":false,"time":50,"warning":null,"consecutiveTime":50},"numberOfStops":4,"trainrunId":92,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1502,"y":2384},{"x":1438,"y":2384},{"x":1346,"y":2384},{"x":1282,"y":2384}],"textPositions":{"0":{"x":1484,"y":2372},"1":{"x":1456,"y":2396},"2":{"x":1300,"y":2396},"3":{"x":1328,"y":2372},"4":{"x":1392,"y":2372},"5":{"x":1392,"y":2372},"6":{"x":1392,"y":2396}}},"warnings":null},{"id":256,"sourceNodeId":140,"sourcePortId":547,"targetNodeId":137,"targetPortId":548,"travelTime":{"lock":false,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":40,"warning":null,"consecutiveTime":100},"sourceArrival":{"lock":false,"time":20,"warning":null,"consecutiveTime":80},"targetDeparture":{"lock":false,"time":10,"warning":null,"consecutiveTime":70},"targetArrival":{"lock":false,"time":50,"warning":null,"consecutiveTime":110},"numberOfStops":0,"trainrunId":85,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1502,"y":2320},{"x":1438,"y":2320},{"x":1346,"y":2320},{"x":1282,"y":2320}],"textPositions":{"0":{"x":1484,"y":2308},"1":{"x":1456,"y":2332},"2":{"x":1300,"y":2332},"3":{"x":1328,"y":2308},"4":{"x":1392,"y":2308},"5":{"x":1392,"y":2308},"6":{"x":1392,"y":2332}}},"warnings":null},{"id":257,"sourceNodeId":140,"sourcePortId":549,"targetNodeId":137,"targetPortId":550,"travelTime":{"lock":false,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":0,"warning":null,"consecutiveTime":120},"sourceArrival":{"lock":false,"time":0,"warning":null,"consecutiveTime":60},"targetDeparture":{"lock":false,"time":50,"warning":null,"consecutiveTime":50},"targetArrival":{"lock":false,"time":10,"warning":null,"consecutiveTime":130},"numberOfStops":4,"trainrunId":91,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1502,"y":2352},{"x":1438,"y":2352},{"x":1346,"y":2352},{"x":1282,"y":2352}],"textPositions":{"0":{"x":1484,"y":2340},"1":{"x":1456,"y":2364},"2":{"x":1300,"y":2364},"3":{"x":1328,"y":2340},"4":{"x":1392,"y":2340},"5":{"x":1392,"y":2340},"6":{"x":1392,"y":2364}}},"warnings":null},{"id":258,"sourceNodeId":159,"sourcePortId":551,"targetNodeId":161,"targetPortId":552,"travelTime":{"lock":true,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":26,"warning":null,"consecutiveTime":86},"sourceArrival":{"lock":false,"time":34,"warning":null,"consecutiveTime":274},"targetDeparture":{"lock":false,"time":24,"warning":null,"consecutiveTime":264},"targetArrival":{"lock":false,"time":36,"warning":null,"consecutiveTime":96},"numberOfStops":0,"trainrunId":84,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1008,"y":1058},{"x":1008,"y":1122},{"x":1008,"y":1246},{"x":1008,"y":1310}],"textPositions":{"0":{"x":996,"y":1076},"1":{"x":1020,"y":1104},"2":{"x":1020,"y":1292},"3":{"x":996,"y":1264},"4":{"x":996,"y":1184},"5":{"x":996,"y":1184},"6":{"x":1020,"y":1184}}},"warnings":null},{"id":259,"sourceNodeId":159,"sourcePortId":553,"targetNodeId":161,"targetPortId":554,"travelTime":{"lock":true,"time":7,"warning":null},"sourceDeparture":{"lock":true,"time":35,"warning":null,"consecutiveTime":35},"sourceArrival":{"lock":true,"time":25,"warning":null,"consecutiveTime":145},"targetDeparture":{"lock":true,"time":18,"warning":null,"consecutiveTime":138},"targetArrival":{"lock":true,"time":42,"warning":null,"consecutiveTime":42},"numberOfStops":0,"trainrunId":87,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1040,"y":1058},{"x":1040,"y":1122},{"x":1040,"y":1246},{"x":1040,"y":1310}],"textPositions":{"0":{"x":1028,"y":1076},"1":{"x":1052,"y":1104},"2":{"x":1052,"y":1292},"3":{"x":1028,"y":1264},"4":{"x":1028,"y":1184},"5":{"x":1028,"y":1184},"6":{"x":1052,"y":1184}}},"warnings":null},{"id":260,"sourceNodeId":159,"sourcePortId":555,"targetNodeId":161,"targetPortId":556,"travelTime":{"lock":true,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":33,"warning":null,"consecutiveTime":33},"sourceArrival":{"lock":false,"time":27,"warning":null,"consecutiveTime":147},"targetDeparture":{"lock":false,"time":17,"warning":null,"consecutiveTime":137},"targetArrival":{"lock":false,"time":43,"warning":null,"consecutiveTime":43},"numberOfStops":0,"trainrunId":93,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1072,"y":1058},{"x":1072,"y":1122},{"x":1072,"y":1246},{"x":1072,"y":1310}],"textPositions":{"0":{"x":1060,"y":1076},"1":{"x":1084,"y":1104},"2":{"x":1084,"y":1292},"3":{"x":1060,"y":1264},"4":{"x":1060,"y":1184},"5":{"x":1060,"y":1184},"6":{"x":1084,"y":1184}}},"warnings":null},{"id":261,"sourceNodeId":159,"sourcePortId":557,"targetNodeId":161,"targetPortId":558,"travelTime":{"lock":true,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":32,"warning":null,"consecutiveTime":32},"sourceArrival":{"lock":false,"time":28,"warning":null,"consecutiveTime":28},"targetDeparture":{"lock":false,"time":18,"warning":null,"consecutiveTime":18},"targetArrival":{"lock":false,"time":42,"warning":null,"consecutiveTime":42},"numberOfStops":4,"trainrunId":86,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1104,"y":1058},{"x":1104,"y":1122},{"x":1104,"y":1246},{"x":1104,"y":1310}],"textPositions":{"0":{"x":1092,"y":1076},"1":{"x":1116,"y":1104},"2":{"x":1116,"y":1292},"3":{"x":1092,"y":1264},"4":{"x":1092,"y":1184},"5":{"x":1092,"y":1184},"6":{"x":1116,"y":1184}}},"warnings":null},{"id":262,"sourceNodeId":149,"sourcePortId":559,"targetNodeId":160,"targetPortId":560,"travelTime":{"lock":true,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":22,"warning":null,"consecutiveTime":142},"sourceArrival":{"lock":false,"time":38,"warning":null,"consecutiveTime":38},"targetDeparture":{"lock":false,"time":28,"warning":null,"consecutiveTime":28},"targetArrival":{"lock":false,"time":32,"warning":null,"consecutiveTime":152},"numberOfStops":3,"trainrunId":91,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1200,"y":1982},{"x":1200,"y":1918},{"x":1200,"y":1826},{"x":1200,"y":1762}],"textPositions":{"0":{"x":1212,"y":1964},"1":{"x":1188,"y":1936},"2":{"x":1188,"y":1780},"3":{"x":1212,"y":1808},"4":{"x":1188,"y":1872},"5":{"x":1188,"y":1872},"6":{"x":1212,"y":1872}}},"warnings":null},{"id":263,"sourceNodeId":160,"sourcePortId":561,"targetNodeId":161,"targetPortId":562,"travelTime":{"lock":true,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":33,"warning":null,"consecutiveTime":153},"sourceArrival":{"lock":false,"time":27,"warning":null,"consecutiveTime":27},"targetDeparture":{"lock":false,"time":17,"warning":null,"consecutiveTime":17},"targetArrival":{"lock":false,"time":43,"warning":null,"consecutiveTime":163},"numberOfStops":2,"trainrunId":91,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1200,"y":1694},{"x":1200,"y":1630},{"x":1104,"y":1442},{"x":1104,"y":1378}],"textPositions":{"0":{"x":1212,"y":1676},"1":{"x":1188,"y":1648},"2":{"x":1092,"y":1396},"3":{"x":1116,"y":1424},"4":{"x":1164,"y":1536},"5":{"x":1164,"y":1536},"6":{"x":1140,"y":1536}}},"warnings":null},{"id":264,"sourceNodeId":149,"sourcePortId":563,"targetNodeId":160,"targetPortId":564,"travelTime":{"lock":true,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":54,"warning":null,"consecutiveTime":114},"sourceArrival":{"lock":false,"time":6,"warning":null,"consecutiveTime":66},"targetDeparture":{"lock":false,"time":56,"warning":null,"consecutiveTime":56},"targetArrival":{"lock":false,"time":4,"warning":null,"consecutiveTime":124},"numberOfStops":0,"trainrunId":93,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1168,"y":1982},{"x":1168,"y":1918},{"x":1168,"y":1826},{"x":1168,"y":1762}],"textPositions":{"0":{"x":1180,"y":1964},"1":{"x":1156,"y":1936},"2":{"x":1156,"y":1780},"3":{"x":1180,"y":1808},"4":{"x":1156,"y":1872},"5":{"x":1156,"y":1872},"6":{"x":1180,"y":1872}}},"warnings":null},{"id":265,"sourceNodeId":160,"sourcePortId":565,"targetNodeId":161,"targetPortId":566,"travelTime":{"lock":true,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":5.5,"warning":null,"consecutiveTime":125.5},"sourceArrival":{"lock":false,"time":54.5,"warning":null,"consecutiveTime":54.5},"targetDeparture":{"lock":false,"time":44.5,"warning":null,"consecutiveTime":44.5},"targetArrival":{"lock":false,"time":15.5,"warning":null,"consecutiveTime":135.5},"numberOfStops":0,"trainrunId":93,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1168,"y":1694},{"x":1168,"y":1630},{"x":1072,"y":1442},{"x":1072,"y":1378}],"textPositions":{"0":{"x":1180,"y":1676},"1":{"x":1156,"y":1648},"2":{"x":1060,"y":1396},"3":{"x":1084,"y":1424},"4":{"x":1132,"y":1536},"5":{"x":1132,"y":1536},"6":{"x":1108,"y":1536}}},"warnings":null},{"id":266,"sourceNodeId":149,"sourcePortId":567,"targetNodeId":160,"targetPortId":568,"travelTime":{"lock":true,"time":4,"warning":null},"sourceDeparture":{"lock":false,"time":4,"warning":null,"consecutiveTime":124},"sourceArrival":{"lock":false,"time":56,"warning":null,"consecutiveTime":56},"targetDeparture":{"lock":false,"time":52,"warning":null,"consecutiveTime":52},"targetArrival":{"lock":false,"time":8,"warning":null,"consecutiveTime":128},"numberOfStops":0,"trainrunId":87,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1136,"y":1982},{"x":1136,"y":1918},{"x":1136,"y":1826},{"x":1136,"y":1762}],"textPositions":{"0":{"x":1148,"y":1964},"1":{"x":1124,"y":1936},"2":{"x":1124,"y":1780},"3":{"x":1148,"y":1808},"4":{"x":1124,"y":1872},"5":{"x":1124,"y":1872},"6":{"x":1148,"y":1872}}},"warnings":null},{"id":267,"sourceNodeId":160,"sourcePortId":569,"targetNodeId":161,"targetPortId":570,"travelTime":{"lock":true,"time":8,"warning":null},"sourceDeparture":{"lock":false,"time":8,"warning":null,"consecutiveTime":128},"sourceArrival":{"lock":false,"time":52,"warning":null,"consecutiveTime":52},"targetDeparture":{"lock":false,"time":44,"warning":null,"consecutiveTime":44},"targetArrival":{"lock":false,"time":16,"warning":null,"consecutiveTime":136},"numberOfStops":0,"trainrunId":87,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1136,"y":1694},{"x":1136,"y":1630},{"x":1040,"y":1442},{"x":1040,"y":1378}],"textPositions":{"0":{"x":1148,"y":1676},"1":{"x":1124,"y":1648},"2":{"x":1028,"y":1396},"3":{"x":1052,"y":1424},"4":{"x":1100,"y":1536},"5":{"x":1100,"y":1536},"6":{"x":1076,"y":1536}}},"warnings":null},{"id":268,"sourceNodeId":149,"sourcePortId":571,"targetNodeId":160,"targetPortId":572,"travelTime":{"lock":true,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":4,"warning":null,"consecutiveTime":244},"sourceArrival":{"lock":false,"time":56,"warning":null,"consecutiveTime":116},"targetDeparture":{"lock":false,"time":46,"warning":null,"consecutiveTime":106},"targetArrival":{"lock":false,"time":14,"warning":null,"consecutiveTime":254},"numberOfStops":0,"trainrunId":84,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1104,"y":1982},{"x":1104,"y":1918},{"x":1104,"y":1826},{"x":1104,"y":1762}],"textPositions":{"0":{"x":1116,"y":1964},"1":{"x":1092,"y":1936},"2":{"x":1092,"y":1780},"3":{"x":1116,"y":1808},"4":{"x":1092,"y":1872},"5":{"x":1092,"y":1872},"6":{"x":1116,"y":1872}}},"warnings":null},{"id":269,"sourceNodeId":160,"sourcePortId":573,"targetNodeId":161,"targetPortId":574,"travelTime":{"lock":true,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":14,"warning":null,"consecutiveTime":254},"sourceArrival":{"lock":false,"time":46,"warning":null,"consecutiveTime":106},"targetDeparture":{"lock":false,"time":36,"warning":null,"consecutiveTime":96},"targetArrival":{"lock":false,"time":24,"warning":null,"consecutiveTime":264},"numberOfStops":0,"trainrunId":84,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1104,"y":1694},{"x":1104,"y":1630},{"x":1008,"y":1442},{"x":1008,"y":1378}],"textPositions":{"0":{"x":1116,"y":1676},"1":{"x":1092,"y":1648},"2":{"x":996,"y":1396},"3":{"x":1020,"y":1424},"4":{"x":1068,"y":1536},"5":{"x":1068,"y":1536},"6":{"x":1044,"y":1536}}},"warnings":null},{"id":270,"sourceNodeId":140,"sourcePortId":575,"targetNodeId":146,"targetPortId":576,"travelTime":{"lock":true,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":1,"warning":null,"consecutiveTime":61},"sourceArrival":{"lock":false,"time":59,"warning":null,"consecutiveTime":119},"targetDeparture":{"lock":false,"time":49,"warning":null,"consecutiveTime":109},"targetArrival":{"lock":false,"time":11,"warning":null,"consecutiveTime":71},"numberOfStops":1,"trainrunId":91,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1602,"y":2320},{"x":1666,"y":2320},{"x":1822,"y":2256},{"x":1886,"y":2256}],"textPositions":{"0":{"x":1620,"y":2332},"1":{"x":1648,"y":2308},"2":{"x":1868,"y":2244},"3":{"x":1840,"y":2268},"4":{"x":1744,"y":2276},"5":{"x":1744,"y":2276},"6":{"x":1744,"y":2300}}},"warnings":null},{"id":271,"sourceNodeId":146,"sourcePortId":577,"targetNodeId":135,"targetPortId":578,"travelTime":{"lock":true,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":12,"warning":null,"consecutiveTime":72},"sourceArrival":{"lock":false,"time":48,"warning":null,"consecutiveTime":108},"targetDeparture":{"lock":false,"time":38,"warning":null,"consecutiveTime":98},"targetArrival":{"lock":false,"time":22,"warning":null,"consecutiveTime":82},"numberOfStops":3,"trainrunId":91,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1936,"y":2206},{"x":1936,"y":2142},{"x":1936,"y":2114},{"x":1936,"y":2050}],"textPositions":{"0":{"x":1948,"y":2188},"1":{"x":1924,"y":2160},"2":{"x":1924,"y":2068},"3":{"x":1948,"y":2096},"4":{"x":1924,"y":2128},"5":{"x":1924,"y":2128},"6":{"x":1948,"y":2128}}},"warnings":null},{"id":272,"sourceNodeId":140,"sourcePortId":579,"targetNodeId":146,"targetPortId":580,"travelTime":{"lock":true,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":20,"warning":null,"consecutiveTime":80},"sourceArrival":{"lock":false,"time":40,"warning":null,"consecutiveTime":100},"targetDeparture":{"lock":false,"time":30,"warning":null,"consecutiveTime":90},"targetArrival":{"lock":false,"time":30,"warning":null,"consecutiveTime":90},"numberOfStops":0,"trainrunId":85,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1602,"y":2288},{"x":1666,"y":2288},{"x":1822,"y":2224},{"x":1886,"y":2224}],"textPositions":{"0":{"x":1620,"y":2300},"1":{"x":1648,"y":2276},"2":{"x":1868,"y":2212},"3":{"x":1840,"y":2236},"4":{"x":1744,"y":2244},"5":{"x":1744,"y":2244},"6":{"x":1744,"y":2268}}},"warnings":null},{"id":273,"sourceNodeId":146,"sourcePortId":581,"targetNodeId":135,"targetPortId":582,"travelTime":{"lock":true,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":30,"warning":null,"consecutiveTime":90},"sourceArrival":{"lock":false,"time":30,"warning":null,"consecutiveTime":90},"targetDeparture":{"lock":false,"time":20,"warning":null,"consecutiveTime":80},"targetArrival":{"lock":false,"time":40,"warning":null,"consecutiveTime":100},"numberOfStops":0,"trainrunId":85,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1904,"y":2206},{"x":1904,"y":2142},{"x":1904,"y":2114},{"x":1904,"y":2050}],"textPositions":{"0":{"x":1916,"y":2188},"1":{"x":1892,"y":2160},"2":{"x":1892,"y":2068},"3":{"x":1916,"y":2096},"4":{"x":1892,"y":2128},"5":{"x":1892,"y":2128},"6":{"x":1916,"y":2128}}},"warnings":null},{"id":274,"sourceNodeId":140,"sourcePortId":583,"targetNodeId":147,"targetPortId":584,"travelTime":{"lock":true,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":21,"warning":null,"consecutiveTime":21},"sourceArrival":{"lock":false,"time":39,"warning":null,"consecutiveTime":39},"targetDeparture":{"lock":false,"time":29,"warning":null,"consecutiveTime":29},"targetArrival":{"lock":false,"time":31,"warning":null,"consecutiveTime":31},"numberOfStops":0,"trainrunId":92,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1602,"y":2384},{"x":1666,"y":2384},{"x":1822,"y":2384},{"x":1886,"y":2384}],"textPositions":{"0":{"x":1620,"y":2396},"1":{"x":1648,"y":2372},"2":{"x":1868,"y":2372},"3":{"x":1840,"y":2396},"4":{"x":1744,"y":2372},"5":{"x":1744,"y":2372},"6":{"x":1744,"y":2396}}},"warnings":null},{"id":275,"sourceNodeId":147,"sourcePortId":585,"targetNodeId":154,"targetPortId":586,"travelTime":{"lock":true,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":32,"warning":null,"consecutiveTime":32},"sourceArrival":{"lock":false,"time":28,"warning":null,"consecutiveTime":28},"targetDeparture":{"lock":false,"time":18,"warning":null,"consecutiveTime":18},"targetArrival":{"lock":false,"time":42,"warning":null,"consecutiveTime":42},"numberOfStops":0,"trainrunId":92,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1986,"y":2384},{"x":2050,"y":2384},{"x":2302,"y":2384},{"x":2366,"y":2384}],"textPositions":{"0":{"x":2004,"y":2396},"1":{"x":2032,"y":2372},"2":{"x":2348,"y":2372},"3":{"x":2320,"y":2396},"4":{"x":2176,"y":2372},"5":{"x":2176,"y":2372},"6":{"x":2176,"y":2396}}},"warnings":null},{"id":276,"sourceNodeId":140,"sourcePortId":587,"targetNodeId":147,"targetPortId":588,"travelTime":{"lock":true,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":18,"warning":null,"consecutiveTime":138},"sourceArrival":{"lock":false,"time":42,"warning":null,"consecutiveTime":222},"targetDeparture":{"lock":false,"time":32,"warning":null,"consecutiveTime":212},"targetArrival":{"lock":false,"time":28,"warning":null,"consecutiveTime":148},"numberOfStops":0,"trainrunId":84,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1602,"y":2352},{"x":1666,"y":2352},{"x":1822,"y":2352},{"x":1886,"y":2352}],"textPositions":{"0":{"x":1620,"y":2364},"1":{"x":1648,"y":2340},"2":{"x":1868,"y":2340},"3":{"x":1840,"y":2364},"4":{"x":1744,"y":2340},"5":{"x":1744,"y":2340},"6":{"x":1744,"y":2364}}},"warnings":null},{"id":277,"sourceNodeId":147,"sourcePortId":589,"targetNodeId":154,"targetPortId":590,"travelTime":{"lock":true,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":30,"warning":null,"consecutiveTime":150},"sourceArrival":{"lock":false,"time":30,"warning":null,"consecutiveTime":210},"targetDeparture":{"lock":false,"time":20,"warning":null,"consecutiveTime":200},"targetArrival":{"lock":false,"time":40,"warning":null,"consecutiveTime":160},"numberOfStops":0,"trainrunId":84,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1986,"y":2352},{"x":2050,"y":2352},{"x":2302,"y":2352},{"x":2366,"y":2352}],"textPositions":{"0":{"x":2004,"y":2364},"1":{"x":2032,"y":2340},"2":{"x":2348,"y":2340},"3":{"x":2320,"y":2364},"4":{"x":2176,"y":2340},"5":{"x":2176,"y":2340},"6":{"x":2176,"y":2364}}},"warnings":null},{"id":278,"sourceNodeId":148,"sourcePortId":591,"targetNodeId":133,"targetPortId":592,"travelTime":{"lock":true,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":44,"warning":null,"consecutiveTime":104},"sourceArrival":{"lock":false,"time":16,"warning":null,"consecutiveTime":76},"targetDeparture":{"lock":false,"time":6,"warning":null,"consecutiveTime":66},"targetArrival":{"lock":false,"time":54,"warning":null,"consecutiveTime":114},"numberOfStops":3,"trainrunId":94,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":240,"y":1918},{"x":240,"y":1854},{"x":240,"y":994},{"x":240,"y":930}],"textPositions":{"0":{"x":252,"y":1900},"1":{"x":228,"y":1872},"2":{"x":228,"y":948},"3":{"x":252,"y":976},"4":{"x":228,"y":1424},"5":{"x":228,"y":1424},"6":{"x":252,"y":1424}}},"warnings":null},{"id":279,"sourceNodeId":133,"sourcePortId":593,"targetNodeId":142,"targetPortId":594,"travelTime":{"lock":true,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":55,"warning":null,"consecutiveTime":115},"sourceArrival":{"lock":false,"time":5,"warning":null,"consecutiveTime":65},"targetDeparture":{"lock":false,"time":55,"warning":null,"consecutiveTime":55},"targetArrival":{"lock":false,"time":5,"warning":null,"consecutiveTime":125},"numberOfStops":3,"trainrunId":94,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":240,"y":862},{"x":240,"y":798},{"x":240,"y":574},{"x":240,"y":510}],"textPositions":{"0":{"x":252,"y":844},"1":{"x":228,"y":816},"2":{"x":228,"y":528},"3":{"x":252,"y":556},"4":{"x":228,"y":686},"5":{"x":228,"y":686},"6":{"x":252,"y":686}}},"warnings":null},{"id":280,"sourceNodeId":148,"sourcePortId":595,"targetNodeId":133,"targetPortId":596,"travelTime":{"lock":true,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":24,"warning":null,"consecutiveTime":144},"sourceArrival":{"lock":false,"time":36,"warning":null,"consecutiveTime":36},"targetDeparture":{"lock":false,"time":26,"warning":null,"consecutiveTime":26},"targetArrival":{"lock":false,"time":34,"warning":null,"consecutiveTime":154},"numberOfStops":3,"trainrunId":95,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":208,"y":1918},{"x":208,"y":1854},{"x":208,"y":994},{"x":208,"y":930}],"textPositions":{"0":{"x":220,"y":1900},"1":{"x":196,"y":1872},"2":{"x":196,"y":948},"3":{"x":220,"y":976},"4":{"x":196,"y":1424},"5":{"x":196,"y":1424},"6":{"x":220,"y":1424}}},"warnings":null},{"id":281,"sourceNodeId":133,"sourcePortId":597,"targetNodeId":142,"targetPortId":598,"travelTime":{"lock":true,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":35,"warning":null,"consecutiveTime":155},"sourceArrival":{"lock":false,"time":25,"warning":null,"consecutiveTime":25},"targetDeparture":{"lock":false,"time":15,"warning":null,"consecutiveTime":15},"targetArrival":{"lock":false,"time":45,"warning":null,"consecutiveTime":165},"numberOfStops":3,"trainrunId":95,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":208,"y":862},{"x":208,"y":798},{"x":208,"y":574},{"x":208,"y":510}],"textPositions":{"0":{"x":220,"y":844},"1":{"x":196,"y":816},"2":{"x":196,"y":528},"3":{"x":220,"y":556},"4":{"x":196,"y":686},"5":{"x":196,"y":686},"6":{"x":220,"y":686}}},"warnings":null},{"id":282,"sourceNodeId":142,"sourcePortId":599,"targetNodeId":157,"targetPortId":600,"travelTime":{"lock":true,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":6,"warning":null,"consecutiveTime":126},"sourceArrival":{"lock":false,"time":54,"warning":null,"consecutiveTime":54},"targetDeparture":{"lock":false,"time":44,"warning":null,"consecutiveTime":44},"targetArrival":{"lock":false,"time":16,"warning":null,"consecutiveTime":136},"numberOfStops":3,"trainrunId":94,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":290,"y":464},{"x":354,"y":464},{"x":926,"y":336},{"x":990,"y":336}],"textPositions":{"0":{"x":308,"y":476},"1":{"x":336,"y":452},"2":{"x":972,"y":324},"3":{"x":944,"y":348},"4":{"x":640,"y":388},"5":{"x":640,"y":388},"6":{"x":640,"y":412}}},"warnings":null},{"id":283,"sourceNodeId":142,"sourcePortId":601,"targetNodeId":157,"targetPortId":602,"travelTime":{"lock":true,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":46,"warning":null,"consecutiveTime":166},"sourceArrival":{"lock":false,"time":14,"warning":null,"consecutiveTime":14},"targetDeparture":{"lock":false,"time":4,"warning":null,"consecutiveTime":4},"targetArrival":{"lock":false,"time":56,"warning":null,"consecutiveTime":176},"numberOfStops":1,"trainrunId":95,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":290,"y":432},{"x":354,"y":432},{"x":926,"y":304},{"x":990,"y":304}],"textPositions":{"0":{"x":308,"y":444},"1":{"x":336,"y":420},"2":{"x":972,"y":292},"3":{"x":944,"y":316},"4":{"x":640,"y":356},"5":{"x":640,"y":356},"6":{"x":640,"y":380}}},"warnings":null},{"id":284,"sourceNodeId":154,"sourcePortId":603,"targetNodeId":155,"targetPortId":604,"travelTime":{"lock":true,"time":10,"warning":null},"sourceDeparture":{"lock":false,"time":0,"warning":null,"consecutiveTime":0},"sourceArrival":{"lock":false,"time":0,"warning":null,"consecutiveTime":60},"targetDeparture":{"lock":false,"time":50,"warning":null,"consecutiveTime":50},"targetArrival":{"lock":false,"time":10,"warning":null,"consecutiveTime":10},"numberOfStops":0,"trainrunId":98,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2384,"y":2430},{"x":2384,"y":2494},{"x":2544,"y":2494},{"x":2544,"y":2558}],"textPositions":{"0":{"x":2372,"y":2448},"1":{"x":2396,"y":2476},"2":{"x":2556,"y":2540},"3":{"x":2532,"y":2512},"4":{"x":2476,"y":2494},"5":{"x":2476,"y":2494},"6":{"x":2452,"y":2494}}},"warnings":null},{"id":415,"sourceNodeId":141,"sourcePortId":691,"targetNodeId":159,"targetPortId":692,"travelTime":{"time":5,"consecutiveTime":1,"lock":true,"warning":null,"timeFormatter":null},"sourceDeparture":{"time":29,"consecutiveTime":29,"lock":false,"warning":null,"timeFormatter":null},"sourceArrival":{"time":31,"consecutiveTime":151,"lock":false,"warning":null,"timeFormatter":null},"targetDeparture":{"time":26,"consecutiveTime":146,"lock":false,"warning":null,"timeFormatter":null},"targetArrival":{"time":34,"consecutiveTime":34,"lock":false,"warning":null,"timeFormatter":null},"numberOfStops":0,"trainrunId":87,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1040,"y":738},{"x":1040,"y":802},{"x":1040,"y":926},{"x":1040,"y":990}],"textPositions":{"0":{"x":1028,"y":756},"1":{"x":1052,"y":784},"2":{"x":1052,"y":972},"3":{"x":1028,"y":944},"4":{"x":1028,"y":864},"5":{"x":1028,"y":864},"6":{"x":1052,"y":864}}},"warnings":null}],"trainruns":[{"id":83,"name":"1","categoryId":2,"frequencyId":2,"trainrunTimeCategoryId":0,"labelIds":[]},{"id":84,"name":"1","categoryId":0,"frequencyId":4,"trainrunTimeCategoryId":0,"labelIds":[]},{"id":85,"name":"12","categoryId":2,"frequencyId":2,"trainrunTimeCategoryId":0,"labelIds":[]},{"id":86,"name":"29","categoryId":4,"frequencyId":2,"trainrunTimeCategoryId":0,"labelIds":[]},{"id":87,"name":"15","categoryId":2,"frequencyId":3,"trainrunTimeCategoryId":0,"labelIds":[]},{"id":88,"name":"8","categoryId":2,"frequencyId":3,"trainrunTimeCategoryId":0,"labelIds":[]},{"id":89,"name":"12","categoryId":2,"frequencyId":3,"trainrunTimeCategoryId":0,"labelIds":[]},{"id":90,"name":"1","categoryId":1,"frequencyId":3,"trainrunTimeCategoryId":0,"labelIds":[]},{"id":91,"name":"1","categoryId":4,"frequencyId":0,"trainrunTimeCategoryId":0,"labelIds":[]},{"id":92,"name":"3","categoryId":4,"frequencyId":3,"trainrunTimeCategoryId":0,"labelIds":[]},{"id":93,"name":"","categoryId":3,"frequencyId":3,"trainrunTimeCategoryId":0,"labelIds":[]},{"id":94,"name":"7","categoryId":4,"frequencyId":3,"trainrunTimeCategoryId":0,"labelIds":[]},{"id":95,"name":"6","categoryId":4,"frequencyId":3,"trainrunTimeCategoryId":0,"labelIds":[]},{"id":96,"name":"77","categoryId":4,"frequencyId":3,"trainrunTimeCategoryId":0,"labelIds":[]},{"id":97,"name":"","categoryId":3,"frequencyId":3,"trainrunTimeCategoryId":0,"labelIds":[]},{"id":98,"name":"X","categoryId":1,"frequencyId":3,"trainrunTimeCategoryId":0,"labelIds":[]}],"resources":[{"id":151,"capacity":2},{"id":152,"capacity":2},{"id":153,"capacity":2},{"id":154,"capacity":2},{"id":155,"capacity":2},{"id":156,"capacity":2},{"id":157,"capacity":2},{"id":158,"capacity":2},{"id":159,"capacity":2},{"id":160,"capacity":2},{"id":161,"capacity":2},{"id":162,"capacity":2},{"id":163,"capacity":2},{"id":164,"capacity":2},{"id":165,"capacity":2},{"id":166,"capacity":2},{"id":167,"capacity":2},{"id":168,"capacity":2},{"id":169,"capacity":2},{"id":170,"capacity":2},{"id":171,"capacity":2},{"id":172,"capacity":2},{"id":173,"capacity":2},{"id":174,"capacity":2},{"id":175,"capacity":2},{"id":176,"capacity":2},{"id":177,"capacity":2},{"id":178,"capacity":2},{"id":179,"capacity":2},{"id":180,"capacity":2},{"id":181,"capacity":2},{"id":182,"capacity":2},{"id":183,"capacity":2},{"id":184,"capacity":2},{"id":185,"capacity":2},{"id":186,"capacity":2},{"id":187,"capacity":2},{"id":188,"capacity":2},{"id":189,"capacity":2},{"id":190,"capacity":2}],"metadata":{"netzgrafikColors":[],"trainrunCategories":[{"id":0,"name":"International","order":0,"colorRef":"EC","shortName":"EC","fachCategory":"HaltezeitIPV","sectionHeadway":2,"nodeHeadwayStop":2,"nodeHeadwayNonStop":2,"minimalTurnaroundTime":4},{"id":1,"name":"InterCity","order":1,"colorRef":"IC","shortName":"IC","fachCategory":"HaltezeitA","sectionHeadway":2,"nodeHeadwayStop":2,"nodeHeadwayNonStop":2,"minimalTurnaroundTime":4},{"id":2,"name":"InterRegio","order":2,"colorRef":"IR","shortName":"IR","fachCategory":"HaltezeitB","sectionHeadway":2,"nodeHeadwayStop":2,"nodeHeadwayNonStop":2,"minimalTurnaroundTime":4},{"id":3,"name":"RegioExpress","order":3,"colorRef":"RE","shortName":"RE","fachCategory":"HaltezeitC","sectionHeadway":2,"nodeHeadwayStop":2,"nodeHeadwayNonStop":2,"minimalTurnaroundTime":4},{"id":4,"name":"RegioUndSBahnverkehr","order":4,"colorRef":"S","shortName":"S","fachCategory":"HaltezeitD","sectionHeadway":2,"nodeHeadwayStop":2,"nodeHeadwayNonStop":2,"minimalTurnaroundTime":4},{"id":5,"name":"GüterExpress","order":5,"colorRef":"GEX","shortName":"GEX","fachCategory":"HaltezeitUncategorized","sectionHeadway":3,"nodeHeadwayStop":3,"nodeHeadwayNonStop":3,"minimalTurnaroundTime":4},{"id":6,"name":"Güterverkehr","order":6,"colorRef":"G","shortName":"G","fachCategory":"HaltezeitUncategorized","sectionHeadway":3,"nodeHeadwayStop":3,"nodeHeadwayNonStop":3,"minimalTurnaroundTime":4}],"trainrunFrequencies":[{"id":0,"name":"verkehrt viertelstündlich","order":0,"offset":0,"frequency":15,"shortName":"15","linePatternRef":"15"},{"id":1,"name":"verkehrt im 20 Minuten Takt","order":0,"offset":0,"frequency":20,"shortName":"20","linePatternRef":"20"},{"id":2,"name":"verkehrt halbstündlich","order":0,"offset":0,"frequency":30,"shortName":"30","linePatternRef":"30"},{"id":3,"name":"verkehrt stündlich","order":0,"offset":0,"frequency":60,"shortName":"60","linePatternRef":"60"},{"id":4,"name":"verkehrt zweistündlich (gerade)","order":0,"offset":0,"frequency":120,"shortName":"120","linePatternRef":"120"},{"id":5,"name":"verkehrt zweistündlich (ungerade)","order":0,"offset":60,"frequency":120,"shortName":"120+","linePatternRef":"120"}],"trainrunTimeCategories":[{"id":0,"name":"verkehrt uneingeschränkt","order":0,"weekday":[1,2,3,4,5,6,7],"shortName":"7/24","linePatternRef":"7/24","dayTimeInterval":[]},{"id":1,"name":"verkehrt zur Hauptverkehrszeit","order":0,"weekday":[1,2,3,4,5,6,7],"shortName":"HVZ","linePatternRef":"HVZ","dayTimeInterval":[{"to":420,"from":360},{"to":1140,"from":960}]},{"id":2,"name":"verkehrt zeitweise","order":0,"weekday":[],"shortName":"zeitweise","linePatternRef":"ZEITWEISE","dayTimeInterval":[]}]},"freeFloatingTexts":[],"labels":[],"labelGroups":[],"filterData":{"filterSettings":[]}}
+{
+  "nodes": [
+    {
+      "id": 133,
+      "betriebspunktName": "MADI",
+      "fullName": "Madiswil ",
+      "positionX": 192,
+      "positionY": 864,
+      "ports": [
+        {
+          "id": 597,
+          "trainrunSectionId": 281,
+          "positionIndex": 0,
+          "positionAlignment": 0
+        },
+        {
+          "id": 593,
+          "trainrunSectionId": 279,
+          "positionIndex": 1,
+          "positionAlignment": 0
+        },
+        {
+          "id": 596,
+          "trainrunSectionId": 280,
+          "positionIndex": 0,
+          "positionAlignment": 1
+        },
+        {
+          "id": 592,
+          "trainrunSectionId": 278,
+          "positionIndex": 1,
+          "positionAlignment": 1
+        }
+      ],
+      "transitions": [
+        {"id": 183, "port1Id": 593, "port2Id": 592, "isNonStopTransit": false},
+        {"id": 185, "port1Id": 597, "port2Id": 596, "isNonStopTransit": false}
+      ],
+      "connections": [],
+      "resourceId": 162,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 134,
+      "betriebspunktName": "WSAU",
+      "fullName": "Willisau",
+      "positionX": 544,
+      "positionY": 1952,
+      "ports": [
+        {
+          "id": 522,
+          "trainrunSectionId": 243,
+          "positionIndex": 0,
+          "positionAlignment": 1
+        },
+        {
+          "id": 527,
+          "trainrunSectionId": 246,
+          "positionIndex": 1,
+          "positionAlignment": 1
+        },
+        {
+          "id": 524,
+          "trainrunSectionId": 244,
+          "positionIndex": 2,
+          "positionAlignment": 1
+        },
+        {
+          "id": 518,
+          "trainrunSectionId": 241,
+          "positionIndex": 0,
+          "positionAlignment": 2
+        },
+        {
+          "id": 515,
+          "trainrunSectionId": 240,
+          "positionIndex": 1,
+          "positionAlignment": 2
+        }
+      ],
+      "transitions": [
+        {"id": 150, "port1Id": 522, "port2Id": 518, "isNonStopTransit": false},
+        {"id": 151, "port1Id": 527, "port2Id": 515, "isNonStopTransit": false}
+      ],
+      "connections": [],
+      "resourceId": 163,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 135,
+      "betriebspunktName": "ZG",
+      "fullName": "Zug",
+      "positionX": 1888,
+      "positionY": 1984,
+      "ports": [
+        {
+          "id": 507,
+          "trainrunSectionId": 236,
+          "positionIndex": 0,
+          "positionAlignment": 0
+        },
+        {
+          "id": 509,
+          "trainrunSectionId": 237,
+          "positionIndex": 1,
+          "positionAlignment": 0
+        },
+        {
+          "id": 582,
+          "trainrunSectionId": 273,
+          "positionIndex": 0,
+          "positionAlignment": 1
+        },
+        {
+          "id": 578,
+          "trainrunSectionId": 271,
+          "positionIndex": 1,
+          "positionAlignment": 1
+        }
+      ],
+      "transitions": [
+        {"id": 174, "port1Id": 509, "port2Id": 578, "isNonStopTransit": false},
+        {"id": 177, "port1Id": 507, "port2Id": 582, "isNonStopTransit": false}
+      ],
+      "connections": [],
+      "resourceId": 164,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 136,
+      "betriebspunktName": "BAA",
+      "fullName": "Baar",
+      "positionX": 1920,
+      "positionY": 1632,
+      "ports": [
+        {
+          "id": 505,
+          "trainrunSectionId": 235,
+          "positionIndex": 0,
+          "positionAlignment": 0
+        },
+        {
+          "id": 508,
+          "trainrunSectionId": 236,
+          "positionIndex": 0,
+          "positionAlignment": 1
+        },
+        {
+          "id": 510,
+          "trainrunSectionId": 237,
+          "positionIndex": 1,
+          "positionAlignment": 1
+        }
+      ],
+      "transitions": [
+        {"id": 147, "port1Id": 505, "port2Id": 508, "isNonStopTransit": true}
+      ],
+      "connections": [],
+      "resourceId": 165,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 137,
+      "betriebspunktName": "LZ",
+      "fullName": "Luzern",
+      "positionX": 1152,
+      "positionY": 2272,
+      "ports": [
+        {
+          "id": 542,
+          "trainrunSectionId": 253,
+          "positionIndex": 0,
+          "positionAlignment": 0
+        },
+        {
+          "id": 540,
+          "trainrunSectionId": 252,
+          "positionIndex": 1,
+          "positionAlignment": 0
+        },
+        {
+          "id": 538,
+          "trainrunSectionId": 251,
+          "positionIndex": 2,
+          "positionAlignment": 0
+        },
+        {
+          "id": 536,
+          "trainrunSectionId": 250,
+          "positionIndex": 3,
+          "positionAlignment": 0
+        },
+        {
+          "id": 532,
+          "trainrunSectionId": 248,
+          "positionIndex": 0,
+          "positionAlignment": 2
+        },
+        {
+          "id": 530,
+          "trainrunSectionId": 247,
+          "positionIndex": 1,
+          "positionAlignment": 2
+        },
+        {
+          "id": 544,
+          "trainrunSectionId": 254,
+          "positionIndex": 0,
+          "positionAlignment": 3
+        },
+        {
+          "id": 548,
+          "trainrunSectionId": 256,
+          "positionIndex": 1,
+          "positionAlignment": 3
+        },
+        {
+          "id": 550,
+          "trainrunSectionId": 257,
+          "positionIndex": 2,
+          "positionAlignment": 3
+        },
+        {
+          "id": 546,
+          "trainrunSectionId": 255,
+          "positionIndex": 3,
+          "positionAlignment": 3
+        }
+      ],
+      "transitions": [
+        {"id": 155, "port1Id": 542, "port2Id": 544, "isNonStopTransit": false},
+        {"id": 156, "port1Id": 536, "port2Id": 550, "isNonStopTransit": false}
+      ],
+      "connections": [],
+      "resourceId": 166,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 138,
+      "betriebspunktName": "WH",
+      "fullName": "Wolhusen",
+      "positionX": 576,
+      "positionY": 2272,
+      "ports": [
+        {
+          "id": 521,
+          "trainrunSectionId": 243,
+          "positionIndex": 0,
+          "positionAlignment": 0
+        },
+        {
+          "id": 528,
+          "trainrunSectionId": 246,
+          "positionIndex": 1,
+          "positionAlignment": 0
+        },
+        {
+          "id": 523,
+          "trainrunSectionId": 244,
+          "positionIndex": 2,
+          "positionAlignment": 0
+        },
+        {
+          "id": 525,
+          "trainrunSectionId": 245,
+          "positionIndex": 0,
+          "positionAlignment": 2
+        },
+        {
+          "id": 520,
+          "trainrunSectionId": 242,
+          "positionIndex": 1,
+          "positionAlignment": 2
+        },
+        {
+          "id": 531,
+          "trainrunSectionId": 248,
+          "positionIndex": 0,
+          "positionAlignment": 3
+        },
+        {
+          "id": 529,
+          "trainrunSectionId": 247,
+          "positionIndex": 1,
+          "positionAlignment": 3
+        }
+      ],
+      "transitions": [
+        {"id": 149, "port1Id": 521, "port2Id": 520, "isNonStopTransit": false},
+        {"id": 152, "port1Id": 523, "port2Id": 529, "isNonStopTransit": false},
+        {"id": 153, "port1Id": 525, "port2Id": 531, "isNonStopTransit": false}
+      ],
+      "connections": [],
+      "resourceId": 167,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 139,
+      "betriebspunktName": "LABE",
+      "fullName": "Langnau i.E.",
+      "positionX": 32,
+      "positionY": 2272,
+      "ports": [
+        {
+          "id": 526,
+          "trainrunSectionId": 245,
+          "positionIndex": 0,
+          "positionAlignment": 3
+        },
+        {
+          "id": 519,
+          "trainrunSectionId": 242,
+          "positionIndex": 1,
+          "positionAlignment": 3
+        }
+      ],
+      "transitions": [],
+      "connections": [],
+      "resourceId": 168,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 140,
+      "betriebspunktName": "RK",
+      "fullName": "Rotkreuz ",
+      "positionX": 1504,
+      "positionY": 2272,
+      "ports": [
+        {
+          "id": 543,
+          "trainrunSectionId": 254,
+          "positionIndex": 0,
+          "positionAlignment": 2
+        },
+        {
+          "id": 547,
+          "trainrunSectionId": 256,
+          "positionIndex": 1,
+          "positionAlignment": 2
+        },
+        {
+          "id": 549,
+          "trainrunSectionId": 257,
+          "positionIndex": 2,
+          "positionAlignment": 2
+        },
+        {
+          "id": 545,
+          "trainrunSectionId": 255,
+          "positionIndex": 3,
+          "positionAlignment": 2
+        },
+        {
+          "id": 579,
+          "trainrunSectionId": 272,
+          "positionIndex": 0,
+          "positionAlignment": 3
+        },
+        {
+          "id": 575,
+          "trainrunSectionId": 270,
+          "positionIndex": 1,
+          "positionAlignment": 3
+        },
+        {
+          "id": 587,
+          "trainrunSectionId": 276,
+          "positionIndex": 2,
+          "positionAlignment": 3
+        },
+        {
+          "id": 583,
+          "trainrunSectionId": 274,
+          "positionIndex": 3,
+          "positionAlignment": 3
+        }
+      ],
+      "transitions": [
+        {"id": 172, "port1Id": 549, "port2Id": 575, "isNonStopTransit": false},
+        {"id": 175, "port1Id": 547, "port2Id": 579, "isNonStopTransit": true},
+        {"id": 178, "port1Id": 545, "port2Id": 583, "isNonStopTransit": false},
+        {"id": 180, "port1Id": 543, "port2Id": 587, "isNonStopTransit": true}
+      ],
+      "connections": [],
+      "resourceId": 169,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 141,
+      "betriebspunktName": "ZF",
+      "fullName": "Zofingen",
+      "positionX": 992,
+      "positionY": 672,
+      "ports": [
+        {
+          "id": 472,
+          "trainrunSectionId": 218,
+          "positionIndex": 0,
+          "positionAlignment": 0
+        },
+        {
+          "id": 511,
+          "trainrunSectionId": 238,
+          "positionIndex": 1,
+          "positionAlignment": 0
+        },
+        {
+          "id": 473,
+          "trainrunSectionId": 219,
+          "positionIndex": 2,
+          "positionAlignment": 0
+        },
+        {
+          "id": 477,
+          "trainrunSectionId": 221,
+          "positionIndex": 0,
+          "positionAlignment": 1
+        },
+        {
+          "id": 691,
+          "trainrunSectionId": 415,
+          "positionIndex": 1,
+          "positionAlignment": 1
+        },
+        {
+          "id": 513,
+          "trainrunSectionId": 239,
+          "positionIndex": 2,
+          "positionAlignment": 1
+        },
+        {
+          "id": 534,
+          "trainrunSectionId": 249,
+          "positionIndex": 3,
+          "positionAlignment": 1
+        },
+        {
+          "id": 479,
+          "trainrunSectionId": 222,
+          "positionIndex": 0,
+          "positionAlignment": 2
+        }
+      ],
+      "transitions": [
+        {"id": 137, "port1Id": 472, "port2Id": 477, "isNonStopTransit": true},
+        {"id": 148, "port1Id": 511, "port2Id": 513, "isNonStopTransit": false},
+        {"id": 154, "port1Id": 473, "port2Id": 534, "isNonStopTransit": false},
+        {"id": 188, "port1Id": 691, "port2Id": 479, "isNonStopTransit": false}
+      ],
+      "connections": [],
+      "resourceId": 170,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 142,
+      "betriebspunktName": "LTH",
+      "fullName": "Langenthal",
+      "positionX": 192,
+      "positionY": 352,
+      "ports": [
+        {
+          "id": 598,
+          "trainrunSectionId": 281,
+          "positionIndex": 0,
+          "positionAlignment": 1
+        },
+        {
+          "id": 594,
+          "trainrunSectionId": 279,
+          "positionIndex": 1,
+          "positionAlignment": 1
+        },
+        {
+          "id": 503,
+          "trainrunSectionId": 234,
+          "positionIndex": 0,
+          "positionAlignment": 2
+        },
+        {
+          "id": 491,
+          "trainrunSectionId": 228,
+          "positionIndex": 1,
+          "positionAlignment": 2
+        },
+        {
+          "id": 501,
+          "trainrunSectionId": 233,
+          "positionIndex": 0,
+          "positionAlignment": 3
+        },
+        {
+          "id": 499,
+          "trainrunSectionId": 232,
+          "positionIndex": 1,
+          "positionAlignment": 3
+        },
+        {
+          "id": 601,
+          "trainrunSectionId": 283,
+          "positionIndex": 2,
+          "positionAlignment": 3
+        },
+        {
+          "id": 599,
+          "trainrunSectionId": 282,
+          "positionIndex": 3,
+          "positionAlignment": 3
+        }
+      ],
+      "transitions": [
+        {"id": 144, "port1Id": 491, "port2Id": 499, "isNonStopTransit": false},
+        {"id": 146, "port1Id": 503, "port2Id": 501, "isNonStopTransit": false},
+        {"id": 186, "port1Id": 594, "port2Id": 599, "isNonStopTransit": false},
+        {"id": 187, "port1Id": 598, "port2Id": 601, "isNonStopTransit": false}
+      ],
+      "connections": [],
+      "resourceId": 171,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 143,
+      "betriebspunktName": "RTR",
+      "fullName": "Rothrist",
+      "positionX": 192,
+      "positionY": 160,
+      "ports": [
+        {
+          "id": 497,
+          "trainrunSectionId": 231,
+          "positionIndex": 0,
+          "positionAlignment": 2
+        },
+        {
+          "id": 487,
+          "trainrunSectionId": 226,
+          "positionIndex": 1,
+          "positionAlignment": 2
+        },
+        {
+          "id": 481,
+          "trainrunSectionId": 223,
+          "positionIndex": 2,
+          "positionAlignment": 2
+        },
+        {
+          "id": 496,
+          "trainrunSectionId": 230,
+          "positionIndex": 0,
+          "positionAlignment": 3
+        },
+        {
+          "id": 486,
+          "trainrunSectionId": 225,
+          "positionIndex": 1,
+          "positionAlignment": 3
+        },
+        {
+          "id": 480,
+          "trainrunSectionId": 222,
+          "positionIndex": 2,
+          "positionAlignment": 3
+        }
+      ],
+      "transitions": [
+        {"id": 139, "port1Id": 481, "port2Id": 480, "isNonStopTransit": true},
+        {"id": 141, "port1Id": 487, "port2Id": 486, "isNonStopTransit": true},
+        {"id": 143, "port1Id": 497, "port2Id": 496, "isNonStopTransit": true}
+      ],
+      "connections": [],
+      "resourceId": 172,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 144,
+      "betriebspunktName": "BN",
+      "fullName": "Bern",
+      "positionX": -672,
+      "positionY": 160,
+      "ports": [
+        {
+          "id": 498,
+          "trainrunSectionId": 231,
+          "positionIndex": 0,
+          "positionAlignment": 3
+        },
+        {
+          "id": 488,
+          "trainrunSectionId": 226,
+          "positionIndex": 1,
+          "positionAlignment": 3
+        },
+        {
+          "id": 482,
+          "trainrunSectionId": 223,
+          "positionIndex": 2,
+          "positionAlignment": 3
+        },
+        {
+          "id": 504,
+          "trainrunSectionId": 234,
+          "positionIndex": 3,
+          "positionAlignment": 3
+        },
+        {
+          "id": 492,
+          "trainrunSectionId": 228,
+          "positionIndex": 4,
+          "positionAlignment": 3
+        }
+      ],
+      "transitions": [],
+      "connections": [],
+      "resourceId": 173,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 145,
+      "betriebspunktName": "ZUE",
+      "fullName": "Zuerich",
+      "positionX": 1920,
+      "positionY": 160,
+      "ports": [
+        {
+          "id": 506,
+          "trainrunSectionId": 235,
+          "positionIndex": 0,
+          "positionAlignment": 1
+        },
+        {
+          "id": 493,
+          "trainrunSectionId": 229,
+          "positionIndex": 0,
+          "positionAlignment": 2
+        },
+        {
+          "id": 484,
+          "trainrunSectionId": 224,
+          "positionIndex": 1,
+          "positionAlignment": 2
+        },
+        {
+          "id": 489,
+          "trainrunSectionId": 227,
+          "positionIndex": 2,
+          "positionAlignment": 2
+        }
+      ],
+      "transitions": [],
+      "connections": [],
+      "resourceId": 174,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 146,
+      "betriebspunktName": "CHAM",
+      "fullName": "Cham",
+      "positionX": 1888,
+      "positionY": 2208,
+      "ports": [
+        {
+          "id": 581,
+          "trainrunSectionId": 273,
+          "positionIndex": 0,
+          "positionAlignment": 0
+        },
+        {
+          "id": 577,
+          "trainrunSectionId": 271,
+          "positionIndex": 1,
+          "positionAlignment": 0
+        },
+        {
+          "id": 580,
+          "trainrunSectionId": 272,
+          "positionIndex": 0,
+          "positionAlignment": 2
+        },
+        {
+          "id": 576,
+          "trainrunSectionId": 270,
+          "positionIndex": 1,
+          "positionAlignment": 2
+        }
+      ],
+      "transitions": [
+        {"id": 173, "port1Id": 577, "port2Id": 576, "isNonStopTransit": false},
+        {"id": 176, "port1Id": 581, "port2Id": 580, "isNonStopTransit": true}
+      ],
+      "connections": [],
+      "resourceId": 175,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 147,
+      "betriebspunktName": "IM",
+      "fullName": "Immensee",
+      "positionX": 1888,
+      "positionY": 2336,
+      "ports": [
+        {
+          "id": 588,
+          "trainrunSectionId": 276,
+          "positionIndex": 0,
+          "positionAlignment": 2
+        },
+        {
+          "id": 584,
+          "trainrunSectionId": 274,
+          "positionIndex": 1,
+          "positionAlignment": 2
+        },
+        {
+          "id": 589,
+          "trainrunSectionId": 277,
+          "positionIndex": 0,
+          "positionAlignment": 3
+        },
+        {
+          "id": 585,
+          "trainrunSectionId": 275,
+          "positionIndex": 1,
+          "positionAlignment": 3
+        }
+      ],
+      "transitions": [
+        {"id": 179, "port1Id": 584, "port2Id": 585, "isNonStopTransit": false},
+        {"id": 181, "port1Id": 588, "port2Id": 589, "isNonStopTransit": false}
+      ],
+      "connections": [],
+      "resourceId": 176,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 148,
+      "betriebspunktName": "HWIL",
+      "fullName": "Huttwil",
+      "positionX": 192,
+      "positionY": 1920,
+      "ports": [
+        {
+          "id": 595,
+          "trainrunSectionId": 280,
+          "positionIndex": 0,
+          "positionAlignment": 0
+        },
+        {
+          "id": 591,
+          "trainrunSectionId": 278,
+          "positionIndex": 1,
+          "positionAlignment": 0
+        },
+        {
+          "id": 517,
+          "trainrunSectionId": 241,
+          "positionIndex": 0,
+          "positionAlignment": 3
+        },
+        {
+          "id": 516,
+          "trainrunSectionId": 240,
+          "positionIndex": 1,
+          "positionAlignment": 3
+        }
+      ],
+      "transitions": [
+        {"id": 182, "port1Id": 591, "port2Id": 516, "isNonStopTransit": false},
+        {"id": 184, "port1Id": 595, "port2Id": 517, "isNonStopTransit": false}
+      ],
+      "connections": [],
+      "resourceId": 177,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 149,
+      "betriebspunktName": "EBR",
+      "fullName": "Emmenbrücke ",
+      "positionX": 1088,
+      "positionY": 1984,
+      "ports": [
+        {
+          "id": 571,
+          "trainrunSectionId": 268,
+          "positionIndex": 0,
+          "positionAlignment": 0
+        },
+        {
+          "id": 567,
+          "trainrunSectionId": 266,
+          "positionIndex": 1,
+          "positionAlignment": 0
+        },
+        {
+          "id": 563,
+          "trainrunSectionId": 264,
+          "positionIndex": 2,
+          "positionAlignment": 0
+        },
+        {
+          "id": 559,
+          "trainrunSectionId": 262,
+          "positionIndex": 3,
+          "positionAlignment": 0
+        },
+        {
+          "id": 541,
+          "trainrunSectionId": 253,
+          "positionIndex": 0,
+          "positionAlignment": 1
+        },
+        {
+          "id": 539,
+          "trainrunSectionId": 252,
+          "positionIndex": 1,
+          "positionAlignment": 1
+        },
+        {
+          "id": 537,
+          "trainrunSectionId": 251,
+          "positionIndex": 2,
+          "positionAlignment": 1
+        },
+        {
+          "id": 535,
+          "trainrunSectionId": 250,
+          "positionIndex": 3,
+          "positionAlignment": 1
+        }
+      ],
+      "transitions": [
+        {"id": 161, "port1Id": 559, "port2Id": 535, "isNonStopTransit": false},
+        {"id": 163, "port1Id": 563, "port2Id": 537, "isNonStopTransit": false},
+        {"id": 166, "port1Id": 567, "port2Id": 539, "isNonStopTransit": true},
+        {"id": 169, "port1Id": 571, "port2Id": 541, "isNonStopTransit": true}
+      ],
+      "connections": [],
+      "resourceId": 178,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 150,
+      "betriebspunktName": "GEAP",
+      "fullName": "Genf Flughafen",
+      "positionX": -864,
+      "positionY": 192,
+      "ports": [],
+      "transitions": [],
+      "connections": [],
+      "resourceId": 179,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 151,
+      "betriebspunktName": "IO",
+      "fullName": "Interlaken Ost",
+      "positionX": -800,
+      "positionY": 416,
+      "ports": [],
+      "transitions": [],
+      "connections": [],
+      "resourceId": 180,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 152,
+      "betriebspunktName": "BI",
+      "fullName": "Biel",
+      "positionX": -512,
+      "positionY": 64,
+      "ports": [],
+      "transitions": [],
+      "connections": [],
+      "resourceId": 181,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 153,
+      "betriebspunktName": "SG",
+      "fullName": "St. Gallen",
+      "positionX": 2752,
+      "positionY": 256,
+      "ports": [],
+      "transitions": [],
+      "connections": [],
+      "resourceId": 182,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 154,
+      "betriebspunktName": "GD",
+      "fullName": "Goldau",
+      "positionX": 2368,
+      "positionY": 2336,
+      "ports": [
+        {
+          "id": 603,
+          "trainrunSectionId": 284,
+          "positionIndex": 0,
+          "positionAlignment": 1
+        },
+        {
+          "id": 590,
+          "trainrunSectionId": 277,
+          "positionIndex": 0,
+          "positionAlignment": 2
+        },
+        {
+          "id": 586,
+          "trainrunSectionId": 275,
+          "positionIndex": 1,
+          "positionAlignment": 2
+        }
+      ],
+      "transitions": [],
+      "connections": [],
+      "resourceId": 183,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 155,
+      "betriebspunktName": "Milano",
+      "fullName": "Neuer Knoten",
+      "positionX": 2528,
+      "positionY": 2560,
+      "ports": [
+        {
+          "id": 604,
+          "trainrunSectionId": 284,
+          "positionIndex": 0,
+          "positionAlignment": 0
+        }
+      ],
+      "transitions": [],
+      "connections": [],
+      "resourceId": 184,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 156,
+      "betriebspunktName": "CH",
+      "fullName": "Chur",
+      "positionX": 2816,
+      "positionY": 2016,
+      "ports": [],
+      "transitions": [],
+      "connections": [],
+      "resourceId": 185,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 157,
+      "betriebspunktName": "OL",
+      "fullName": "Olten",
+      "positionX": 992,
+      "positionY": 160,
+      "ports": [
+        {
+          "id": 471,
+          "trainrunSectionId": 218,
+          "positionIndex": 0,
+          "positionAlignment": 1
+        },
+        {
+          "id": 512,
+          "trainrunSectionId": 238,
+          "positionIndex": 1,
+          "positionAlignment": 1
+        },
+        {
+          "id": 474,
+          "trainrunSectionId": 219,
+          "positionIndex": 2,
+          "positionAlignment": 1
+        },
+        {
+          "id": 495,
+          "trainrunSectionId": 230,
+          "positionIndex": 0,
+          "positionAlignment": 2
+        },
+        {
+          "id": 485,
+          "trainrunSectionId": 225,
+          "positionIndex": 1,
+          "positionAlignment": 2
+        },
+        {
+          "id": 502,
+          "trainrunSectionId": 233,
+          "positionIndex": 2,
+          "positionAlignment": 2
+        },
+        {
+          "id": 500,
+          "trainrunSectionId": 232,
+          "positionIndex": 3,
+          "positionAlignment": 2
+        },
+        {
+          "id": 602,
+          "trainrunSectionId": 283,
+          "positionIndex": 4,
+          "positionAlignment": 2
+        },
+        {
+          "id": 600,
+          "trainrunSectionId": 282,
+          "positionIndex": 5,
+          "positionAlignment": 2
+        },
+        {
+          "id": 494,
+          "trainrunSectionId": 229,
+          "positionIndex": 0,
+          "positionAlignment": 3
+        },
+        {
+          "id": 483,
+          "trainrunSectionId": 224,
+          "positionIndex": 1,
+          "positionAlignment": 3
+        },
+        {
+          "id": 490,
+          "trainrunSectionId": 227,
+          "positionIndex": 2,
+          "positionAlignment": 3
+        }
+      ],
+      "transitions": [
+        {"id": 140, "port1Id": 485, "port2Id": 483, "isNonStopTransit": false},
+        {"id": 142, "port1Id": 495, "port2Id": 494, "isNonStopTransit": false},
+        {"id": 145, "port1Id": 500, "port2Id": 490, "isNonStopTransit": false}
+      ],
+      "connections": [],
+      "resourceId": 186,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 158,
+      "betriebspunktName": "BS",
+      "fullName": "Basel",
+      "positionX": 992,
+      "positionY": -64,
+      "ports": [],
+      "transitions": [],
+      "connections": [],
+      "resourceId": 187,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 159,
+      "betriebspunktName": "REID",
+      "fullName": "Reiden",
+      "positionX": 992,
+      "positionY": 992,
+      "ports": [
+        {
+          "id": 478,
+          "trainrunSectionId": 221,
+          "positionIndex": 0,
+          "positionAlignment": 0
+        },
+        {
+          "id": 692,
+          "trainrunSectionId": 415,
+          "positionIndex": 1,
+          "positionAlignment": 0
+        },
+        {
+          "id": 514,
+          "trainrunSectionId": 239,
+          "positionIndex": 2,
+          "positionAlignment": 0
+        },
+        {
+          "id": 533,
+          "trainrunSectionId": 249,
+          "positionIndex": 3,
+          "positionAlignment": 0
+        },
+        {
+          "id": 551,
+          "trainrunSectionId": 258,
+          "positionIndex": 0,
+          "positionAlignment": 1
+        },
+        {
+          "id": 553,
+          "trainrunSectionId": 259,
+          "positionIndex": 1,
+          "positionAlignment": 1
+        },
+        {
+          "id": 555,
+          "trainrunSectionId": 260,
+          "positionIndex": 2,
+          "positionAlignment": 1
+        },
+        {
+          "id": 557,
+          "trainrunSectionId": 261,
+          "positionIndex": 3,
+          "positionAlignment": 1
+        }
+      ],
+      "transitions": [
+        {"id": 157, "port1Id": 551, "port2Id": 478, "isNonStopTransit": true},
+        {"id": 159, "port1Id": 555, "port2Id": 514, "isNonStopTransit": false},
+        {"id": 160, "port1Id": 557, "port2Id": 533, "isNonStopTransit": false},
+        {"id": 189, "port1Id": 692, "port2Id": 553, "isNonStopTransit": false}
+      ],
+      "connections": [],
+      "resourceId": 188,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 160,
+      "betriebspunktName": "SEM",
+      "fullName": "Sempach-Neuenkirch",
+      "positionX": 1088,
+      "positionY": 1696,
+      "ports": [
+        {
+          "id": 573,
+          "trainrunSectionId": 269,
+          "positionIndex": 0,
+          "positionAlignment": 0
+        },
+        {
+          "id": 569,
+          "trainrunSectionId": 267,
+          "positionIndex": 1,
+          "positionAlignment": 0
+        },
+        {
+          "id": 565,
+          "trainrunSectionId": 265,
+          "positionIndex": 2,
+          "positionAlignment": 0
+        },
+        {
+          "id": 561,
+          "trainrunSectionId": 263,
+          "positionIndex": 3,
+          "positionAlignment": 0
+        },
+        {
+          "id": 572,
+          "trainrunSectionId": 268,
+          "positionIndex": 0,
+          "positionAlignment": 1
+        },
+        {
+          "id": 568,
+          "trainrunSectionId": 266,
+          "positionIndex": 1,
+          "positionAlignment": 1
+        },
+        {
+          "id": 564,
+          "trainrunSectionId": 264,
+          "positionIndex": 2,
+          "positionAlignment": 1
+        },
+        {
+          "id": 560,
+          "trainrunSectionId": 262,
+          "positionIndex": 3,
+          "positionAlignment": 1
+        }
+      ],
+      "transitions": [
+        {"id": 162, "port1Id": 560, "port2Id": 561, "isNonStopTransit": false},
+        {"id": 164, "port1Id": 564, "port2Id": 565, "isNonStopTransit": false},
+        {"id": 167, "port1Id": 568, "port2Id": 569, "isNonStopTransit": true},
+        {"id": 170, "port1Id": 572, "port2Id": 573, "isNonStopTransit": true}
+      ],
+      "connections": [],
+      "resourceId": 189,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 161,
+      "betriebspunktName": "SS",
+      "fullName": "Sursee",
+      "positionX": 992,
+      "positionY": 1312,
+      "ports": [
+        {
+          "id": 552,
+          "trainrunSectionId": 258,
+          "positionIndex": 0,
+          "positionAlignment": 0
+        },
+        {
+          "id": 554,
+          "trainrunSectionId": 259,
+          "positionIndex": 1,
+          "positionAlignment": 0
+        },
+        {
+          "id": 556,
+          "trainrunSectionId": 260,
+          "positionIndex": 2,
+          "positionAlignment": 0
+        },
+        {
+          "id": 558,
+          "trainrunSectionId": 261,
+          "positionIndex": 3,
+          "positionAlignment": 0
+        },
+        {
+          "id": 574,
+          "trainrunSectionId": 269,
+          "positionIndex": 0,
+          "positionAlignment": 1
+        },
+        {
+          "id": 570,
+          "trainrunSectionId": 267,
+          "positionIndex": 1,
+          "positionAlignment": 1
+        },
+        {
+          "id": 566,
+          "trainrunSectionId": 265,
+          "positionIndex": 2,
+          "positionAlignment": 1
+        },
+        {
+          "id": 562,
+          "trainrunSectionId": 263,
+          "positionIndex": 3,
+          "positionAlignment": 1
+        }
+      ],
+      "transitions": [
+        {"id": 165, "port1Id": 556, "port2Id": 566, "isNonStopTransit": false},
+        {"id": 168, "port1Id": 554, "port2Id": 570, "isNonStopTransit": false},
+        {"id": 171, "port1Id": 552, "port2Id": 574, "isNonStopTransit": true}
+      ],
+      "connections": [
+        {"id": 11, "port1Id": 558, "port2Id": 566},
+        {"id": 12, "port1Id": 562, "port2Id": 556},
+        {"id": 13, "port1Id": 554, "port2Id": 566}
+      ],
+      "resourceId": 190,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    }
+  ],
+  "trainrunSections": [
+    {
+      "id": 218,
+      "sourceNodeId": 157,
+      "sourcePortId": 471,
+      "targetNodeId": 141,
+      "targetPortId": 472,
+      "travelTime": {"lock": false, "time": 30, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 46,
+        "warning": null,
+        "consecutiveTime": 46
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 14,
+        "warning": null,
+        "consecutiveTime": 314
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 44,
+        "warning": null,
+        "consecutiveTime": 284
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 16,
+        "warning": null,
+        "consecutiveTime": 76
+      },
+      "numberOfStops": 0,
+      "trainrunId": 84,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1008, "y": 382},
+          {"x": 1008, "y": 446},
+          {"x": 1008, "y": 606},
+          {"x": 1008, "y": 670}
+        ],
+        "textPositions": {
+          "0": {"x": 996, "y": 400},
+          "1": {"x": 1020, "y": 428},
+          "2": {"x": 1020, "y": 652},
+          "3": {"x": 996, "y": 624},
+          "4": {"x": 996, "y": 526},
+          "5": {"x": 996, "y": 526},
+          "6": {"x": 1020, "y": 526}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 219,
+      "sourceNodeId": 141,
+      "sourcePortId": 473,
+      "targetNodeId": 157,
+      "targetPortId": 474,
+      "travelTime": {"lock": false, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 40,
+        "warning": null,
+        "consecutiveTime": 40
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 20,
+        "warning": null,
+        "consecutiveTime": 20
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 10,
+        "warning": null,
+        "consecutiveTime": 10
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 50,
+        "warning": null,
+        "consecutiveTime": 50
+      },
+      "numberOfStops": 0,
+      "trainrunId": 86,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1072, "y": 670},
+          {"x": 1072, "y": 606},
+          {"x": 1072, "y": 446},
+          {"x": 1072, "y": 382}
+        ],
+        "textPositions": {
+          "0": {"x": 1084, "y": 652},
+          "1": {"x": 1060, "y": 624},
+          "2": {"x": 1060, "y": 400},
+          "3": {"x": 1084, "y": 428},
+          "4": {"x": 1060, "y": 526},
+          "5": {"x": 1060, "y": 526},
+          "6": {"x": 1084, "y": 526}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 221,
+      "sourceNodeId": 141,
+      "sourcePortId": 477,
+      "targetNodeId": 159,
+      "targetPortId": 478,
+      "travelTime": {"lock": false, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 16,
+        "warning": null,
+        "consecutiveTime": 76
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 44,
+        "warning": null,
+        "consecutiveTime": 284
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 34,
+        "warning": null,
+        "consecutiveTime": 274
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 26,
+        "warning": null,
+        "consecutiveTime": 86
+      },
+      "numberOfStops": 0,
+      "trainrunId": 84,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1008, "y": 738},
+          {"x": 1008, "y": 802},
+          {"x": 1008, "y": 926},
+          {"x": 1008, "y": 990}
+        ],
+        "textPositions": {
+          "0": {"x": 996, "y": 756},
+          "1": {"x": 1020, "y": 784},
+          "2": {"x": 1020, "y": 972},
+          "3": {"x": 996, "y": 944},
+          "4": {"x": 996, "y": 864},
+          "5": {"x": 996, "y": 864},
+          "6": {"x": 1020, "y": 864}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 222,
+      "sourceNodeId": 141,
+      "sourcePortId": 479,
+      "targetNodeId": 143,
+      "targetPortId": 480,
+      "travelTime": {"lock": false, "time": 6, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 33,
+        "warning": null,
+        "consecutiveTime": 153
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 27,
+        "warning": null,
+        "consecutiveTime": 27
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 21,
+        "warning": null,
+        "consecutiveTime": 21
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 39,
+        "warning": null,
+        "consecutiveTime": 159
+      },
+      "numberOfStops": 0,
+      "trainrunId": 87,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 990, "y": 688},
+          {"x": 926, "y": 688},
+          {"x": 354, "y": 240},
+          {"x": 290, "y": 240}
+        ],
+        "textPositions": {
+          "0": {"x": 972, "y": 676},
+          "1": {"x": 944, "y": 700},
+          "2": {"x": 308, "y": 252},
+          "3": {"x": 336, "y": 228},
+          "4": {"x": 640, "y": 452},
+          "5": {"x": 640, "y": 452},
+          "6": {"x": 640, "y": 476}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 223,
+      "sourceNodeId": 143,
+      "sourcePortId": 481,
+      "targetNodeId": 144,
+      "targetPortId": 482,
+      "travelTime": {"lock": false, "time": 21, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 39,
+        "warning": null,
+        "consecutiveTime": 159
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 21,
+        "warning": null,
+        "consecutiveTime": 21
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 0,
+        "warning": null,
+        "consecutiveTime": 0
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 0,
+        "warning": null,
+        "consecutiveTime": 180
+      },
+      "numberOfStops": 0,
+      "trainrunId": 87,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 190, "y": 240},
+          {"x": 126, "y": 240},
+          {"x": -510, "y": 240},
+          {"x": -574, "y": 240}
+        ],
+        "textPositions": {
+          "0": {"x": 172, "y": 228},
+          "1": {"x": 144, "y": 252},
+          "2": {"x": -556, "y": 252},
+          "3": {"x": -528, "y": 228},
+          "4": {"x": -192, "y": 228},
+          "5": {"x": -192, "y": 228},
+          "6": {"x": -192, "y": 252}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 224,
+      "sourceNodeId": 157,
+      "sourcePortId": 483,
+      "targetNodeId": 145,
+      "targetPortId": 484,
+      "travelTime": {"lock": false, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 31,
+        "warning": null,
+        "consecutiveTime": 91
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 29,
+        "warning": null,
+        "consecutiveTime": 89
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 19,
+        "warning": null,
+        "consecutiveTime": 79
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 41,
+        "warning": null,
+        "consecutiveTime": 101
+      },
+      "numberOfStops": 0,
+      "trainrunId": 83,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1090, "y": 208},
+          {"x": 1154, "y": 208},
+          {"x": 1854, "y": 208},
+          {"x": 1918, "y": 208}
+        ],
+        "textPositions": {
+          "0": {"x": 1108, "y": 220},
+          "1": {"x": 1136, "y": 196},
+          "2": {"x": 1900, "y": 196},
+          "3": {"x": 1872, "y": 220},
+          "4": {"x": 1504, "y": 196},
+          "5": {"x": 1504, "y": 196},
+          "6": {"x": 1504, "y": 220}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 225,
+      "sourceNodeId": 157,
+      "sourcePortId": 485,
+      "targetNodeId": 143,
+      "targetPortId": 486,
+      "travelTime": {"lock": false, "time": 20, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 31,
+        "warning": null,
+        "consecutiveTime": 91
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 29,
+        "warning": null,
+        "consecutiveTime": 89
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 9,
+        "warning": null,
+        "consecutiveTime": 69
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 51,
+        "warning": null,
+        "consecutiveTime": 111
+      },
+      "numberOfStops": 0,
+      "trainrunId": 83,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 990, "y": 208},
+          {"x": 926, "y": 208},
+          {"x": 354, "y": 208},
+          {"x": 290, "y": 208}
+        ],
+        "textPositions": {
+          "0": {"x": 972, "y": 196},
+          "1": {"x": 944, "y": 220},
+          "2": {"x": 308, "y": 220},
+          "3": {"x": 336, "y": 196},
+          "4": {"x": 640, "y": 196},
+          "5": {"x": 640, "y": 196},
+          "6": {"x": 640, "y": 220}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 226,
+      "sourceNodeId": 143,
+      "sourcePortId": 487,
+      "targetNodeId": 144,
+      "targetPortId": 488,
+      "travelTime": {"lock": false, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 51,
+        "warning": null,
+        "consecutiveTime": 111
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 9,
+        "warning": null,
+        "consecutiveTime": 69
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 59,
+        "warning": null,
+        "consecutiveTime": 59
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 1,
+        "warning": null,
+        "consecutiveTime": 121
+      },
+      "numberOfStops": 0,
+      "trainrunId": 83,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 190, "y": 208},
+          {"x": 126, "y": 208},
+          {"x": -510, "y": 208},
+          {"x": -574, "y": 208}
+        ],
+        "textPositions": {
+          "0": {"x": 172, "y": 196},
+          "1": {"x": 144, "y": 220},
+          "2": {"x": -556, "y": 220},
+          "3": {"x": -528, "y": 196},
+          "4": {"x": -192, "y": 196},
+          "5": {"x": -192, "y": 196},
+          "6": {"x": -192, "y": 220}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 227,
+      "sourceNodeId": 145,
+      "sourcePortId": 489,
+      "targetNodeId": 157,
+      "targetPortId": 490,
+      "travelTime": {"lock": false, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 32,
+        "warning": null,
+        "consecutiveTime": 152
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 28,
+        "warning": null,
+        "consecutiveTime": 148
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 18,
+        "warning": null,
+        "consecutiveTime": 138
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 42,
+        "warning": null,
+        "consecutiveTime": 162
+      },
+      "numberOfStops": 0,
+      "trainrunId": 88,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1918, "y": 240},
+          {"x": 1854, "y": 240},
+          {"x": 1154, "y": 240},
+          {"x": 1090, "y": 240}
+        ],
+        "textPositions": {
+          "0": {"x": 1900, "y": 228},
+          "1": {"x": 1872, "y": 252},
+          "2": {"x": 1108, "y": 252},
+          "3": {"x": 1136, "y": 228},
+          "4": {"x": 1504, "y": 228},
+          "5": {"x": 1504, "y": 228},
+          "6": {"x": 1504, "y": 252}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 228,
+      "sourceNodeId": 142,
+      "sourcePortId": 491,
+      "targetNodeId": 144,
+      "targetPortId": 492,
+      "travelTime": {"lock": false, "time": 78, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 56,
+        "warning": null,
+        "consecutiveTime": 176
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 4,
+        "warning": null,
+        "consecutiveTime": 124
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 46,
+        "warning": null,
+        "consecutiveTime": 46
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 14,
+        "warning": null,
+        "consecutiveTime": 254
+      },
+      "numberOfStops": 0,
+      "trainrunId": 88,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 190, "y": 400},
+          {"x": 126, "y": 400},
+          {"x": -510, "y": 304},
+          {"x": -574, "y": 304}
+        ],
+        "textPositions": {
+          "0": {"x": 172, "y": 388},
+          "1": {"x": 144, "y": 412},
+          "2": {"x": -556, "y": 316},
+          "3": {"x": -528, "y": 292},
+          "4": {"x": -192, "y": 340},
+          "5": {"x": -192, "y": 340},
+          "6": {"x": -192, "y": 364}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 229,
+      "sourceNodeId": 145,
+      "sourcePortId": 493,
+      "targetNodeId": 157,
+      "targetPortId": 494,
+      "travelTime": {"lock": false, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 19,
+        "warning": null,
+        "consecutiveTime": 19
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 41,
+        "warning": null,
+        "consecutiveTime": 41
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 31,
+        "warning": null,
+        "consecutiveTime": 31
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 29,
+        "warning": null,
+        "consecutiveTime": 29
+      },
+      "numberOfStops": 0,
+      "trainrunId": 90,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1918, "y": 176},
+          {"x": 1854, "y": 176},
+          {"x": 1154, "y": 176},
+          {"x": 1090, "y": 176}
+        ],
+        "textPositions": {
+          "0": {"x": 1900, "y": 164},
+          "1": {"x": 1872, "y": 188},
+          "2": {"x": 1108, "y": 188},
+          "3": {"x": 1136, "y": 164},
+          "4": {"x": 1504, "y": 164},
+          "5": {"x": 1504, "y": 164},
+          "6": {"x": 1504, "y": 188}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 230,
+      "sourceNodeId": 157,
+      "sourcePortId": 495,
+      "targetNodeId": 143,
+      "targetPortId": 496,
+      "travelTime": {"lock": false, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 31,
+        "warning": null,
+        "consecutiveTime": 31
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 29,
+        "warning": null,
+        "consecutiveTime": 29
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 19,
+        "warning": null,
+        "consecutiveTime": 19
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 41,
+        "warning": null,
+        "consecutiveTime": 41
+      },
+      "numberOfStops": 0,
+      "trainrunId": 90,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 990, "y": 176},
+          {"x": 926, "y": 176},
+          {"x": 354, "y": 176},
+          {"x": 290, "y": 176}
+        ],
+        "textPositions": {
+          "0": {"x": 972, "y": 164},
+          "1": {"x": 944, "y": 188},
+          "2": {"x": 308, "y": 188},
+          "3": {"x": 336, "y": 164},
+          "4": {"x": 640, "y": 164},
+          "5": {"x": 640, "y": 164},
+          "6": {"x": 640, "y": 188}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 231,
+      "sourceNodeId": 143,
+      "sourcePortId": 497,
+      "targetNodeId": 144,
+      "targetPortId": 498,
+      "travelTime": {"lock": false, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 41,
+        "warning": null,
+        "consecutiveTime": 41
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 19,
+        "warning": null,
+        "consecutiveTime": 19
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 9,
+        "warning": null,
+        "consecutiveTime": 9
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 51,
+        "warning": null,
+        "consecutiveTime": 51
+      },
+      "numberOfStops": 0,
+      "trainrunId": 90,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 190, "y": 176},
+          {"x": 126, "y": 176},
+          {"x": -510, "y": 176},
+          {"x": -574, "y": 176}
+        ],
+        "textPositions": {
+          "0": {"x": 172, "y": 164},
+          "1": {"x": 144, "y": 188},
+          "2": {"x": -556, "y": 188},
+          "3": {"x": -528, "y": 164},
+          "4": {"x": -192, "y": 164},
+          "5": {"x": -192, "y": 164},
+          "6": {"x": -192, "y": 188}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 232,
+      "sourceNodeId": 142,
+      "sourcePortId": 499,
+      "targetNodeId": 157,
+      "targetPortId": 500,
+      "travelTime": {"lock": false, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 6,
+        "warning": null,
+        "consecutiveTime": 126
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 54,
+        "warning": null,
+        "consecutiveTime": 174
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 44,
+        "warning": null,
+        "consecutiveTime": 164
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 16,
+        "warning": null,
+        "consecutiveTime": 136
+      },
+      "numberOfStops": 0,
+      "trainrunId": 88,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 290, "y": 400},
+          {"x": 354, "y": 400},
+          {"x": 926, "y": 272},
+          {"x": 990, "y": 272}
+        ],
+        "textPositions": {
+          "0": {"x": 308, "y": 412},
+          "1": {"x": 336, "y": 388},
+          "2": {"x": 972, "y": 260},
+          "3": {"x": 944, "y": 284},
+          "4": {"x": 640, "y": 324},
+          "5": {"x": 640, "y": 324},
+          "6": {"x": 640, "y": 348}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 233,
+      "sourceNodeId": 142,
+      "sourcePortId": 501,
+      "targetNodeId": 157,
+      "targetPortId": 502,
+      "travelTime": {"lock": false, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 22,
+        "warning": null,
+        "consecutiveTime": 22
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 38,
+        "warning": null,
+        "consecutiveTime": 38
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 28,
+        "warning": null,
+        "consecutiveTime": 28
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 32,
+        "warning": null,
+        "consecutiveTime": 32
+      },
+      "numberOfStops": 0,
+      "trainrunId": 89,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 290, "y": 368},
+          {"x": 354, "y": 368},
+          {"x": 926, "y": 240},
+          {"x": 990, "y": 240}
+        ],
+        "textPositions": {
+          "0": {"x": 308, "y": 380},
+          "1": {"x": 336, "y": 356},
+          "2": {"x": 972, "y": 228},
+          "3": {"x": 944, "y": 252},
+          "4": {"x": 640, "y": 292},
+          "5": {"x": 640, "y": 292},
+          "6": {"x": 640, "y": 316}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 234,
+      "sourceNodeId": 142,
+      "sourcePortId": 503,
+      "targetNodeId": 144,
+      "targetPortId": 504,
+      "travelTime": {"lock": false, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 40,
+        "warning": null,
+        "consecutiveTime": 40
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 20,
+        "warning": null,
+        "consecutiveTime": 20
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 10,
+        "warning": null,
+        "consecutiveTime": 10
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 50,
+        "warning": null,
+        "consecutiveTime": 50
+      },
+      "numberOfStops": 0,
+      "trainrunId": 89,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 190, "y": 368},
+          {"x": 126, "y": 368},
+          {"x": -510, "y": 272},
+          {"x": -574, "y": 272}
+        ],
+        "textPositions": {
+          "0": {"x": 172, "y": 356},
+          "1": {"x": 144, "y": 380},
+          "2": {"x": -556, "y": 284},
+          "3": {"x": -528, "y": 260},
+          "4": {"x": -192, "y": 308},
+          "5": {"x": -192, "y": 308},
+          "6": {"x": -192, "y": 332}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 235,
+      "sourceNodeId": 136,
+      "sourcePortId": 505,
+      "targetNodeId": 145,
+      "targetPortId": 506,
+      "travelTime": {"lock": false, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 52,
+        "warning": null,
+        "consecutiveTime": 112
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 8,
+        "warning": null,
+        "consecutiveTime": 68
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 58,
+        "warning": null,
+        "consecutiveTime": 58
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 2,
+        "warning": null,
+        "consecutiveTime": 122
+      },
+      "numberOfStops": 0,
+      "trainrunId": 85,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1936, "y": 1630},
+          {"x": 1936, "y": 1566},
+          {"x": 1936, "y": 350},
+          {"x": 1936, "y": 286}
+        ],
+        "textPositions": {
+          "0": {"x": 1948, "y": 1612},
+          "1": {"x": 1924, "y": 1584},
+          "2": {"x": 1924, "y": 304},
+          "3": {"x": 1948, "y": 332},
+          "4": {"x": 1924, "y": 958},
+          "5": {"x": 1924, "y": 958},
+          "6": {"x": 1948, "y": 958}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 236,
+      "sourceNodeId": 135,
+      "sourcePortId": 507,
+      "targetNodeId": 136,
+      "targetPortId": 508,
+      "travelTime": {"lock": false, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 42,
+        "warning": null,
+        "consecutiveTime": 102
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 18,
+        "warning": null,
+        "consecutiveTime": 78
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 8,
+        "warning": null,
+        "consecutiveTime": 68
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 52,
+        "warning": null,
+        "consecutiveTime": 112
+      },
+      "numberOfStops": 0,
+      "trainrunId": 85,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1904, "y": 1982},
+          {"x": 1904, "y": 1918},
+          {"x": 1936, "y": 1762},
+          {"x": 1936, "y": 1698}
+        ],
+        "textPositions": {
+          "0": {"x": 1916, "y": 1964},
+          "1": {"x": 1892, "y": 1936},
+          "2": {"x": 1924, "y": 1716},
+          "3": {"x": 1948, "y": 1744},
+          "4": {"x": 1908, "y": 1840},
+          "5": {"x": 1908, "y": 1840},
+          "6": {"x": 1932, "y": 1840}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 237,
+      "sourceNodeId": 135,
+      "sourcePortId": 509,
+      "targetNodeId": 136,
+      "targetPortId": 510,
+      "travelTime": {"lock": false, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 23,
+        "warning": null,
+        "consecutiveTime": 83
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 37,
+        "warning": null,
+        "consecutiveTime": 97
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 27,
+        "warning": null,
+        "consecutiveTime": 87
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 33,
+        "warning": null,
+        "consecutiveTime": 93
+      },
+      "numberOfStops": 0,
+      "trainrunId": 91,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1936, "y": 1982},
+          {"x": 1936, "y": 1918},
+          {"x": 1968, "y": 1762},
+          {"x": 1968, "y": 1698}
+        ],
+        "textPositions": {
+          "0": {"x": 1948, "y": 1964},
+          "1": {"x": 1924, "y": 1936},
+          "2": {"x": 1956, "y": 1716},
+          "3": {"x": 1980, "y": 1744},
+          "4": {"x": 1940, "y": 1840},
+          "5": {"x": 1940, "y": 1840},
+          "6": {"x": 1964, "y": 1840}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 238,
+      "sourceNodeId": 141,
+      "sourcePortId": 511,
+      "targetNodeId": 157,
+      "targetPortId": 512,
+      "travelTime": {"lock": false, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 40,
+        "warning": null,
+        "consecutiveTime": 160
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 20,
+        "warning": null,
+        "consecutiveTime": 20
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 10,
+        "warning": null,
+        "consecutiveTime": 10
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 50,
+        "warning": null,
+        "consecutiveTime": 170
+      },
+      "numberOfStops": 0,
+      "trainrunId": 93,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1040, "y": 670},
+          {"x": 1040, "y": 606},
+          {"x": 1040, "y": 446},
+          {"x": 1040, "y": 382}
+        ],
+        "textPositions": {
+          "0": {"x": 1052, "y": 652},
+          "1": {"x": 1028, "y": 624},
+          "2": {"x": 1028, "y": 400},
+          "3": {"x": 1052, "y": 428},
+          "4": {"x": 1028, "y": 526},
+          "5": {"x": 1028, "y": 526},
+          "6": {"x": 1052, "y": 526}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 239,
+      "sourceNodeId": 141,
+      "sourcePortId": 513,
+      "targetNodeId": 159,
+      "targetPortId": 514,
+      "travelTime": {"lock": false, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 21.5,
+        "warning": null,
+        "consecutiveTime": 21.5
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 38.5,
+        "warning": null,
+        "consecutiveTime": 158.5
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 28.5,
+        "warning": null,
+        "consecutiveTime": 148.5
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 31.5,
+        "warning": null,
+        "consecutiveTime": 31.5
+      },
+      "numberOfStops": 0,
+      "trainrunId": 93,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1072, "y": 738},
+          {"x": 1072, "y": 802},
+          {"x": 1072, "y": 926},
+          {"x": 1072, "y": 990}
+        ],
+        "textPositions": {
+          "0": {"x": 1060, "y": 756},
+          "1": {"x": 1084, "y": 784},
+          "2": {"x": 1084, "y": 972},
+          "3": {"x": 1060, "y": 944},
+          "4": {"x": 1060, "y": 864},
+          "5": {"x": 1060, "y": 864},
+          "6": {"x": 1084, "y": 864}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 240,
+      "sourceNodeId": 134,
+      "sourcePortId": 515,
+      "targetNodeId": 148,
+      "targetPortId": 516,
+      "travelTime": {"lock": false, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 33,
+        "warning": null,
+        "consecutiveTime": 93
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 27,
+        "warning": null,
+        "consecutiveTime": 87
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 17,
+        "warning": null,
+        "consecutiveTime": 77
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 43,
+        "warning": null,
+        "consecutiveTime": 103
+      },
+      "numberOfStops": 3,
+      "trainrunId": 94,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 542, "y": 2000},
+          {"x": 478, "y": 2000},
+          {"x": 354, "y": 1968},
+          {"x": 290, "y": 1968}
+        ],
+        "textPositions": {
+          "0": {"x": 524, "y": 1988},
+          "1": {"x": 496, "y": 2012},
+          "2": {"x": 308, "y": 1980},
+          "3": {"x": 336, "y": 1956},
+          "4": {"x": 416, "y": 1972},
+          "5": {"x": 416, "y": 1972},
+          "6": {"x": 416, "y": 1996}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 241,
+      "sourceNodeId": 148,
+      "sourcePortId": 517,
+      "targetNodeId": 134,
+      "targetPortId": 518,
+      "travelTime": {"lock": false, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 37,
+        "warning": null,
+        "consecutiveTime": 37
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 23,
+        "warning": null,
+        "consecutiveTime": 143
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 13,
+        "warning": null,
+        "consecutiveTime": 133
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 47,
+        "warning": null,
+        "consecutiveTime": 47
+      },
+      "numberOfStops": 2,
+      "trainrunId": 95,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 290, "y": 1936},
+          {"x": 354, "y": 1936},
+          {"x": 478, "y": 1968},
+          {"x": 542, "y": 1968}
+        ],
+        "textPositions": {
+          "0": {"x": 308, "y": 1948},
+          "1": {"x": 336, "y": 1924},
+          "2": {"x": 524, "y": 1956},
+          "3": {"x": 496, "y": 1980},
+          "4": {"x": 416, "y": 1940},
+          "5": {"x": 416, "y": 1940},
+          "6": {"x": 416, "y": 1964}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 242,
+      "sourceNodeId": 139,
+      "sourcePortId": 519,
+      "targetNodeId": 138,
+      "targetPortId": 520,
+      "travelTime": {"lock": false, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 51,
+        "warning": null,
+        "consecutiveTime": 111
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 9,
+        "warning": null,
+        "consecutiveTime": 69
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 59,
+        "warning": null,
+        "consecutiveTime": 59
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 1,
+        "warning": null,
+        "consecutiveTime": 121
+      },
+      "numberOfStops": 4,
+      "trainrunId": 95,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 130, "y": 2320},
+          {"x": 194, "y": 2320},
+          {"x": 510, "y": 2320},
+          {"x": 574, "y": 2320}
+        ],
+        "textPositions": {
+          "0": {"x": 148, "y": 2332},
+          "1": {"x": 176, "y": 2308},
+          "2": {"x": 556, "y": 2308},
+          "3": {"x": 528, "y": 2332},
+          "4": {"x": 352, "y": 2308},
+          "5": {"x": 352, "y": 2308},
+          "6": {"x": 352, "y": 2332}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 243,
+      "sourceNodeId": 138,
+      "sourcePortId": 521,
+      "targetNodeId": 134,
+      "targetPortId": 522,
+      "travelTime": {"lock": false, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 2,
+        "warning": null,
+        "consecutiveTime": 122
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 58,
+        "warning": null,
+        "consecutiveTime": 58
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 48,
+        "warning": null,
+        "consecutiveTime": 48
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 12,
+        "warning": null,
+        "consecutiveTime": 132
+      },
+      "numberOfStops": 1,
+      "trainrunId": 95,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 592, "y": 2270},
+          {"x": 592, "y": 2206},
+          {"x": 560, "y": 2110},
+          {"x": 560, "y": 2046}
+        ],
+        "textPositions": {
+          "0": {"x": 604, "y": 2252},
+          "1": {"x": 580, "y": 2224},
+          "2": {"x": 548, "y": 2064},
+          "3": {"x": 572, "y": 2092},
+          "4": {"x": 588, "y": 2158},
+          "5": {"x": 588, "y": 2158},
+          "6": {"x": 564, "y": 2158}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 244,
+      "sourceNodeId": 138,
+      "sourcePortId": 523,
+      "targetNodeId": 134,
+      "targetPortId": 524,
+      "travelTime": {"lock": false, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 40,
+        "warning": null,
+        "consecutiveTime": 40
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 20,
+        "warning": null,
+        "consecutiveTime": 20
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 10,
+        "warning": null,
+        "consecutiveTime": 10
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 50,
+        "warning": null,
+        "consecutiveTime": 50
+      },
+      "numberOfStops": 2,
+      "trainrunId": 96,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 656, "y": 2270},
+          {"x": 656, "y": 2206},
+          {"x": 624, "y": 2110},
+          {"x": 624, "y": 2046}
+        ],
+        "textPositions": {
+          "0": {"x": 668, "y": 2252},
+          "1": {"x": 644, "y": 2224},
+          "2": {"x": 612, "y": 2064},
+          "3": {"x": 636, "y": 2092},
+          "4": {"x": 652, "y": 2158},
+          "5": {"x": 652, "y": 2158},
+          "6": {"x": 628, "y": 2158}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 245,
+      "sourceNodeId": 138,
+      "sourcePortId": 525,
+      "targetNodeId": 139,
+      "targetPortId": 526,
+      "travelTime": {"lock": false, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 20,
+        "warning": null,
+        "consecutiveTime": 20
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 40,
+        "warning": null,
+        "consecutiveTime": 40
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 30,
+        "warning": null,
+        "consecutiveTime": 30
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 30,
+        "warning": null,
+        "consecutiveTime": 30
+      },
+      "numberOfStops": 5,
+      "trainrunId": 97,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 574, "y": 2288},
+          {"x": 510, "y": 2288},
+          {"x": 194, "y": 2288},
+          {"x": 130, "y": 2288}
+        ],
+        "textPositions": {
+          "0": {"x": 556, "y": 2276},
+          "1": {"x": 528, "y": 2300},
+          "2": {"x": 148, "y": 2300},
+          "3": {"x": 176, "y": 2276},
+          "4": {"x": 352, "y": 2276},
+          "5": {"x": 352, "y": 2276},
+          "6": {"x": 352, "y": 2300}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 246,
+      "sourceNodeId": 134,
+      "sourcePortId": 527,
+      "targetNodeId": 138,
+      "targetPortId": 528,
+      "travelTime": {"lock": false, "time": 20, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 28,
+        "warning": null,
+        "consecutiveTime": 88
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 32,
+        "warning": null,
+        "consecutiveTime": 92
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 12,
+        "warning": null,
+        "consecutiveTime": 72
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 48,
+        "warning": null,
+        "consecutiveTime": 108
+      },
+      "numberOfStops": 2,
+      "trainrunId": 94,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 592, "y": 2046},
+          {"x": 592, "y": 2110},
+          {"x": 624, "y": 2206},
+          {"x": 624, "y": 2270}
+        ],
+        "textPositions": {
+          "0": {"x": 580, "y": 2064},
+          "1": {"x": 604, "y": 2092},
+          "2": {"x": 636, "y": 2252},
+          "3": {"x": 612, "y": 2224},
+          "4": {"x": 620, "y": 2158},
+          "5": {"x": 620, "y": 2158},
+          "6": {"x": 596, "y": 2158}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 247,
+      "sourceNodeId": 138,
+      "sourcePortId": 529,
+      "targetNodeId": 137,
+      "targetPortId": 530,
+      "travelTime": {"lock": false, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 21,
+        "warning": null,
+        "consecutiveTime": 21
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 39,
+        "warning": null,
+        "consecutiveTime": 39
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 29,
+        "warning": null,
+        "consecutiveTime": 29
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 31,
+        "warning": null,
+        "consecutiveTime": 31
+      },
+      "numberOfStops": 4,
+      "trainrunId": 96,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 674, "y": 2320},
+          {"x": 738, "y": 2320},
+          {"x": 1086, "y": 2320},
+          {"x": 1150, "y": 2320}
+        ],
+        "textPositions": {
+          "0": {"x": 692, "y": 2332},
+          "1": {"x": 720, "y": 2308},
+          "2": {"x": 1132, "y": 2308},
+          "3": {"x": 1104, "y": 2332},
+          "4": {"x": 912, "y": 2308},
+          "5": {"x": 912, "y": 2308},
+          "6": {"x": 912, "y": 2332}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 248,
+      "sourceNodeId": 138,
+      "sourcePortId": 531,
+      "targetNodeId": 137,
+      "targetPortId": 532,
+      "travelTime": {"lock": false, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 41.5,
+        "warning": null,
+        "consecutiveTime": 41.5
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 18.5,
+        "warning": null,
+        "consecutiveTime": 18.5
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 8.5,
+        "warning": null,
+        "consecutiveTime": 8.5
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 51.5,
+        "warning": null,
+        "consecutiveTime": 51.5
+      },
+      "numberOfStops": 2,
+      "trainrunId": 97,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 674, "y": 2288},
+          {"x": 738, "y": 2288},
+          {"x": 1086, "y": 2288},
+          {"x": 1150, "y": 2288}
+        ],
+        "textPositions": {
+          "0": {"x": 692, "y": 2300},
+          "1": {"x": 720, "y": 2276},
+          "2": {"x": 1132, "y": 2276},
+          "3": {"x": 1104, "y": 2300},
+          "4": {"x": 912, "y": 2276},
+          "5": {"x": 912, "y": 2276},
+          "6": {"x": 912, "y": 2300}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 249,
+      "sourceNodeId": 159,
+      "sourcePortId": 533,
+      "targetNodeId": 141,
+      "targetPortId": 534,
+      "travelTime": {"lock": false, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 29,
+        "warning": null,
+        "consecutiveTime": 29
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 31,
+        "warning": null,
+        "consecutiveTime": 31
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 21,
+        "warning": null,
+        "consecutiveTime": 21
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 39,
+        "warning": null,
+        "consecutiveTime": 39
+      },
+      "numberOfStops": 1,
+      "trainrunId": 86,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1104, "y": 990},
+          {"x": 1104, "y": 926},
+          {"x": 1104, "y": 802},
+          {"x": 1104, "y": 738}
+        ],
+        "textPositions": {
+          "0": {"x": 1116, "y": 972},
+          "1": {"x": 1092, "y": 944},
+          "2": {"x": 1092, "y": 756},
+          "3": {"x": 1116, "y": 784},
+          "4": {"x": 1092, "y": 864},
+          "5": {"x": 1092, "y": 864},
+          "6": {"x": 1116, "y": 864}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 250,
+      "sourceNodeId": 149,
+      "sourcePortId": 535,
+      "targetNodeId": 137,
+      "targetPortId": 536,
+      "travelTime": {"lock": false, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 39,
+        "warning": null,
+        "consecutiveTime": 39
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 21,
+        "warning": null,
+        "consecutiveTime": 141
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 11,
+        "warning": null,
+        "consecutiveTime": 131
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 49,
+        "warning": null,
+        "consecutiveTime": 49
+      },
+      "numberOfStops": 0,
+      "trainrunId": 91,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1200, "y": 2050},
+          {"x": 1200, "y": 2114},
+          {"x": 1264, "y": 2206},
+          {"x": 1264, "y": 2270}
+        ],
+        "textPositions": {
+          "0": {"x": 1188, "y": 2068},
+          "1": {"x": 1212, "y": 2096},
+          "2": {"x": 1276, "y": 2252},
+          "3": {"x": 1252, "y": 2224},
+          "4": {"x": 1244, "y": 2160},
+          "5": {"x": 1244, "y": 2160},
+          "6": {"x": 1220, "y": 2160}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 251,
+      "sourceNodeId": 149,
+      "sourcePortId": 537,
+      "targetNodeId": 137,
+      "targetPortId": 538,
+      "travelTime": {"lock": false, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 7.5,
+        "warning": null,
+        "consecutiveTime": 67.5
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 52.5,
+        "warning": null,
+        "consecutiveTime": 112.5
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 42.5,
+        "warning": null,
+        "consecutiveTime": 102.5
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 17.5,
+        "warning": null,
+        "consecutiveTime": 77.5
+      },
+      "numberOfStops": 0,
+      "trainrunId": 93,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1168, "y": 2050},
+          {"x": 1168, "y": 2114},
+          {"x": 1232, "y": 2206},
+          {"x": 1232, "y": 2270}
+        ],
+        "textPositions": {
+          "0": {"x": 1156, "y": 2068},
+          "1": {"x": 1180, "y": 2096},
+          "2": {"x": 1244, "y": 2252},
+          "3": {"x": 1220, "y": 2224},
+          "4": {"x": 1212, "y": 2160},
+          "5": {"x": 1212, "y": 2160},
+          "6": {"x": 1188, "y": 2160}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 252,
+      "sourceNodeId": 149,
+      "sourcePortId": 539,
+      "targetNodeId": 137,
+      "targetPortId": 540,
+      "travelTime": {"lock": false, "time": 5, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 56,
+        "warning": null,
+        "consecutiveTime": 56
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 4,
+        "warning": null,
+        "consecutiveTime": 124
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 59,
+        "warning": null,
+        "consecutiveTime": 119
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 1,
+        "warning": null,
+        "consecutiveTime": 61
+      },
+      "numberOfStops": 0,
+      "trainrunId": 87,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1136, "y": 2050},
+          {"x": 1136, "y": 2114},
+          {"x": 1200, "y": 2206},
+          {"x": 1200, "y": 2270}
+        ],
+        "textPositions": {
+          "0": {"x": 1124, "y": 2068},
+          "1": {"x": 1148, "y": 2096},
+          "2": {"x": 1212, "y": 2252},
+          "3": {"x": 1188, "y": 2224},
+          "4": {"x": 1180, "y": 2160},
+          "5": {"x": 1180, "y": 2160},
+          "6": {"x": 1156, "y": 2160}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 253,
+      "sourceNodeId": 149,
+      "sourcePortId": 541,
+      "targetNodeId": 137,
+      "targetPortId": 542,
+      "travelTime": {"lock": false, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 56,
+        "warning": null,
+        "consecutiveTime": 116
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 4,
+        "warning": null,
+        "consecutiveTime": 244
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 54,
+        "warning": null,
+        "consecutiveTime": 234
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 6,
+        "warning": null,
+        "consecutiveTime": 126
+      },
+      "numberOfStops": 0,
+      "trainrunId": 84,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1104, "y": 2050},
+          {"x": 1104, "y": 2114},
+          {"x": 1168, "y": 2206},
+          {"x": 1168, "y": 2270}
+        ],
+        "textPositions": {
+          "0": {"x": 1092, "y": 2068},
+          "1": {"x": 1116, "y": 2096},
+          "2": {"x": 1180, "y": 2252},
+          "3": {"x": 1156, "y": 2224},
+          "4": {"x": 1148, "y": 2160},
+          "5": {"x": 1148, "y": 2160},
+          "6": {"x": 1124, "y": 2160}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 254,
+      "sourceNodeId": 140,
+      "sourcePortId": 543,
+      "targetNodeId": 137,
+      "targetPortId": 544,
+      "travelTime": {"lock": false, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 42,
+        "warning": null,
+        "consecutiveTime": 222
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 18,
+        "warning": null,
+        "consecutiveTime": 138
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 8,
+        "warning": null,
+        "consecutiveTime": 128
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 52,
+        "warning": null,
+        "consecutiveTime": 232
+      },
+      "numberOfStops": 0,
+      "trainrunId": 84,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1502, "y": 2288},
+          {"x": 1438, "y": 2288},
+          {"x": 1346, "y": 2288},
+          {"x": 1282, "y": 2288}
+        ],
+        "textPositions": {
+          "0": {"x": 1484, "y": 2276},
+          "1": {"x": 1456, "y": 2300},
+          "2": {"x": 1300, "y": 2300},
+          "3": {"x": 1328, "y": 2276},
+          "4": {"x": 1392, "y": 2276},
+          "5": {"x": 1392, "y": 2276},
+          "6": {"x": 1392, "y": 2300}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 255,
+      "sourceNodeId": 140,
+      "sourcePortId": 545,
+      "targetNodeId": 137,
+      "targetPortId": 546,
+      "travelTime": {"lock": false, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 40,
+        "warning": null,
+        "consecutiveTime": 40
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 20,
+        "warning": null,
+        "consecutiveTime": 20
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 10,
+        "warning": null,
+        "consecutiveTime": 10
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 50,
+        "warning": null,
+        "consecutiveTime": 50
+      },
+      "numberOfStops": 4,
+      "trainrunId": 92,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1502, "y": 2384},
+          {"x": 1438, "y": 2384},
+          {"x": 1346, "y": 2384},
+          {"x": 1282, "y": 2384}
+        ],
+        "textPositions": {
+          "0": {"x": 1484, "y": 2372},
+          "1": {"x": 1456, "y": 2396},
+          "2": {"x": 1300, "y": 2396},
+          "3": {"x": 1328, "y": 2372},
+          "4": {"x": 1392, "y": 2372},
+          "5": {"x": 1392, "y": 2372},
+          "6": {"x": 1392, "y": 2396}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 256,
+      "sourceNodeId": 140,
+      "sourcePortId": 547,
+      "targetNodeId": 137,
+      "targetPortId": 548,
+      "travelTime": {"lock": false, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 40,
+        "warning": null,
+        "consecutiveTime": 100
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 20,
+        "warning": null,
+        "consecutiveTime": 80
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 10,
+        "warning": null,
+        "consecutiveTime": 70
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 50,
+        "warning": null,
+        "consecutiveTime": 110
+      },
+      "numberOfStops": 0,
+      "trainrunId": 85,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1502, "y": 2320},
+          {"x": 1438, "y": 2320},
+          {"x": 1346, "y": 2320},
+          {"x": 1282, "y": 2320}
+        ],
+        "textPositions": {
+          "0": {"x": 1484, "y": 2308},
+          "1": {"x": 1456, "y": 2332},
+          "2": {"x": 1300, "y": 2332},
+          "3": {"x": 1328, "y": 2308},
+          "4": {"x": 1392, "y": 2308},
+          "5": {"x": 1392, "y": 2308},
+          "6": {"x": 1392, "y": 2332}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 257,
+      "sourceNodeId": 140,
+      "sourcePortId": 549,
+      "targetNodeId": 137,
+      "targetPortId": 550,
+      "travelTime": {"lock": false, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 0,
+        "warning": null,
+        "consecutiveTime": 120
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 0,
+        "warning": null,
+        "consecutiveTime": 60
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 50,
+        "warning": null,
+        "consecutiveTime": 50
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 10,
+        "warning": null,
+        "consecutiveTime": 130
+      },
+      "numberOfStops": 4,
+      "trainrunId": 91,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1502, "y": 2352},
+          {"x": 1438, "y": 2352},
+          {"x": 1346, "y": 2352},
+          {"x": 1282, "y": 2352}
+        ],
+        "textPositions": {
+          "0": {"x": 1484, "y": 2340},
+          "1": {"x": 1456, "y": 2364},
+          "2": {"x": 1300, "y": 2364},
+          "3": {"x": 1328, "y": 2340},
+          "4": {"x": 1392, "y": 2340},
+          "5": {"x": 1392, "y": 2340},
+          "6": {"x": 1392, "y": 2364}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 258,
+      "sourceNodeId": 159,
+      "sourcePortId": 551,
+      "targetNodeId": 161,
+      "targetPortId": 552,
+      "travelTime": {"lock": true, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 26,
+        "warning": null,
+        "consecutiveTime": 86
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 34,
+        "warning": null,
+        "consecutiveTime": 274
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 24,
+        "warning": null,
+        "consecutiveTime": 264
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 36,
+        "warning": null,
+        "consecutiveTime": 96
+      },
+      "numberOfStops": 0,
+      "trainrunId": 84,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1008, "y": 1058},
+          {"x": 1008, "y": 1122},
+          {"x": 1008, "y": 1246},
+          {"x": 1008, "y": 1310}
+        ],
+        "textPositions": {
+          "0": {"x": 996, "y": 1076},
+          "1": {"x": 1020, "y": 1104},
+          "2": {"x": 1020, "y": 1292},
+          "3": {"x": 996, "y": 1264},
+          "4": {"x": 996, "y": 1184},
+          "5": {"x": 996, "y": 1184},
+          "6": {"x": 1020, "y": 1184}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 259,
+      "sourceNodeId": 159,
+      "sourcePortId": 553,
+      "targetNodeId": 161,
+      "targetPortId": 554,
+      "travelTime": {"lock": true, "time": 7, "warning": null},
+      "sourceDeparture": {
+        "lock": true,
+        "time": 35,
+        "warning": null,
+        "consecutiveTime": 35
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 25,
+        "warning": null,
+        "consecutiveTime": 145
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 18,
+        "warning": null,
+        "consecutiveTime": 138
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 42,
+        "warning": null,
+        "consecutiveTime": 42
+      },
+      "numberOfStops": 0,
+      "trainrunId": 87,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1040, "y": 1058},
+          {"x": 1040, "y": 1122},
+          {"x": 1040, "y": 1246},
+          {"x": 1040, "y": 1310}
+        ],
+        "textPositions": {
+          "0": {"x": 1028, "y": 1076},
+          "1": {"x": 1052, "y": 1104},
+          "2": {"x": 1052, "y": 1292},
+          "3": {"x": 1028, "y": 1264},
+          "4": {"x": 1028, "y": 1184},
+          "5": {"x": 1028, "y": 1184},
+          "6": {"x": 1052, "y": 1184}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 260,
+      "sourceNodeId": 159,
+      "sourcePortId": 555,
+      "targetNodeId": 161,
+      "targetPortId": 556,
+      "travelTime": {"lock": true, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 33,
+        "warning": null,
+        "consecutiveTime": 33
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 27,
+        "warning": null,
+        "consecutiveTime": 147
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 17,
+        "warning": null,
+        "consecutiveTime": 137
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 43,
+        "warning": null,
+        "consecutiveTime": 43
+      },
+      "numberOfStops": 0,
+      "trainrunId": 93,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1072, "y": 1058},
+          {"x": 1072, "y": 1122},
+          {"x": 1072, "y": 1246},
+          {"x": 1072, "y": 1310}
+        ],
+        "textPositions": {
+          "0": {"x": 1060, "y": 1076},
+          "1": {"x": 1084, "y": 1104},
+          "2": {"x": 1084, "y": 1292},
+          "3": {"x": 1060, "y": 1264},
+          "4": {"x": 1060, "y": 1184},
+          "5": {"x": 1060, "y": 1184},
+          "6": {"x": 1084, "y": 1184}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 261,
+      "sourceNodeId": 159,
+      "sourcePortId": 557,
+      "targetNodeId": 161,
+      "targetPortId": 558,
+      "travelTime": {"lock": true, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 32,
+        "warning": null,
+        "consecutiveTime": 32
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 28,
+        "warning": null,
+        "consecutiveTime": 28
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 18,
+        "warning": null,
+        "consecutiveTime": 18
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 42,
+        "warning": null,
+        "consecutiveTime": 42
+      },
+      "numberOfStops": 4,
+      "trainrunId": 86,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1104, "y": 1058},
+          {"x": 1104, "y": 1122},
+          {"x": 1104, "y": 1246},
+          {"x": 1104, "y": 1310}
+        ],
+        "textPositions": {
+          "0": {"x": 1092, "y": 1076},
+          "1": {"x": 1116, "y": 1104},
+          "2": {"x": 1116, "y": 1292},
+          "3": {"x": 1092, "y": 1264},
+          "4": {"x": 1092, "y": 1184},
+          "5": {"x": 1092, "y": 1184},
+          "6": {"x": 1116, "y": 1184}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 262,
+      "sourceNodeId": 149,
+      "sourcePortId": 559,
+      "targetNodeId": 160,
+      "targetPortId": 560,
+      "travelTime": {"lock": true, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 22,
+        "warning": null,
+        "consecutiveTime": 142
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 38,
+        "warning": null,
+        "consecutiveTime": 38
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 28,
+        "warning": null,
+        "consecutiveTime": 28
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 32,
+        "warning": null,
+        "consecutiveTime": 152
+      },
+      "numberOfStops": 3,
+      "trainrunId": 91,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1200, "y": 1982},
+          {"x": 1200, "y": 1918},
+          {"x": 1200, "y": 1826},
+          {"x": 1200, "y": 1762}
+        ],
+        "textPositions": {
+          "0": {"x": 1212, "y": 1964},
+          "1": {"x": 1188, "y": 1936},
+          "2": {"x": 1188, "y": 1780},
+          "3": {"x": 1212, "y": 1808},
+          "4": {"x": 1188, "y": 1872},
+          "5": {"x": 1188, "y": 1872},
+          "6": {"x": 1212, "y": 1872}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 263,
+      "sourceNodeId": 160,
+      "sourcePortId": 561,
+      "targetNodeId": 161,
+      "targetPortId": 562,
+      "travelTime": {"lock": true, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 33,
+        "warning": null,
+        "consecutiveTime": 153
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 27,
+        "warning": null,
+        "consecutiveTime": 27
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 17,
+        "warning": null,
+        "consecutiveTime": 17
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 43,
+        "warning": null,
+        "consecutiveTime": 163
+      },
+      "numberOfStops": 2,
+      "trainrunId": 91,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1200, "y": 1694},
+          {"x": 1200, "y": 1630},
+          {"x": 1104, "y": 1442},
+          {"x": 1104, "y": 1378}
+        ],
+        "textPositions": {
+          "0": {"x": 1212, "y": 1676},
+          "1": {"x": 1188, "y": 1648},
+          "2": {"x": 1092, "y": 1396},
+          "3": {"x": 1116, "y": 1424},
+          "4": {"x": 1164, "y": 1536},
+          "5": {"x": 1164, "y": 1536},
+          "6": {"x": 1140, "y": 1536}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 264,
+      "sourceNodeId": 149,
+      "sourcePortId": 563,
+      "targetNodeId": 160,
+      "targetPortId": 564,
+      "travelTime": {"lock": true, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 54,
+        "warning": null,
+        "consecutiveTime": 114
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 6,
+        "warning": null,
+        "consecutiveTime": 66
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 56,
+        "warning": null,
+        "consecutiveTime": 56
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 4,
+        "warning": null,
+        "consecutiveTime": 124
+      },
+      "numberOfStops": 0,
+      "trainrunId": 93,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1168, "y": 1982},
+          {"x": 1168, "y": 1918},
+          {"x": 1168, "y": 1826},
+          {"x": 1168, "y": 1762}
+        ],
+        "textPositions": {
+          "0": {"x": 1180, "y": 1964},
+          "1": {"x": 1156, "y": 1936},
+          "2": {"x": 1156, "y": 1780},
+          "3": {"x": 1180, "y": 1808},
+          "4": {"x": 1156, "y": 1872},
+          "5": {"x": 1156, "y": 1872},
+          "6": {"x": 1180, "y": 1872}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 265,
+      "sourceNodeId": 160,
+      "sourcePortId": 565,
+      "targetNodeId": 161,
+      "targetPortId": 566,
+      "travelTime": {"lock": true, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 5.5,
+        "warning": null,
+        "consecutiveTime": 125.5
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 54.5,
+        "warning": null,
+        "consecutiveTime": 54.5
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 44.5,
+        "warning": null,
+        "consecutiveTime": 44.5
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 15.5,
+        "warning": null,
+        "consecutiveTime": 135.5
+      },
+      "numberOfStops": 0,
+      "trainrunId": 93,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1168, "y": 1694},
+          {"x": 1168, "y": 1630},
+          {"x": 1072, "y": 1442},
+          {"x": 1072, "y": 1378}
+        ],
+        "textPositions": {
+          "0": {"x": 1180, "y": 1676},
+          "1": {"x": 1156, "y": 1648},
+          "2": {"x": 1060, "y": 1396},
+          "3": {"x": 1084, "y": 1424},
+          "4": {"x": 1132, "y": 1536},
+          "5": {"x": 1132, "y": 1536},
+          "6": {"x": 1108, "y": 1536}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 266,
+      "sourceNodeId": 149,
+      "sourcePortId": 567,
+      "targetNodeId": 160,
+      "targetPortId": 568,
+      "travelTime": {"lock": true, "time": 4, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 4,
+        "warning": null,
+        "consecutiveTime": 124
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 56,
+        "warning": null,
+        "consecutiveTime": 56
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 52,
+        "warning": null,
+        "consecutiveTime": 52
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 8,
+        "warning": null,
+        "consecutiveTime": 128
+      },
+      "numberOfStops": 0,
+      "trainrunId": 87,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1136, "y": 1982},
+          {"x": 1136, "y": 1918},
+          {"x": 1136, "y": 1826},
+          {"x": 1136, "y": 1762}
+        ],
+        "textPositions": {
+          "0": {"x": 1148, "y": 1964},
+          "1": {"x": 1124, "y": 1936},
+          "2": {"x": 1124, "y": 1780},
+          "3": {"x": 1148, "y": 1808},
+          "4": {"x": 1124, "y": 1872},
+          "5": {"x": 1124, "y": 1872},
+          "6": {"x": 1148, "y": 1872}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 267,
+      "sourceNodeId": 160,
+      "sourcePortId": 569,
+      "targetNodeId": 161,
+      "targetPortId": 570,
+      "travelTime": {"lock": true, "time": 8, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 8,
+        "warning": null,
+        "consecutiveTime": 128
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 52,
+        "warning": null,
+        "consecutiveTime": 52
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 44,
+        "warning": null,
+        "consecutiveTime": 44
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 16,
+        "warning": null,
+        "consecutiveTime": 136
+      },
+      "numberOfStops": 0,
+      "trainrunId": 87,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1136, "y": 1694},
+          {"x": 1136, "y": 1630},
+          {"x": 1040, "y": 1442},
+          {"x": 1040, "y": 1378}
+        ],
+        "textPositions": {
+          "0": {"x": 1148, "y": 1676},
+          "1": {"x": 1124, "y": 1648},
+          "2": {"x": 1028, "y": 1396},
+          "3": {"x": 1052, "y": 1424},
+          "4": {"x": 1100, "y": 1536},
+          "5": {"x": 1100, "y": 1536},
+          "6": {"x": 1076, "y": 1536}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 268,
+      "sourceNodeId": 149,
+      "sourcePortId": 571,
+      "targetNodeId": 160,
+      "targetPortId": 572,
+      "travelTime": {"lock": true, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 4,
+        "warning": null,
+        "consecutiveTime": 244
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 56,
+        "warning": null,
+        "consecutiveTime": 116
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 46,
+        "warning": null,
+        "consecutiveTime": 106
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 14,
+        "warning": null,
+        "consecutiveTime": 254
+      },
+      "numberOfStops": 0,
+      "trainrunId": 84,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1104, "y": 1982},
+          {"x": 1104, "y": 1918},
+          {"x": 1104, "y": 1826},
+          {"x": 1104, "y": 1762}
+        ],
+        "textPositions": {
+          "0": {"x": 1116, "y": 1964},
+          "1": {"x": 1092, "y": 1936},
+          "2": {"x": 1092, "y": 1780},
+          "3": {"x": 1116, "y": 1808},
+          "4": {"x": 1092, "y": 1872},
+          "5": {"x": 1092, "y": 1872},
+          "6": {"x": 1116, "y": 1872}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 269,
+      "sourceNodeId": 160,
+      "sourcePortId": 573,
+      "targetNodeId": 161,
+      "targetPortId": 574,
+      "travelTime": {"lock": true, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 14,
+        "warning": null,
+        "consecutiveTime": 254
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 46,
+        "warning": null,
+        "consecutiveTime": 106
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 36,
+        "warning": null,
+        "consecutiveTime": 96
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 24,
+        "warning": null,
+        "consecutiveTime": 264
+      },
+      "numberOfStops": 0,
+      "trainrunId": 84,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1104, "y": 1694},
+          {"x": 1104, "y": 1630},
+          {"x": 1008, "y": 1442},
+          {"x": 1008, "y": 1378}
+        ],
+        "textPositions": {
+          "0": {"x": 1116, "y": 1676},
+          "1": {"x": 1092, "y": 1648},
+          "2": {"x": 996, "y": 1396},
+          "3": {"x": 1020, "y": 1424},
+          "4": {"x": 1068, "y": 1536},
+          "5": {"x": 1068, "y": 1536},
+          "6": {"x": 1044, "y": 1536}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 270,
+      "sourceNodeId": 140,
+      "sourcePortId": 575,
+      "targetNodeId": 146,
+      "targetPortId": 576,
+      "travelTime": {"lock": true, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 1,
+        "warning": null,
+        "consecutiveTime": 61
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 59,
+        "warning": null,
+        "consecutiveTime": 119
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 49,
+        "warning": null,
+        "consecutiveTime": 109
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 11,
+        "warning": null,
+        "consecutiveTime": 71
+      },
+      "numberOfStops": 1,
+      "trainrunId": 91,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1602, "y": 2320},
+          {"x": 1666, "y": 2320},
+          {"x": 1822, "y": 2256},
+          {"x": 1886, "y": 2256}
+        ],
+        "textPositions": {
+          "0": {"x": 1620, "y": 2332},
+          "1": {"x": 1648, "y": 2308},
+          "2": {"x": 1868, "y": 2244},
+          "3": {"x": 1840, "y": 2268},
+          "4": {"x": 1744, "y": 2276},
+          "5": {"x": 1744, "y": 2276},
+          "6": {"x": 1744, "y": 2300}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 271,
+      "sourceNodeId": 146,
+      "sourcePortId": 577,
+      "targetNodeId": 135,
+      "targetPortId": 578,
+      "travelTime": {"lock": true, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 12,
+        "warning": null,
+        "consecutiveTime": 72
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 48,
+        "warning": null,
+        "consecutiveTime": 108
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 38,
+        "warning": null,
+        "consecutiveTime": 98
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 22,
+        "warning": null,
+        "consecutiveTime": 82
+      },
+      "numberOfStops": 3,
+      "trainrunId": 91,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1936, "y": 2206},
+          {"x": 1936, "y": 2142},
+          {"x": 1936, "y": 2114},
+          {"x": 1936, "y": 2050}
+        ],
+        "textPositions": {
+          "0": {"x": 1948, "y": 2188},
+          "1": {"x": 1924, "y": 2160},
+          "2": {"x": 1924, "y": 2068},
+          "3": {"x": 1948, "y": 2096},
+          "4": {"x": 1924, "y": 2128},
+          "5": {"x": 1924, "y": 2128},
+          "6": {"x": 1948, "y": 2128}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 272,
+      "sourceNodeId": 140,
+      "sourcePortId": 579,
+      "targetNodeId": 146,
+      "targetPortId": 580,
+      "travelTime": {"lock": true, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 20,
+        "warning": null,
+        "consecutiveTime": 80
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 40,
+        "warning": null,
+        "consecutiveTime": 100
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 30,
+        "warning": null,
+        "consecutiveTime": 90
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 30,
+        "warning": null,
+        "consecutiveTime": 90
+      },
+      "numberOfStops": 0,
+      "trainrunId": 85,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1602, "y": 2288},
+          {"x": 1666, "y": 2288},
+          {"x": 1822, "y": 2224},
+          {"x": 1886, "y": 2224}
+        ],
+        "textPositions": {
+          "0": {"x": 1620, "y": 2300},
+          "1": {"x": 1648, "y": 2276},
+          "2": {"x": 1868, "y": 2212},
+          "3": {"x": 1840, "y": 2236},
+          "4": {"x": 1744, "y": 2244},
+          "5": {"x": 1744, "y": 2244},
+          "6": {"x": 1744, "y": 2268}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 273,
+      "sourceNodeId": 146,
+      "sourcePortId": 581,
+      "targetNodeId": 135,
+      "targetPortId": 582,
+      "travelTime": {"lock": true, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 30,
+        "warning": null,
+        "consecutiveTime": 90
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 30,
+        "warning": null,
+        "consecutiveTime": 90
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 20,
+        "warning": null,
+        "consecutiveTime": 80
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 40,
+        "warning": null,
+        "consecutiveTime": 100
+      },
+      "numberOfStops": 0,
+      "trainrunId": 85,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1904, "y": 2206},
+          {"x": 1904, "y": 2142},
+          {"x": 1904, "y": 2114},
+          {"x": 1904, "y": 2050}
+        ],
+        "textPositions": {
+          "0": {"x": 1916, "y": 2188},
+          "1": {"x": 1892, "y": 2160},
+          "2": {"x": 1892, "y": 2068},
+          "3": {"x": 1916, "y": 2096},
+          "4": {"x": 1892, "y": 2128},
+          "5": {"x": 1892, "y": 2128},
+          "6": {"x": 1916, "y": 2128}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 274,
+      "sourceNodeId": 140,
+      "sourcePortId": 583,
+      "targetNodeId": 147,
+      "targetPortId": 584,
+      "travelTime": {"lock": true, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 21,
+        "warning": null,
+        "consecutiveTime": 21
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 39,
+        "warning": null,
+        "consecutiveTime": 39
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 29,
+        "warning": null,
+        "consecutiveTime": 29
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 31,
+        "warning": null,
+        "consecutiveTime": 31
+      },
+      "numberOfStops": 0,
+      "trainrunId": 92,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1602, "y": 2384},
+          {"x": 1666, "y": 2384},
+          {"x": 1822, "y": 2384},
+          {"x": 1886, "y": 2384}
+        ],
+        "textPositions": {
+          "0": {"x": 1620, "y": 2396},
+          "1": {"x": 1648, "y": 2372},
+          "2": {"x": 1868, "y": 2372},
+          "3": {"x": 1840, "y": 2396},
+          "4": {"x": 1744, "y": 2372},
+          "5": {"x": 1744, "y": 2372},
+          "6": {"x": 1744, "y": 2396}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 275,
+      "sourceNodeId": 147,
+      "sourcePortId": 585,
+      "targetNodeId": 154,
+      "targetPortId": 586,
+      "travelTime": {"lock": true, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 32,
+        "warning": null,
+        "consecutiveTime": 32
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 28,
+        "warning": null,
+        "consecutiveTime": 28
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 18,
+        "warning": null,
+        "consecutiveTime": 18
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 42,
+        "warning": null,
+        "consecutiveTime": 42
+      },
+      "numberOfStops": 0,
+      "trainrunId": 92,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1986, "y": 2384},
+          {"x": 2050, "y": 2384},
+          {"x": 2302, "y": 2384},
+          {"x": 2366, "y": 2384}
+        ],
+        "textPositions": {
+          "0": {"x": 2004, "y": 2396},
+          "1": {"x": 2032, "y": 2372},
+          "2": {"x": 2348, "y": 2372},
+          "3": {"x": 2320, "y": 2396},
+          "4": {"x": 2176, "y": 2372},
+          "5": {"x": 2176, "y": 2372},
+          "6": {"x": 2176, "y": 2396}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 276,
+      "sourceNodeId": 140,
+      "sourcePortId": 587,
+      "targetNodeId": 147,
+      "targetPortId": 588,
+      "travelTime": {"lock": true, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 18,
+        "warning": null,
+        "consecutiveTime": 138
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 42,
+        "warning": null,
+        "consecutiveTime": 222
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 32,
+        "warning": null,
+        "consecutiveTime": 212
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 28,
+        "warning": null,
+        "consecutiveTime": 148
+      },
+      "numberOfStops": 0,
+      "trainrunId": 84,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1602, "y": 2352},
+          {"x": 1666, "y": 2352},
+          {"x": 1822, "y": 2352},
+          {"x": 1886, "y": 2352}
+        ],
+        "textPositions": {
+          "0": {"x": 1620, "y": 2364},
+          "1": {"x": 1648, "y": 2340},
+          "2": {"x": 1868, "y": 2340},
+          "3": {"x": 1840, "y": 2364},
+          "4": {"x": 1744, "y": 2340},
+          "5": {"x": 1744, "y": 2340},
+          "6": {"x": 1744, "y": 2364}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 277,
+      "sourceNodeId": 147,
+      "sourcePortId": 589,
+      "targetNodeId": 154,
+      "targetPortId": 590,
+      "travelTime": {"lock": true, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 30,
+        "warning": null,
+        "consecutiveTime": 150
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 30,
+        "warning": null,
+        "consecutiveTime": 210
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 20,
+        "warning": null,
+        "consecutiveTime": 200
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 40,
+        "warning": null,
+        "consecutiveTime": 160
+      },
+      "numberOfStops": 0,
+      "trainrunId": 84,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1986, "y": 2352},
+          {"x": 2050, "y": 2352},
+          {"x": 2302, "y": 2352},
+          {"x": 2366, "y": 2352}
+        ],
+        "textPositions": {
+          "0": {"x": 2004, "y": 2364},
+          "1": {"x": 2032, "y": 2340},
+          "2": {"x": 2348, "y": 2340},
+          "3": {"x": 2320, "y": 2364},
+          "4": {"x": 2176, "y": 2340},
+          "5": {"x": 2176, "y": 2340},
+          "6": {"x": 2176, "y": 2364}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 278,
+      "sourceNodeId": 148,
+      "sourcePortId": 591,
+      "targetNodeId": 133,
+      "targetPortId": 592,
+      "travelTime": {"lock": true, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 44,
+        "warning": null,
+        "consecutiveTime": 104
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 16,
+        "warning": null,
+        "consecutiveTime": 76
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 6,
+        "warning": null,
+        "consecutiveTime": 66
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 54,
+        "warning": null,
+        "consecutiveTime": 114
+      },
+      "numberOfStops": 3,
+      "trainrunId": 94,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 240, "y": 1918},
+          {"x": 240, "y": 1854},
+          {"x": 240, "y": 994},
+          {"x": 240, "y": 930}
+        ],
+        "textPositions": {
+          "0": {"x": 252, "y": 1900},
+          "1": {"x": 228, "y": 1872},
+          "2": {"x": 228, "y": 948},
+          "3": {"x": 252, "y": 976},
+          "4": {"x": 228, "y": 1424},
+          "5": {"x": 228, "y": 1424},
+          "6": {"x": 252, "y": 1424}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 279,
+      "sourceNodeId": 133,
+      "sourcePortId": 593,
+      "targetNodeId": 142,
+      "targetPortId": 594,
+      "travelTime": {"lock": true, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 55,
+        "warning": null,
+        "consecutiveTime": 115
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 5,
+        "warning": null,
+        "consecutiveTime": 65
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 55,
+        "warning": null,
+        "consecutiveTime": 55
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 5,
+        "warning": null,
+        "consecutiveTime": 125
+      },
+      "numberOfStops": 3,
+      "trainrunId": 94,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 240, "y": 862},
+          {"x": 240, "y": 798},
+          {"x": 240, "y": 574},
+          {"x": 240, "y": 510}
+        ],
+        "textPositions": {
+          "0": {"x": 252, "y": 844},
+          "1": {"x": 228, "y": 816},
+          "2": {"x": 228, "y": 528},
+          "3": {"x": 252, "y": 556},
+          "4": {"x": 228, "y": 686},
+          "5": {"x": 228, "y": 686},
+          "6": {"x": 252, "y": 686}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 280,
+      "sourceNodeId": 148,
+      "sourcePortId": 595,
+      "targetNodeId": 133,
+      "targetPortId": 596,
+      "travelTime": {"lock": true, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 24,
+        "warning": null,
+        "consecutiveTime": 144
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 36,
+        "warning": null,
+        "consecutiveTime": 36
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 26,
+        "warning": null,
+        "consecutiveTime": 26
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 34,
+        "warning": null,
+        "consecutiveTime": 154
+      },
+      "numberOfStops": 3,
+      "trainrunId": 95,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 208, "y": 1918},
+          {"x": 208, "y": 1854},
+          {"x": 208, "y": 994},
+          {"x": 208, "y": 930}
+        ],
+        "textPositions": {
+          "0": {"x": 220, "y": 1900},
+          "1": {"x": 196, "y": 1872},
+          "2": {"x": 196, "y": 948},
+          "3": {"x": 220, "y": 976},
+          "4": {"x": 196, "y": 1424},
+          "5": {"x": 196, "y": 1424},
+          "6": {"x": 220, "y": 1424}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 281,
+      "sourceNodeId": 133,
+      "sourcePortId": 597,
+      "targetNodeId": 142,
+      "targetPortId": 598,
+      "travelTime": {"lock": true, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 35,
+        "warning": null,
+        "consecutiveTime": 155
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 25,
+        "warning": null,
+        "consecutiveTime": 25
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 15,
+        "warning": null,
+        "consecutiveTime": 15
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 45,
+        "warning": null,
+        "consecutiveTime": 165
+      },
+      "numberOfStops": 3,
+      "trainrunId": 95,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 208, "y": 862},
+          {"x": 208, "y": 798},
+          {"x": 208, "y": 574},
+          {"x": 208, "y": 510}
+        ],
+        "textPositions": {
+          "0": {"x": 220, "y": 844},
+          "1": {"x": 196, "y": 816},
+          "2": {"x": 196, "y": 528},
+          "3": {"x": 220, "y": 556},
+          "4": {"x": 196, "y": 686},
+          "5": {"x": 196, "y": 686},
+          "6": {"x": 220, "y": 686}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 282,
+      "sourceNodeId": 142,
+      "sourcePortId": 599,
+      "targetNodeId": 157,
+      "targetPortId": 600,
+      "travelTime": {"lock": true, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 6,
+        "warning": null,
+        "consecutiveTime": 126
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 54,
+        "warning": null,
+        "consecutiveTime": 54
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 44,
+        "warning": null,
+        "consecutiveTime": 44
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 16,
+        "warning": null,
+        "consecutiveTime": 136
+      },
+      "numberOfStops": 3,
+      "trainrunId": 94,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 290, "y": 464},
+          {"x": 354, "y": 464},
+          {"x": 926, "y": 336},
+          {"x": 990, "y": 336}
+        ],
+        "textPositions": {
+          "0": {"x": 308, "y": 476},
+          "1": {"x": 336, "y": 452},
+          "2": {"x": 972, "y": 324},
+          "3": {"x": 944, "y": 348},
+          "4": {"x": 640, "y": 388},
+          "5": {"x": 640, "y": 388},
+          "6": {"x": 640, "y": 412}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 283,
+      "sourceNodeId": 142,
+      "sourcePortId": 601,
+      "targetNodeId": 157,
+      "targetPortId": 602,
+      "travelTime": {"lock": true, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 46,
+        "warning": null,
+        "consecutiveTime": 166
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 14,
+        "warning": null,
+        "consecutiveTime": 14
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 4,
+        "warning": null,
+        "consecutiveTime": 4
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 56,
+        "warning": null,
+        "consecutiveTime": 176
+      },
+      "numberOfStops": 1,
+      "trainrunId": 95,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 290, "y": 432},
+          {"x": 354, "y": 432},
+          {"x": 926, "y": 304},
+          {"x": 990, "y": 304}
+        ],
+        "textPositions": {
+          "0": {"x": 308, "y": 444},
+          "1": {"x": 336, "y": 420},
+          "2": {"x": 972, "y": 292},
+          "3": {"x": 944, "y": 316},
+          "4": {"x": 640, "y": 356},
+          "5": {"x": 640, "y": 356},
+          "6": {"x": 640, "y": 380}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 284,
+      "sourceNodeId": 154,
+      "sourcePortId": 603,
+      "targetNodeId": 155,
+      "targetPortId": 604,
+      "travelTime": {"lock": true, "time": 10, "warning": null},
+      "sourceDeparture": {
+        "lock": false,
+        "time": 0,
+        "warning": null,
+        "consecutiveTime": 0
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 0,
+        "warning": null,
+        "consecutiveTime": 60
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 50,
+        "warning": null,
+        "consecutiveTime": 50
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 10,
+        "warning": null,
+        "consecutiveTime": 10
+      },
+      "numberOfStops": 0,
+      "trainrunId": 98,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2384, "y": 2430},
+          {"x": 2384, "y": 2494},
+          {"x": 2544, "y": 2494},
+          {"x": 2544, "y": 2558}
+        ],
+        "textPositions": {
+          "0": {"x": 2372, "y": 2448},
+          "1": {"x": 2396, "y": 2476},
+          "2": {"x": 2556, "y": 2540},
+          "3": {"x": 2532, "y": 2512},
+          "4": {"x": 2476, "y": 2494},
+          "5": {"x": 2476, "y": 2494},
+          "6": {"x": 2452, "y": 2494}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 415,
+      "sourceNodeId": 141,
+      "sourcePortId": 691,
+      "targetNodeId": 159,
+      "targetPortId": 692,
+      "travelTime": {
+        "time": 5,
+        "consecutiveTime": 1,
+        "lock": true,
+        "warning": null,
+        "timeFormatter": null
+      },
+      "sourceDeparture": {
+        "time": 29,
+        "consecutiveTime": 29,
+        "lock": false,
+        "warning": null,
+        "timeFormatter": null
+      },
+      "sourceArrival": {
+        "time": 31,
+        "consecutiveTime": 151,
+        "lock": false,
+        "warning": null,
+        "timeFormatter": null
+      },
+      "targetDeparture": {
+        "time": 26,
+        "consecutiveTime": 146,
+        "lock": false,
+        "warning": null,
+        "timeFormatter": null
+      },
+      "targetArrival": {
+        "time": 34,
+        "consecutiveTime": 34,
+        "lock": false,
+        "warning": null,
+        "timeFormatter": null
+      },
+      "numberOfStops": 0,
+      "trainrunId": 87,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1040, "y": 738},
+          {"x": 1040, "y": 802},
+          {"x": 1040, "y": 926},
+          {"x": 1040, "y": 990}
+        ],
+        "textPositions": {
+          "0": {"x": 1028, "y": 756},
+          "1": {"x": 1052, "y": 784},
+          "2": {"x": 1052, "y": 972},
+          "3": {"x": 1028, "y": 944},
+          "4": {"x": 1028, "y": 864},
+          "5": {"x": 1028, "y": 864},
+          "6": {"x": 1052, "y": 864}
+        }
+      },
+      "warnings": null
+    }
+  ],
+  "trainruns": [
+    {
+      "id": 83,
+      "name": "1",
+      "categoryId": 2,
+      "frequencyId": 2,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": []
+    },
+    {
+      "id": 84,
+      "name": "1",
+      "categoryId": 0,
+      "frequencyId": 4,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": []
+    },
+    {
+      "id": 85,
+      "name": "12",
+      "categoryId": 2,
+      "frequencyId": 2,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": []
+    },
+    {
+      "id": 86,
+      "name": "29",
+      "categoryId": 4,
+      "frequencyId": 2,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": []
+    },
+    {
+      "id": 87,
+      "name": "15",
+      "categoryId": 2,
+      "frequencyId": 3,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": []
+    },
+    {
+      "id": 88,
+      "name": "8",
+      "categoryId": 2,
+      "frequencyId": 3,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": []
+    },
+    {
+      "id": 89,
+      "name": "12",
+      "categoryId": 2,
+      "frequencyId": 3,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": []
+    },
+    {
+      "id": 90,
+      "name": "1",
+      "categoryId": 1,
+      "frequencyId": 3,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": []
+    },
+    {
+      "id": 91,
+      "name": "1",
+      "categoryId": 4,
+      "frequencyId": 0,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": []
+    },
+    {
+      "id": 92,
+      "name": "3",
+      "categoryId": 4,
+      "frequencyId": 3,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": []
+    },
+    {
+      "id": 93,
+      "name": "",
+      "categoryId": 3,
+      "frequencyId": 3,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": []
+    },
+    {
+      "id": 94,
+      "name": "7",
+      "categoryId": 4,
+      "frequencyId": 3,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": []
+    },
+    {
+      "id": 95,
+      "name": "6",
+      "categoryId": 4,
+      "frequencyId": 3,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": []
+    },
+    {
+      "id": 96,
+      "name": "77",
+      "categoryId": 4,
+      "frequencyId": 3,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": []
+    },
+    {
+      "id": 97,
+      "name": "",
+      "categoryId": 3,
+      "frequencyId": 3,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": []
+    },
+    {
+      "id": 98,
+      "name": "X",
+      "categoryId": 1,
+      "frequencyId": 3,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": []
+    }
+  ],
+  "resources": [
+    {"id": 151, "capacity": 2},
+    {"id": 152, "capacity": 2},
+    {"id": 153, "capacity": 2},
+    {"id": 154, "capacity": 2},
+    {"id": 155, "capacity": 2},
+    {"id": 156, "capacity": 2},
+    {"id": 157, "capacity": 2},
+    {"id": 158, "capacity": 2},
+    {"id": 159, "capacity": 2},
+    {"id": 160, "capacity": 2},
+    {"id": 161, "capacity": 2},
+    {"id": 162, "capacity": 2},
+    {"id": 163, "capacity": 2},
+    {"id": 164, "capacity": 2},
+    {"id": 165, "capacity": 2},
+    {"id": 166, "capacity": 2},
+    {"id": 167, "capacity": 2},
+    {"id": 168, "capacity": 2},
+    {"id": 169, "capacity": 2},
+    {"id": 170, "capacity": 2},
+    {"id": 171, "capacity": 2},
+    {"id": 172, "capacity": 2},
+    {"id": 173, "capacity": 2},
+    {"id": 174, "capacity": 2},
+    {"id": 175, "capacity": 2},
+    {"id": 176, "capacity": 2},
+    {"id": 177, "capacity": 2},
+    {"id": 178, "capacity": 2},
+    {"id": 179, "capacity": 2},
+    {"id": 180, "capacity": 2},
+    {"id": 181, "capacity": 2},
+    {"id": 182, "capacity": 2},
+    {"id": 183, "capacity": 2},
+    {"id": 184, "capacity": 2},
+    {"id": 185, "capacity": 2},
+    {"id": 186, "capacity": 2},
+    {"id": 187, "capacity": 2},
+    {"id": 188, "capacity": 2},
+    {"id": 189, "capacity": 2},
+    {"id": 190, "capacity": 2}
+  ],
+  "metadata": {
+    "netzgrafikColors": [],
+    "trainrunCategories": [
+      {
+        "id": 0,
+        "name": "International",
+        "order": 0,
+        "colorRef": "EC",
+        "shortName": "EC",
+        "fachCategory": "HaltezeitIPV",
+        "sectionHeadway": 2,
+        "nodeHeadwayStop": 2,
+        "nodeHeadwayNonStop": 2,
+        "minimalTurnaroundTime": 4
+      },
+      {
+        "id": 1,
+        "name": "InterCity",
+        "order": 1,
+        "colorRef": "IC",
+        "shortName": "IC",
+        "fachCategory": "HaltezeitA",
+        "sectionHeadway": 2,
+        "nodeHeadwayStop": 2,
+        "nodeHeadwayNonStop": 2,
+        "minimalTurnaroundTime": 4
+      },
+      {
+        "id": 2,
+        "name": "InterRegio",
+        "order": 2,
+        "colorRef": "IR",
+        "shortName": "IR",
+        "fachCategory": "HaltezeitB",
+        "sectionHeadway": 2,
+        "nodeHeadwayStop": 2,
+        "nodeHeadwayNonStop": 2,
+        "minimalTurnaroundTime": 4
+      },
+      {
+        "id": 3,
+        "name": "RegioExpress",
+        "order": 3,
+        "colorRef": "RE",
+        "shortName": "RE",
+        "fachCategory": "HaltezeitC",
+        "sectionHeadway": 2,
+        "nodeHeadwayStop": 2,
+        "nodeHeadwayNonStop": 2,
+        "minimalTurnaroundTime": 4
+      },
+      {
+        "id": 4,
+        "name": "RegioUndSBahnverkehr",
+        "order": 4,
+        "colorRef": "S",
+        "shortName": "S",
+        "fachCategory": "HaltezeitD",
+        "sectionHeadway": 2,
+        "nodeHeadwayStop": 2,
+        "nodeHeadwayNonStop": 2,
+        "minimalTurnaroundTime": 4
+      },
+      {
+        "id": 5,
+        "name": "GüterExpress",
+        "order": 5,
+        "colorRef": "GEX",
+        "shortName": "GEX",
+        "fachCategory": "HaltezeitUncategorized",
+        "sectionHeadway": 3,
+        "nodeHeadwayStop": 3,
+        "nodeHeadwayNonStop": 3,
+        "minimalTurnaroundTime": 4
+      },
+      {
+        "id": 6,
+        "name": "Güterverkehr",
+        "order": 6,
+        "colorRef": "G",
+        "shortName": "G",
+        "fachCategory": "HaltezeitUncategorized",
+        "sectionHeadway": 3,
+        "nodeHeadwayStop": 3,
+        "nodeHeadwayNonStop": 3,
+        "minimalTurnaroundTime": 4
+      }
+    ],
+    "trainrunFrequencies": [
+      {
+        "id": 0,
+        "name": "verkehrt viertelstündlich",
+        "order": 0,
+        "offset": 0,
+        "frequency": 15,
+        "shortName": "15",
+        "linePatternRef": "15"
+      },
+      {
+        "id": 1,
+        "name": "verkehrt im 20 Minuten Takt",
+        "order": 0,
+        "offset": 0,
+        "frequency": 20,
+        "shortName": "20",
+        "linePatternRef": "20"
+      },
+      {
+        "id": 2,
+        "name": "verkehrt halbstündlich",
+        "order": 0,
+        "offset": 0,
+        "frequency": 30,
+        "shortName": "30",
+        "linePatternRef": "30"
+      },
+      {
+        "id": 3,
+        "name": "verkehrt stündlich",
+        "order": 0,
+        "offset": 0,
+        "frequency": 60,
+        "shortName": "60",
+        "linePatternRef": "60"
+      },
+      {
+        "id": 4,
+        "name": "verkehrt zweistündlich (gerade)",
+        "order": 0,
+        "offset": 0,
+        "frequency": 120,
+        "shortName": "120",
+        "linePatternRef": "120"
+      },
+      {
+        "id": 5,
+        "name": "verkehrt zweistündlich (ungerade)",
+        "order": 0,
+        "offset": 60,
+        "frequency": 120,
+        "shortName": "120+",
+        "linePatternRef": "120"
+      }
+    ],
+    "trainrunTimeCategories": [
+      {
+        "id": 0,
+        "name": "verkehrt uneingeschränkt",
+        "order": 0,
+        "weekday": [1, 2, 3, 4, 5, 6, 7],
+        "shortName": "7/24",
+        "linePatternRef": "7/24",
+        "dayTimeInterval": []
+      },
+      {
+        "id": 1,
+        "name": "verkehrt zur Hauptverkehrszeit",
+        "order": 0,
+        "weekday": [1, 2, 3, 4, 5, 6, 7],
+        "shortName": "HVZ",
+        "linePatternRef": "HVZ",
+        "dayTimeInterval": [
+          {"to": 420, "from": 360},
+          {"to": 1140, "from": 960}
+        ]
+      },
+      {
+        "id": 2,
+        "name": "verkehrt zeitweise",
+        "order": 0,
+        "weekday": [],
+        "shortName": "zeitweise",
+        "linePatternRef": "ZEITWEISE",
+        "dayTimeInterval": []
+      }
+    ]
+  },
+  "freeFloatingTexts": [],
+  "labels": [],
+  "labelGroups": [],
+  "filterData": {"filterSettings": []}
+}

--- a/src/app/sample-netzgrafik/Demo_Netzgrafik_Fernverkehr_2024.json
+++ b/src/app/sample-netzgrafik/Demo_Netzgrafik_Fernverkehr_2024.json
@@ -1,1 +1,18054 @@
-{"nodes":[{"id":128,"betriebspunktName":"Lausanne","fullName":"Lausanne","positionX":-3072,"positionY":544,"ports":[{"id":1207,"trainrunSectionId":596,"positionIndex":0,"positionAlignment":2},{"id":1187,"trainrunSectionId":586,"positionIndex":1,"positionAlignment":2},{"id":1382,"trainrunSectionId":683,"positionIndex":0,"positionAlignment":3},{"id":1380,"trainrunSectionId":682,"positionIndex":1,"positionAlignment":3}],"transitions":[{"id":345,"port1Id":1187,"port2Id":1380,"isNonStopTransit":false},{"id":347,"port1Id":1207,"port2Id":1382,"isNonStopTransit":false}],"connections":[],"resourceId":152,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":129,"betriebspunktName":"Bern","fullName":"Bern","positionX":-2144,"positionY":128,"ports":[{"id":1328,"trainrunSectionId":656,"positionIndex":0,"positionAlignment":1},{"id":1311,"trainrunSectionId":648,"positionIndex":1,"positionAlignment":1},{"id":1313,"trainrunSectionId":649,"positionIndex":2,"positionAlignment":1},{"id":1339,"trainrunSectionId":662,"positionIndex":3,"positionAlignment":1},{"id":1205,"trainrunSectionId":595,"positionIndex":0,"positionAlignment":2},{"id":1109,"trainrunSectionId":547,"positionIndex":1,"positionAlignment":2},{"id":1440,"trainrunSectionId":712,"positionIndex":0,"positionAlignment":3},{"id":1329,"trainrunSectionId":657,"positionIndex":1,"positionAlignment":3},{"id":1436,"trainrunSectionId":710,"positionIndex":2,"positionAlignment":3},{"id":1434,"trainrunSectionId":709,"positionIndex":3,"positionAlignment":3},{"id":1432,"trainrunSectionId":708,"positionIndex":4,"positionAlignment":3},{"id":1430,"trainrunSectionId":707,"positionIndex":5,"positionAlignment":3},{"id":1428,"trainrunSectionId":706,"positionIndex":6,"positionAlignment":3}],"transitions":[{"id":315,"port1Id":1328,"port2Id":1329,"isNonStopTransit":false},{"id":376,"port1Id":1109,"port2Id":1430,"isNonStopTransit":false},{"id":378,"port1Id":1339,"port2Id":1432,"isNonStopTransit":false},{"id":380,"port1Id":1313,"port2Id":1434,"isNonStopTransit":false},{"id":382,"port1Id":1311,"port2Id":1436,"isNonStopTransit":false},{"id":386,"port1Id":1205,"port2Id":1440,"isNonStopTransit":false}],"connections":[],"resourceId":153,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":130,"betriebspunktName":"Biel","fullName":"Biel","positionX":-2528,"positionY":-32,"ports":[{"id":1183,"trainrunSectionId":584,"positionIndex":0,"positionAlignment":2},{"id":1418,"trainrunSectionId":701,"positionIndex":0,"positionAlignment":3}],"transitions":[{"id":366,"port1Id":1183,"port2Id":1418,"isNonStopTransit":false}],"connections":[],"resourceId":154,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":131,"betriebspunktName":"Interlaken ","fullName":"Interlaken Ost","positionX":-1088,"positionY":928,"ports":[{"id":1318,"trainrunSectionId":651,"positionIndex":0,"positionAlignment":2},{"id":1344,"trainrunSectionId":664,"positionIndex":1,"positionAlignment":2}],"transitions":[],"connections":[],"resourceId":155,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":132,"betriebspunktName":"Visp","fullName":"Visp","positionX":-2144,"positionY":1440,"ports":[{"id":1323,"trainrunSectionId":654,"positionIndex":0,"positionAlignment":0},{"id":1322,"trainrunSectionId":653,"positionIndex":1,"positionAlignment":0}],"transitions":[],"connections":[],"resourceId":156,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":133,"betriebspunktName":"Olten","fullName":"Olten","positionX":64,"positionY":96,"ports":[{"id":1047,"trainrunSectionId":516,"positionIndex":0,"positionAlignment":0},{"id":1331,"trainrunSectionId":658,"positionIndex":1,"positionAlignment":0},{"id":1308,"trainrunSectionId":646,"positionIndex":2,"positionAlignment":0},{"id":1371,"trainrunSectionId":678,"positionIndex":3,"positionAlignment":0},{"id":1131,"trainrunSectionId":558,"positionIndex":4,"positionAlignment":0},{"id":1117,"trainrunSectionId":551,"positionIndex":5,"positionAlignment":0},{"id":1046,"trainrunSectionId":515,"positionIndex":0,"positionAlignment":1},{"id":1370,"trainrunSectionId":677,"positionIndex":1,"positionAlignment":1},{"id":1130,"trainrunSectionId":557,"positionIndex":2,"positionAlignment":1},{"id":1116,"trainrunSectionId":550,"positionIndex":3,"positionAlignment":1},{"id":1181,"trainrunSectionId":583,"positionIndex":0,"positionAlignment":2},{"id":1203,"trainrunSectionId":594,"positionIndex":1,"positionAlignment":2},{"id":1394,"trainrunSectionId":689,"positionIndex":2,"positionAlignment":2},{"id":1309,"trainrunSectionId":647,"positionIndex":3,"positionAlignment":2},{"id":1225,"trainrunSectionId":605,"positionIndex":4,"positionAlignment":2},{"id":1241,"trainrunSectionId":613,"positionIndex":5,"positionAlignment":2},{"id":1165,"trainrunSectionId":575,"positionIndex":6,"positionAlignment":2},{"id":1202,"trainrunSectionId":593,"positionIndex":0,"positionAlignment":3},{"id":1180,"trainrunSectionId":582,"positionIndex":1,"positionAlignment":3},{"id":1224,"trainrunSectionId":604,"positionIndex":2,"positionAlignment":3},{"id":1240,"trainrunSectionId":612,"positionIndex":3,"positionAlignment":3},{"id":1164,"trainrunSectionId":574,"positionIndex":4,"positionAlignment":3}],"transitions":[{"id":210,"port1Id":1047,"port2Id":1046,"isNonStopTransit":false},{"id":236,"port1Id":1117,"port2Id":1116,"isNonStopTransit":false},{"id":242,"port1Id":1131,"port2Id":1130,"isNonStopTransit":false},{"id":253,"port1Id":1165,"port2Id":1164,"isNonStopTransit":false},{"id":259,"port1Id":1181,"port2Id":1180,"isNonStopTransit":false},{"id":264,"port1Id":1203,"port2Id":1202,"isNonStopTransit":true},{"id":270,"port1Id":1225,"port2Id":1224,"isNonStopTransit":true},{"id":276,"port1Id":1241,"port2Id":1240,"isNonStopTransit":true},{"id":308,"port1Id":1308,"port2Id":1309,"isNonStopTransit":false},{"id":340,"port1Id":1371,"port2Id":1370,"isNonStopTransit":false},{"id":353,"port1Id":1331,"port2Id":1394,"isNonStopTransit":false}],"connections":[],"resourceId":157,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":134,"betriebspunktName":"Basel","fullName":"Basel","positionX":64,"positionY":-1888,"ports":[{"id":1054,"trainrunSectionId":519,"positionIndex":0,"positionAlignment":1},{"id":1416,"trainrunSectionId":700,"positionIndex":1,"positionAlignment":1},{"id":1277,"trainrunSectionId":631,"positionIndex":2,"positionAlignment":1},{"id":1338,"trainrunSectionId":661,"positionIndex":3,"positionAlignment":1},{"id":1301,"trainrunSectionId":643,"positionIndex":4,"positionAlignment":1},{"id":1378,"trainrunSectionId":681,"positionIndex":5,"positionAlignment":1},{"id":1138,"trainrunSectionId":561,"positionIndex":6,"positionAlignment":1},{"id":1124,"trainrunSectionId":554,"positionIndex":7,"positionAlignment":1},{"id":1267,"trainrunSectionId":626,"positionIndex":0,"positionAlignment":3}],"transitions":[],"connections":[],"resourceId":158,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":135,"betriebspunktName":"Zürich","fullName":"Zürich","positionX":2656,"positionY":32,"ports":[{"id":1255,"trainrunSectionId":620,"positionIndex":0,"positionAlignment":0},{"id":1254,"trainrunSectionId":619,"positionIndex":1,"positionAlignment":0},{"id":1360,"trainrunSectionId":672,"positionIndex":0,"positionAlignment":1},{"id":1149,"trainrunSectionId":567,"positionIndex":1,"positionAlignment":1},{"id":1153,"trainrunSectionId":569,"positionIndex":2,"positionAlignment":1},{"id":1358,"trainrunSectionId":671,"positionIndex":3,"positionAlignment":1},{"id":1356,"trainrunSectionId":670,"positionIndex":4,"positionAlignment":1},{"id":1354,"trainrunSectionId":669,"positionIndex":5,"positionAlignment":1},{"id":1195,"trainrunSectionId":590,"positionIndex":0,"positionAlignment":2},{"id":1401,"trainrunSectionId":693,"positionIndex":1,"positionAlignment":2},{"id":1292,"trainrunSectionId":638,"positionIndex":2,"positionAlignment":2},{"id":1173,"trainrunSectionId":579,"positionIndex":3,"positionAlignment":2},{"id":1217,"trainrunSectionId":601,"positionIndex":4,"positionAlignment":2},{"id":1233,"trainrunSectionId":609,"positionIndex":5,"positionAlignment":2},{"id":1157,"trainrunSectionId":571,"positionIndex":6,"positionAlignment":2},{"id":1276,"trainrunSectionId":630,"positionIndex":7,"positionAlignment":2},{"id":1300,"trainrunSectionId":642,"positionIndex":8,"positionAlignment":2},{"id":1191,"trainrunSectionId":588,"positionIndex":0,"positionAlignment":3},{"id":1172,"trainrunSectionId":578,"positionIndex":1,"positionAlignment":3},{"id":1213,"trainrunSectionId":599,"positionIndex":2,"positionAlignment":3},{"id":1229,"trainrunSectionId":607,"positionIndex":3,"positionAlignment":3},{"id":1139,"trainrunSectionId":562,"positionIndex":4,"positionAlignment":3},{"id":1245,"trainrunSectionId":615,"positionIndex":5,"positionAlignment":3}],"transitions":[{"id":250,"port1Id":1153,"port2Id":1157,"isNonStopTransit":false},{"id":256,"port1Id":1173,"port2Id":1172,"isNonStopTransit":false},{"id":261,"port1Id":1195,"port2Id":1191,"isNonStopTransit":false},{"id":267,"port1Id":1217,"port2Id":1213,"isNonStopTransit":false},{"id":273,"port1Id":1233,"port2Id":1229,"isNonStopTransit":false},{"id":329,"port1Id":1354,"port2Id":1245,"isNonStopTransit":false},{"id":357,"port1Id":1149,"port2Id":1401,"isNonStopTransit":false}],"connections":[],"resourceId":159,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":136,"betriebspunktName":"Bellinz.","fullName":"Bellinzona","positionX":2592,"positionY":3232,"ports":[{"id":1059,"trainrunSectionId":522,"positionIndex":0,"positionAlignment":0},{"id":1035,"trainrunSectionId":510,"positionIndex":1,"positionAlignment":0},{"id":1071,"trainrunSectionId":528,"positionIndex":2,"positionAlignment":0},{"id":1083,"trainrunSectionId":534,"positionIndex":3,"positionAlignment":0},{"id":1058,"trainrunSectionId":521,"positionIndex":0,"positionAlignment":1},{"id":1034,"trainrunSectionId":509,"positionIndex":1,"positionAlignment":1},{"id":1070,"trainrunSectionId":527,"positionIndex":0,"positionAlignment":2},{"id":1082,"trainrunSectionId":533,"positionIndex":1,"positionAlignment":2}],"transitions":[{"id":206,"port1Id":1035,"port2Id":1034,"isNonStopTransit":false},{"id":216,"port1Id":1059,"port2Id":1058,"isNonStopTransit":false},{"id":221,"port1Id":1071,"port2Id":1070,"isNonStopTransit":false},{"id":226,"port1Id":1083,"port2Id":1082,"isNonStopTransit":false}],"connections":[],"resourceId":160,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":137,"betriebspunktName":"St. Gallen","fullName":"Sankt Gallen","positionX":4640,"positionY":96,"ports":[{"id":1145,"trainrunSectionId":565,"positionIndex":0,"positionAlignment":1},{"id":1212,"trainrunSectionId":598,"positionIndex":0,"positionAlignment":2},{"id":1167,"trainrunSectionId":576,"positionIndex":1,"positionAlignment":2},{"id":1144,"trainrunSectionId":564,"positionIndex":2,"positionAlignment":2},{"id":1419,"trainrunSectionId":702,"positionIndex":0,"positionAlignment":3}],"transitions":[{"id":248,"port1Id":1145,"port2Id":1144,"isNonStopTransit":false},{"id":367,"port1Id":1167,"port2Id":1419,"isNonStopTransit":false}],"connections":[],"resourceId":161,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":138,"betriebspunktName":"Schaffh.","fullName":"Schaffhausen","positionX":2624,"positionY":-1120,"ports":[{"id":1256,"trainrunSectionId":620,"positionIndex":0,"positionAlignment":1},{"id":1251,"trainrunSectionId":618,"positionIndex":1,"positionAlignment":1}],"transitions":[],"connections":[],"resourceId":162,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":139,"betriebspunktName":"Konstanz","fullName":"Konstanz","positionX":4256,"positionY":-416,"ports":[{"id":1250,"trainrunSectionId":617,"positionIndex":0,"positionAlignment":1}],"transitions":[],"connections":[],"resourceId":163,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":140,"betriebspunktName":"Sargans","fullName":"Sargans","positionX":4640,"positionY":1184,"ports":[{"id":1146,"trainrunSectionId":565,"positionIndex":0,"positionAlignment":0},{"id":1151,"trainrunSectionId":568,"positionIndex":0,"positionAlignment":1},{"id":1147,"trainrunSectionId":566,"positionIndex":1,"positionAlignment":1},{"id":1155,"trainrunSectionId":570,"positionIndex":2,"positionAlignment":1},{"id":1362,"trainrunSectionId":673,"positionIndex":0,"positionAlignment":2},{"id":1364,"trainrunSectionId":674,"positionIndex":1,"positionAlignment":2}],"transitions":[{"id":249,"port1Id":1146,"port2Id":1147,"isNonStopTransit":false},{"id":334,"port1Id":1151,"port2Id":1362,"isNonStopTransit":false},{"id":336,"port1Id":1155,"port2Id":1364,"isNonStopTransit":false}],"connections":[],"resourceId":164,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":141,"betriebspunktName":"Sursee","fullName":"Sursee","positionX":64,"positionY":1184,"ports":[{"id":1043,"trainrunSectionId":514,"positionIndex":0,"positionAlignment":0},{"id":1105,"trainrunSectionId":545,"positionIndex":1,"positionAlignment":0},{"id":1367,"trainrunSectionId":676,"positionIndex":2,"positionAlignment":0},{"id":1127,"trainrunSectionId":556,"positionIndex":3,"positionAlignment":0},{"id":1113,"trainrunSectionId":549,"positionIndex":4,"positionAlignment":0},{"id":1042,"trainrunSectionId":513,"positionIndex":0,"positionAlignment":1},{"id":1104,"trainrunSectionId":544,"positionIndex":1,"positionAlignment":1},{"id":1366,"trainrunSectionId":675,"positionIndex":2,"positionAlignment":1},{"id":1126,"trainrunSectionId":555,"positionIndex":3,"positionAlignment":1},{"id":1112,"trainrunSectionId":548,"positionIndex":4,"positionAlignment":1}],"transitions":[{"id":208,"port1Id":1043,"port2Id":1042,"isNonStopTransit":true},{"id":232,"port1Id":1105,"port2Id":1104,"isNonStopTransit":false},{"id":234,"port1Id":1113,"port2Id":1112,"isNonStopTransit":false},{"id":240,"port1Id":1127,"port2Id":1126,"isNonStopTransit":true},{"id":338,"port1Id":1367,"port2Id":1366,"isNonStopTransit":true}],"connections":[],"resourceId":165,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":142,"betriebspunktName":"Luzern","fullName":"Luzern","positionX":64,"positionY":1728,"ports":[{"id":1041,"trainrunSectionId":513,"positionIndex":0,"positionAlignment":0},{"id":1103,"trainrunSectionId":544,"positionIndex":1,"positionAlignment":0},{"id":1365,"trainrunSectionId":675,"positionIndex":2,"positionAlignment":0},{"id":1125,"trainrunSectionId":555,"positionIndex":3,"positionAlignment":0},{"id":1111,"trainrunSectionId":548,"positionIndex":4,"positionAlignment":0},{"id":1352,"trainrunSectionId":668,"positionIndex":0,"positionAlignment":3},{"id":1350,"trainrunSectionId":667,"positionIndex":1,"positionAlignment":3},{"id":1099,"trainrunSectionId":542,"positionIndex":2,"positionAlignment":3},{"id":1095,"trainrunSectionId":540,"positionIndex":3,"positionAlignment":3}],"transitions":[{"id":327,"port1Id":1041,"port2Id":1352,"isNonStopTransit":false},{"id":337,"port1Id":1365,"port2Id":1350,"isNonStopTransit":false}],"connections":[],"resourceId":166,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":143,"betriebspunktName":"Zofingen","fullName":"Zofingen","positionX":64,"positionY":736,"ports":[{"id":1045,"trainrunSectionId":515,"positionIndex":0,"positionAlignment":0},{"id":1369,"trainrunSectionId":677,"positionIndex":1,"positionAlignment":0},{"id":1129,"trainrunSectionId":557,"positionIndex":2,"positionAlignment":0},{"id":1115,"trainrunSectionId":550,"positionIndex":3,"positionAlignment":0},{"id":1044,"trainrunSectionId":514,"positionIndex":0,"positionAlignment":1},{"id":1106,"trainrunSectionId":545,"positionIndex":1,"positionAlignment":1},{"id":1368,"trainrunSectionId":676,"positionIndex":2,"positionAlignment":1},{"id":1128,"trainrunSectionId":556,"positionIndex":3,"positionAlignment":1},{"id":1114,"trainrunSectionId":549,"positionIndex":4,"positionAlignment":1},{"id":1107,"trainrunSectionId":546,"positionIndex":0,"positionAlignment":2}],"transitions":[{"id":209,"port1Id":1045,"port2Id":1044,"isNonStopTransit":true},{"id":233,"port1Id":1107,"port2Id":1106,"isNonStopTransit":false},{"id":235,"port1Id":1115,"port2Id":1114,"isNonStopTransit":false},{"id":241,"port1Id":1129,"port2Id":1128,"isNonStopTransit":true},{"id":339,"port1Id":1369,"port2Id":1368,"isNonStopTransit":false}],"connections":[],"resourceId":167,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":144,"betriebspunktName":"Gelterk.","fullName":"Gelterkinden","positionX":64,"positionY":-448,"ports":[{"id":1049,"trainrunSectionId":517,"positionIndex":0,"positionAlignment":0},{"id":1411,"trainrunSectionId":698,"positionIndex":1,"positionAlignment":0},{"id":1282,"trainrunSectionId":633,"positionIndex":2,"positionAlignment":0},{"id":1333,"trainrunSectionId":659,"positionIndex":3,"positionAlignment":0},{"id":1306,"trainrunSectionId":645,"positionIndex":4,"positionAlignment":0},{"id":1373,"trainrunSectionId":679,"positionIndex":5,"positionAlignment":0},{"id":1133,"trainrunSectionId":559,"positionIndex":6,"positionAlignment":0},{"id":1119,"trainrunSectionId":552,"positionIndex":7,"positionAlignment":0},{"id":1048,"trainrunSectionId":516,"positionIndex":0,"positionAlignment":1},{"id":1332,"trainrunSectionId":658,"positionIndex":1,"positionAlignment":1},{"id":1307,"trainrunSectionId":646,"positionIndex":2,"positionAlignment":1},{"id":1372,"trainrunSectionId":678,"positionIndex":3,"positionAlignment":1},{"id":1132,"trainrunSectionId":558,"positionIndex":4,"positionAlignment":1},{"id":1118,"trainrunSectionId":551,"positionIndex":5,"positionAlignment":1},{"id":1410,"trainrunSectionId":697,"positionIndex":0,"positionAlignment":3},{"id":1283,"trainrunSectionId":634,"positionIndex":1,"positionAlignment":3}],"transitions":[{"id":211,"port1Id":1049,"port2Id":1048,"isNonStopTransit":true},{"id":237,"port1Id":1119,"port2Id":1118,"isNonStopTransit":false},{"id":243,"port1Id":1133,"port2Id":1132,"isNonStopTransit":true},{"id":297,"port1Id":1282,"port2Id":1283,"isNonStopTransit":true},{"id":307,"port1Id":1306,"port2Id":1307,"isNonStopTransit":true},{"id":316,"port1Id":1333,"port2Id":1332,"isNonStopTransit":true},{"id":341,"port1Id":1373,"port2Id":1372,"isNonStopTransit":true},{"id":362,"port1Id":1411,"port2Id":1410,"isNonStopTransit":true}],"connections":[],"resourceId":168,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":145,"betriebspunktName":"Sissach","fullName":"Sissach","positionX":64,"positionY":-928,"ports":[{"id":1051,"trainrunSectionId":518,"positionIndex":0,"positionAlignment":0},{"id":1413,"trainrunSectionId":699,"positionIndex":1,"positionAlignment":0},{"id":1280,"trainrunSectionId":632,"positionIndex":2,"positionAlignment":0},{"id":1335,"trainrunSectionId":660,"positionIndex":3,"positionAlignment":0},{"id":1304,"trainrunSectionId":644,"positionIndex":4,"positionAlignment":0},{"id":1375,"trainrunSectionId":680,"positionIndex":5,"positionAlignment":0},{"id":1135,"trainrunSectionId":560,"positionIndex":6,"positionAlignment":0},{"id":1121,"trainrunSectionId":553,"positionIndex":7,"positionAlignment":0},{"id":1050,"trainrunSectionId":517,"positionIndex":0,"positionAlignment":1},{"id":1412,"trainrunSectionId":698,"positionIndex":1,"positionAlignment":1},{"id":1281,"trainrunSectionId":633,"positionIndex":2,"positionAlignment":1},{"id":1334,"trainrunSectionId":659,"positionIndex":3,"positionAlignment":1},{"id":1305,"trainrunSectionId":645,"positionIndex":4,"positionAlignment":1},{"id":1374,"trainrunSectionId":679,"positionIndex":5,"positionAlignment":1},{"id":1134,"trainrunSectionId":559,"positionIndex":6,"positionAlignment":1},{"id":1120,"trainrunSectionId":552,"positionIndex":7,"positionAlignment":1}],"transitions":[{"id":212,"port1Id":1051,"port2Id":1050,"isNonStopTransit":true},{"id":238,"port1Id":1121,"port2Id":1120,"isNonStopTransit":false},{"id":244,"port1Id":1135,"port2Id":1134,"isNonStopTransit":true},{"id":296,"port1Id":1280,"port2Id":1281,"isNonStopTransit":true},{"id":306,"port1Id":1304,"port2Id":1305,"isNonStopTransit":true},{"id":317,"port1Id":1335,"port2Id":1334,"isNonStopTransit":true},{"id":342,"port1Id":1375,"port2Id":1374,"isNonStopTransit":true},{"id":363,"port1Id":1413,"port2Id":1412,"isNonStopTransit":true}],"connections":[],"resourceId":169,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":146,"betriebspunktName":"Liestal","fullName":"Liestal","positionX":64,"positionY":-1408,"ports":[{"id":1053,"trainrunSectionId":519,"positionIndex":0,"positionAlignment":0},{"id":1415,"trainrunSectionId":700,"positionIndex":1,"positionAlignment":0},{"id":1278,"trainrunSectionId":631,"positionIndex":2,"positionAlignment":0},{"id":1337,"trainrunSectionId":661,"positionIndex":3,"positionAlignment":0},{"id":1302,"trainrunSectionId":643,"positionIndex":4,"positionAlignment":0},{"id":1377,"trainrunSectionId":681,"positionIndex":5,"positionAlignment":0},{"id":1137,"trainrunSectionId":561,"positionIndex":6,"positionAlignment":0},{"id":1123,"trainrunSectionId":554,"positionIndex":7,"positionAlignment":0},{"id":1052,"trainrunSectionId":518,"positionIndex":0,"positionAlignment":1},{"id":1414,"trainrunSectionId":699,"positionIndex":1,"positionAlignment":1},{"id":1279,"trainrunSectionId":632,"positionIndex":2,"positionAlignment":1},{"id":1336,"trainrunSectionId":660,"positionIndex":3,"positionAlignment":1},{"id":1303,"trainrunSectionId":644,"positionIndex":4,"positionAlignment":1},{"id":1376,"trainrunSectionId":680,"positionIndex":5,"positionAlignment":1},{"id":1136,"trainrunSectionId":560,"positionIndex":6,"positionAlignment":1},{"id":1122,"trainrunSectionId":553,"positionIndex":7,"positionAlignment":1}],"transitions":[{"id":213,"port1Id":1053,"port2Id":1052,"isNonStopTransit":true},{"id":239,"port1Id":1123,"port2Id":1122,"isNonStopTransit":false},{"id":245,"port1Id":1137,"port2Id":1136,"isNonStopTransit":true},{"id":295,"port1Id":1278,"port2Id":1279,"isNonStopTransit":true},{"id":305,"port1Id":1302,"port2Id":1303,"isNonStopTransit":true},{"id":318,"port1Id":1337,"port2Id":1336,"isNonStopTransit":true},{"id":343,"port1Id":1377,"port2Id":1376,"isNonStopTransit":true},{"id":364,"port1Id":1415,"port2Id":1414,"isNonStopTransit":true}],"connections":[],"resourceId":170,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":147,"betriebspunktName":"Aarau","fullName":"Aarau","positionX":960,"positionY":32,"ports":[{"id":1409,"trainrunSectionId":697,"positionIndex":0,"positionAlignment":2},{"id":1284,"trainrunSectionId":634,"positionIndex":1,"positionAlignment":2},{"id":1201,"trainrunSectionId":593,"positionIndex":2,"positionAlignment":2},{"id":1179,"trainrunSectionId":582,"positionIndex":3,"positionAlignment":2},{"id":1223,"trainrunSectionId":604,"positionIndex":4,"positionAlignment":2},{"id":1239,"trainrunSectionId":612,"positionIndex":5,"positionAlignment":2},{"id":1163,"trainrunSectionId":574,"positionIndex":6,"positionAlignment":2},{"id":1200,"trainrunSectionId":592,"positionIndex":0,"positionAlignment":3},{"id":1408,"trainrunSectionId":696,"positionIndex":1,"positionAlignment":3},{"id":1285,"trainrunSectionId":635,"positionIndex":2,"positionAlignment":3},{"id":1178,"trainrunSectionId":581,"positionIndex":3,"positionAlignment":3},{"id":1222,"trainrunSectionId":603,"positionIndex":4,"positionAlignment":3},{"id":1238,"trainrunSectionId":611,"positionIndex":5,"positionAlignment":3},{"id":1162,"trainrunSectionId":573,"positionIndex":6,"positionAlignment":3},{"id":1293,"trainrunSectionId":639,"positionIndex":7,"positionAlignment":3}],"transitions":[{"id":252,"port1Id":1163,"port2Id":1162,"isNonStopTransit":true},{"id":258,"port1Id":1179,"port2Id":1178,"isNonStopTransit":false},{"id":263,"port1Id":1201,"port2Id":1200,"isNonStopTransit":true},{"id":269,"port1Id":1223,"port2Id":1222,"isNonStopTransit":true},{"id":275,"port1Id":1239,"port2Id":1238,"isNonStopTransit":true},{"id":298,"port1Id":1284,"port2Id":1285,"isNonStopTransit":true},{"id":361,"port1Id":1409,"port2Id":1408,"isNonStopTransit":true}],"connections":[],"resourceId":171,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":148,"betriebspunktName":"Lenzburg","fullName":"Lenzburg","positionX":1344,"positionY":32,"ports":[{"id":1199,"trainrunSectionId":592,"positionIndex":0,"positionAlignment":2},{"id":1407,"trainrunSectionId":696,"positionIndex":1,"positionAlignment":2},{"id":1286,"trainrunSectionId":635,"positionIndex":2,"positionAlignment":2},{"id":1177,"trainrunSectionId":581,"positionIndex":3,"positionAlignment":2},{"id":1221,"trainrunSectionId":603,"positionIndex":4,"positionAlignment":2},{"id":1237,"trainrunSectionId":611,"positionIndex":5,"positionAlignment":2},{"id":1161,"trainrunSectionId":573,"positionIndex":6,"positionAlignment":2},{"id":1294,"trainrunSectionId":639,"positionIndex":7,"positionAlignment":2},{"id":1258,"trainrunSectionId":621,"positionIndex":0,"positionAlignment":3},{"id":1406,"trainrunSectionId":695,"positionIndex":1,"positionAlignment":3},{"id":1287,"trainrunSectionId":636,"positionIndex":2,"positionAlignment":3},{"id":1260,"trainrunSectionId":622,"positionIndex":3,"positionAlignment":3},{"id":1262,"trainrunSectionId":623,"positionIndex":4,"positionAlignment":3},{"id":1264,"trainrunSectionId":624,"positionIndex":5,"positionAlignment":3},{"id":1266,"trainrunSectionId":625,"positionIndex":6,"positionAlignment":3},{"id":1295,"trainrunSectionId":640,"positionIndex":7,"positionAlignment":3}],"transitions":[{"id":282,"port1Id":1199,"port2Id":1258,"isNonStopTransit":true},{"id":284,"port1Id":1177,"port2Id":1260,"isNonStopTransit":true},{"id":286,"port1Id":1221,"port2Id":1262,"isNonStopTransit":true},{"id":288,"port1Id":1237,"port2Id":1264,"isNonStopTransit":true},{"id":290,"port1Id":1161,"port2Id":1266,"isNonStopTransit":true},{"id":299,"port1Id":1286,"port2Id":1287,"isNonStopTransit":true},{"id":302,"port1Id":1294,"port2Id":1295,"isNonStopTransit":false},{"id":360,"port1Id":1407,"port2Id":1406,"isNonStopTransit":true}],"connections":[],"resourceId":172,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":149,"betriebspunktName":"Baden","fullName":"Baden","positionX":2240,"positionY":32,"ports":[{"id":1197,"trainrunSectionId":591,"positionIndex":0,"positionAlignment":2},{"id":1403,"trainrunSectionId":694,"positionIndex":1,"positionAlignment":2},{"id":1290,"trainrunSectionId":637,"positionIndex":2,"positionAlignment":2},{"id":1175,"trainrunSectionId":580,"positionIndex":3,"positionAlignment":2},{"id":1219,"trainrunSectionId":602,"positionIndex":4,"positionAlignment":2},{"id":1235,"trainrunSectionId":610,"positionIndex":5,"positionAlignment":2},{"id":1159,"trainrunSectionId":572,"positionIndex":6,"positionAlignment":2},{"id":1274,"trainrunSectionId":629,"positionIndex":7,"positionAlignment":2},{"id":1298,"trainrunSectionId":641,"positionIndex":8,"positionAlignment":2},{"id":1196,"trainrunSectionId":590,"positionIndex":0,"positionAlignment":3},{"id":1402,"trainrunSectionId":693,"positionIndex":1,"positionAlignment":3},{"id":1291,"trainrunSectionId":638,"positionIndex":2,"positionAlignment":3},{"id":1174,"trainrunSectionId":579,"positionIndex":3,"positionAlignment":3},{"id":1218,"trainrunSectionId":601,"positionIndex":4,"positionAlignment":3},{"id":1234,"trainrunSectionId":609,"positionIndex":5,"positionAlignment":3},{"id":1158,"trainrunSectionId":571,"positionIndex":6,"positionAlignment":3},{"id":1275,"trainrunSectionId":630,"positionIndex":7,"positionAlignment":3},{"id":1299,"trainrunSectionId":642,"positionIndex":8,"positionAlignment":3}],"transitions":[{"id":251,"port1Id":1159,"port2Id":1158,"isNonStopTransit":true},{"id":257,"port1Id":1175,"port2Id":1174,"isNonStopTransit":true},{"id":262,"port1Id":1197,"port2Id":1196,"isNonStopTransit":true},{"id":268,"port1Id":1219,"port2Id":1218,"isNonStopTransit":true},{"id":274,"port1Id":1235,"port2Id":1234,"isNonStopTransit":true},{"id":294,"port1Id":1274,"port2Id":1275,"isNonStopTransit":false},{"id":301,"port1Id":1290,"port2Id":1291,"isNonStopTransit":true},{"id":304,"port1Id":1298,"port2Id":1299,"isNonStopTransit":true},{"id":358,"port1Id":1403,"port2Id":1402,"isNonStopTransit":true}],"connections":[],"resourceId":173,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":150,"betriebspunktName":"Zürich ✈","fullName":"Zürich Flughafen","positionX":3296,"positionY":32,"ports":[{"id":1192,"trainrunSectionId":588,"positionIndex":0,"positionAlignment":2},{"id":1171,"trainrunSectionId":578,"positionIndex":1,"positionAlignment":2},{"id":1214,"trainrunSectionId":599,"positionIndex":2,"positionAlignment":2},{"id":1230,"trainrunSectionId":607,"positionIndex":3,"positionAlignment":2},{"id":1140,"trainrunSectionId":562,"positionIndex":4,"positionAlignment":2},{"id":1246,"trainrunSectionId":615,"positionIndex":5,"positionAlignment":2},{"id":1193,"trainrunSectionId":589,"positionIndex":0,"positionAlignment":3},{"id":1170,"trainrunSectionId":577,"positionIndex":1,"positionAlignment":3},{"id":1215,"trainrunSectionId":600,"positionIndex":2,"positionAlignment":3},{"id":1231,"trainrunSectionId":608,"positionIndex":3,"positionAlignment":3},{"id":1141,"trainrunSectionId":563,"positionIndex":4,"positionAlignment":3},{"id":1247,"trainrunSectionId":616,"positionIndex":5,"positionAlignment":3}],"transitions":[{"id":246,"port1Id":1140,"port2Id":1141,"isNonStopTransit":false},{"id":255,"port1Id":1171,"port2Id":1170,"isNonStopTransit":false},{"id":260,"port1Id":1192,"port2Id":1193,"isNonStopTransit":false},{"id":266,"port1Id":1214,"port2Id":1215,"isNonStopTransit":false},{"id":272,"port1Id":1230,"port2Id":1231,"isNonStopTransit":false},{"id":278,"port1Id":1246,"port2Id":1247,"isNonStopTransit":false}],"connections":[],"resourceId":174,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":151,"betriebspunktName":"Wintert.","fullName":"Winterthur","positionX":3872,"positionY":32,"ports":[{"id":1249,"trainrunSectionId":617,"positionIndex":0,"positionAlignment":0},{"id":1194,"trainrunSectionId":589,"positionIndex":0,"positionAlignment":2},{"id":1169,"trainrunSectionId":577,"positionIndex":1,"positionAlignment":2},{"id":1216,"trainrunSectionId":600,"positionIndex":2,"positionAlignment":2},{"id":1232,"trainrunSectionId":608,"positionIndex":3,"positionAlignment":2},{"id":1142,"trainrunSectionId":563,"positionIndex":4,"positionAlignment":2},{"id":1248,"trainrunSectionId":616,"positionIndex":5,"positionAlignment":2},{"id":1227,"trainrunSectionId":606,"positionIndex":0,"positionAlignment":3},{"id":1243,"trainrunSectionId":614,"positionIndex":1,"positionAlignment":3},{"id":1211,"trainrunSectionId":598,"positionIndex":2,"positionAlignment":3},{"id":1168,"trainrunSectionId":576,"positionIndex":3,"positionAlignment":3},{"id":1143,"trainrunSectionId":564,"positionIndex":4,"positionAlignment":3}],"transitions":[{"id":247,"port1Id":1142,"port2Id":1143,"isNonStopTransit":false},{"id":254,"port1Id":1169,"port2Id":1168,"isNonStopTransit":false},{"id":265,"port1Id":1194,"port2Id":1211,"isNonStopTransit":false},{"id":271,"port1Id":1216,"port2Id":1227,"isNonStopTransit":false},{"id":277,"port1Id":1232,"port2Id":1243,"isNonStopTransit":false},{"id":279,"port1Id":1249,"port2Id":1248,"isNonStopTransit":false}],"connections":[],"resourceId":175,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":152,"betriebspunktName":"Chur","fullName":"Chur","positionX":4640,"positionY":1888,"ports":[{"id":1152,"trainrunSectionId":568,"positionIndex":0,"positionAlignment":0},{"id":1148,"trainrunSectionId":566,"positionIndex":1,"positionAlignment":0},{"id":1156,"trainrunSectionId":570,"positionIndex":2,"positionAlignment":0}],"transitions":[],"connections":[],"resourceId":176,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":153,"betriebspunktName":"Zug","fullName":"Zug","positionX":2656,"positionY":1312,"ports":[{"id":1067,"trainrunSectionId":526,"positionIndex":0,"positionAlignment":0},{"id":1093,"trainrunSectionId":539,"positionIndex":1,"positionAlignment":0},{"id":1101,"trainrunSectionId":543,"positionIndex":2,"positionAlignment":0},{"id":1097,"trainrunSectionId":541,"positionIndex":3,"positionAlignment":0},{"id":1066,"trainrunSectionId":525,"positionIndex":0,"positionAlignment":1},{"id":1092,"trainrunSectionId":538,"positionIndex":1,"positionAlignment":1},{"id":1348,"trainrunSectionId":666,"positionIndex":0,"positionAlignment":2},{"id":1346,"trainrunSectionId":665,"positionIndex":1,"positionAlignment":2}],"transitions":[{"id":220,"port1Id":1067,"port2Id":1066,"isNonStopTransit":false},{"id":231,"port1Id":1093,"port2Id":1092,"isNonStopTransit":false},{"id":322,"port1Id":1097,"port2Id":1346,"isNonStopTransit":false},{"id":324,"port1Id":1101,"port2Id":1348,"isNonStopTransit":false}],"connections":[],"resourceId":177,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":154,"betriebspunktName":"Arth-G.","fullName":"Arth-Goldau","positionX":2656,"positionY":1792,"ports":[{"id":1065,"trainrunSectionId":525,"positionIndex":0,"positionAlignment":0},{"id":1091,"trainrunSectionId":538,"positionIndex":1,"positionAlignment":0},{"id":1064,"trainrunSectionId":524,"positionIndex":0,"positionAlignment":1},{"id":1038,"trainrunSectionId":511,"positionIndex":1,"positionAlignment":1},{"id":1078,"trainrunSectionId":531,"positionIndex":2,"positionAlignment":1},{"id":1090,"trainrunSectionId":537,"positionIndex":3,"positionAlignment":1},{"id":1039,"trainrunSectionId":512,"positionIndex":0,"positionAlignment":2},{"id":1079,"trainrunSectionId":532,"positionIndex":1,"positionAlignment":2}],"transitions":[{"id":207,"port1Id":1038,"port2Id":1039,"isNonStopTransit":false},{"id":219,"port1Id":1065,"port2Id":1064,"isNonStopTransit":false},{"id":225,"port1Id":1078,"port2Id":1079,"isNonStopTransit":false},{"id":230,"port1Id":1091,"port2Id":1090,"isNonStopTransit":false}],"connections":[],"resourceId":178,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":155,"betriebspunktName":"Altdorf","fullName":"Altdorf","positionX":2656,"positionY":2176,"ports":[{"id":1063,"trainrunSectionId":524,"positionIndex":0,"positionAlignment":0},{"id":1037,"trainrunSectionId":511,"positionIndex":1,"positionAlignment":0},{"id":1077,"trainrunSectionId":531,"positionIndex":2,"positionAlignment":0},{"id":1089,"trainrunSectionId":537,"positionIndex":3,"positionAlignment":0},{"id":1062,"trainrunSectionId":523,"positionIndex":0,"positionAlignment":1},{"id":1055,"trainrunSectionId":520,"positionIndex":1,"positionAlignment":1},{"id":1076,"trainrunSectionId":530,"positionIndex":0,"positionAlignment":2},{"id":1088,"trainrunSectionId":536,"positionIndex":1,"positionAlignment":2}],"transitions":[{"id":214,"port1Id":1037,"port2Id":1055,"isNonStopTransit":true},{"id":218,"port1Id":1063,"port2Id":1062,"isNonStopTransit":false},{"id":224,"port1Id":1077,"port2Id":1076,"isNonStopTransit":false},{"id":229,"port1Id":1089,"port2Id":1088,"isNonStopTransit":false}],"connections":[],"resourceId":179,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":156,"betriebspunktName":"Lugano","fullName":"Lugano","positionX":2592,"positionY":3712,"ports":[{"id":1057,"trainrunSectionId":521,"positionIndex":0,"positionAlignment":0},{"id":1033,"trainrunSectionId":509,"positionIndex":1,"positionAlignment":0}],"transitions":[],"connections":[],"resourceId":180,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":157,"betriebspunktName":"Locarno","fullName":"Locarno","positionX":2208,"positionY":3232,"ports":[{"id":1069,"trainrunSectionId":527,"positionIndex":0,"positionAlignment":3},{"id":1081,"trainrunSectionId":533,"positionIndex":1,"positionAlignment":3}],"transitions":[],"connections":[],"resourceId":181,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":158,"betriebspunktName":"Biasca","fullName":"Biasca","positionX":2592,"positionY":2688,"ports":[{"id":1073,"trainrunSectionId":529,"positionIndex":0,"positionAlignment":0},{"id":1085,"trainrunSectionId":535,"positionIndex":1,"positionAlignment":0},{"id":1061,"trainrunSectionId":523,"positionIndex":2,"positionAlignment":0},{"id":1056,"trainrunSectionId":520,"positionIndex":3,"positionAlignment":0},{"id":1060,"trainrunSectionId":522,"positionIndex":0,"positionAlignment":1},{"id":1036,"trainrunSectionId":510,"positionIndex":1,"positionAlignment":1},{"id":1072,"trainrunSectionId":528,"positionIndex":2,"positionAlignment":1},{"id":1084,"trainrunSectionId":534,"positionIndex":3,"positionAlignment":1}],"transitions":[{"id":215,"port1Id":1056,"port2Id":1036,"isNonStopTransit":true},{"id":217,"port1Id":1061,"port2Id":1060,"isNonStopTransit":true},{"id":222,"port1Id":1073,"port2Id":1072,"isNonStopTransit":false},{"id":227,"port1Id":1085,"port2Id":1084,"isNonStopTransit":false}],"connections":[],"resourceId":182,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":159,"betriebspunktName":"Göschn.","fullName":"Göschenen","positionX":2272,"positionY":2240,"ports":[{"id":1074,"trainrunSectionId":529,"positionIndex":0,"positionAlignment":1},{"id":1086,"trainrunSectionId":535,"positionIndex":1,"positionAlignment":1},{"id":1075,"trainrunSectionId":530,"positionIndex":0,"positionAlignment":3},{"id":1087,"trainrunSectionId":536,"positionIndex":1,"positionAlignment":3}],"transitions":[{"id":223,"port1Id":1074,"port2Id":1075,"isNonStopTransit":false},{"id":228,"port1Id":1086,"port2Id":1087,"isNonStopTransit":false}],"connections":[],"resourceId":183,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":160,"betriebspunktName":"Genf","fullName":"Genf","positionX":-3936,"positionY":608,"ports":[{"id":1209,"trainrunSectionId":597,"positionIndex":0,"positionAlignment":2},{"id":1185,"trainrunSectionId":585,"positionIndex":1,"positionAlignment":2},{"id":1189,"trainrunSectionId":587,"positionIndex":2,"positionAlignment":2},{"id":1424,"trainrunSectionId":704,"positionIndex":0,"positionAlignment":3},{"id":1426,"trainrunSectionId":705,"positionIndex":1,"positionAlignment":3},{"id":1422,"trainrunSectionId":703,"positionIndex":2,"positionAlignment":3}],"transitions":[{"id":369,"port1Id":1189,"port2Id":1422,"isNonStopTransit":false},{"id":371,"port1Id":1209,"port2Id":1424,"isNonStopTransit":false},{"id":373,"port1Id":1185,"port2Id":1426,"isNonStopTransit":false}],"connections":[],"resourceId":184,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":161,"betriebspunktName":"Genf ✈","fullName":"Aiport","positionX":-4352,"positionY":608,"ports":[{"id":1210,"trainrunSectionId":597,"positionIndex":0,"positionAlignment":3},{"id":1186,"trainrunSectionId":585,"positionIndex":1,"positionAlignment":3},{"id":1190,"trainrunSectionId":587,"positionIndex":2,"positionAlignment":3}],"transitions":[],"connections":[],"resourceId":185,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":162,"betriebspunktName":"Romansh.","fullName":"Romanshorn","positionX":4640,"positionY":-192,"ports":[{"id":1228,"trainrunSectionId":606,"positionIndex":0,"positionAlignment":2},{"id":1244,"trainrunSectionId":614,"positionIndex":1,"positionAlignment":2}],"transitions":[],"connections":[],"resourceId":186,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":163,"betriebspunktName":"Bülach","fullName":"Bülach","positionX":2784,"positionY":-544,"ports":[{"id":1252,"trainrunSectionId":618,"positionIndex":0,"positionAlignment":0},{"id":1253,"trainrunSectionId":619,"positionIndex":0,"positionAlignment":1}],"transitions":[{"id":280,"port1Id":1252,"port2Id":1253,"isNonStopTransit":false}],"connections":[],"resourceId":187,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":164,"betriebspunktName":"Reihnf.","fullName":"Reihnfelden","positionX":1056,"positionY":-960,"ports":[{"id":1268,"trainrunSectionId":626,"positionIndex":0,"positionAlignment":2},{"id":1269,"trainrunSectionId":627,"positionIndex":0,"positionAlignment":3}],"transitions":[{"id":291,"port1Id":1268,"port2Id":1269,"isNonStopTransit":false}],"connections":[],"resourceId":188,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":165,"betriebspunktName":"Frick","fullName":"Frick","positionX":1792,"positionY":-672,"ports":[{"id":1271,"trainrunSectionId":628,"positionIndex":0,"positionAlignment":1},{"id":1270,"trainrunSectionId":627,"positionIndex":0,"positionAlignment":2}],"transitions":[{"id":292,"port1Id":1271,"port2Id":1270,"isNonStopTransit":false}],"connections":[],"resourceId":189,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":166,"betriebspunktName":"Brugg","fullName":"Brugg","positionX":1792,"positionY":32,"ports":[{"id":1272,"trainrunSectionId":628,"positionIndex":0,"positionAlignment":0},{"id":1257,"trainrunSectionId":621,"positionIndex":0,"positionAlignment":2},{"id":1405,"trainrunSectionId":695,"positionIndex":1,"positionAlignment":2},{"id":1288,"trainrunSectionId":636,"positionIndex":2,"positionAlignment":2},{"id":1259,"trainrunSectionId":622,"positionIndex":3,"positionAlignment":2},{"id":1261,"trainrunSectionId":623,"positionIndex":4,"positionAlignment":2},{"id":1263,"trainrunSectionId":624,"positionIndex":5,"positionAlignment":2},{"id":1265,"trainrunSectionId":625,"positionIndex":6,"positionAlignment":2},{"id":1296,"trainrunSectionId":640,"positionIndex":7,"positionAlignment":2},{"id":1198,"trainrunSectionId":591,"positionIndex":0,"positionAlignment":3},{"id":1404,"trainrunSectionId":694,"positionIndex":1,"positionAlignment":3},{"id":1289,"trainrunSectionId":637,"positionIndex":2,"positionAlignment":3},{"id":1176,"trainrunSectionId":580,"positionIndex":3,"positionAlignment":3},{"id":1220,"trainrunSectionId":602,"positionIndex":4,"positionAlignment":3},{"id":1236,"trainrunSectionId":610,"positionIndex":5,"positionAlignment":3},{"id":1160,"trainrunSectionId":572,"positionIndex":6,"positionAlignment":3},{"id":1273,"trainrunSectionId":629,"positionIndex":7,"positionAlignment":3},{"id":1297,"trainrunSectionId":641,"positionIndex":8,"positionAlignment":3}],"transitions":[{"id":281,"port1Id":1257,"port2Id":1198,"isNonStopTransit":true},{"id":283,"port1Id":1259,"port2Id":1176,"isNonStopTransit":true},{"id":285,"port1Id":1261,"port2Id":1220,"isNonStopTransit":true},{"id":287,"port1Id":1263,"port2Id":1236,"isNonStopTransit":false},{"id":289,"port1Id":1265,"port2Id":1160,"isNonStopTransit":true},{"id":293,"port1Id":1272,"port2Id":1273,"isNonStopTransit":false},{"id":300,"port1Id":1288,"port2Id":1289,"isNonStopTransit":true},{"id":303,"port1Id":1296,"port2Id":1297,"isNonStopTransit":true},{"id":359,"port1Id":1405,"port2Id":1404,"isNonStopTransit":true}],"connections":[],"resourceId":190,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":167,"betriebspunktName":"Thun","fullName":"Thun","positionX":-2144,"positionY":640,"ports":[{"id":1327,"trainrunSectionId":656,"positionIndex":0,"positionAlignment":0},{"id":1312,"trainrunSectionId":648,"positionIndex":1,"positionAlignment":0},{"id":1314,"trainrunSectionId":649,"positionIndex":2,"positionAlignment":0},{"id":1340,"trainrunSectionId":662,"positionIndex":3,"positionAlignment":0},{"id":1326,"trainrunSectionId":655,"positionIndex":0,"positionAlignment":1},{"id":1315,"trainrunSectionId":650,"positionIndex":1,"positionAlignment":1},{"id":1319,"trainrunSectionId":652,"positionIndex":2,"positionAlignment":1},{"id":1341,"trainrunSectionId":663,"positionIndex":3,"positionAlignment":1}],"transitions":[{"id":309,"port1Id":1312,"port2Id":1315,"isNonStopTransit":false},{"id":311,"port1Id":1314,"port2Id":1319,"isNonStopTransit":false},{"id":314,"port1Id":1327,"port2Id":1326,"isNonStopTransit":false},{"id":319,"port1Id":1340,"port2Id":1341,"isNonStopTransit":false}],"connections":[],"resourceId":191,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":168,"betriebspunktName":"Spiez","fullName":"Spiez","positionX":-2144,"positionY":928,"ports":[{"id":1325,"trainrunSectionId":655,"positionIndex":0,"positionAlignment":0},{"id":1316,"trainrunSectionId":650,"positionIndex":1,"positionAlignment":0},{"id":1320,"trainrunSectionId":652,"positionIndex":2,"positionAlignment":0},{"id":1342,"trainrunSectionId":663,"positionIndex":3,"positionAlignment":0},{"id":1324,"trainrunSectionId":654,"positionIndex":0,"positionAlignment":1},{"id":1321,"trainrunSectionId":653,"positionIndex":1,"positionAlignment":1},{"id":1317,"trainrunSectionId":651,"positionIndex":0,"positionAlignment":3},{"id":1343,"trainrunSectionId":664,"positionIndex":1,"positionAlignment":3}],"transitions":[{"id":310,"port1Id":1316,"port2Id":1317,"isNonStopTransit":false},{"id":312,"port1Id":1320,"port2Id":1321,"isNonStopTransit":false},{"id":313,"port1Id":1325,"port2Id":1324,"isNonStopTransit":false},{"id":320,"port1Id":1342,"port2Id":1343,"isNonStopTransit":false}],"connections":[],"resourceId":192,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":169,"betriebspunktName":"Rothkr.","fullName":"Rothkreuz","positionX":1856,"positionY":1728,"ports":[{"id":1351,"trainrunSectionId":668,"positionIndex":0,"positionAlignment":2},{"id":1349,"trainrunSectionId":667,"positionIndex":1,"positionAlignment":2},{"id":1100,"trainrunSectionId":542,"positionIndex":2,"positionAlignment":2},{"id":1096,"trainrunSectionId":540,"positionIndex":3,"positionAlignment":2},{"id":1347,"trainrunSectionId":666,"positionIndex":0,"positionAlignment":3},{"id":1345,"trainrunSectionId":665,"positionIndex":1,"positionAlignment":3},{"id":1040,"trainrunSectionId":512,"positionIndex":2,"positionAlignment":3},{"id":1080,"trainrunSectionId":532,"positionIndex":3,"positionAlignment":3}],"transitions":[{"id":321,"port1Id":1096,"port2Id":1345,"isNonStopTransit":false},{"id":323,"port1Id":1100,"port2Id":1347,"isNonStopTransit":true},{"id":325,"port1Id":1349,"port2Id":1080,"isNonStopTransit":true},{"id":326,"port1Id":1351,"port2Id":1040,"isNonStopTransit":true}],"connections":[],"resourceId":193,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":170,"betriebspunktName":"Thalwil","fullName":"Thalwil","positionX":2656,"positionY":736,"ports":[{"id":1359,"trainrunSectionId":672,"positionIndex":0,"positionAlignment":0},{"id":1150,"trainrunSectionId":567,"positionIndex":1,"positionAlignment":0},{"id":1154,"trainrunSectionId":569,"positionIndex":2,"positionAlignment":0},{"id":1357,"trainrunSectionId":671,"positionIndex":3,"positionAlignment":0},{"id":1355,"trainrunSectionId":670,"positionIndex":4,"positionAlignment":0},{"id":1353,"trainrunSectionId":669,"positionIndex":5,"positionAlignment":0},{"id":1068,"trainrunSectionId":526,"positionIndex":0,"positionAlignment":1},{"id":1094,"trainrunSectionId":539,"positionIndex":1,"positionAlignment":1},{"id":1102,"trainrunSectionId":543,"positionIndex":2,"positionAlignment":1},{"id":1098,"trainrunSectionId":541,"positionIndex":3,"positionAlignment":1},{"id":1361,"trainrunSectionId":673,"positionIndex":0,"positionAlignment":3},{"id":1363,"trainrunSectionId":674,"positionIndex":1,"positionAlignment":3}],"transitions":[{"id":328,"port1Id":1353,"port2Id":1098,"isNonStopTransit":false},{"id":330,"port1Id":1355,"port2Id":1102,"isNonStopTransit":true},{"id":331,"port1Id":1357,"port2Id":1094,"isNonStopTransit":true},{"id":332,"port1Id":1359,"port2Id":1068,"isNonStopTransit":true},{"id":333,"port1Id":1150,"port2Id":1361,"isNonStopTransit":true},{"id":335,"port1Id":1154,"port2Id":1363,"isNonStopTransit":false}],"connections":[],"resourceId":194,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":171,"betriebspunktName":"Fribourg","fullName":"Fribourg","positionX":-2560,"positionY":288,"ports":[{"id":1381,"trainrunSectionId":683,"positionIndex":0,"positionAlignment":2},{"id":1379,"trainrunSectionId":682,"positionIndex":1,"positionAlignment":2},{"id":1206,"trainrunSectionId":595,"positionIndex":0,"positionAlignment":3},{"id":1110,"trainrunSectionId":547,"positionIndex":1,"positionAlignment":3}],"transitions":[{"id":344,"port1Id":1379,"port2Id":1110,"isNonStopTransit":false},{"id":346,"port1Id":1381,"port2Id":1206,"isNonStopTransit":false}],"connections":[],"resourceId":195,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":172,"betriebspunktName":"RTR","fullName":"Rothrist","positionX":-608,"positionY":128,"ports":[{"id":1395,"trainrunSectionId":690,"positionIndex":0,"positionAlignment":2},{"id":1438,"trainrunSectionId":711,"positionIndex":1,"positionAlignment":2},{"id":1391,"trainrunSectionId":688,"positionIndex":2,"positionAlignment":2},{"id":1389,"trainrunSectionId":687,"positionIndex":3,"positionAlignment":2},{"id":1387,"trainrunSectionId":686,"positionIndex":4,"positionAlignment":2},{"id":1383,"trainrunSectionId":684,"positionIndex":5,"positionAlignment":2},{"id":1385,"trainrunSectionId":685,"positionIndex":6,"positionAlignment":2},{"id":1204,"trainrunSectionId":594,"positionIndex":0,"positionAlignment":3},{"id":1393,"trainrunSectionId":689,"positionIndex":1,"positionAlignment":3},{"id":1310,"trainrunSectionId":647,"positionIndex":2,"positionAlignment":3},{"id":1226,"trainrunSectionId":605,"positionIndex":3,"positionAlignment":3},{"id":1242,"trainrunSectionId":613,"positionIndex":4,"positionAlignment":3},{"id":1166,"trainrunSectionId":575,"positionIndex":5,"positionAlignment":3},{"id":1108,"trainrunSectionId":546,"positionIndex":6,"positionAlignment":3}],"transitions":[{"id":348,"port1Id":1108,"port2Id":1383,"isNonStopTransit":true},{"id":349,"port1Id":1385,"port2Id":1166,"isNonStopTransit":true},{"id":350,"port1Id":1387,"port2Id":1242,"isNonStopTransit":true},{"id":351,"port1Id":1389,"port2Id":1226,"isNonStopTransit":true},{"id":352,"port1Id":1391,"port2Id":1310,"isNonStopTransit":true},{"id":354,"port1Id":1395,"port2Id":1204,"isNonStopTransit":true},{"id":384,"port1Id":1438,"port2Id":1393,"isNonStopTransit":true}],"connections":[],"resourceId":196,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":173,"betriebspunktName":"Burgdorf","fullName":"Burgdorf","positionX":-1344,"positionY":352,"ports":[{"id":1397,"trainrunSectionId":691,"positionIndex":0,"positionAlignment":2},{"id":1400,"trainrunSectionId":692,"positionIndex":0,"positionAlignment":3}],"transitions":[{"id":356,"port1Id":1397,"port2Id":1400,"isNonStopTransit":false}],"connections":[],"resourceId":197,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":174,"betriebspunktName":"Langent.","fullName":"Langenthal","positionX":-992,"positionY":352,"ports":[{"id":1399,"trainrunSectionId":692,"positionIndex":0,"positionAlignment":2},{"id":1386,"trainrunSectionId":685,"positionIndex":0,"positionAlignment":3}],"transitions":[{"id":355,"port1Id":1399,"port2Id":1386,"isNonStopTransit":false}],"connections":[],"resourceId":198,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":175,"betriebspunktName":"Solothurn","fullName":"Solothurn","positionX":-1696,"positionY":-32,"ports":[{"id":1417,"trainrunSectionId":701,"positionIndex":0,"positionAlignment":2},{"id":1182,"trainrunSectionId":583,"positionIndex":0,"positionAlignment":3}],"transitions":[{"id":365,"port1Id":1417,"port2Id":1182,"isNonStopTransit":false}],"connections":[],"resourceId":199,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":176,"betriebspunktName":"Rohrsch.","fullName":"Rohrschach","positionX":5376,"positionY":96,"ports":[{"id":1420,"trainrunSectionId":702,"positionIndex":0,"positionAlignment":2}],"transitions":[],"connections":[],"resourceId":200,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":177,"betriebspunktName":"Morges","fullName":"Morges","positionX":-3520,"positionY":544,"ports":[{"id":1423,"trainrunSectionId":704,"positionIndex":0,"positionAlignment":2},{"id":1425,"trainrunSectionId":705,"positionIndex":1,"positionAlignment":2},{"id":1421,"trainrunSectionId":703,"positionIndex":2,"positionAlignment":2},{"id":1184,"trainrunSectionId":584,"positionIndex":0,"positionAlignment":3},{"id":1208,"trainrunSectionId":596,"positionIndex":1,"positionAlignment":3},{"id":1188,"trainrunSectionId":586,"positionIndex":2,"positionAlignment":3}],"transitions":[{"id":368,"port1Id":1421,"port2Id":1188,"isNonStopTransit":false},{"id":370,"port1Id":1423,"port2Id":1208,"isNonStopTransit":true},{"id":372,"port1Id":1425,"port2Id":1184,"isNonStopTransit":false}],"connections":[],"resourceId":201,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]},{"id":178,"betriebspunktName":"BNWD","fullName":"Bern Wankdorf","positionX":-1696,"positionY":128,"ports":[{"id":1439,"trainrunSectionId":712,"positionIndex":0,"positionAlignment":2},{"id":1330,"trainrunSectionId":657,"positionIndex":1,"positionAlignment":2},{"id":1435,"trainrunSectionId":710,"positionIndex":2,"positionAlignment":2},{"id":1433,"trainrunSectionId":709,"positionIndex":3,"positionAlignment":2},{"id":1431,"trainrunSectionId":708,"positionIndex":4,"positionAlignment":2},{"id":1429,"trainrunSectionId":707,"positionIndex":5,"positionAlignment":2},{"id":1427,"trainrunSectionId":706,"positionIndex":6,"positionAlignment":2},{"id":1396,"trainrunSectionId":690,"positionIndex":0,"positionAlignment":3},{"id":1437,"trainrunSectionId":711,"positionIndex":1,"positionAlignment":3},{"id":1392,"trainrunSectionId":688,"positionIndex":2,"positionAlignment":3},{"id":1390,"trainrunSectionId":687,"positionIndex":3,"positionAlignment":3},{"id":1388,"trainrunSectionId":686,"positionIndex":4,"positionAlignment":3},{"id":1384,"trainrunSectionId":684,"positionIndex":5,"positionAlignment":3},{"id":1398,"trainrunSectionId":691,"positionIndex":6,"positionAlignment":3}],"transitions":[{"id":374,"port1Id":1427,"port2Id":1398,"isNonStopTransit":true},{"id":375,"port1Id":1429,"port2Id":1384,"isNonStopTransit":true},{"id":377,"port1Id":1431,"port2Id":1388,"isNonStopTransit":true},{"id":379,"port1Id":1433,"port2Id":1390,"isNonStopTransit":true},{"id":381,"port1Id":1435,"port2Id":1392,"isNonStopTransit":true},{"id":383,"port1Id":1330,"port2Id":1437,"isNonStopTransit":true},{"id":385,"port1Id":1439,"port2Id":1396,"isNonStopTransit":true}],"connections":[],"resourceId":202,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[]}],"trainrunSections":[{"id":509,"sourceNodeId":156,"sourcePortId":1033,"targetNodeId":136,"targetPortId":1034,"travelTime":{"lock":true,"time":14,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":2,"warning":null,"timeFormatter":null,"consecutiveTime":182},"sourceArrival":{"lock":false,"time":58,"warning":null,"timeFormatter":null,"consecutiveTime":178},"targetDeparture":{"lock":false,"time":44,"warning":null,"timeFormatter":null,"consecutiveTime":164},"targetArrival":{"lock":false,"time":16,"warning":null,"timeFormatter":null,"consecutiveTime":196},"numberOfStops":0,"trainrunId":75,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2640,"y":3710},{"x":2640,"y":3646},{"x":2640,"y":3390},{"x":2640,"y":3326}],"textPositions":{"0":{"x":2652,"y":3692},"1":{"x":2628,"y":3664},"2":{"x":2628,"y":3344},"3":{"x":2652,"y":3372},"4":{"x":2628,"y":3518},"5":{"x":2628,"y":3518},"6":{"x":2652,"y":3518}}},"warnings":null},{"id":510,"sourceNodeId":136,"sourcePortId":1035,"targetNodeId":158,"targetPortId":1036,"travelTime":{"lock":true,"time":6,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":18,"warning":null,"timeFormatter":null,"consecutiveTime":198},"sourceArrival":{"lock":true,"time":42,"warning":null,"timeFormatter":null,"consecutiveTime":162},"targetDeparture":{"lock":false,"time":36,"warning":null,"timeFormatter":null,"consecutiveTime":156},"targetArrival":{"lock":false,"time":24,"warning":null,"timeFormatter":null,"consecutiveTime":204},"numberOfStops":0,"trainrunId":75,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2640,"y":3230},{"x":2640,"y":3166},{"x":2640,"y":2818},{"x":2640,"y":2754}],"textPositions":{"0":{"x":2652,"y":3212},"1":{"x":2628,"y":3184},"2":{"x":2628,"y":2772},"3":{"x":2652,"y":2800},"4":{"x":2628,"y":2992},"5":{"x":2628,"y":2992},"6":{"x":2652,"y":2992}}},"warnings":null},{"id":511,"sourceNodeId":155,"sourcePortId":1037,"targetNodeId":154,"targetPortId":1038,"travelTime":{"lock":true,"time":19,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":52,"warning":null,"timeFormatter":null,"consecutiveTime":232},"sourceArrival":{"lock":false,"time":8,"warning":null,"timeFormatter":null,"consecutiveTime":128},"targetDeparture":{"lock":true,"time":49,"warning":null,"timeFormatter":null,"consecutiveTime":109},"targetArrival":{"lock":true,"time":11,"warning":null,"timeFormatter":null,"consecutiveTime":251},"numberOfStops":0,"trainrunId":75,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2704,"y":2174},{"x":2704,"y":2110},{"x":2704,"y":1950},{"x":2704,"y":1886}],"textPositions":{"0":{"x":2716,"y":2156},"1":{"x":2692,"y":2128},"2":{"x":2692,"y":1904},"3":{"x":2716,"y":1932},"4":{"x":2692,"y":2030},"5":{"x":2692,"y":2030},"6":{"x":2716,"y":2030}}},"warnings":null},{"id":512,"sourceNodeId":154,"sourcePortId":1039,"targetNodeId":169,"targetPortId":1040,"travelTime":{"lock":true,"time":18,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":15,"warning":null,"timeFormatter":null,"consecutiveTime":255},"sourceArrival":{"lock":true,"time":45,"warning":null,"timeFormatter":null,"consecutiveTime":105},"targetDeparture":{"lock":false,"time":27,"warning":null,"timeFormatter":null,"consecutiveTime":87},"targetArrival":{"lock":false,"time":33,"warning":null,"timeFormatter":null,"consecutiveTime":273},"numberOfStops":0,"trainrunId":75,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2654,"y":1808},{"x":2590,"y":1808},{"x":2018,"y":1808},{"x":1954,"y":1808}],"textPositions":{"0":{"x":2636,"y":1796},"1":{"x":2608,"y":1820},"2":{"x":1972,"y":1820},"3":{"x":2000,"y":1796},"4":{"x":2304,"y":1796},"5":{"x":2304,"y":1796},"6":{"x":2304,"y":1820}}},"warnings":null},{"id":513,"sourceNodeId":142,"sourcePortId":1041,"targetNodeId":141,"targetPortId":1042,"travelTime":{"lock":true,"time":19,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":55,"warning":null,"timeFormatter":null,"consecutiveTime":295},"sourceArrival":{"lock":true,"time":5,"warning":null,"timeFormatter":null,"consecutiveTime":65},"targetDeparture":{"lock":false,"time":46,"warning":null,"timeFormatter":null,"consecutiveTime":46},"targetArrival":{"lock":false,"time":14,"warning":null,"timeFormatter":null,"consecutiveTime":314},"numberOfStops":0,"trainrunId":75,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":80,"y":1726},{"x":80,"y":1662},{"x":80,"y":1314},{"x":80,"y":1250}],"textPositions":{"0":{"x":92,"y":1708},"1":{"x":68,"y":1680},"2":{"x":68,"y":1268},"3":{"x":92,"y":1296},"4":{"x":68,"y":1488},"5":{"x":68,"y":1488},"6":{"x":92,"y":1488}}},"warnings":null},{"id":514,"sourceNodeId":141,"sourcePortId":1043,"targetNodeId":143,"targetPortId":1044,"travelTime":{"lock":true,"time":9,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":14,"warning":null,"timeFormatter":null,"consecutiveTime":314},"sourceArrival":{"lock":false,"time":46,"warning":null,"timeFormatter":null,"consecutiveTime":46},"targetDeparture":{"lock":false,"time":37,"warning":null,"timeFormatter":null,"consecutiveTime":37},"targetArrival":{"lock":false,"time":23,"warning":null,"timeFormatter":null,"consecutiveTime":323},"numberOfStops":0,"trainrunId":75,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":80,"y":1182},{"x":80,"y":1118},{"x":80,"y":866},{"x":80,"y":802}],"textPositions":{"0":{"x":92,"y":1164},"1":{"x":68,"y":1136},"2":{"x":68,"y":820},"3":{"x":92,"y":848},"4":{"x":68,"y":992},"5":{"x":68,"y":992},"6":{"x":92,"y":992}}},"warnings":null},{"id":515,"sourceNodeId":143,"sourcePortId":1045,"targetNodeId":133,"targetPortId":1046,"travelTime":{"lock":true,"time":7,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":23,"warning":null,"timeFormatter":null,"consecutiveTime":323},"sourceArrival":{"lock":false,"time":37,"warning":null,"timeFormatter":null,"consecutiveTime":37},"targetDeparture":{"lock":true,"time":30,"warning":null,"timeFormatter":null,"consecutiveTime":30},"targetArrival":{"lock":true,"time":30,"warning":null,"timeFormatter":null,"consecutiveTime":330},"numberOfStops":0,"trainrunId":75,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":80,"y":734},{"x":80,"y":670},{"x":80,"y":414},{"x":80,"y":350}],"textPositions":{"0":{"x":92,"y":716},"1":{"x":68,"y":688},"2":{"x":68,"y":368},"3":{"x":92,"y":396},"4":{"x":68,"y":542},"5":{"x":68,"y":542},"6":{"x":92,"y":542}}},"warnings":null},{"id":516,"sourceNodeId":133,"sourcePortId":1047,"targetNodeId":144,"targetPortId":1048,"travelTime":{"lock":true,"time":10,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":32,"warning":null,"timeFormatter":null,"consecutiveTime":332},"sourceArrival":{"lock":true,"time":28,"warning":null,"timeFormatter":null,"consecutiveTime":28},"targetDeparture":{"lock":false,"time":18,"warning":null,"timeFormatter":null,"consecutiveTime":18},"targetArrival":{"lock":false,"time":42,"warning":null,"timeFormatter":null,"consecutiveTime":342},"numberOfStops":0,"trainrunId":75,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":80,"y":94},{"x":80,"y":30},{"x":80,"y":-290},{"x":80,"y":-354}],"textPositions":{"0":{"x":92,"y":76},"1":{"x":68,"y":48},"2":{"x":68,"y":-336},"3":{"x":92,"y":-308},"4":{"x":68,"y":-130},"5":{"x":68,"y":-130},"6":{"x":92,"y":-130}}},"warnings":null},{"id":517,"sourceNodeId":144,"sourcePortId":1049,"targetNodeId":145,"targetPortId":1050,"travelTime":{"lock":true,"time":5,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":42,"warning":null,"timeFormatter":null,"consecutiveTime":342},"sourceArrival":{"lock":false,"time":18,"warning":null,"timeFormatter":null,"consecutiveTime":18},"targetDeparture":{"lock":false,"time":13,"warning":null,"timeFormatter":null,"consecutiveTime":13},"targetArrival":{"lock":false,"time":47,"warning":null,"timeFormatter":null,"consecutiveTime":347},"numberOfStops":0,"trainrunId":75,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":80,"y":-450},{"x":80,"y":-514},{"x":80,"y":-798},{"x":80,"y":-862}],"textPositions":{"0":{"x":92,"y":-468},"1":{"x":68,"y":-496},"2":{"x":68,"y":-844},"3":{"x":92,"y":-816},"4":{"x":68,"y":-656},"5":{"x":68,"y":-656},"6":{"x":92,"y":-656}}},"warnings":null},{"id":518,"sourceNodeId":145,"sourcePortId":1051,"targetNodeId":146,"targetPortId":1052,"travelTime":{"lock":true,"time":5,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":47,"warning":null,"timeFormatter":null,"consecutiveTime":347},"sourceArrival":{"lock":false,"time":13,"warning":null,"timeFormatter":null,"consecutiveTime":13},"targetDeparture":{"lock":false,"time":8,"warning":null,"timeFormatter":null,"consecutiveTime":8},"targetArrival":{"lock":false,"time":52,"warning":null,"timeFormatter":null,"consecutiveTime":352},"numberOfStops":0,"trainrunId":75,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":80,"y":-930},{"x":80,"y":-994},{"x":80,"y":-1278},{"x":80,"y":-1342}],"textPositions":{"0":{"x":92,"y":-948},"1":{"x":68,"y":-976},"2":{"x":68,"y":-1324},"3":{"x":92,"y":-1296},"4":{"x":68,"y":-1136},"5":{"x":68,"y":-1136},"6":{"x":92,"y":-1136}}},"warnings":null},{"id":519,"sourceNodeId":146,"sourcePortId":1053,"targetNodeId":134,"targetPortId":1054,"travelTime":{"lock":true,"time":5,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":52,"warning":null,"timeFormatter":null,"consecutiveTime":352},"sourceArrival":{"lock":false,"time":8,"warning":null,"timeFormatter":null,"consecutiveTime":8},"targetDeparture":{"lock":true,"time":3,"warning":null,"timeFormatter":null,"consecutiveTime":3},"targetArrival":{"lock":true,"time":57,"warning":null,"timeFormatter":null,"consecutiveTime":357},"numberOfStops":0,"trainrunId":75,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":80,"y":-1410},{"x":80,"y":-1474},{"x":80,"y":-1758},{"x":80,"y":-1822}],"textPositions":{"0":{"x":92,"y":-1428},"1":{"x":68,"y":-1456},"2":{"x":68,"y":-1804},"3":{"x":92,"y":-1776},"4":{"x":68,"y":-1616},"5":{"x":68,"y":-1616},"6":{"x":92,"y":-1616}}},"warnings":null},{"id":520,"sourceNodeId":155,"sourcePortId":1055,"targetNodeId":158,"targetPortId":1056,"travelTime":{"lock":true,"time":28,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":8,"warning":null,"timeFormatter":null,"consecutiveTime":128},"sourceArrival":{"lock":true,"time":52,"warning":null,"timeFormatter":null,"consecutiveTime":232},"targetDeparture":{"lock":false,"time":24,"warning":null,"timeFormatter":null,"consecutiveTime":204},"targetArrival":{"lock":false,"time":36,"warning":null,"timeFormatter":null,"consecutiveTime":156},"numberOfStops":0,"trainrunId":75,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2704,"y":2270},{"x":2704,"y":2334},{"x":2704,"y":2622},{"x":2704,"y":2686}],"textPositions":{"0":{"x":2692,"y":2288},"1":{"x":2716,"y":2316},"2":{"x":2716,"y":2668},"3":{"x":2692,"y":2640},"4":{"x":2692,"y":2478},"5":{"x":2692,"y":2478},"6":{"x":2716,"y":2478}}},"warnings":null},{"id":521,"sourceNodeId":156,"sourcePortId":1057,"targetNodeId":136,"targetPortId":1058,"travelTime":{"lock":true,"time":14,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":2,"warning":null,"timeFormatter":null,"consecutiveTime":2},"sourceArrival":{"lock":true,"time":58,"warning":null,"timeFormatter":null,"consecutiveTime":118},"targetDeparture":{"lock":false,"time":44,"warning":null,"timeFormatter":null,"consecutiveTime":104},"targetArrival":{"lock":false,"time":16,"warning":null,"timeFormatter":null,"consecutiveTime":16},"numberOfStops":0,"trainrunId":76,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2608,"y":3710},{"x":2608,"y":3646},{"x":2608,"y":3390},{"x":2608,"y":3326}],"textPositions":{"0":{"x":2620,"y":3692},"1":{"x":2596,"y":3664},"2":{"x":2596,"y":3344},"3":{"x":2620,"y":3372},"4":{"x":2596,"y":3518},"5":{"x":2596,"y":3518},"6":{"x":2620,"y":3518}}},"warnings":null},{"id":522,"sourceNodeId":136,"sourcePortId":1059,"targetNodeId":158,"targetPortId":1060,"travelTime":{"lock":true,"time":6,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":18,"warning":null,"timeFormatter":null,"consecutiveTime":18},"sourceArrival":{"lock":true,"time":42,"warning":null,"timeFormatter":null,"consecutiveTime":102},"targetDeparture":{"lock":false,"time":36,"warning":null,"timeFormatter":null,"consecutiveTime":96},"targetArrival":{"lock":false,"time":24,"warning":null,"timeFormatter":null,"consecutiveTime":24},"numberOfStops":0,"trainrunId":76,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2608,"y":3230},{"x":2608,"y":3166},{"x":2608,"y":2818},{"x":2608,"y":2754}],"textPositions":{"0":{"x":2620,"y":3212},"1":{"x":2596,"y":3184},"2":{"x":2596,"y":2772},"3":{"x":2620,"y":2800},"4":{"x":2596,"y":2992},"5":{"x":2596,"y":2992},"6":{"x":2620,"y":2992}}},"warnings":null},{"id":523,"sourceNodeId":158,"sourcePortId":1061,"targetNodeId":155,"targetPortId":1062,"travelTime":{"lock":true,"time":28,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":24,"warning":null,"timeFormatter":null,"consecutiveTime":24},"sourceArrival":{"lock":false,"time":36,"warning":null,"timeFormatter":null,"consecutiveTime":96},"targetDeparture":{"lock":false,"time":8,"warning":null,"timeFormatter":null,"consecutiveTime":68},"targetArrival":{"lock":false,"time":52,"warning":null,"timeFormatter":null,"consecutiveTime":52},"numberOfStops":0,"trainrunId":76,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2672,"y":2686},{"x":2672,"y":2622},{"x":2672,"y":2334},{"x":2672,"y":2270}],"textPositions":{"0":{"x":2684,"y":2668},"1":{"x":2660,"y":2640},"2":{"x":2660,"y":2288},"3":{"x":2684,"y":2316},"4":{"x":2660,"y":2478},"5":{"x":2660,"y":2478},"6":{"x":2684,"y":2478}}},"warnings":null},{"id":524,"sourceNodeId":155,"sourcePortId":1063,"targetNodeId":154,"targetPortId":1064,"travelTime":{"lock":false,"time":19,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":52,"warning":null,"timeFormatter":null,"consecutiveTime":52},"sourceArrival":{"lock":false,"time":8,"warning":null,"timeFormatter":null,"consecutiveTime":68},"targetDeparture":{"lock":true,"time":49,"warning":null,"timeFormatter":null,"consecutiveTime":49},"targetArrival":{"lock":true,"time":11,"warning":null,"timeFormatter":null,"consecutiveTime":71},"numberOfStops":0,"trainrunId":76,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2672,"y":2174},{"x":2672,"y":2110},{"x":2672,"y":1950},{"x":2672,"y":1886}],"textPositions":{"0":{"x":2684,"y":2156},"1":{"x":2660,"y":2128},"2":{"x":2660,"y":1904},"3":{"x":2684,"y":1932},"4":{"x":2660,"y":2030},"5":{"x":2660,"y":2030},"6":{"x":2684,"y":2030}}},"warnings":null},{"id":525,"sourceNodeId":154,"sourcePortId":1065,"targetNodeId":153,"targetPortId":1066,"travelTime":{"lock":true,"time":15,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":15,"warning":null,"timeFormatter":null,"consecutiveTime":75},"sourceArrival":{"lock":true,"time":45,"warning":null,"timeFormatter":null,"consecutiveTime":45},"targetDeparture":{"lock":true,"time":30,"warning":null,"timeFormatter":null,"consecutiveTime":30},"targetArrival":{"lock":true,"time":30,"warning":null,"timeFormatter":null,"consecutiveTime":90},"numberOfStops":0,"trainrunId":76,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2672,"y":1790},{"x":2672,"y":1726},{"x":2672,"y":1470},{"x":2672,"y":1406}],"textPositions":{"0":{"x":2684,"y":1772},"1":{"x":2660,"y":1744},"2":{"x":2660,"y":1424},"3":{"x":2684,"y":1452},"4":{"x":2660,"y":1598},"5":{"x":2660,"y":1598},"6":{"x":2684,"y":1598}}},"warnings":null},{"id":526,"sourceNodeId":153,"sourcePortId":1067,"targetNodeId":170,"targetPortId":1068,"travelTime":{"lock":true,"time":16,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":31,"warning":null,"timeFormatter":null,"consecutiveTime":91},"sourceArrival":{"lock":true,"time":29,"warning":null,"timeFormatter":null,"consecutiveTime":29},"targetDeparture":{"lock":false,"time":13,"warning":null,"timeFormatter":null,"consecutiveTime":13},"targetArrival":{"lock":false,"time":47,"warning":null,"timeFormatter":null,"consecutiveTime":107},"numberOfStops":0,"trainrunId":76,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2672,"y":1310},{"x":2672,"y":1246},{"x":2672,"y":894},{"x":2672,"y":830}],"textPositions":{"0":{"x":2684,"y":1292},"1":{"x":2660,"y":1264},"2":{"x":2660,"y":848},"3":{"x":2684,"y":876},"4":{"x":2660,"y":1070},"5":{"x":2660,"y":1070},"6":{"x":2684,"y":1070}}},"warnings":null},{"id":527,"sourceNodeId":157,"sourcePortId":1069,"targetNodeId":136,"targetPortId":1070,"travelTime":{"lock":true,"time":23,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":33,"warning":null,"timeFormatter":null,"consecutiveTime":273},"sourceArrival":{"lock":true,"time":27,"warning":null,"timeFormatter":null,"consecutiveTime":327},"targetDeparture":{"lock":true,"time":4,"warning":null,"timeFormatter":null,"consecutiveTime":304},"targetArrival":{"lock":true,"time":56,"warning":null,"timeFormatter":null,"consecutiveTime":296},"numberOfStops":0,"trainrunId":77,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2306,"y":3248},{"x":2370,"y":3248},{"x":2526,"y":3248},{"x":2590,"y":3248}],"textPositions":{"0":{"x":2324,"y":3260},"1":{"x":2352,"y":3236},"2":{"x":2572,"y":3236},"3":{"x":2544,"y":3260},"4":{"x":2448,"y":3236},"5":{"x":2448,"y":3236},"6":{"x":2448,"y":3260}}},"warnings":null},{"id":528,"sourceNodeId":136,"sourcePortId":1071,"targetNodeId":158,"targetPortId":1072,"travelTime":{"lock":true,"time":15,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":0,"warning":null,"timeFormatter":null,"consecutiveTime":300},"sourceArrival":{"lock":true,"time":0,"warning":null,"timeFormatter":null,"consecutiveTime":300},"targetDeparture":{"lock":true,"time":45,"warning":null,"timeFormatter":null,"consecutiveTime":285},"targetArrival":{"lock":true,"time":15,"warning":null,"timeFormatter":null,"consecutiveTime":315},"numberOfStops":0,"trainrunId":77,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2672,"y":3230},{"x":2672,"y":3166},{"x":2672,"y":2818},{"x":2672,"y":2754}],"textPositions":{"0":{"x":2684,"y":3212},"1":{"x":2660,"y":3184},"2":{"x":2660,"y":2772},"3":{"x":2684,"y":2800},"4":{"x":2660,"y":2992},"5":{"x":2660,"y":2992},"6":{"x":2684,"y":2992}}},"warnings":null},{"id":529,"sourceNodeId":158,"sourcePortId":1073,"targetNodeId":159,"targetPortId":1074,"travelTime":{"lock":true,"time":53,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":16,"warning":null,"timeFormatter":null,"consecutiveTime":316},"sourceArrival":{"lock":true,"time":44,"warning":null,"timeFormatter":null,"consecutiveTime":284},"targetDeparture":{"lock":true,"time":51,"warning":null,"timeFormatter":null,"consecutiveTime":231},"targetArrival":{"lock":true,"time":9,"warning":null,"timeFormatter":null,"consecutiveTime":369},"numberOfStops":5,"trainrunId":77,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2608,"y":2686},{"x":2608,"y":2622},{"x":2288,"y":2398},{"x":2288,"y":2334}],"textPositions":{"0":{"x":2620,"y":2668},"1":{"x":2596,"y":2640},"2":{"x":2276,"y":2352},"3":{"x":2300,"y":2380},"4":{"x":2460,"y":2510},"5":{"x":2460,"y":2510},"6":{"x":2436,"y":2510}}},"warnings":null},{"id":530,"sourceNodeId":159,"sourcePortId":1075,"targetNodeId":155,"targetPortId":1076,"travelTime":{"lock":true,"time":32,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":10,"warning":null,"timeFormatter":null,"consecutiveTime":370},"sourceArrival":{"lock":true,"time":50,"warning":null,"timeFormatter":null,"consecutiveTime":230},"targetDeparture":{"lock":false,"time":18,"warning":null,"timeFormatter":null,"consecutiveTime":198},"targetArrival":{"lock":false,"time":42,"warning":null,"timeFormatter":null,"consecutiveTime":402},"numberOfStops":1,"trainrunId":77,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2370,"y":2256},{"x":2434,"y":2256},{"x":2590,"y":2192},{"x":2654,"y":2192}],"textPositions":{"0":{"x":2388,"y":2268},"1":{"x":2416,"y":2244},"2":{"x":2636,"y":2180},"3":{"x":2608,"y":2204},"4":{"x":2512,"y":2212},"5":{"x":2512,"y":2212},"6":{"x":2512,"y":2236}}},"warnings":null},{"id":531,"sourceNodeId":155,"sourcePortId":1077,"targetNodeId":154,"targetPortId":1078,"travelTime":{"lock":true,"time":23,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":43,"warning":null,"timeFormatter":null,"consecutiveTime":403},"sourceArrival":{"lock":true,"time":17,"warning":null,"timeFormatter":null,"consecutiveTime":197},"targetDeparture":{"lock":true,"time":54,"warning":null,"timeFormatter":null,"consecutiveTime":174},"targetArrival":{"lock":true,"time":6,"warning":null,"timeFormatter":null,"consecutiveTime":426},"numberOfStops":3,"trainrunId":77,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2736,"y":2174},{"x":2736,"y":2110},{"x":2736,"y":1950},{"x":2736,"y":1886}],"textPositions":{"0":{"x":2748,"y":2156},"1":{"x":2724,"y":2128},"2":{"x":2724,"y":1904},"3":{"x":2748,"y":1932},"4":{"x":2724,"y":2030},"5":{"x":2724,"y":2030},"6":{"x":2748,"y":2030}}},"warnings":null},{"id":532,"sourceNodeId":154,"sourcePortId":1079,"targetNodeId":169,"targetPortId":1080,"travelTime":{"lock":true,"time":18,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":15,"warning":null,"timeFormatter":null,"consecutiveTime":435},"sourceArrival":{"lock":true,"time":45,"warning":null,"timeFormatter":null,"consecutiveTime":165},"targetDeparture":{"lock":false,"time":27,"warning":null,"timeFormatter":null,"consecutiveTime":147},"targetArrival":{"lock":false,"time":33,"warning":null,"timeFormatter":null,"consecutiveTime":453},"numberOfStops":0,"trainrunId":77,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2654,"y":1840},{"x":2590,"y":1840},{"x":2018,"y":1840},{"x":1954,"y":1840}],"textPositions":{"0":{"x":2636,"y":1828},"1":{"x":2608,"y":1852},"2":{"x":1972,"y":1852},"3":{"x":2000,"y":1828},"4":{"x":2304,"y":1828},"5":{"x":2304,"y":1828},"6":{"x":2304,"y":1852}}},"warnings":null},{"id":533,"sourceNodeId":157,"sourcePortId":1081,"targetNodeId":136,"targetPortId":1082,"travelTime":{"lock":true,"time":23,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":33,"warning":null,"timeFormatter":null,"consecutiveTime":153},"sourceArrival":{"lock":true,"time":27,"warning":null,"timeFormatter":null,"consecutiveTime":207},"targetDeparture":{"lock":true,"time":4,"warning":null,"timeFormatter":null,"consecutiveTime":184},"targetArrival":{"lock":true,"time":56,"warning":null,"timeFormatter":null,"consecutiveTime":176},"numberOfStops":3,"trainrunId":78,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2306,"y":3280},{"x":2370,"y":3280},{"x":2526,"y":3280},{"x":2590,"y":3280}],"textPositions":{"0":{"x":2324,"y":3292},"1":{"x":2352,"y":3268},"2":{"x":2572,"y":3268},"3":{"x":2544,"y":3292},"4":{"x":2448,"y":3268},"5":{"x":2448,"y":3268},"6":{"x":2448,"y":3292}}},"warnings":null},{"id":534,"sourceNodeId":136,"sourcePortId":1083,"targetNodeId":158,"targetPortId":1084,"travelTime":{"lock":true,"time":15,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":0,"warning":null,"timeFormatter":null,"consecutiveTime":180},"sourceArrival":{"lock":true,"time":0,"warning":null,"timeFormatter":null,"consecutiveTime":180},"targetDeparture":{"lock":true,"time":45,"warning":null,"timeFormatter":null,"consecutiveTime":165},"targetArrival":{"lock":true,"time":15,"warning":null,"timeFormatter":null,"consecutiveTime":195},"numberOfStops":1,"trainrunId":78,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2704,"y":3230},{"x":2704,"y":3166},{"x":2704,"y":2818},{"x":2704,"y":2754}],"textPositions":{"0":{"x":2716,"y":3212},"1":{"x":2692,"y":3184},"2":{"x":2692,"y":2772},"3":{"x":2716,"y":2800},"4":{"x":2692,"y":2992},"5":{"x":2692,"y":2992},"6":{"x":2716,"y":2992}}},"warnings":null},{"id":535,"sourceNodeId":158,"sourcePortId":1085,"targetNodeId":159,"targetPortId":1086,"travelTime":{"lock":true,"time":53,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":16,"warning":null,"timeFormatter":null,"consecutiveTime":196},"sourceArrival":{"lock":true,"time":44,"warning":null,"timeFormatter":null,"consecutiveTime":164},"targetDeparture":{"lock":true,"time":51,"warning":null,"timeFormatter":null,"consecutiveTime":111},"targetArrival":{"lock":true,"time":9,"warning":null,"timeFormatter":null,"consecutiveTime":249},"numberOfStops":5,"trainrunId":78,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2640,"y":2686},{"x":2640,"y":2622},{"x":2320,"y":2398},{"x":2320,"y":2334}],"textPositions":{"0":{"x":2652,"y":2668},"1":{"x":2628,"y":2640},"2":{"x":2308,"y":2352},"3":{"x":2332,"y":2380},"4":{"x":2492,"y":2510},"5":{"x":2492,"y":2510},"6":{"x":2468,"y":2510}}},"warnings":null},{"id":536,"sourceNodeId":159,"sourcePortId":1087,"targetNodeId":155,"targetPortId":1088,"travelTime":{"lock":true,"time":32,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":10,"warning":null,"timeFormatter":null,"consecutiveTime":250},"sourceArrival":{"lock":true,"time":50,"warning":null,"timeFormatter":null,"consecutiveTime":110},"targetDeparture":{"lock":true,"time":18,"warning":null,"timeFormatter":null,"consecutiveTime":78},"targetArrival":{"lock":true,"time":42,"warning":null,"timeFormatter":null,"consecutiveTime":282},"numberOfStops":1,"trainrunId":78,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2370,"y":2288},{"x":2434,"y":2288},{"x":2590,"y":2224},{"x":2654,"y":2224}],"textPositions":{"0":{"x":2388,"y":2300},"1":{"x":2416,"y":2276},"2":{"x":2636,"y":2212},"3":{"x":2608,"y":2236},"4":{"x":2512,"y":2244},"5":{"x":2512,"y":2244},"6":{"x":2512,"y":2268}}},"warnings":null},{"id":537,"sourceNodeId":155,"sourcePortId":1089,"targetNodeId":154,"targetPortId":1090,"travelTime":{"lock":false,"time":23,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":43,"warning":null,"timeFormatter":null,"consecutiveTime":283},"sourceArrival":{"lock":true,"time":17,"warning":null,"timeFormatter":null,"consecutiveTime":77},"targetDeparture":{"lock":true,"time":54,"warning":null,"timeFormatter":null,"consecutiveTime":54},"targetArrival":{"lock":true,"time":6,"warning":null,"timeFormatter":null,"consecutiveTime":306},"numberOfStops":3,"trainrunId":78,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2768,"y":2174},{"x":2768,"y":2110},{"x":2768,"y":1950},{"x":2768,"y":1886}],"textPositions":{"0":{"x":2780,"y":2156},"1":{"x":2756,"y":2128},"2":{"x":2756,"y":1904},"3":{"x":2780,"y":1932},"4":{"x":2756,"y":2030},"5":{"x":2756,"y":2030},"6":{"x":2780,"y":2030}}},"warnings":null},{"id":538,"sourceNodeId":154,"sourcePortId":1091,"targetNodeId":153,"targetPortId":1092,"travelTime":{"lock":true,"time":15,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":15,"warning":null,"timeFormatter":null,"consecutiveTime":315},"sourceArrival":{"lock":false,"time":45,"warning":null,"timeFormatter":null,"consecutiveTime":45},"targetDeparture":{"lock":true,"time":30,"warning":null,"timeFormatter":null,"consecutiveTime":30},"targetArrival":{"lock":true,"time":30,"warning":null,"timeFormatter":null,"consecutiveTime":330},"numberOfStops":0,"trainrunId":78,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2704,"y":1790},{"x":2704,"y":1726},{"x":2704,"y":1470},{"x":2704,"y":1406}],"textPositions":{"0":{"x":2716,"y":1772},"1":{"x":2692,"y":1744},"2":{"x":2692,"y":1424},"3":{"x":2716,"y":1452},"4":{"x":2692,"y":1598},"5":{"x":2692,"y":1598},"6":{"x":2716,"y":1598}}},"warnings":null},{"id":539,"sourceNodeId":153,"sourcePortId":1093,"targetNodeId":170,"targetPortId":1094,"travelTime":{"lock":true,"time":16,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":31,"warning":null,"timeFormatter":null,"consecutiveTime":331},"sourceArrival":{"lock":true,"time":29,"warning":null,"timeFormatter":null,"consecutiveTime":29},"targetDeparture":{"lock":false,"time":13,"warning":null,"timeFormatter":null,"consecutiveTime":13},"targetArrival":{"lock":false,"time":47,"warning":null,"timeFormatter":null,"consecutiveTime":347},"numberOfStops":0,"trainrunId":78,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2704,"y":1310},{"x":2704,"y":1246},{"x":2704,"y":894},{"x":2704,"y":830}],"textPositions":{"0":{"x":2716,"y":1292},"1":{"x":2692,"y":1264},"2":{"x":2692,"y":848},"3":{"x":2716,"y":876},"4":{"x":2692,"y":1070},"5":{"x":2692,"y":1070},"6":{"x":2716,"y":1070}}},"warnings":null},{"id":540,"sourceNodeId":142,"sourcePortId":1095,"targetNodeId":169,"targetPortId":1096,"travelTime":{"lock":false,"time":12,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":35,"warning":null,"timeFormatter":null,"consecutiveTime":35},"sourceArrival":{"lock":true,"time":25,"warning":null,"timeFormatter":null,"consecutiveTime":265},"targetDeparture":{"lock":true,"time":13,"warning":null,"timeFormatter":null,"consecutiveTime":253},"targetArrival":{"lock":true,"time":47,"warning":null,"timeFormatter":null,"consecutiveTime":47},"numberOfStops":0,"trainrunId":79,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":226,"y":1840},{"x":290,"y":1840},{"x":1790,"y":1840},{"x":1854,"y":1840}],"textPositions":{"0":{"x":244,"y":1852},"1":{"x":272,"y":1828},"2":{"x":1836,"y":1828},"3":{"x":1808,"y":1852},"4":{"x":1040,"y":1828},"5":{"x":1040,"y":1828},"6":{"x":1040,"y":1852}}},"warnings":null},{"id":541,"sourceNodeId":153,"sourcePortId":1097,"targetNodeId":170,"targetPortId":1098,"travelTime":{"lock":false,"time":15,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":58,"warning":null,"timeFormatter":null,"consecutiveTime":58},"sourceArrival":{"lock":true,"time":2,"warning":null,"timeFormatter":null,"consecutiveTime":242},"targetDeparture":{"lock":true,"time":47,"warning":null,"timeFormatter":null,"consecutiveTime":227},"targetArrival":{"lock":true,"time":13,"warning":null,"timeFormatter":null,"consecutiveTime":73},"numberOfStops":1,"trainrunId":79,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2768,"y":1310},{"x":2768,"y":1246},{"x":2768,"y":894},{"x":2768,"y":830}],"textPositions":{"0":{"x":2780,"y":1292},"1":{"x":2756,"y":1264},"2":{"x":2756,"y":848},"3":{"x":2780,"y":876},"4":{"x":2756,"y":1070},"5":{"x":2756,"y":1070},"6":{"x":2780,"y":1070}}},"warnings":null},{"id":542,"sourceNodeId":142,"sourcePortId":1099,"targetNodeId":169,"targetPortId":1100,"travelTime":{"lock":true,"time":9,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":9,"warning":null,"timeFormatter":null,"consecutiveTime":9},"sourceArrival":{"lock":true,"time":51,"warning":null,"timeFormatter":null,"consecutiveTime":51},"targetDeparture":{"lock":false,"time":42,"warning":null,"timeFormatter":null,"consecutiveTime":42},"targetArrival":{"lock":false,"time":18,"warning":null,"timeFormatter":null,"consecutiveTime":18},"numberOfStops":0,"trainrunId":80,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":226,"y":1808},{"x":290,"y":1808},{"x":1790,"y":1808},{"x":1854,"y":1808}],"textPositions":{"0":{"x":244,"y":1820},"1":{"x":272,"y":1796},"2":{"x":1836,"y":1796},"3":{"x":1808,"y":1820},"4":{"x":1040,"y":1796},"5":{"x":1040,"y":1796},"6":{"x":1040,"y":1820}}},"warnings":null},{"id":543,"sourceNodeId":153,"sourcePortId":1101,"targetNodeId":170,"targetPortId":1102,"travelTime":{"lock":true,"time":14,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":29,"warning":null,"timeFormatter":null,"consecutiveTime":29},"sourceArrival":{"lock":true,"time":31,"warning":null,"timeFormatter":null,"consecutiveTime":31},"targetDeparture":{"lock":false,"time":17,"warning":null,"timeFormatter":null,"consecutiveTime":17},"targetArrival":{"lock":false,"time":43,"warning":null,"timeFormatter":null,"consecutiveTime":43},"numberOfStops":0,"trainrunId":80,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2736,"y":1310},{"x":2736,"y":1246},{"x":2736,"y":894},{"x":2736,"y":830}],"textPositions":{"0":{"x":2748,"y":1292},"1":{"x":2724,"y":1264},"2":{"x":2724,"y":848},"3":{"x":2748,"y":876},"4":{"x":2724,"y":1070},"5":{"x":2724,"y":1070},"6":{"x":2748,"y":1070}}},"warnings":null},{"id":544,"sourceNodeId":142,"sourcePortId":1103,"targetNodeId":141,"targetPortId":1104,"travelTime":{"lock":true,"time":19,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":59,"warning":null,"timeFormatter":null,"consecutiveTime":299},"sourceArrival":{"lock":false,"time":1,"warning":null,"timeFormatter":null,"consecutiveTime":241},"targetDeparture":{"lock":true,"time":42,"warning":null,"timeFormatter":null,"consecutiveTime":222},"targetArrival":{"lock":true,"time":18,"warning":null,"timeFormatter":null,"consecutiveTime":318},"numberOfStops":0,"trainrunId":81,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":112,"y":1726},{"x":112,"y":1662},{"x":112,"y":1314},{"x":112,"y":1250}],"textPositions":{"0":{"x":124,"y":1708},"1":{"x":100,"y":1680},"2":{"x":100,"y":1268},"3":{"x":124,"y":1296},"4":{"x":100,"y":1488},"5":{"x":100,"y":1488},"6":{"x":124,"y":1488}}},"warnings":null},{"id":545,"sourceNodeId":141,"sourcePortId":1105,"targetNodeId":143,"targetPortId":1106,"travelTime":{"lock":true,"time":12,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":19,"warning":null,"timeFormatter":null,"consecutiveTime":319},"sourceArrival":{"lock":true,"time":41,"warning":null,"timeFormatter":null,"consecutiveTime":221},"targetDeparture":{"lock":true,"time":29,"warning":null,"timeFormatter":null,"consecutiveTime":209},"targetArrival":{"lock":true,"time":31,"warning":null,"timeFormatter":null,"consecutiveTime":331},"numberOfStops":0,"trainrunId":81,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":112,"y":1182},{"x":112,"y":1118},{"x":112,"y":866},{"x":112,"y":802}],"textPositions":{"0":{"x":124,"y":1164},"1":{"x":100,"y":1136},"2":{"x":100,"y":820},"3":{"x":124,"y":848},"4":{"x":100,"y":992},"5":{"x":100,"y":992},"6":{"x":124,"y":992}}},"warnings":null},{"id":546,"sourceNodeId":143,"sourcePortId":1107,"targetNodeId":172,"targetPortId":1108,"travelTime":{"lock":true,"time":6,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":32,"warning":null,"timeFormatter":null,"consecutiveTime":332},"sourceArrival":{"lock":true,"time":28,"warning":null,"timeFormatter":null,"consecutiveTime":208},"targetDeparture":{"lock":false,"time":22,"warning":null,"timeFormatter":null,"consecutiveTime":202},"targetArrival":{"lock":false,"time":38,"warning":null,"timeFormatter":null,"consecutiveTime":338},"numberOfStops":0,"trainrunId":81,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":62,"y":752},{"x":-2,"y":752},{"x":-446,"y":336},{"x":-510,"y":336}],"textPositions":{"0":{"x":44,"y":740},"1":{"x":16,"y":764},"2":{"x":-492,"y":348},"3":{"x":-464,"y":324},"4":{"x":-224,"y":532},"5":{"x":-224,"y":532},"6":{"x":-224,"y":556}}},"warnings":null},{"id":547,"sourceNodeId":129,"sourcePortId":1109,"targetNodeId":171,"targetPortId":1110,"travelTime":{"lock":false,"time":22,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":4,"warning":null,"timeFormatter":null,"consecutiveTime":364},"sourceArrival":{"lock":true,"time":56,"warning":null,"timeFormatter":null,"consecutiveTime":176},"targetDeparture":{"lock":true,"time":34,"warning":null,"timeFormatter":null,"consecutiveTime":154},"targetArrival":{"lock":true,"time":26,"warning":null,"timeFormatter":null,"consecutiveTime":386},"numberOfStops":0,"trainrunId":81,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-2146,"y":176},{"x":-2210,"y":176},{"x":-2398,"y":336},{"x":-2462,"y":336}],"textPositions":{"0":{"x":-2164,"y":164},"1":{"x":-2192,"y":188},"2":{"x":-2444,"y":348},"3":{"x":-2416,"y":324},"4":{"x":-2304,"y":244},"5":{"x":-2304,"y":244},"6":{"x":-2304,"y":268}}},"warnings":null},{"id":548,"sourceNodeId":142,"sourcePortId":1111,"targetNodeId":141,"targetPortId":1112,"travelTime":{"lock":true,"time":18,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":30,"warning":null,"timeFormatter":null,"consecutiveTime":90},"sourceArrival":{"lock":true,"time":30,"warning":null,"timeFormatter":null,"consecutiveTime":90},"targetDeparture":{"lock":true,"time":12,"warning":null,"timeFormatter":null,"consecutiveTime":72},"targetArrival":{"lock":true,"time":48,"warning":null,"timeFormatter":null,"consecutiveTime":108},"numberOfStops":0,"trainrunId":82,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":208,"y":1726},{"x":208,"y":1662},{"x":208,"y":1314},{"x":208,"y":1250}],"textPositions":{"0":{"x":220,"y":1708},"1":{"x":196,"y":1680},"2":{"x":196,"y":1268},"3":{"x":220,"y":1296},"4":{"x":196,"y":1488},"5":{"x":196,"y":1488},"6":{"x":220,"y":1488}}},"warnings":null},{"id":549,"sourceNodeId":141,"sourcePortId":1113,"targetNodeId":143,"targetPortId":1114,"travelTime":{"lock":true,"time":13,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":49,"warning":null,"timeFormatter":null,"consecutiveTime":109},"sourceArrival":{"lock":true,"time":11,"warning":null,"timeFormatter":null,"consecutiveTime":71},"targetDeparture":{"lock":false,"time":58,"warning":null,"timeFormatter":null,"consecutiveTime":58},"targetArrival":{"lock":false,"time":2,"warning":null,"timeFormatter":null,"consecutiveTime":122},"numberOfStops":0,"trainrunId":82,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":208,"y":1182},{"x":208,"y":1118},{"x":208,"y":866},{"x":208,"y":802}],"textPositions":{"0":{"x":220,"y":1164},"1":{"x":196,"y":1136},"2":{"x":196,"y":820},"3":{"x":220,"y":848},"4":{"x":196,"y":992},"5":{"x":196,"y":992},"6":{"x":220,"y":992}}},"warnings":null},{"id":550,"sourceNodeId":143,"sourcePortId":1115,"targetNodeId":133,"targetPortId":1116,"travelTime":{"lock":true,"time":7,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":4,"warning":null,"timeFormatter":null,"consecutiveTime":124},"sourceArrival":{"lock":true,"time":56,"warning":null,"timeFormatter":null,"consecutiveTime":56},"targetDeparture":{"lock":true,"time":49,"warning":null,"timeFormatter":null,"consecutiveTime":49},"targetArrival":{"lock":true,"time":11,"warning":null,"timeFormatter":null,"consecutiveTime":131},"numberOfStops":0,"trainrunId":82,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":176,"y":734},{"x":176,"y":670},{"x":176,"y":414},{"x":176,"y":350}],"textPositions":{"0":{"x":188,"y":716},"1":{"x":164,"y":688},"2":{"x":164,"y":368},"3":{"x":188,"y":396},"4":{"x":164,"y":542},"5":{"x":164,"y":542},"6":{"x":188,"y":542}}},"warnings":null},{"id":551,"sourceNodeId":133,"sourcePortId":1117,"targetNodeId":144,"targetPortId":1118,"travelTime":{"lock":true,"time":10,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":12,"warning":null,"timeFormatter":null,"consecutiveTime":132},"sourceArrival":{"lock":true,"time":48,"warning":null,"timeFormatter":null,"consecutiveTime":48},"targetDeparture":{"lock":true,"time":38,"warning":null,"timeFormatter":null,"consecutiveTime":38},"targetArrival":{"lock":true,"time":22,"warning":null,"timeFormatter":null,"consecutiveTime":142},"numberOfStops":0,"trainrunId":82,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":240,"y":94},{"x":240,"y":30},{"x":240,"y":-290},{"x":240,"y":-354}],"textPositions":{"0":{"x":252,"y":76},"1":{"x":228,"y":48},"2":{"x":228,"y":-336},"3":{"x":252,"y":-308},"4":{"x":228,"y":-130},"5":{"x":228,"y":-130},"6":{"x":252,"y":-130}}},"warnings":null},{"id":552,"sourceNodeId":144,"sourcePortId":1119,"targetNodeId":145,"targetPortId":1120,"travelTime":{"lock":true,"time":4,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":23,"warning":null,"timeFormatter":null,"consecutiveTime":143},"sourceArrival":{"lock":true,"time":37,"warning":null,"timeFormatter":null,"consecutiveTime":37},"targetDeparture":{"lock":true,"time":33,"warning":null,"timeFormatter":null,"consecutiveTime":33},"targetArrival":{"lock":true,"time":27,"warning":null,"timeFormatter":null,"consecutiveTime":147},"numberOfStops":0,"trainrunId":82,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":304,"y":-450},{"x":304,"y":-514},{"x":304,"y":-798},{"x":304,"y":-862}],"textPositions":{"0":{"x":316,"y":-468},"1":{"x":292,"y":-496},"2":{"x":292,"y":-844},"3":{"x":316,"y":-816},"4":{"x":292,"y":-656},"5":{"x":292,"y":-656},"6":{"x":316,"y":-656}}},"warnings":null},{"id":553,"sourceNodeId":145,"sourcePortId":1121,"targetNodeId":146,"targetPortId":1122,"travelTime":{"lock":true,"time":5,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":28,"warning":null,"timeFormatter":null,"consecutiveTime":148},"sourceArrival":{"lock":true,"time":32,"warning":null,"timeFormatter":null,"consecutiveTime":32},"targetDeparture":{"lock":true,"time":27,"warning":null,"timeFormatter":null,"consecutiveTime":27},"targetArrival":{"lock":true,"time":33,"warning":null,"timeFormatter":null,"consecutiveTime":153},"numberOfStops":0,"trainrunId":82,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":304,"y":-930},{"x":304,"y":-994},{"x":304,"y":-1278},{"x":304,"y":-1342}],"textPositions":{"0":{"x":316,"y":-948},"1":{"x":292,"y":-976},"2":{"x":292,"y":-1324},"3":{"x":316,"y":-1296},"4":{"x":292,"y":-1136},"5":{"x":292,"y":-1136},"6":{"x":316,"y":-1136}}},"warnings":null},{"id":554,"sourceNodeId":146,"sourcePortId":1123,"targetNodeId":134,"targetPortId":1124,"travelTime":{"lock":true,"time":10,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":34,"warning":null,"timeFormatter":null,"consecutiveTime":154},"sourceArrival":{"lock":true,"time":26,"warning":null,"timeFormatter":null,"consecutiveTime":26},"targetDeparture":{"lock":true,"time":16,"warning":null,"timeFormatter":null,"consecutiveTime":16},"targetArrival":{"lock":true,"time":44,"warning":null,"timeFormatter":null,"consecutiveTime":164},"numberOfStops":0,"trainrunId":82,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":304,"y":-1410},{"x":304,"y":-1474},{"x":304,"y":-1758},{"x":304,"y":-1822}],"textPositions":{"0":{"x":316,"y":-1428},"1":{"x":292,"y":-1456},"2":{"x":292,"y":-1804},"3":{"x":316,"y":-1776},"4":{"x":292,"y":-1616},"5":{"x":292,"y":-1616},"6":{"x":316,"y":-1616}}},"warnings":null},{"id":555,"sourceNodeId":142,"sourcePortId":1125,"targetNodeId":141,"targetPortId":1126,"travelTime":{"lock":true,"time":19,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":55,"warning":null,"timeFormatter":null,"consecutiveTime":115},"sourceArrival":{"lock":false,"time":5,"warning":null,"timeFormatter":null,"consecutiveTime":65},"targetDeparture":{"lock":false,"time":46,"warning":null,"timeFormatter":null,"consecutiveTime":46},"targetArrival":{"lock":false,"time":14,"warning":null,"timeFormatter":null,"consecutiveTime":134},"numberOfStops":0,"trainrunId":83,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":176,"y":1726},{"x":176,"y":1662},{"x":176,"y":1314},{"x":176,"y":1250}],"textPositions":{"0":{"x":188,"y":1708},"1":{"x":164,"y":1680},"2":{"x":164,"y":1268},"3":{"x":188,"y":1296},"4":{"x":164,"y":1488},"5":{"x":164,"y":1488},"6":{"x":188,"y":1488}}},"warnings":null},{"id":556,"sourceNodeId":141,"sourcePortId":1127,"targetNodeId":143,"targetPortId":1128,"travelTime":{"lock":true,"time":8,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":14,"warning":null,"timeFormatter":null,"consecutiveTime":134},"sourceArrival":{"lock":false,"time":46,"warning":null,"timeFormatter":null,"consecutiveTime":46},"targetDeparture":{"lock":false,"time":38,"warning":null,"timeFormatter":null,"consecutiveTime":38},"targetArrival":{"lock":false,"time":22,"warning":null,"timeFormatter":null,"consecutiveTime":142},"numberOfStops":0,"trainrunId":83,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":176,"y":1182},{"x":176,"y":1118},{"x":176,"y":866},{"x":176,"y":802}],"textPositions":{"0":{"x":188,"y":1164},"1":{"x":164,"y":1136},"2":{"x":164,"y":820},"3":{"x":188,"y":848},"4":{"x":164,"y":992},"5":{"x":164,"y":992},"6":{"x":188,"y":992}}},"warnings":null},{"id":557,"sourceNodeId":143,"sourcePortId":1129,"targetNodeId":133,"targetPortId":1130,"travelTime":{"lock":true,"time":8,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":22,"warning":null,"timeFormatter":null,"consecutiveTime":142},"sourceArrival":{"lock":false,"time":38,"warning":null,"timeFormatter":null,"consecutiveTime":38},"targetDeparture":{"lock":true,"time":30,"warning":null,"timeFormatter":null,"consecutiveTime":30},"targetArrival":{"lock":true,"time":30,"warning":null,"timeFormatter":null,"consecutiveTime":150},"numberOfStops":0,"trainrunId":83,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":144,"y":734},{"x":144,"y":670},{"x":144,"y":414},{"x":144,"y":350}],"textPositions":{"0":{"x":156,"y":716},"1":{"x":132,"y":688},"2":{"x":132,"y":368},"3":{"x":156,"y":396},"4":{"x":132,"y":542},"5":{"x":132,"y":542},"6":{"x":156,"y":542}}},"warnings":null},{"id":558,"sourceNodeId":133,"sourcePortId":1131,"targetNodeId":144,"targetPortId":1132,"travelTime":{"lock":true,"time":10,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":32,"warning":null,"timeFormatter":null,"consecutiveTime":152},"sourceArrival":{"lock":true,"time":28,"warning":null,"timeFormatter":null,"consecutiveTime":28},"targetDeparture":{"lock":false,"time":18,"warning":null,"timeFormatter":null,"consecutiveTime":18},"targetArrival":{"lock":false,"time":42,"warning":null,"timeFormatter":null,"consecutiveTime":162},"numberOfStops":0,"trainrunId":83,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":208,"y":94},{"x":208,"y":30},{"x":208,"y":-290},{"x":208,"y":-354}],"textPositions":{"0":{"x":220,"y":76},"1":{"x":196,"y":48},"2":{"x":196,"y":-336},"3":{"x":220,"y":-308},"4":{"x":196,"y":-130},"5":{"x":196,"y":-130},"6":{"x":220,"y":-130}}},"warnings":null},{"id":559,"sourceNodeId":144,"sourcePortId":1133,"targetNodeId":145,"targetPortId":1134,"travelTime":{"lock":true,"time":5,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":42,"warning":null,"timeFormatter":null,"consecutiveTime":162},"sourceArrival":{"lock":false,"time":18,"warning":null,"timeFormatter":null,"consecutiveTime":18},"targetDeparture":{"lock":false,"time":13,"warning":null,"timeFormatter":null,"consecutiveTime":13},"targetArrival":{"lock":false,"time":47,"warning":null,"timeFormatter":null,"consecutiveTime":167},"numberOfStops":0,"trainrunId":83,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":272,"y":-450},{"x":272,"y":-514},{"x":272,"y":-798},{"x":272,"y":-862}],"textPositions":{"0":{"x":284,"y":-468},"1":{"x":260,"y":-496},"2":{"x":260,"y":-844},"3":{"x":284,"y":-816},"4":{"x":260,"y":-656},"5":{"x":260,"y":-656},"6":{"x":284,"y":-656}}},"warnings":null},{"id":560,"sourceNodeId":145,"sourcePortId":1135,"targetNodeId":146,"targetPortId":1136,"travelTime":{"lock":true,"time":5,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":47,"warning":null,"timeFormatter":null,"consecutiveTime":167},"sourceArrival":{"lock":false,"time":13,"warning":null,"timeFormatter":null,"consecutiveTime":13},"targetDeparture":{"lock":false,"time":8,"warning":null,"timeFormatter":null,"consecutiveTime":8},"targetArrival":{"lock":false,"time":52,"warning":null,"timeFormatter":null,"consecutiveTime":172},"numberOfStops":0,"trainrunId":83,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":272,"y":-930},{"x":272,"y":-994},{"x":272,"y":-1278},{"x":272,"y":-1342}],"textPositions":{"0":{"x":284,"y":-948},"1":{"x":260,"y":-976},"2":{"x":260,"y":-1324},"3":{"x":284,"y":-1296},"4":{"x":260,"y":-1136},"5":{"x":260,"y":-1136},"6":{"x":284,"y":-1136}}},"warnings":null},{"id":561,"sourceNodeId":146,"sourcePortId":1137,"targetNodeId":134,"targetPortId":1138,"travelTime":{"lock":true,"time":5,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":52,"warning":null,"timeFormatter":null,"consecutiveTime":172},"sourceArrival":{"lock":false,"time":8,"warning":null,"timeFormatter":null,"consecutiveTime":8},"targetDeparture":{"lock":false,"time":3,"warning":null,"timeFormatter":null,"consecutiveTime":3},"targetArrival":{"lock":false,"time":57,"warning":null,"timeFormatter":null,"consecutiveTime":177},"numberOfStops":0,"trainrunId":83,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":272,"y":-1410},{"x":272,"y":-1474},{"x":272,"y":-1758},{"x":272,"y":-1822}],"textPositions":{"0":{"x":284,"y":-1428},"1":{"x":260,"y":-1456},"2":{"x":260,"y":-1804},"3":{"x":284,"y":-1776},"4":{"x":260,"y":-1616},"5":{"x":260,"y":-1616},"6":{"x":284,"y":-1616}}},"warnings":null},{"id":562,"sourceNodeId":135,"sourcePortId":1139,"targetNodeId":150,"targetPortId":1140,"travelTime":{"lock":true,"time":12,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":9,"warning":null,"timeFormatter":null,"consecutiveTime":9},"sourceArrival":{"lock":true,"time":51,"warning":null,"timeFormatter":null,"consecutiveTime":291},"targetDeparture":{"lock":true,"time":39,"warning":null,"timeFormatter":null,"consecutiveTime":279},"targetArrival":{"lock":true,"time":21,"warning":null,"timeFormatter":null,"consecutiveTime":21},"numberOfStops":1,"trainrunId":84,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2850,"y":176},{"x":2914,"y":176},{"x":3230,"y":176},{"x":3294,"y":176}],"textPositions":{"0":{"x":2868,"y":188},"1":{"x":2896,"y":164},"2":{"x":3276,"y":164},"3":{"x":3248,"y":188},"4":{"x":3072,"y":164},"5":{"x":3072,"y":164},"6":{"x":3072,"y":188}}},"warnings":null},{"id":563,"sourceNodeId":150,"sourcePortId":1141,"targetNodeId":151,"targetPortId":1142,"travelTime":{"lock":true,"time":13,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":23,"warning":null,"timeFormatter":null,"consecutiveTime":23},"sourceArrival":{"lock":false,"time":37,"warning":null,"timeFormatter":null,"consecutiveTime":277},"targetDeparture":{"lock":true,"time":24,"warning":null,"timeFormatter":null,"consecutiveTime":264},"targetArrival":{"lock":true,"time":36,"warning":null,"timeFormatter":null,"consecutiveTime":36},"numberOfStops":0,"trainrunId":84,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":3394,"y":176},{"x":3458,"y":176},{"x":3806,"y":176},{"x":3870,"y":176}],"textPositions":{"0":{"x":3412,"y":188},"1":{"x":3440,"y":164},"2":{"x":3852,"y":164},"3":{"x":3824,"y":188},"4":{"x":3632,"y":164},"5":{"x":3632,"y":164},"6":{"x":3632,"y":188}}},"warnings":null},{"id":564,"sourceNodeId":151,"sourcePortId":1143,"targetNodeId":137,"targetPortId":1144,"travelTime":{"lock":true,"time":44,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":38,"warning":null,"timeFormatter":null,"consecutiveTime":38},"sourceArrival":{"lock":false,"time":22,"warning":null,"timeFormatter":null,"consecutiveTime":262},"targetDeparture":{"lock":false,"time":38,"warning":null,"timeFormatter":null,"consecutiveTime":218},"targetArrival":{"lock":false,"time":22,"warning":null,"timeFormatter":null,"consecutiveTime":82},"numberOfStops":4,"trainrunId":84,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":3970,"y":176},{"x":4034,"y":176},{"x":4574,"y":176},{"x":4638,"y":176}],"textPositions":{"0":{"x":3988,"y":188},"1":{"x":4016,"y":164},"2":{"x":4620,"y":164},"3":{"x":4592,"y":188},"4":{"x":4304,"y":164},"5":{"x":4304,"y":164},"6":{"x":4304,"y":188}}},"warnings":null},{"id":565,"sourceNodeId":137,"sourcePortId":1145,"targetNodeId":140,"targetPortId":1146,"travelTime":{"lock":true,"time":61,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":24,"warning":null,"timeFormatter":null,"consecutiveTime":84},"sourceArrival":{"lock":false,"time":36,"warning":null,"timeFormatter":null,"consecutiveTime":216},"targetDeparture":{"lock":false,"time":35,"warning":null,"timeFormatter":null,"consecutiveTime":155},"targetArrival":{"lock":false,"time":25,"warning":null,"timeFormatter":null,"consecutiveTime":145},"numberOfStops":5,"trainrunId":84,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":4656,"y":222},{"x":4656,"y":286},{"x":4656,"y":1118},{"x":4656,"y":1182}],"textPositions":{"0":{"x":4644,"y":240},"1":{"x":4668,"y":268},"2":{"x":4668,"y":1164},"3":{"x":4644,"y":1136},"4":{"x":4644,"y":702},"5":{"x":4644,"y":702},"6":{"x":4668,"y":702}}},"warnings":null},{"id":566,"sourceNodeId":140,"sourcePortId":1147,"targetNodeId":152,"targetPortId":1148,"travelTime":{"lock":true,"time":22,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":26,"warning":null,"timeFormatter":null,"consecutiveTime":146},"sourceArrival":{"lock":true,"time":34,"warning":null,"timeFormatter":null,"consecutiveTime":154},"targetDeparture":{"lock":true,"time":12,"warning":null,"timeFormatter":null,"consecutiveTime":132},"targetArrival":{"lock":true,"time":48,"warning":null,"timeFormatter":null,"consecutiveTime":168},"numberOfStops":2,"trainrunId":84,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":4688,"y":1278},{"x":4688,"y":1342},{"x":4688,"y":1822},{"x":4688,"y":1886}],"textPositions":{"0":{"x":4676,"y":1296},"1":{"x":4700,"y":1324},"2":{"x":4700,"y":1868},"3":{"x":4676,"y":1840},"4":{"x":4676,"y":1582},"5":{"x":4676,"y":1582},"6":{"x":4700,"y":1582}}},"warnings":null},{"id":567,"sourceNodeId":135,"sourcePortId":1149,"targetNodeId":170,"targetPortId":1150,"travelTime":{"lock":false,"time":8,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":7,"warning":null,"timeFormatter":null,"consecutiveTime":67},"sourceArrival":{"lock":true,"time":53,"warning":null,"timeFormatter":null,"consecutiveTime":293},"targetDeparture":{"lock":false,"time":45,"warning":null,"timeFormatter":null,"consecutiveTime":285},"targetArrival":{"lock":false,"time":15,"warning":null,"timeFormatter":null,"consecutiveTime":75},"numberOfStops":0,"trainrunId":85,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2704,"y":350},{"x":2704,"y":414},{"x":2704,"y":670},{"x":2704,"y":734}],"textPositions":{"0":{"x":2692,"y":368},"1":{"x":2716,"y":396},"2":{"x":2716,"y":716},"3":{"x":2692,"y":688},"4":{"x":2692,"y":542},"5":{"x":2692,"y":542},"6":{"x":2716,"y":542}}},"warnings":null},{"id":568,"sourceNodeId":140,"sourcePortId":1151,"targetNodeId":152,"targetPortId":1152,"travelTime":{"lock":true,"time":19,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":3,"warning":null,"timeFormatter":null,"consecutiveTime":123},"sourceArrival":{"lock":true,"time":57,"warning":null,"timeFormatter":null,"consecutiveTime":237},"targetDeparture":{"lock":true,"time":38,"warning":null,"timeFormatter":null,"consecutiveTime":218},"targetArrival":{"lock":true,"time":22,"warning":null,"timeFormatter":null,"consecutiveTime":142},"numberOfStops":1,"trainrunId":85,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":4656,"y":1278},{"x":4656,"y":1342},{"x":4656,"y":1822},{"x":4656,"y":1886}],"textPositions":{"0":{"x":4644,"y":1296},"1":{"x":4668,"y":1324},"2":{"x":4668,"y":1868},"3":{"x":4644,"y":1840},"4":{"x":4644,"y":1582},"5":{"x":4644,"y":1582},"6":{"x":4668,"y":1582}}},"warnings":null},{"id":569,"sourceNodeId":135,"sourcePortId":1153,"targetNodeId":170,"targetPortId":1154,"travelTime":{"lock":true,"time":8,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":12,"warning":null,"timeFormatter":null,"consecutiveTime":132},"sourceArrival":{"lock":false,"time":48,"warning":null,"timeFormatter":null,"consecutiveTime":288},"targetDeparture":{"lock":true,"time":40,"warning":null,"timeFormatter":null,"consecutiveTime":280},"targetArrival":{"lock":true,"time":20,"warning":null,"timeFormatter":null,"consecutiveTime":140},"numberOfStops":0,"trainrunId":86,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2736,"y":350},{"x":2736,"y":414},{"x":2736,"y":670},{"x":2736,"y":734}],"textPositions":{"0":{"x":2724,"y":368},"1":{"x":2748,"y":396},"2":{"x":2748,"y":716},"3":{"x":2724,"y":688},"4":{"x":2724,"y":542},"5":{"x":2724,"y":542},"6":{"x":2748,"y":542}}},"warnings":null},{"id":570,"sourceNodeId":140,"sourcePortId":1155,"targetNodeId":152,"targetPortId":1156,"travelTime":{"lock":true,"time":20,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":23,"warning":null,"timeFormatter":null,"consecutiveTime":203},"sourceArrival":{"lock":true,"time":37,"warning":null,"timeFormatter":null,"consecutiveTime":217},"targetDeparture":{"lock":true,"time":17,"warning":null,"timeFormatter":null,"consecutiveTime":197},"targetArrival":{"lock":true,"time":43,"warning":null,"timeFormatter":null,"consecutiveTime":223},"numberOfStops":1,"trainrunId":86,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":4720,"y":1278},{"x":4720,"y":1342},{"x":4720,"y":1822},{"x":4720,"y":1886}],"textPositions":{"0":{"x":4708,"y":1296},"1":{"x":4732,"y":1324},"2":{"x":4732,"y":1868},"3":{"x":4708,"y":1840},"4":{"x":4708,"y":1582},"5":{"x":4708,"y":1582},"6":{"x":4732,"y":1582}}},"warnings":null},{"id":571,"sourceNodeId":135,"sourcePortId":1157,"targetNodeId":149,"targetPortId":1158,"travelTime":{"lock":true,"time":7,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":54,"warning":null,"timeFormatter":null,"consecutiveTime":294},"sourceArrival":{"lock":true,"time":6,"warning":null,"timeFormatter":null,"consecutiveTime":126},"targetDeparture":{"lock":false,"time":59,"warning":null,"timeFormatter":null,"consecutiveTime":119},"targetArrival":{"lock":false,"time":1,"warning":null,"timeFormatter":null,"consecutiveTime":301},"numberOfStops":1,"trainrunId":86,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2654,"y":240},{"x":2590,"y":240},{"x":2402,"y":240},{"x":2338,"y":240}],"textPositions":{"0":{"x":2636,"y":228},"1":{"x":2608,"y":252},"2":{"x":2356,"y":252},"3":{"x":2384,"y":228},"4":{"x":2496,"y":228},"5":{"x":2496,"y":228},"6":{"x":2496,"y":252}}},"warnings":null},{"id":572,"sourceNodeId":149,"sourcePortId":1159,"targetNodeId":166,"targetPortId":1160,"travelTime":{"lock":true,"time":7,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":1,"warning":null,"timeFormatter":null,"consecutiveTime":301},"sourceArrival":{"lock":false,"time":59,"warning":null,"timeFormatter":null,"consecutiveTime":119},"targetDeparture":{"lock":false,"time":52,"warning":null,"timeFormatter":null,"consecutiveTime":112},"targetArrival":{"lock":false,"time":8,"warning":null,"timeFormatter":null,"consecutiveTime":308},"numberOfStops":0,"trainrunId":86,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2238,"y":240},{"x":2174,"y":240},{"x":1954,"y":240},{"x":1890,"y":240}],"textPositions":{"0":{"x":2220,"y":228},"1":{"x":2192,"y":252},"2":{"x":1908,"y":252},"3":{"x":1936,"y":228},"4":{"x":2064,"y":228},"5":{"x":2064,"y":228},"6":{"x":2064,"y":252}}},"warnings":null},{"id":573,"sourceNodeId":148,"sourcePortId":1161,"targetNodeId":147,"targetPortId":1162,"travelTime":{"lock":true,"time":7,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":15,"warning":null,"timeFormatter":null,"consecutiveTime":315},"sourceArrival":{"lock":false,"time":45,"warning":null,"timeFormatter":null,"consecutiveTime":105},"targetDeparture":{"lock":false,"time":38,"warning":null,"timeFormatter":null,"consecutiveTime":98},"targetArrival":{"lock":false,"time":22,"warning":null,"timeFormatter":null,"consecutiveTime":322},"numberOfStops":0,"trainrunId":86,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1342,"y":240},{"x":1278,"y":240},{"x":1122,"y":240},{"x":1058,"y":240}],"textPositions":{"0":{"x":1324,"y":228},"1":{"x":1296,"y":252},"2":{"x":1076,"y":252},"3":{"x":1104,"y":228},"4":{"x":1200,"y":228},"5":{"x":1200,"y":228},"6":{"x":1200,"y":252}}},"warnings":null},{"id":574,"sourceNodeId":147,"sourcePortId":1163,"targetNodeId":133,"targetPortId":1164,"travelTime":{"lock":true,"time":8,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":22,"warning":null,"timeFormatter":null,"consecutiveTime":322},"sourceArrival":{"lock":false,"time":38,"warning":null,"timeFormatter":null,"consecutiveTime":98},"targetDeparture":{"lock":true,"time":30,"warning":null,"timeFormatter":null,"consecutiveTime":90},"targetArrival":{"lock":true,"time":30,"warning":null,"timeFormatter":null,"consecutiveTime":330},"numberOfStops":0,"trainrunId":86,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":958,"y":240},{"x":894,"y":240},{"x":322,"y":240},{"x":258,"y":240}],"textPositions":{"0":{"x":940,"y":228},"1":{"x":912,"y":252},"2":{"x":276,"y":252},"3":{"x":304,"y":228},"4":{"x":608,"y":228},"5":{"x":608,"y":228},"6":{"x":608,"y":252}}},"warnings":null},{"id":575,"sourceNodeId":133,"sourcePortId":1165,"targetNodeId":172,"targetPortId":1166,"travelTime":{"lock":true,"time":7,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":36,"warning":null,"timeFormatter":null,"consecutiveTime":336},"sourceArrival":{"lock":true,"time":24,"warning":null,"timeFormatter":null,"consecutiveTime":84},"targetDeparture":{"lock":false,"time":17,"warning":null,"timeFormatter":null,"consecutiveTime":77},"targetArrival":{"lock":false,"time":43,"warning":null,"timeFormatter":null,"consecutiveTime":343},"numberOfStops":0,"trainrunId":86,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":62,"y":304},{"x":-2,"y":304},{"x":-446,"y":304},{"x":-510,"y":304}],"textPositions":{"0":{"x":44,"y":292},"1":{"x":16,"y":316},"2":{"x":-492,"y":316},"3":{"x":-464,"y":292},"4":{"x":-224,"y":292},"5":{"x":-224,"y":292},"6":{"x":-224,"y":316}}},"warnings":null},{"id":576,"sourceNodeId":137,"sourcePortId":1167,"targetNodeId":151,"targetPortId":1168,"travelTime":{"lock":true,"time":33,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":58,"warning":null,"timeFormatter":null,"consecutiveTime":298},"sourceArrival":{"lock":false,"time":2,"warning":null,"timeFormatter":null,"consecutiveTime":242},"targetDeparture":{"lock":false,"time":29,"warning":null,"timeFormatter":null,"consecutiveTime":209},"targetArrival":{"lock":false,"time":31,"warning":null,"timeFormatter":null,"consecutiveTime":331},"numberOfStops":0,"trainrunId":87,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":4638,"y":144},{"x":4574,"y":144},{"x":4034,"y":144},{"x":3970,"y":144}],"textPositions":{"0":{"x":4620,"y":132},"1":{"x":4592,"y":156},"2":{"x":3988,"y":156},"3":{"x":4016,"y":132},"4":{"x":4304,"y":132},"5":{"x":4304,"y":132},"6":{"x":4304,"y":156}}},"warnings":null},{"id":577,"sourceNodeId":151,"sourcePortId":1169,"targetNodeId":150,"targetPortId":1170,"travelTime":{"lock":true,"time":14,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":33,"warning":null,"timeFormatter":null,"consecutiveTime":333},"sourceArrival":{"lock":false,"time":27,"warning":null,"timeFormatter":null,"consecutiveTime":207},"targetDeparture":{"lock":true,"time":13,"warning":null,"timeFormatter":null,"consecutiveTime":193},"targetArrival":{"lock":true,"time":47,"warning":null,"timeFormatter":null,"consecutiveTime":347},"numberOfStops":0,"trainrunId":87,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":3870,"y":80},{"x":3806,"y":80},{"x":3458,"y":80},{"x":3394,"y":80}],"textPositions":{"0":{"x":3852,"y":68},"1":{"x":3824,"y":92},"2":{"x":3412,"y":92},"3":{"x":3440,"y":68},"4":{"x":3632,"y":68},"5":{"x":3632,"y":68},"6":{"x":3632,"y":92}}},"warnings":null},{"id":578,"sourceNodeId":150,"sourcePortId":1171,"targetNodeId":135,"targetPortId":1172,"travelTime":{"lock":true,"time":9,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":48,"warning":null,"timeFormatter":null,"consecutiveTime":348},"sourceArrival":{"lock":true,"time":12,"warning":null,"timeFormatter":null,"consecutiveTime":192},"targetDeparture":{"lock":true,"time":3,"warning":null,"timeFormatter":null,"consecutiveTime":183},"targetArrival":{"lock":true,"time":57,"warning":null,"timeFormatter":null,"consecutiveTime":357},"numberOfStops":0,"trainrunId":87,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":3294,"y":80},{"x":3230,"y":80},{"x":2914,"y":80},{"x":2850,"y":80}],"textPositions":{"0":{"x":3276,"y":68},"1":{"x":3248,"y":92},"2":{"x":2868,"y":92},"3":{"x":2896,"y":68},"4":{"x":3072,"y":68},"5":{"x":3072,"y":68},"6":{"x":3072,"y":92}}},"warnings":null},{"id":579,"sourceNodeId":135,"sourcePortId":1173,"targetNodeId":149,"targetPortId":1174,"travelTime":{"lock":true,"time":10,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":4,"warning":null,"timeFormatter":null,"consecutiveTime":364},"sourceArrival":{"lock":true,"time":56,"warning":{"title":"Source Arrival Warning","description":"Source arrival time cannot be reached"},"timeFormatter":null,"consecutiveTime":176},"targetDeparture":{"lock":false,"time":50,"warning":null,"timeFormatter":null,"consecutiveTime":170},"targetArrival":{"lock":false,"time":10,"warning":{"title":"Target Arrival Warning","description":"Target arrival time cannot be reached"},"timeFormatter":null,"consecutiveTime":370},"numberOfStops":0,"trainrunId":87,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2654,"y":144},{"x":2590,"y":144},{"x":2402,"y":144},{"x":2338,"y":144}],"textPositions":{"0":{"x":2636,"y":132},"1":{"x":2608,"y":156},"2":{"x":2356,"y":156},"3":{"x":2384,"y":132},"4":{"x":2496,"y":132},"5":{"x":2496,"y":132},"6":{"x":2496,"y":156}}},"warnings":null},{"id":580,"sourceNodeId":149,"sourcePortId":1175,"targetNodeId":166,"targetPortId":1176,"travelTime":{"lock":true,"time":7,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":10,"warning":null,"timeFormatter":null,"consecutiveTime":370},"sourceArrival":{"lock":false,"time":50,"warning":null,"timeFormatter":null,"consecutiveTime":170},"targetDeparture":{"lock":false,"time":43,"warning":null,"timeFormatter":null,"consecutiveTime":163},"targetArrival":{"lock":false,"time":17,"warning":null,"timeFormatter":null,"consecutiveTime":377},"numberOfStops":0,"trainrunId":87,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2238,"y":144},{"x":2174,"y":144},{"x":1954,"y":144},{"x":1890,"y":144}],"textPositions":{"0":{"x":2220,"y":132},"1":{"x":2192,"y":156},"2":{"x":1908,"y":156},"3":{"x":1936,"y":132},"4":{"x":2064,"y":132},"5":{"x":2064,"y":132},"6":{"x":2064,"y":156}}},"warnings":null},{"id":581,"sourceNodeId":148,"sourcePortId":1177,"targetNodeId":147,"targetPortId":1178,"travelTime":{"lock":true,"time":5,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":24,"warning":null,"timeFormatter":null,"consecutiveTime":384},"sourceArrival":{"lock":false,"time":36,"warning":null,"timeFormatter":null,"consecutiveTime":156},"targetDeparture":{"lock":true,"time":31,"warning":null,"timeFormatter":null,"consecutiveTime":151},"targetArrival":{"lock":true,"time":29,"warning":null,"timeFormatter":null,"consecutiveTime":389},"numberOfStops":0,"trainrunId":87,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1342,"y":144},{"x":1278,"y":144},{"x":1122,"y":144},{"x":1058,"y":144}],"textPositions":{"0":{"x":1324,"y":132},"1":{"x":1296,"y":156},"2":{"x":1076,"y":156},"3":{"x":1104,"y":132},"4":{"x":1200,"y":132},"5":{"x":1200,"y":132},"6":{"x":1200,"y":156}}},"warnings":null},{"id":582,"sourceNodeId":147,"sourcePortId":1179,"targetNodeId":133,"targetPortId":1180,"travelTime":{"lock":true,"time":9,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":31,"warning":null,"timeFormatter":null,"consecutiveTime":391},"sourceArrival":{"lock":true,"time":29,"warning":null,"timeFormatter":null,"consecutiveTime":149},"targetDeparture":{"lock":true,"time":20,"warning":null,"timeFormatter":null,"consecutiveTime":140},"targetArrival":{"lock":true,"time":40,"warning":null,"timeFormatter":null,"consecutiveTime":400},"numberOfStops":0,"trainrunId":87,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":958,"y":144},{"x":894,"y":144},{"x":322,"y":144},{"x":258,"y":144}],"textPositions":{"0":{"x":940,"y":132},"1":{"x":912,"y":156},"2":{"x":276,"y":156},"3":{"x":304,"y":132},"4":{"x":608,"y":132},"5":{"x":608,"y":132},"6":{"x":608,"y":156}}},"warnings":null},{"id":583,"sourceNodeId":133,"sourcePortId":1181,"targetNodeId":175,"targetPortId":1182,"travelTime":{"lock":true,"time":17,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":42,"warning":null,"timeFormatter":null,"consecutiveTime":402},"sourceArrival":{"lock":true,"time":18,"warning":null,"timeFormatter":null,"consecutiveTime":138},"targetDeparture":{"lock":false,"time":1,"warning":null,"timeFormatter":null,"consecutiveTime":121},"targetArrival":{"lock":false,"time":59,"warning":null,"timeFormatter":null,"consecutiveTime":419},"numberOfStops":0,"trainrunId":87,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":62,"y":112},{"x":-2,"y":112},{"x":-1534,"y":-16},{"x":-1598,"y":-16}],"textPositions":{"0":{"x":44,"y":100},"1":{"x":16,"y":124},"2":{"x":-1580,"y":-4},"3":{"x":-1552,"y":-28},"4":{"x":-768,"y":36},"5":{"x":-768,"y":36},"6":{"x":-768,"y":60}}},"warnings":null},{"id":584,"sourceNodeId":130,"sourcePortId":1183,"targetNodeId":177,"targetPortId":1184,"travelTime":{"lock":false,"time":61,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":17,"warning":null,"timeFormatter":null,"consecutiveTime":437},"sourceArrival":{"lock":true,"time":43,"warning":null,"timeFormatter":null,"consecutiveTime":103},"targetDeparture":{"lock":true,"time":42,"warning":null,"timeFormatter":null,"consecutiveTime":42},"targetArrival":{"lock":true,"time":18,"warning":null,"timeFormatter":null,"consecutiveTime":498},"numberOfStops":2,"trainrunId":87,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-2530,"y":-16},{"x":-2594,"y":-16},{"x":-3358,"y":560},{"x":-3422,"y":560}],"textPositions":{"0":{"x":-2548,"y":-28},"1":{"x":-2576,"y":-4},"2":{"x":-3404,"y":572},"3":{"x":-3376,"y":548},"4":{"x":-2976,"y":260},"5":{"x":-2976,"y":260},"6":{"x":-2976,"y":284}}},"warnings":null},{"id":585,"sourceNodeId":160,"sourcePortId":1185,"targetNodeId":161,"targetPortId":1186,"travelTime":{"lock":true,"time":8,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":48,"warning":null,"timeFormatter":null,"consecutiveTime":528},"sourceArrival":{"lock":true,"time":12,"warning":null,"timeFormatter":null,"consecutiveTime":12},"targetDeparture":{"lock":false,"time":4,"warning":null,"timeFormatter":null,"consecutiveTime":4},"targetArrival":{"lock":false,"time":56,"warning":null,"timeFormatter":null,"consecutiveTime":536},"numberOfStops":0,"trainrunId":87,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-3938,"y":656},{"x":-4002,"y":656},{"x":-4190,"y":656},{"x":-4254,"y":656}],"textPositions":{"0":{"x":-3956,"y":644},"1":{"x":-3984,"y":668},"2":{"x":-4236,"y":668},"3":{"x":-4208,"y":644},"4":{"x":-4096,"y":644},"5":{"x":-4096,"y":644},"6":{"x":-4096,"y":668}}},"warnings":null},{"id":586,"sourceNodeId":128,"sourcePortId":1187,"targetNodeId":177,"targetPortId":1188,"travelTime":{"lock":false,"time":11,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":19,"warning":null,"timeFormatter":null,"consecutiveTime":439},"sourceArrival":{"lock":true,"time":41,"warning":null,"timeFormatter":null,"consecutiveTime":101},"targetDeparture":{"lock":true,"time":30,"warning":null,"timeFormatter":null,"consecutiveTime":90},"targetArrival":{"lock":true,"time":30,"warning":null,"timeFormatter":null,"consecutiveTime":450},"numberOfStops":0,"trainrunId":81,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-3074,"y":592},{"x":-3138,"y":592},{"x":-3358,"y":624},{"x":-3422,"y":624}],"textPositions":{"0":{"x":-3092,"y":580},"1":{"x":-3120,"y":604},"2":{"x":-3404,"y":636},"3":{"x":-3376,"y":612},"4":{"x":-3248,"y":596},"5":{"x":-3248,"y":596},"6":{"x":-3248,"y":620}}},"warnings":null},{"id":587,"sourceNodeId":160,"sourcePortId":1189,"targetNodeId":161,"targetPortId":1190,"travelTime":{"lock":false,"time":8,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":4,"warning":null,"timeFormatter":null,"consecutiveTime":484},"sourceArrival":{"lock":true,"time":56,"warning":null,"timeFormatter":null,"consecutiveTime":56},"targetDeparture":{"lock":true,"time":48,"warning":null,"timeFormatter":null,"consecutiveTime":48},"targetArrival":{"lock":true,"time":12,"warning":null,"timeFormatter":null,"consecutiveTime":492},"numberOfStops":0,"trainrunId":81,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-3938,"y":688},{"x":-4002,"y":688},{"x":-4190,"y":688},{"x":-4254,"y":688}],"textPositions":{"0":{"x":-3956,"y":676},"1":{"x":-3984,"y":700},"2":{"x":-4236,"y":700},"3":{"x":-4208,"y":676},"4":{"x":-4096,"y":676},"5":{"x":-4096,"y":676},"6":{"x":-4096,"y":700}}},"warnings":null},{"id":588,"sourceNodeId":135,"sourcePortId":1191,"targetNodeId":150,"targetPortId":1192,"travelTime":{"lock":true,"time":12,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":39,"warning":null,"timeFormatter":null,"consecutiveTime":219},"sourceArrival":{"lock":true,"time":21,"warning":null,"timeFormatter":null,"consecutiveTime":321},"targetDeparture":{"lock":true,"time":9,"warning":null,"timeFormatter":null,"consecutiveTime":309},"targetArrival":{"lock":true,"time":51,"warning":null,"timeFormatter":null,"consecutiveTime":231},"numberOfStops":1,"trainrunId":88,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2850,"y":48},{"x":2914,"y":48},{"x":3230,"y":48},{"x":3294,"y":48}],"textPositions":{"0":{"x":2868,"y":60},"1":{"x":2896,"y":36},"2":{"x":3276,"y":36},"3":{"x":3248,"y":60},"4":{"x":3072,"y":36},"5":{"x":3072,"y":36},"6":{"x":3072,"y":60}}},"warnings":null},{"id":589,"sourceNodeId":150,"sourcePortId":1193,"targetNodeId":151,"targetPortId":1194,"travelTime":{"lock":true,"time":13,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":53,"warning":null,"timeFormatter":null,"consecutiveTime":233},"sourceArrival":{"lock":false,"time":7,"warning":null,"timeFormatter":null,"consecutiveTime":307},"targetDeparture":{"lock":false,"time":54,"warning":null,"timeFormatter":null,"consecutiveTime":294},"targetArrival":{"lock":false,"time":6,"warning":null,"timeFormatter":null,"consecutiveTime":246},"numberOfStops":0,"trainrunId":88,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":3394,"y":48},{"x":3458,"y":48},{"x":3806,"y":48},{"x":3870,"y":48}],"textPositions":{"0":{"x":3412,"y":60},"1":{"x":3440,"y":36},"2":{"x":3852,"y":36},"3":{"x":3824,"y":60},"4":{"x":3632,"y":36},"5":{"x":3632,"y":36},"6":{"x":3632,"y":60}}},"warnings":null},{"id":590,"sourceNodeId":135,"sourcePortId":1195,"targetNodeId":149,"targetPortId":1196,"travelTime":{"lock":true,"time":5,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":46,"warning":null,"timeFormatter":null,"consecutiveTime":346},"sourceArrival":{"lock":false,"time":14,"warning":null,"timeFormatter":null,"consecutiveTime":194},"targetDeparture":{"lock":false,"time":9,"warning":null,"timeFormatter":null,"consecutiveTime":189},"targetArrival":{"lock":false,"time":51,"warning":null,"timeFormatter":null,"consecutiveTime":351},"numberOfStops":0,"trainrunId":88,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2654,"y":48},{"x":2590,"y":48},{"x":2402,"y":48},{"x":2338,"y":48}],"textPositions":{"0":{"x":2636,"y":36},"1":{"x":2608,"y":60},"2":{"x":2356,"y":60},"3":{"x":2384,"y":36},"4":{"x":2496,"y":36},"5":{"x":2496,"y":36},"6":{"x":2496,"y":60}}},"warnings":null},{"id":591,"sourceNodeId":149,"sourcePortId":1197,"targetNodeId":166,"targetPortId":1198,"travelTime":{"lock":true,"time":5,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":51,"warning":null,"timeFormatter":null,"consecutiveTime":351},"sourceArrival":{"lock":false,"time":9,"warning":null,"timeFormatter":null,"consecutiveTime":189},"targetDeparture":{"lock":false,"time":4,"warning":null,"timeFormatter":null,"consecutiveTime":184},"targetArrival":{"lock":false,"time":56,"warning":null,"timeFormatter":null,"consecutiveTime":356},"numberOfStops":0,"trainrunId":88,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2238,"y":48},{"x":2174,"y":48},{"x":1954,"y":48},{"x":1890,"y":48}],"textPositions":{"0":{"x":2220,"y":36},"1":{"x":2192,"y":60},"2":{"x":1908,"y":60},"3":{"x":1936,"y":36},"4":{"x":2064,"y":36},"5":{"x":2064,"y":36},"6":{"x":2064,"y":60}}},"warnings":null},{"id":592,"sourceNodeId":148,"sourcePortId":1199,"targetNodeId":147,"targetPortId":1200,"travelTime":{"lock":true,"time":4,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":1,"warning":null,"timeFormatter":null,"consecutiveTime":361},"sourceArrival":{"lock":false,"time":59,"warning":null,"timeFormatter":null,"consecutiveTime":179},"targetDeparture":{"lock":false,"time":55,"warning":null,"timeFormatter":null,"consecutiveTime":175},"targetArrival":{"lock":false,"time":5,"warning":null,"timeFormatter":null,"consecutiveTime":365},"numberOfStops":0,"trainrunId":88,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1342,"y":48},{"x":1278,"y":48},{"x":1122,"y":48},{"x":1058,"y":48}],"textPositions":{"0":{"x":1324,"y":36},"1":{"x":1296,"y":60},"2":{"x":1076,"y":60},"3":{"x":1104,"y":36},"4":{"x":1200,"y":36},"5":{"x":1200,"y":36},"6":{"x":1200,"y":60}}},"warnings":null},{"id":593,"sourceNodeId":147,"sourcePortId":1201,"targetNodeId":133,"targetPortId":1202,"travelTime":{"lock":true,"time":5,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":5,"warning":null,"timeFormatter":null,"consecutiveTime":365},"sourceArrival":{"lock":false,"time":55,"warning":null,"timeFormatter":null,"consecutiveTime":175},"targetDeparture":{"lock":false,"time":50,"warning":null,"timeFormatter":null,"consecutiveTime":170},"targetArrival":{"lock":false,"time":10,"warning":null,"timeFormatter":null,"consecutiveTime":370},"numberOfStops":0,"trainrunId":88,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":958,"y":112},{"x":894,"y":112},{"x":322,"y":112},{"x":258,"y":112}],"textPositions":{"0":{"x":940,"y":100},"1":{"x":912,"y":124},"2":{"x":276,"y":124},"3":{"x":304,"y":100},"4":{"x":608,"y":100},"5":{"x":608,"y":100},"6":{"x":608,"y":124}}},"warnings":null},{"id":594,"sourceNodeId":133,"sourcePortId":1203,"targetNodeId":172,"targetPortId":1204,"travelTime":{"lock":true,"time":7,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":10,"warning":null,"timeFormatter":null,"consecutiveTime":370},"sourceArrival":{"lock":false,"time":50,"warning":null,"timeFormatter":null,"consecutiveTime":170},"targetDeparture":{"lock":false,"time":43,"warning":null,"timeFormatter":null,"consecutiveTime":163},"targetArrival":{"lock":false,"time":17,"warning":null,"timeFormatter":null,"consecutiveTime":377},"numberOfStops":0,"trainrunId":88,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":62,"y":144},{"x":-2,"y":144},{"x":-446,"y":144},{"x":-510,"y":144}],"textPositions":{"0":{"x":44,"y":132},"1":{"x":16,"y":156},"2":{"x":-492,"y":156},"3":{"x":-464,"y":132},"4":{"x":-224,"y":132},"5":{"x":-224,"y":132},"6":{"x":-224,"y":156}}},"warnings":null},{"id":595,"sourceNodeId":129,"sourcePortId":1205,"targetNodeId":171,"targetPortId":1206,"travelTime":{"lock":true,"time":22,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":30,"warning":null,"timeFormatter":null,"consecutiveTime":390},"sourceArrival":{"lock":false,"time":30,"warning":null,"timeFormatter":null,"consecutiveTime":150},"targetDeparture":{"lock":false,"time":8,"warning":null,"timeFormatter":null,"consecutiveTime":128},"targetArrival":{"lock":false,"time":52,"warning":null,"timeFormatter":null,"consecutiveTime":412},"numberOfStops":0,"trainrunId":88,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-2146,"y":144},{"x":-2210,"y":144},{"x":-2398,"y":304},{"x":-2462,"y":304}],"textPositions":{"0":{"x":-2164,"y":132},"1":{"x":-2192,"y":156},"2":{"x":-2444,"y":316},"3":{"x":-2416,"y":292},"4":{"x":-2304,"y":212},"5":{"x":-2304,"y":212},"6":{"x":-2304,"y":236}}},"warnings":null},{"id":596,"sourceNodeId":128,"sourcePortId":1207,"targetNodeId":177,"targetPortId":1208,"travelTime":{"lock":true,"time":9,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":43,"warning":null,"timeFormatter":null,"consecutiveTime":463},"sourceArrival":{"lock":true,"time":17,"warning":null,"timeFormatter":null,"consecutiveTime":77},"targetDeparture":{"lock":false,"time":8,"warning":null,"timeFormatter":null,"consecutiveTime":68},"targetArrival":{"lock":false,"time":52,"warning":null,"timeFormatter":null,"consecutiveTime":472},"numberOfStops":0,"trainrunId":88,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-3074,"y":560},{"x":-3138,"y":560},{"x":-3358,"y":592},{"x":-3422,"y":592}],"textPositions":{"0":{"x":-3092,"y":548},"1":{"x":-3120,"y":572},"2":{"x":-3404,"y":604},"3":{"x":-3376,"y":580},"4":{"x":-3248,"y":564},"5":{"x":-3248,"y":564},"6":{"x":-3248,"y":588}}},"warnings":null},{"id":597,"sourceNodeId":160,"sourcePortId":1209,"targetNodeId":161,"targetPortId":1210,"travelTime":{"lock":true,"time":7,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":21,"warning":null,"timeFormatter":null,"consecutiveTime":501},"sourceArrival":{"lock":true,"time":39,"warning":null,"timeFormatter":null,"consecutiveTime":39},"targetDeparture":{"lock":true,"time":32,"warning":null,"timeFormatter":null,"consecutiveTime":32},"targetArrival":{"lock":true,"time":28,"warning":null,"timeFormatter":null,"consecutiveTime":508},"numberOfStops":0,"trainrunId":88,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-3938,"y":624},{"x":-4002,"y":624},{"x":-4190,"y":624},{"x":-4254,"y":624}],"textPositions":{"0":{"x":-3956,"y":612},"1":{"x":-3984,"y":636},"2":{"x":-4236,"y":636},"3":{"x":-4208,"y":612},"4":{"x":-4096,"y":612},"5":{"x":-4096,"y":612},"6":{"x":-4096,"y":636}}},"warnings":null},{"id":598,"sourceNodeId":151,"sourcePortId":1211,"targetNodeId":137,"targetPortId":1212,"travelTime":{"lock":false,"time":44,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":8,"warning":null,"timeFormatter":null,"consecutiveTime":248},"sourceArrival":{"lock":true,"time":52,"warning":null,"timeFormatter":null,"consecutiveTime":292},"targetDeparture":{"lock":false,"time":8,"warning":null,"timeFormatter":null,"consecutiveTime":248},"targetArrival":{"lock":false,"time":52,"warning":null,"timeFormatter":null,"consecutiveTime":292},"numberOfStops":4,"trainrunId":88,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":3970,"y":112},{"x":4034,"y":112},{"x":4574,"y":112},{"x":4638,"y":112}],"textPositions":{"0":{"x":3988,"y":124},"1":{"x":4016,"y":100},"2":{"x":4620,"y":100},"3":{"x":4592,"y":124},"4":{"x":4304,"y":100},"5":{"x":4304,"y":100},"6":{"x":4304,"y":124}}},"warnings":null},{"id":599,"sourceNodeId":135,"sourcePortId":1213,"targetNodeId":150,"targetPortId":1214,"travelTime":{"lock":true,"time":9,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":5,"warning":null,"timeFormatter":null,"consecutiveTime":125},"sourceArrival":{"lock":false,"time":55,"warning":null,"timeFormatter":null,"consecutiveTime":295},"targetDeparture":{"lock":false,"time":46,"warning":null,"timeFormatter":null,"consecutiveTime":286},"targetArrival":{"lock":false,"time":14,"warning":null,"timeFormatter":null,"consecutiveTime":134},"numberOfStops":0,"trainrunId":89,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2850,"y":112},{"x":2914,"y":112},{"x":3230,"y":112},{"x":3294,"y":112}],"textPositions":{"0":{"x":2868,"y":124},"1":{"x":2896,"y":100},"2":{"x":3276,"y":100},"3":{"x":3248,"y":124},"4":{"x":3072,"y":100},"5":{"x":3072,"y":100},"6":{"x":3072,"y":124}}},"warnings":null},{"id":600,"sourceNodeId":150,"sourcePortId":1215,"targetNodeId":151,"targetPortId":1216,"travelTime":{"lock":true,"time":13,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":16,"warning":null,"timeFormatter":null,"consecutiveTime":136},"sourceArrival":{"lock":false,"time":44,"warning":null,"timeFormatter":null,"consecutiveTime":284},"targetDeparture":{"lock":false,"time":31,"warning":null,"timeFormatter":null,"consecutiveTime":271},"targetArrival":{"lock":false,"time":29,"warning":null,"timeFormatter":null,"consecutiveTime":149},"numberOfStops":0,"trainrunId":89,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":3394,"y":112},{"x":3458,"y":112},{"x":3806,"y":112},{"x":3870,"y":112}],"textPositions":{"0":{"x":3412,"y":124},"1":{"x":3440,"y":100},"2":{"x":3852,"y":100},"3":{"x":3824,"y":124},"4":{"x":3632,"y":100},"5":{"x":3632,"y":100},"6":{"x":3632,"y":124}}},"warnings":null},{"id":601,"sourceNodeId":135,"sourcePortId":1217,"targetNodeId":149,"targetPortId":1218,"travelTime":{"lock":true,"time":6,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":2,"warning":null,"timeFormatter":null,"consecutiveTime":302},"sourceArrival":{"lock":true,"time":58,"warning":null,"timeFormatter":null,"consecutiveTime":118},"targetDeparture":{"lock":false,"time":52,"warning":null,"timeFormatter":null,"consecutiveTime":112},"targetArrival":{"lock":false,"time":8,"warning":null,"timeFormatter":null,"consecutiveTime":308},"numberOfStops":0,"trainrunId":89,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2654,"y":176},{"x":2590,"y":176},{"x":2402,"y":176},{"x":2338,"y":176}],"textPositions":{"0":{"x":2636,"y":164},"1":{"x":2608,"y":188},"2":{"x":2356,"y":188},"3":{"x":2384,"y":164},"4":{"x":2496,"y":164},"5":{"x":2496,"y":164},"6":{"x":2496,"y":188}}},"warnings":null},{"id":602,"sourceNodeId":149,"sourcePortId":1219,"targetNodeId":166,"targetPortId":1220,"travelTime":{"lock":true,"time":6,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":8,"warning":null,"timeFormatter":null,"consecutiveTime":308},"sourceArrival":{"lock":false,"time":52,"warning":null,"timeFormatter":null,"consecutiveTime":112},"targetDeparture":{"lock":false,"time":46,"warning":null,"timeFormatter":null,"consecutiveTime":106},"targetArrival":{"lock":false,"time":14,"warning":null,"timeFormatter":null,"consecutiveTime":314},"numberOfStops":0,"trainrunId":89,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2238,"y":176},{"x":2174,"y":176},{"x":1954,"y":176},{"x":1890,"y":176}],"textPositions":{"0":{"x":2220,"y":164},"1":{"x":2192,"y":188},"2":{"x":1908,"y":188},"3":{"x":1936,"y":164},"4":{"x":2064,"y":164},"5":{"x":2064,"y":164},"6":{"x":2064,"y":188}}},"warnings":null},{"id":603,"sourceNodeId":148,"sourcePortId":1221,"targetNodeId":147,"targetPortId":1222,"travelTime":{"lock":true,"time":5,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":20,"warning":null,"timeFormatter":null,"consecutiveTime":320},"sourceArrival":{"lock":false,"time":40,"warning":null,"timeFormatter":null,"consecutiveTime":100},"targetDeparture":{"lock":false,"time":35,"warning":null,"timeFormatter":null,"consecutiveTime":95},"targetArrival":{"lock":false,"time":25,"warning":null,"timeFormatter":null,"consecutiveTime":325},"numberOfStops":0,"trainrunId":89,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1342,"y":176},{"x":1278,"y":176},{"x":1122,"y":176},{"x":1058,"y":176}],"textPositions":{"0":{"x":1324,"y":164},"1":{"x":1296,"y":188},"2":{"x":1076,"y":188},"3":{"x":1104,"y":164},"4":{"x":1200,"y":164},"5":{"x":1200,"y":164},"6":{"x":1200,"y":188}}},"warnings":null},{"id":604,"sourceNodeId":147,"sourcePortId":1223,"targetNodeId":133,"targetPortId":1224,"travelTime":{"lock":true,"time":5,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":25,"warning":null,"timeFormatter":null,"consecutiveTime":325},"sourceArrival":{"lock":false,"time":35,"warning":null,"timeFormatter":null,"consecutiveTime":95},"targetDeparture":{"lock":false,"time":30,"warning":null,"timeFormatter":null,"consecutiveTime":90},"targetArrival":{"lock":false,"time":30,"warning":null,"timeFormatter":null,"consecutiveTime":330},"numberOfStops":0,"trainrunId":89,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":958,"y":176},{"x":894,"y":176},{"x":322,"y":176},{"x":258,"y":176}],"textPositions":{"0":{"x":940,"y":164},"1":{"x":912,"y":188},"2":{"x":276,"y":188},"3":{"x":304,"y":164},"4":{"x":608,"y":164},"5":{"x":608,"y":164},"6":{"x":608,"y":188}}},"warnings":null},{"id":605,"sourceNodeId":133,"sourcePortId":1225,"targetNodeId":172,"targetPortId":1226,"travelTime":{"lock":true,"time":7,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":30,"warning":null,"timeFormatter":null,"consecutiveTime":330},"sourceArrival":{"lock":true,"time":30,"warning":null,"timeFormatter":null,"consecutiveTime":90},"targetDeparture":{"lock":false,"time":23,"warning":null,"timeFormatter":null,"consecutiveTime":83},"targetArrival":{"lock":false,"time":37,"warning":null,"timeFormatter":null,"consecutiveTime":337},"numberOfStops":0,"trainrunId":89,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":62,"y":240},{"x":-2,"y":240},{"x":-446,"y":240},{"x":-510,"y":240}],"textPositions":{"0":{"x":44,"y":228},"1":{"x":16,"y":252},"2":{"x":-492,"y":252},"3":{"x":-464,"y":228},"4":{"x":-224,"y":228},"5":{"x":-224,"y":228},"6":{"x":-224,"y":252}}},"warnings":null},{"id":606,"sourceNodeId":151,"sourcePortId":1227,"targetNodeId":162,"targetPortId":1228,"travelTime":{"lock":true,"time":51,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":31,"warning":null,"timeFormatter":null,"consecutiveTime":151},"sourceArrival":{"lock":false,"time":29,"warning":null,"timeFormatter":null,"consecutiveTime":269},"targetDeparture":{"lock":false,"time":38,"warning":null,"timeFormatter":null,"consecutiveTime":218},"targetArrival":{"lock":false,"time":22,"warning":null,"timeFormatter":null,"consecutiveTime":202},"numberOfStops":0,"trainrunId":89,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":3970,"y":48},{"x":4034,"y":48},{"x":4574,"y":-176},{"x":4638,"y":-176}],"textPositions":{"0":{"x":3988,"y":60},"1":{"x":4016,"y":36},"2":{"x":4620,"y":-188},"3":{"x":4592,"y":-164},"4":{"x":4304,"y":-76},"5":{"x":4304,"y":-76},"6":{"x":4304,"y":-52}}},"warnings":null},{"id":607,"sourceNodeId":135,"sourcePortId":1229,"targetNodeId":150,"targetPortId":1230,"travelTime":{"lock":true,"time":9,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":5,"warning":null,"timeFormatter":null,"consecutiveTime":125},"sourceArrival":{"lock":false,"time":55,"warning":null,"timeFormatter":null,"consecutiveTime":295},"targetDeparture":{"lock":true,"time":46,"warning":null,"timeFormatter":null,"consecutiveTime":286},"targetArrival":{"lock":true,"time":14,"warning":null,"timeFormatter":null,"consecutiveTime":134},"numberOfStops":0,"trainrunId":90,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2850,"y":144},{"x":2914,"y":144},{"x":3230,"y":144},{"x":3294,"y":144}],"textPositions":{"0":{"x":2868,"y":156},"1":{"x":2896,"y":132},"2":{"x":3276,"y":132},"3":{"x":3248,"y":156},"4":{"x":3072,"y":132},"5":{"x":3072,"y":132},"6":{"x":3072,"y":156}}},"warnings":null},{"id":608,"sourceNodeId":150,"sourcePortId":1231,"targetNodeId":151,"targetPortId":1232,"travelTime":{"lock":true,"time":13,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":16,"warning":null,"timeFormatter":null,"consecutiveTime":136},"sourceArrival":{"lock":false,"time":44,"warning":null,"timeFormatter":null,"consecutiveTime":284},"targetDeparture":{"lock":false,"time":31,"warning":null,"timeFormatter":null,"consecutiveTime":271},"targetArrival":{"lock":false,"time":29,"warning":null,"timeFormatter":null,"consecutiveTime":149},"numberOfStops":0,"trainrunId":90,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":3394,"y":144},{"x":3458,"y":144},{"x":3806,"y":144},{"x":3870,"y":144}],"textPositions":{"0":{"x":3412,"y":156},"1":{"x":3440,"y":132},"2":{"x":3852,"y":132},"3":{"x":3824,"y":156},"4":{"x":3632,"y":132},"5":{"x":3632,"y":132},"6":{"x":3632,"y":156}}},"warnings":null},{"id":609,"sourceNodeId":135,"sourcePortId":1233,"targetNodeId":149,"targetPortId":1234,"travelTime":{"lock":true,"time":15,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":2,"warning":null,"timeFormatter":null,"consecutiveTime":302},"sourceArrival":{"lock":true,"time":58,"warning":null,"timeFormatter":null,"consecutiveTime":118},"targetDeparture":{"lock":true,"time":43,"warning":null,"timeFormatter":null,"consecutiveTime":103},"targetArrival":{"lock":true,"time":17,"warning":null,"timeFormatter":null,"consecutiveTime":317},"numberOfStops":0,"trainrunId":90,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2654,"y":208},{"x":2590,"y":208},{"x":2402,"y":208},{"x":2338,"y":208}],"textPositions":{"0":{"x":2636,"y":196},"1":{"x":2608,"y":220},"2":{"x":2356,"y":220},"3":{"x":2384,"y":196},"4":{"x":2496,"y":196},"5":{"x":2496,"y":196},"6":{"x":2496,"y":220}}},"warnings":null},{"id":610,"sourceNodeId":149,"sourcePortId":1235,"targetNodeId":166,"targetPortId":1236,"travelTime":{"lock":true,"time":6,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":17,"warning":null,"timeFormatter":null,"consecutiveTime":317},"sourceArrival":{"lock":false,"time":43,"warning":null,"timeFormatter":null,"consecutiveTime":103},"targetDeparture":{"lock":false,"time":37,"warning":null,"timeFormatter":null,"consecutiveTime":97},"targetArrival":{"lock":false,"time":23,"warning":null,"timeFormatter":null,"consecutiveTime":323},"numberOfStops":0,"trainrunId":90,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2238,"y":208},{"x":2174,"y":208},{"x":1954,"y":208},{"x":1890,"y":208}],"textPositions":{"0":{"x":2220,"y":196},"1":{"x":2192,"y":220},"2":{"x":1908,"y":220},"3":{"x":1936,"y":196},"4":{"x":2064,"y":196},"5":{"x":2064,"y":196},"6":{"x":2064,"y":220}}},"warnings":null},{"id":611,"sourceNodeId":148,"sourcePortId":1237,"targetNodeId":147,"targetPortId":1238,"travelTime":{"lock":true,"time":5,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":30,"warning":null,"timeFormatter":null,"consecutiveTime":330},"sourceArrival":{"lock":false,"time":30,"warning":null,"timeFormatter":null,"consecutiveTime":90},"targetDeparture":{"lock":false,"time":25,"warning":null,"timeFormatter":null,"consecutiveTime":85},"targetArrival":{"lock":false,"time":35,"warning":null,"timeFormatter":null,"consecutiveTime":335},"numberOfStops":0,"trainrunId":90,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1342,"y":208},{"x":1278,"y":208},{"x":1122,"y":208},{"x":1058,"y":208}],"textPositions":{"0":{"x":1324,"y":196},"1":{"x":1296,"y":220},"2":{"x":1076,"y":220},"3":{"x":1104,"y":196},"4":{"x":1200,"y":196},"5":{"x":1200,"y":196},"6":{"x":1200,"y":220}}},"warnings":null},{"id":612,"sourceNodeId":147,"sourcePortId":1239,"targetNodeId":133,"targetPortId":1240,"travelTime":{"lock":true,"time":5,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":35,"warning":null,"timeFormatter":null,"consecutiveTime":335},"sourceArrival":{"lock":false,"time":25,"warning":null,"timeFormatter":null,"consecutiveTime":85},"targetDeparture":{"lock":false,"time":20,"warning":null,"timeFormatter":null,"consecutiveTime":80},"targetArrival":{"lock":false,"time":40,"warning":null,"timeFormatter":null,"consecutiveTime":340},"numberOfStops":0,"trainrunId":90,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":958,"y":208},{"x":894,"y":208},{"x":322,"y":208},{"x":258,"y":208}],"textPositions":{"0":{"x":940,"y":196},"1":{"x":912,"y":220},"2":{"x":276,"y":220},"3":{"x":304,"y":196},"4":{"x":608,"y":196},"5":{"x":608,"y":196},"6":{"x":608,"y":220}}},"warnings":null},{"id":613,"sourceNodeId":133,"sourcePortId":1241,"targetNodeId":172,"targetPortId":1242,"travelTime":{"lock":true,"time":7,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":40,"warning":null,"timeFormatter":null,"consecutiveTime":340},"sourceArrival":{"lock":false,"time":20,"warning":null,"timeFormatter":null,"consecutiveTime":80},"targetDeparture":{"lock":false,"time":13,"warning":null,"timeFormatter":null,"consecutiveTime":73},"targetArrival":{"lock":false,"time":47,"warning":null,"timeFormatter":null,"consecutiveTime":347},"numberOfStops":0,"trainrunId":90,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":62,"y":272},{"x":-2,"y":272},{"x":-446,"y":272},{"x":-510,"y":272}],"textPositions":{"0":{"x":44,"y":260},"1":{"x":16,"y":284},"2":{"x":-492,"y":284},"3":{"x":-464,"y":260},"4":{"x":-224,"y":260},"5":{"x":-224,"y":260},"6":{"x":-224,"y":284}}},"warnings":null},{"id":614,"sourceNodeId":151,"sourcePortId":1243,"targetNodeId":162,"targetPortId":1244,"travelTime":{"lock":true,"time":41,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":31,"warning":null,"timeFormatter":null,"consecutiveTime":151},"sourceArrival":{"lock":false,"time":29,"warning":null,"timeFormatter":null,"consecutiveTime":269},"targetDeparture":{"lock":false,"time":48,"warning":null,"timeFormatter":null,"consecutiveTime":228},"targetArrival":{"lock":false,"time":12,"warning":null,"timeFormatter":null,"consecutiveTime":192},"numberOfStops":0,"trainrunId":90,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":3970,"y":80},{"x":4034,"y":80},{"x":4574,"y":-144},{"x":4638,"y":-144}],"textPositions":{"0":{"x":3988,"y":92},"1":{"x":4016,"y":68},"2":{"x":4620,"y":-156},"3":{"x":4592,"y":-132},"4":{"x":4304,"y":-44},"5":{"x":4304,"y":-44},"6":{"x":4304,"y":-20}}},"warnings":null},{"id":615,"sourceNodeId":135,"sourcePortId":1245,"targetNodeId":150,"targetPortId":1246,"travelTime":{"lock":true,"time":9,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":35,"warning":null,"timeFormatter":null,"consecutiveTime":95},"sourceArrival":{"lock":true,"time":25,"warning":null,"timeFormatter":null,"consecutiveTime":205},"targetDeparture":{"lock":true,"time":16,"warning":null,"timeFormatter":null,"consecutiveTime":196},"targetArrival":{"lock":true,"time":44,"warning":null,"timeFormatter":null,"consecutiveTime":104},"numberOfStops":0,"trainrunId":79,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2850,"y":208},{"x":2914,"y":208},{"x":3230,"y":208},{"x":3294,"y":208}],"textPositions":{"0":{"x":2868,"y":220},"1":{"x":2896,"y":196},"2":{"x":3276,"y":196},"3":{"x":3248,"y":220},"4":{"x":3072,"y":196},"5":{"x":3072,"y":196},"6":{"x":3072,"y":220}}},"warnings":null},{"id":616,"sourceNodeId":150,"sourcePortId":1247,"targetNodeId":151,"targetPortId":1248,"travelTime":{"lock":false,"time":13,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":46,"warning":null,"timeFormatter":null,"consecutiveTime":106},"sourceArrival":{"lock":true,"time":14,"warning":null,"timeFormatter":null,"consecutiveTime":194},"targetDeparture":{"lock":true,"time":1,"warning":null,"timeFormatter":null,"consecutiveTime":181},"targetArrival":{"lock":true,"time":59,"warning":null,"timeFormatter":null,"consecutiveTime":119},"numberOfStops":0,"trainrunId":79,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":3394,"y":208},{"x":3458,"y":208},{"x":3806,"y":208},{"x":3870,"y":208}],"textPositions":{"0":{"x":3412,"y":220},"1":{"x":3440,"y":196},"2":{"x":3852,"y":196},"3":{"x":3824,"y":220},"4":{"x":3632,"y":196},"5":{"x":3632,"y":196},"6":{"x":3632,"y":220}}},"warnings":null},{"id":617,"sourceNodeId":151,"sourcePortId":1249,"targetNodeId":139,"targetPortId":1250,"travelTime":{"lock":false,"time":49,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":1,"warning":null,"timeFormatter":null,"consecutiveTime":121},"sourceArrival":{"lock":true,"time":59,"warning":null,"timeFormatter":null,"consecutiveTime":179},"targetDeparture":{"lock":true,"time":10,"warning":null,"timeFormatter":null,"consecutiveTime":130},"targetArrival":{"lock":true,"time":50,"warning":null,"timeFormatter":null,"consecutiveTime":170},"numberOfStops":2,"trainrunId":79,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":3888,"y":30},{"x":3888,"y":-34},{"x":4272,"y":-286},{"x":4272,"y":-350}],"textPositions":{"0":{"x":3900,"y":12},"1":{"x":3876,"y":-16},"2":{"x":4260,"y":-332},"3":{"x":4284,"y":-304},"4":{"x":4068,"y":-160},"5":{"x":4068,"y":-160},"6":{"x":4092,"y":-160}}},"warnings":null},{"id":618,"sourceNodeId":138,"sourcePortId":1251,"targetNodeId":163,"targetPortId":1252,"travelTime":{"lock":true,"time":1,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":0,"warning":null,"timeFormatter":null,"consecutiveTime":0},"sourceArrival":{"lock":false,"time":0,"warning":null,"timeFormatter":null,"consecutiveTime":60},"targetDeparture":{"lock":false,"time":59,"warning":null,"timeFormatter":null,"consecutiveTime":59},"targetArrival":{"lock":false,"time":1,"warning":null,"timeFormatter":null,"consecutiveTime":1},"numberOfStops":0,"trainrunId":91,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2672,"y":-1054},{"x":2672,"y":-990},{"x":2800,"y":-610},{"x":2800,"y":-546}],"textPositions":{"0":{"x":2660,"y":-1036},"1":{"x":2684,"y":-1008},"2":{"x":2812,"y":-564},"3":{"x":2788,"y":-592},"4":{"x":2748,"y":-800},"5":{"x":2748,"y":-800},"6":{"x":2724,"y":-800}}},"warnings":null},{"id":619,"sourceNodeId":163,"sourcePortId":1253,"targetNodeId":135,"targetPortId":1254,"travelTime":{"lock":true,"time":1,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":3,"warning":null,"timeFormatter":null,"consecutiveTime":3},"sourceArrival":{"lock":false,"time":57,"warning":null,"timeFormatter":null,"consecutiveTime":57},"targetDeparture":{"lock":false,"time":56,"warning":null,"timeFormatter":null,"consecutiveTime":56},"targetArrival":{"lock":false,"time":4,"warning":null,"timeFormatter":null,"consecutiveTime":4},"numberOfStops":0,"trainrunId":91,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2800,"y":-478},{"x":2800,"y":-414},{"x":2704,"y":-34},{"x":2704,"y":30}],"textPositions":{"0":{"x":2788,"y":-460},"1":{"x":2812,"y":-432},"2":{"x":2716,"y":12},"3":{"x":2692,"y":-16},"4":{"x":2740,"y":-224},"5":{"x":2740,"y":-224},"6":{"x":2764,"y":-224}}},"warnings":null},{"id":620,"sourceNodeId":135,"sourcePortId":1255,"targetNodeId":138,"targetPortId":1256,"travelTime":{"lock":true,"time":1,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":0,"warning":null,"timeFormatter":null,"consecutiveTime":120},"sourceArrival":{"lock":false,"time":0,"warning":null,"timeFormatter":null,"consecutiveTime":60},"targetDeparture":{"lock":false,"time":59,"warning":null,"timeFormatter":null,"consecutiveTime":59},"targetArrival":{"lock":false,"time":1,"warning":null,"timeFormatter":null,"consecutiveTime":121},"numberOfStops":0,"trainrunId":92,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2672,"y":30},{"x":2672,"y":-34},{"x":2640,"y":-990},{"x":2640,"y":-1054}],"textPositions":{"0":{"x":2684,"y":12},"1":{"x":2660,"y":-16},"2":{"x":2628,"y":-1036},"3":{"x":2652,"y":-1008},"4":{"x":2668,"y":-512},"5":{"x":2668,"y":-512},"6":{"x":2644,"y":-512}}},"warnings":null},{"id":621,"sourceNodeId":166,"sourcePortId":1257,"targetNodeId":148,"targetPortId":1258,"travelTime":{"lock":true,"time":5,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":56,"warning":null,"timeFormatter":null,"consecutiveTime":356},"sourceArrival":{"lock":false,"time":4,"warning":null,"timeFormatter":null,"consecutiveTime":184},"targetDeparture":{"lock":false,"time":59,"warning":null,"timeFormatter":null,"consecutiveTime":179},"targetArrival":{"lock":false,"time":1,"warning":null,"timeFormatter":null,"consecutiveTime":361},"numberOfStops":0,"trainrunId":88,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1790,"y":48},{"x":1726,"y":48},{"x":1506,"y":48},{"x":1442,"y":48}],"textPositions":{"0":{"x":1772,"y":36},"1":{"x":1744,"y":60},"2":{"x":1460,"y":60},"3":{"x":1488,"y":36},"4":{"x":1616,"y":36},"5":{"x":1616,"y":36},"6":{"x":1616,"y":60}}},"warnings":null},{"id":622,"sourceNodeId":166,"sourcePortId":1259,"targetNodeId":148,"targetPortId":1260,"travelTime":{"lock":true,"time":7,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":17,"warning":null,"timeFormatter":null,"consecutiveTime":377},"sourceArrival":{"lock":false,"time":43,"warning":null,"timeFormatter":null,"consecutiveTime":163},"targetDeparture":{"lock":false,"time":36,"warning":null,"timeFormatter":null,"consecutiveTime":156},"targetArrival":{"lock":false,"time":24,"warning":null,"timeFormatter":null,"consecutiveTime":384},"numberOfStops":0,"trainrunId":87,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1790,"y":144},{"x":1726,"y":144},{"x":1506,"y":144},{"x":1442,"y":144}],"textPositions":{"0":{"x":1772,"y":132},"1":{"x":1744,"y":156},"2":{"x":1460,"y":156},"3":{"x":1488,"y":132},"4":{"x":1616,"y":132},"5":{"x":1616,"y":132},"6":{"x":1616,"y":156}}},"warnings":null},{"id":623,"sourceNodeId":166,"sourcePortId":1261,"targetNodeId":148,"targetPortId":1262,"travelTime":{"lock":true,"time":6,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":14,"warning":null,"timeFormatter":null,"consecutiveTime":314},"sourceArrival":{"lock":false,"time":46,"warning":null,"timeFormatter":null,"consecutiveTime":106},"targetDeparture":{"lock":false,"time":40,"warning":null,"timeFormatter":null,"consecutiveTime":100},"targetArrival":{"lock":false,"time":20,"warning":null,"timeFormatter":null,"consecutiveTime":320},"numberOfStops":0,"trainrunId":89,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1790,"y":176},{"x":1726,"y":176},{"x":1506,"y":176},{"x":1442,"y":176}],"textPositions":{"0":{"x":1772,"y":164},"1":{"x":1744,"y":188},"2":{"x":1460,"y":188},"3":{"x":1488,"y":164},"4":{"x":1616,"y":164},"5":{"x":1616,"y":164},"6":{"x":1616,"y":188}}},"warnings":null},{"id":624,"sourceNodeId":166,"sourcePortId":1263,"targetNodeId":148,"targetPortId":1264,"travelTime":{"lock":true,"time":5,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":25,"warning":null,"timeFormatter":null,"consecutiveTime":325},"sourceArrival":{"lock":false,"time":35,"warning":null,"timeFormatter":null,"consecutiveTime":95},"targetDeparture":{"lock":false,"time":30,"warning":null,"timeFormatter":null,"consecutiveTime":90},"targetArrival":{"lock":false,"time":30,"warning":null,"timeFormatter":null,"consecutiveTime":330},"numberOfStops":0,"trainrunId":90,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1790,"y":208},{"x":1726,"y":208},{"x":1506,"y":208},{"x":1442,"y":208}],"textPositions":{"0":{"x":1772,"y":196},"1":{"x":1744,"y":220},"2":{"x":1460,"y":220},"3":{"x":1488,"y":196},"4":{"x":1616,"y":196},"5":{"x":1616,"y":196},"6":{"x":1616,"y":220}}},"warnings":null},{"id":625,"sourceNodeId":166,"sourcePortId":1265,"targetNodeId":148,"targetPortId":1266,"travelTime":{"lock":true,"time":7,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":8,"warning":null,"timeFormatter":null,"consecutiveTime":308},"sourceArrival":{"lock":false,"time":52,"warning":null,"timeFormatter":null,"consecutiveTime":112},"targetDeparture":{"lock":false,"time":45,"warning":null,"timeFormatter":null,"consecutiveTime":105},"targetArrival":{"lock":false,"time":15,"warning":null,"timeFormatter":null,"consecutiveTime":315},"numberOfStops":0,"trainrunId":86,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1790,"y":240},{"x":1726,"y":240},{"x":1506,"y":240},{"x":1442,"y":240}],"textPositions":{"0":{"x":1772,"y":228},"1":{"x":1744,"y":252},"2":{"x":1460,"y":252},"3":{"x":1488,"y":228},"4":{"x":1616,"y":228},"5":{"x":1616,"y":228},"6":{"x":1616,"y":252}}},"warnings":null},{"id":626,"sourceNodeId":134,"sourcePortId":1267,"targetNodeId":164,"targetPortId":1268,"travelTime":{"lock":true,"time":13,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":11,"warning":null,"timeFormatter":null,"consecutiveTime":11},"sourceArrival":{"lock":false,"time":49,"warning":null,"timeFormatter":null,"consecutiveTime":169},"targetDeparture":{"lock":false,"time":36,"warning":null,"timeFormatter":null,"consecutiveTime":156},"targetArrival":{"lock":false,"time":24,"warning":null,"timeFormatter":null,"consecutiveTime":24},"numberOfStops":0,"trainrunId":93,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":322,"y":-1872},{"x":386,"y":-1872},{"x":990,"y":-944},{"x":1054,"y":-944}],"textPositions":{"0":{"x":340,"y":-1860},"1":{"x":368,"y":-1884},"2":{"x":1036,"y":-956},"3":{"x":1008,"y":-932},"4":{"x":688,"y":-1420},"5":{"x":688,"y":-1420},"6":{"x":688,"y":-1396}}},"warnings":null},{"id":627,"sourceNodeId":164,"sourcePortId":1269,"targetNodeId":165,"targetPortId":1270,"travelTime":{"lock":true,"time":9,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":25,"warning":null,"timeFormatter":null,"consecutiveTime":25},"sourceArrival":{"lock":false,"time":35,"warning":null,"timeFormatter":null,"consecutiveTime":155},"targetDeparture":{"lock":false,"time":26,"warning":null,"timeFormatter":null,"consecutiveTime":146},"targetArrival":{"lock":false,"time":34,"warning":null,"timeFormatter":null,"consecutiveTime":34},"numberOfStops":0,"trainrunId":93,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1154,"y":-944},{"x":1218,"y":-944},{"x":1726,"y":-656},{"x":1790,"y":-656}],"textPositions":{"0":{"x":1172,"y":-932},"1":{"x":1200,"y":-956},"2":{"x":1772,"y":-668},"3":{"x":1744,"y":-644},"4":{"x":1472,"y":-812},"5":{"x":1472,"y":-812},"6":{"x":1472,"y":-788}}},"warnings":null},{"id":628,"sourceNodeId":165,"sourcePortId":1271,"targetNodeId":166,"targetPortId":1272,"travelTime":{"lock":true,"time":22,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":35,"warning":null,"timeFormatter":null,"consecutiveTime":35},"sourceArrival":{"lock":false,"time":25,"warning":null,"timeFormatter":null,"consecutiveTime":145},"targetDeparture":{"lock":false,"time":3,"warning":null,"timeFormatter":null,"consecutiveTime":123},"targetArrival":{"lock":false,"time":57,"warning":null,"timeFormatter":null,"consecutiveTime":57},"numberOfStops":0,"trainrunId":93,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1808,"y":-606},{"x":1808,"y":-542},{"x":1808,"y":-34},{"x":1808,"y":30}],"textPositions":{"0":{"x":1796,"y":-588},"1":{"x":1820,"y":-560},"2":{"x":1820,"y":12},"3":{"x":1796,"y":-16},"4":{"x":1796,"y":-288},"5":{"x":1796,"y":-288},"6":{"x":1820,"y":-288}}},"warnings":null},{"id":629,"sourceNodeId":166,"sourcePortId":1273,"targetNodeId":149,"targetPortId":1274,"travelTime":{"lock":true,"time":7,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":0,"warning":null,"timeFormatter":null,"consecutiveTime":60},"sourceArrival":{"lock":false,"time":0,"warning":null,"timeFormatter":null,"consecutiveTime":120},"targetDeparture":{"lock":false,"time":53,"warning":null,"timeFormatter":null,"consecutiveTime":113},"targetArrival":{"lock":false,"time":7,"warning":null,"timeFormatter":null,"consecutiveTime":67},"numberOfStops":0,"trainrunId":93,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1890,"y":272},{"x":1954,"y":272},{"x":2174,"y":272},{"x":2238,"y":272}],"textPositions":{"0":{"x":1908,"y":284},"1":{"x":1936,"y":260},"2":{"x":2220,"y":260},"3":{"x":2192,"y":284},"4":{"x":2064,"y":260},"5":{"x":2064,"y":260},"6":{"x":2064,"y":284}}},"warnings":null},{"id":630,"sourceNodeId":149,"sourcePortId":1275,"targetNodeId":135,"targetPortId":1276,"travelTime":{"lock":true,"time":16,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":8,"warning":null,"timeFormatter":null,"consecutiveTime":68},"sourceArrival":{"lock":false,"time":52,"warning":null,"timeFormatter":null,"consecutiveTime":112},"targetDeparture":{"lock":false,"time":36,"warning":null,"timeFormatter":null,"consecutiveTime":96},"targetArrival":{"lock":false,"time":24,"warning":null,"timeFormatter":null,"consecutiveTime":84},"numberOfStops":0,"trainrunId":93,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2338,"y":272},{"x":2402,"y":272},{"x":2590,"y":272},{"x":2654,"y":272}],"textPositions":{"0":{"x":2356,"y":284},"1":{"x":2384,"y":260},"2":{"x":2636,"y":260},"3":{"x":2608,"y":284},"4":{"x":2496,"y":260},"5":{"x":2496,"y":260},"6":{"x":2496,"y":284}}},"warnings":null},{"id":631,"sourceNodeId":134,"sourcePortId":1277,"targetNodeId":146,"targetPortId":1278,"travelTime":{"lock":true,"time":5,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":6,"warning":null,"timeFormatter":null,"consecutiveTime":6},"sourceArrival":{"lock":false,"time":54,"warning":null,"timeFormatter":null,"consecutiveTime":174},"targetDeparture":{"lock":false,"time":49,"warning":null,"timeFormatter":null,"consecutiveTime":169},"targetArrival":{"lock":false,"time":11,"warning":null,"timeFormatter":null,"consecutiveTime":11},"numberOfStops":0,"trainrunId":94,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":144,"y":-1822},{"x":144,"y":-1758},{"x":144,"y":-1474},{"x":144,"y":-1410}],"textPositions":{"0":{"x":132,"y":-1804},"1":{"x":156,"y":-1776},"2":{"x":156,"y":-1428},"3":{"x":132,"y":-1456},"4":{"x":132,"y":-1616},"5":{"x":132,"y":-1616},"6":{"x":156,"y":-1616}}},"warnings":null},{"id":632,"sourceNodeId":146,"sourcePortId":1279,"targetNodeId":145,"targetPortId":1280,"travelTime":{"lock":true,"time":6,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":11,"warning":null,"timeFormatter":null,"consecutiveTime":11},"sourceArrival":{"lock":false,"time":49,"warning":null,"timeFormatter":null,"consecutiveTime":169},"targetDeparture":{"lock":false,"time":43,"warning":null,"timeFormatter":null,"consecutiveTime":163},"targetArrival":{"lock":false,"time":17,"warning":null,"timeFormatter":null,"consecutiveTime":17},"numberOfStops":0,"trainrunId":94,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":144,"y":-1342},{"x":144,"y":-1278},{"x":144,"y":-994},{"x":144,"y":-930}],"textPositions":{"0":{"x":132,"y":-1324},"1":{"x":156,"y":-1296},"2":{"x":156,"y":-948},"3":{"x":132,"y":-976},"4":{"x":132,"y":-1136},"5":{"x":132,"y":-1136},"6":{"x":156,"y":-1136}}},"warnings":null},{"id":633,"sourceNodeId":145,"sourcePortId":1281,"targetNodeId":144,"targetPortId":1282,"travelTime":{"lock":true,"time":6,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":17,"warning":null,"timeFormatter":null,"consecutiveTime":17},"sourceArrival":{"lock":false,"time":43,"warning":null,"timeFormatter":null,"consecutiveTime":163},"targetDeparture":{"lock":false,"time":37,"warning":null,"timeFormatter":null,"consecutiveTime":157},"targetArrival":{"lock":false,"time":23,"warning":null,"timeFormatter":null,"consecutiveTime":23},"numberOfStops":0,"trainrunId":94,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":144,"y":-862},{"x":144,"y":-798},{"x":144,"y":-514},{"x":144,"y":-450}],"textPositions":{"0":{"x":132,"y":-844},"1":{"x":156,"y":-816},"2":{"x":156,"y":-468},"3":{"x":132,"y":-496},"4":{"x":132,"y":-656},"5":{"x":132,"y":-656},"6":{"x":156,"y":-656}}},"warnings":null},{"id":634,"sourceNodeId":144,"sourcePortId":1283,"targetNodeId":147,"targetPortId":1284,"travelTime":{"lock":true,"time":10,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":23,"warning":null,"timeFormatter":null,"consecutiveTime":23},"sourceArrival":{"lock":false,"time":37,"warning":null,"timeFormatter":null,"consecutiveTime":157},"targetDeparture":{"lock":false,"time":27,"warning":null,"timeFormatter":null,"consecutiveTime":147},"targetArrival":{"lock":false,"time":33,"warning":null,"timeFormatter":null,"consecutiveTime":33},"numberOfStops":0,"trainrunId":94,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":322,"y":-400},{"x":386,"y":-400},{"x":894,"y":80},{"x":958,"y":80}],"textPositions":{"0":{"x":340,"y":-388},"1":{"x":368,"y":-412},"2":{"x":940,"y":68},"3":{"x":912,"y":92},"4":{"x":640,"y":-172},"5":{"x":640,"y":-172},"6":{"x":640,"y":-148}}},"warnings":null},{"id":635,"sourceNodeId":147,"sourcePortId":1285,"targetNodeId":148,"targetPortId":1286,"travelTime":{"lock":true,"time":7,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":33,"warning":null,"timeFormatter":null,"consecutiveTime":33},"sourceArrival":{"lock":false,"time":27,"warning":null,"timeFormatter":null,"consecutiveTime":147},"targetDeparture":{"lock":false,"time":20,"warning":null,"timeFormatter":null,"consecutiveTime":140},"targetArrival":{"lock":false,"time":40,"warning":null,"timeFormatter":null,"consecutiveTime":40},"numberOfStops":0,"trainrunId":94,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1058,"y":112},{"x":1122,"y":112},{"x":1278,"y":112},{"x":1342,"y":112}],"textPositions":{"0":{"x":1076,"y":124},"1":{"x":1104,"y":100},"2":{"x":1324,"y":100},"3":{"x":1296,"y":124},"4":{"x":1200,"y":100},"5":{"x":1200,"y":100},"6":{"x":1200,"y":124}}},"warnings":null},{"id":636,"sourceNodeId":148,"sourcePortId":1287,"targetNodeId":166,"targetPortId":1288,"travelTime":{"lock":true,"time":6,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":40,"warning":null,"timeFormatter":null,"consecutiveTime":40},"sourceArrival":{"lock":false,"time":20,"warning":null,"timeFormatter":null,"consecutiveTime":140},"targetDeparture":{"lock":false,"time":14,"warning":null,"timeFormatter":null,"consecutiveTime":134},"targetArrival":{"lock":false,"time":46,"warning":null,"timeFormatter":null,"consecutiveTime":46},"numberOfStops":0,"trainrunId":94,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1442,"y":112},{"x":1506,"y":112},{"x":1726,"y":112},{"x":1790,"y":112}],"textPositions":{"0":{"x":1460,"y":124},"1":{"x":1488,"y":100},"2":{"x":1772,"y":100},"3":{"x":1744,"y":124},"4":{"x":1616,"y":100},"5":{"x":1616,"y":100},"6":{"x":1616,"y":124}}},"warnings":null},{"id":637,"sourceNodeId":166,"sourcePortId":1289,"targetNodeId":149,"targetPortId":1290,"travelTime":{"lock":true,"time":6,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":46,"warning":null,"timeFormatter":null,"consecutiveTime":46},"sourceArrival":{"lock":false,"time":14,"warning":null,"timeFormatter":null,"consecutiveTime":134},"targetDeparture":{"lock":false,"time":8,"warning":null,"timeFormatter":null,"consecutiveTime":128},"targetArrival":{"lock":false,"time":52,"warning":null,"timeFormatter":null,"consecutiveTime":52},"numberOfStops":0,"trainrunId":94,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1890,"y":112},{"x":1954,"y":112},{"x":2174,"y":112},{"x":2238,"y":112}],"textPositions":{"0":{"x":1908,"y":124},"1":{"x":1936,"y":100},"2":{"x":2220,"y":100},"3":{"x":2192,"y":124},"4":{"x":2064,"y":100},"5":{"x":2064,"y":100},"6":{"x":2064,"y":124}}},"warnings":null},{"id":638,"sourceNodeId":149,"sourcePortId":1291,"targetNodeId":135,"targetPortId":1292,"travelTime":{"lock":true,"time":8,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":52,"warning":null,"timeFormatter":null,"consecutiveTime":52},"sourceArrival":{"lock":false,"time":8,"warning":null,"timeFormatter":null,"consecutiveTime":128},"targetDeparture":{"lock":false,"time":0,"warning":null,"timeFormatter":null,"consecutiveTime":120},"targetArrival":{"lock":false,"time":0,"warning":null,"timeFormatter":null,"consecutiveTime":60},"numberOfStops":0,"trainrunId":94,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2338,"y":112},{"x":2402,"y":112},{"x":2590,"y":112},{"x":2654,"y":112}],"textPositions":{"0":{"x":2356,"y":124},"1":{"x":2384,"y":100},"2":{"x":2636,"y":100},"3":{"x":2608,"y":124},"4":{"x":2496,"y":100},"5":{"x":2496,"y":100},"6":{"x":2496,"y":124}}},"warnings":null},{"id":639,"sourceNodeId":147,"sourcePortId":1293,"targetNodeId":148,"targetPortId":1294,"travelTime":{"lock":true,"time":6,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":54,"warning":null,"timeFormatter":null,"consecutiveTime":54},"sourceArrival":{"lock":false,"time":6,"warning":null,"timeFormatter":null,"consecutiveTime":126},"targetDeparture":{"lock":false,"time":0,"warning":null,"timeFormatter":null,"consecutiveTime":120},"targetArrival":{"lock":false,"time":0,"warning":null,"timeFormatter":null,"consecutiveTime":60},"numberOfStops":0,"trainrunId":97,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1058,"y":272},{"x":1122,"y":272},{"x":1278,"y":272},{"x":1342,"y":272}],"textPositions":{"0":{"x":1076,"y":284},"1":{"x":1104,"y":260},"2":{"x":1324,"y":260},"3":{"x":1296,"y":284},"4":{"x":1200,"y":260},"5":{"x":1200,"y":260},"6":{"x":1200,"y":284}}},"warnings":null},{"id":640,"sourceNodeId":148,"sourcePortId":1295,"targetNodeId":166,"targetPortId":1296,"travelTime":{"lock":true,"time":6,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":2,"warning":null,"timeFormatter":null,"consecutiveTime":62},"sourceArrival":{"lock":false,"time":58,"warning":null,"timeFormatter":null,"consecutiveTime":118},"targetDeparture":{"lock":false,"time":52,"warning":null,"timeFormatter":null,"consecutiveTime":112},"targetArrival":{"lock":false,"time":8,"warning":null,"timeFormatter":null,"consecutiveTime":68},"numberOfStops":0,"trainrunId":97,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1442,"y":272},{"x":1506,"y":272},{"x":1726,"y":272},{"x":1790,"y":272}],"textPositions":{"0":{"x":1460,"y":284},"1":{"x":1488,"y":260},"2":{"x":1772,"y":260},"3":{"x":1744,"y":284},"4":{"x":1616,"y":260},"5":{"x":1616,"y":260},"6":{"x":1616,"y":284}}},"warnings":null},{"id":641,"sourceNodeId":166,"sourcePortId":1297,"targetNodeId":149,"targetPortId":1298,"travelTime":{"lock":true,"time":7,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":8,"warning":null,"timeFormatter":null,"consecutiveTime":68},"sourceArrival":{"lock":false,"time":52,"warning":null,"timeFormatter":null,"consecutiveTime":112},"targetDeparture":{"lock":false,"time":45,"warning":null,"timeFormatter":null,"consecutiveTime":105},"targetArrival":{"lock":false,"time":15,"warning":null,"timeFormatter":null,"consecutiveTime":75},"numberOfStops":0,"trainrunId":97,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1890,"y":304},{"x":1954,"y":304},{"x":2174,"y":304},{"x":2238,"y":304}],"textPositions":{"0":{"x":1908,"y":316},"1":{"x":1936,"y":292},"2":{"x":2220,"y":292},"3":{"x":2192,"y":316},"4":{"x":2064,"y":292},"5":{"x":2064,"y":292},"6":{"x":2064,"y":316}}},"warnings":null},{"id":642,"sourceNodeId":149,"sourcePortId":1299,"targetNodeId":135,"targetPortId":1300,"travelTime":{"lock":true,"time":7,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":15,"warning":null,"timeFormatter":null,"consecutiveTime":75},"sourceArrival":{"lock":false,"time":45,"warning":null,"timeFormatter":null,"consecutiveTime":105},"targetDeparture":{"lock":false,"time":38,"warning":null,"timeFormatter":null,"consecutiveTime":98},"targetArrival":{"lock":false,"time":22,"warning":null,"timeFormatter":null,"consecutiveTime":82},"numberOfStops":0,"trainrunId":97,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2338,"y":304},{"x":2402,"y":304},{"x":2590,"y":304},{"x":2654,"y":304}],"textPositions":{"0":{"x":2356,"y":316},"1":{"x":2384,"y":292},"2":{"x":2636,"y":292},"3":{"x":2608,"y":316},"4":{"x":2496,"y":292},"5":{"x":2496,"y":292},"6":{"x":2496,"y":316}}},"warnings":null},{"id":643,"sourceNodeId":134,"sourcePortId":1301,"targetNodeId":146,"targetPortId":1302,"travelTime":{"lock":true,"time":7,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":28,"warning":null,"timeFormatter":null,"consecutiveTime":28},"sourceArrival":{"lock":false,"time":32,"warning":null,"timeFormatter":null,"consecutiveTime":272},"targetDeparture":{"lock":false,"time":25,"warning":null,"timeFormatter":null,"consecutiveTime":265},"targetArrival":{"lock":false,"time":35,"warning":null,"timeFormatter":null,"consecutiveTime":35},"numberOfStops":0,"trainrunId":95,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":208,"y":-1822},{"x":208,"y":-1758},{"x":208,"y":-1474},{"x":208,"y":-1410}],"textPositions":{"0":{"x":196,"y":-1804},"1":{"x":220,"y":-1776},"2":{"x":220,"y":-1428},"3":{"x":196,"y":-1456},"4":{"x":196,"y":-1616},"5":{"x":196,"y":-1616},"6":{"x":220,"y":-1616}}},"warnings":null},{"id":644,"sourceNodeId":146,"sourcePortId":1303,"targetNodeId":145,"targetPortId":1304,"travelTime":{"lock":true,"time":6,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":35,"warning":null,"timeFormatter":null,"consecutiveTime":35},"sourceArrival":{"lock":false,"time":25,"warning":null,"timeFormatter":null,"consecutiveTime":265},"targetDeparture":{"lock":false,"time":19,"warning":null,"timeFormatter":null,"consecutiveTime":259},"targetArrival":{"lock":false,"time":41,"warning":null,"timeFormatter":null,"consecutiveTime":41},"numberOfStops":0,"trainrunId":95,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":208,"y":-1342},{"x":208,"y":-1278},{"x":208,"y":-994},{"x":208,"y":-930}],"textPositions":{"0":{"x":196,"y":-1324},"1":{"x":220,"y":-1296},"2":{"x":220,"y":-948},"3":{"x":196,"y":-976},"4":{"x":196,"y":-1136},"5":{"x":196,"y":-1136},"6":{"x":220,"y":-1136}}},"warnings":null},{"id":645,"sourceNodeId":145,"sourcePortId":1305,"targetNodeId":144,"targetPortId":1306,"travelTime":{"lock":true,"time":6,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":41,"warning":null,"timeFormatter":null,"consecutiveTime":41},"sourceArrival":{"lock":false,"time":19,"warning":null,"timeFormatter":null,"consecutiveTime":259},"targetDeparture":{"lock":false,"time":13,"warning":null,"timeFormatter":null,"consecutiveTime":253},"targetArrival":{"lock":false,"time":47,"warning":null,"timeFormatter":null,"consecutiveTime":47},"numberOfStops":0,"trainrunId":95,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":208,"y":-862},{"x":208,"y":-798},{"x":208,"y":-514},{"x":208,"y":-450}],"textPositions":{"0":{"x":196,"y":-844},"1":{"x":220,"y":-816},"2":{"x":220,"y":-468},"3":{"x":196,"y":-496},"4":{"x":196,"y":-656},"5":{"x":196,"y":-656},"6":{"x":220,"y":-656}}},"warnings":null},{"id":646,"sourceNodeId":144,"sourcePortId":1307,"targetNodeId":133,"targetPortId":1308,"travelTime":{"lock":true,"time":8,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":47,"warning":null,"timeFormatter":null,"consecutiveTime":47},"sourceArrival":{"lock":false,"time":13,"warning":null,"timeFormatter":null,"consecutiveTime":253},"targetDeparture":{"lock":true,"time":5,"warning":null,"timeFormatter":null,"consecutiveTime":245},"targetArrival":{"lock":true,"time":55,"warning":null,"timeFormatter":null,"consecutiveTime":55},"numberOfStops":0,"trainrunId":95,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":144,"y":-354},{"x":144,"y":-290},{"x":144,"y":30},{"x":144,"y":94}],"textPositions":{"0":{"x":132,"y":-336},"1":{"x":156,"y":-308},"2":{"x":156,"y":76},"3":{"x":132,"y":48},"4":{"x":132,"y":-130},"5":{"x":132,"y":-130},"6":{"x":156,"y":-130}}},"warnings":null},{"id":647,"sourceNodeId":133,"sourcePortId":1309,"targetNodeId":172,"targetPortId":1310,"travelTime":{"lock":true,"time":7,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":58,"warning":null,"timeFormatter":null,"consecutiveTime":58},"sourceArrival":{"lock":true,"time":2,"warning":null,"timeFormatter":null,"consecutiveTime":242},"targetDeparture":{"lock":false,"time":55,"warning":null,"timeFormatter":null,"consecutiveTime":235},"targetArrival":{"lock":false,"time":5,"warning":null,"timeFormatter":null,"consecutiveTime":65},"numberOfStops":0,"trainrunId":95,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":62,"y":208},{"x":-2,"y":208},{"x":-446,"y":208},{"x":-510,"y":208}],"textPositions":{"0":{"x":44,"y":196},"1":{"x":16,"y":220},"2":{"x":-492,"y":220},"3":{"x":-464,"y":196},"4":{"x":-224,"y":196},"5":{"x":-224,"y":196},"6":{"x":-224,"y":220}}},"warnings":null},{"id":648,"sourceNodeId":129,"sourcePortId":1311,"targetNodeId":167,"targetPortId":1312,"travelTime":{"lock":true,"time":18,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":34,"warning":null,"timeFormatter":null,"consecutiveTime":94},"sourceArrival":{"lock":true,"time":26,"warning":null,"timeFormatter":null,"consecutiveTime":206},"targetDeparture":{"lock":true,"time":8,"warning":null,"timeFormatter":null,"consecutiveTime":188},"targetArrival":{"lock":true,"time":52,"warning":null,"timeFormatter":null,"consecutiveTime":112},"numberOfStops":0,"trainrunId":95,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-2096,"y":382},{"x":-2096,"y":446},{"x":-2096,"y":574},{"x":-2096,"y":638}],"textPositions":{"0":{"x":-2108,"y":400},"1":{"x":-2084,"y":428},"2":{"x":-2084,"y":620},"3":{"x":-2108,"y":592},"4":{"x":-2108,"y":510},"5":{"x":-2108,"y":510},"6":{"x":-2084,"y":510}}},"warnings":null},{"id":649,"sourceNodeId":129,"sourcePortId":1313,"targetNodeId":167,"targetPortId":1314,"travelTime":{"lock":true,"time":18,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":59,"warning":null,"timeFormatter":null,"consecutiveTime":359},"sourceArrival":{"lock":false,"time":1,"warning":null,"timeFormatter":null,"consecutiveTime":61},"targetDeparture":{"lock":false,"time":43,"warning":null,"timeFormatter":null,"consecutiveTime":43},"targetArrival":{"lock":false,"time":17,"warning":null,"timeFormatter":null,"consecutiveTime":377},"numberOfStops":0,"trainrunId":89,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-2064,"y":382},{"x":-2064,"y":446},{"x":-2064,"y":574},{"x":-2064,"y":638}],"textPositions":{"0":{"x":-2076,"y":400},"1":{"x":-2052,"y":428},"2":{"x":-2052,"y":620},"3":{"x":-2076,"y":592},"4":{"x":-2076,"y":510},"5":{"x":-2076,"y":510},"6":{"x":-2052,"y":510}}},"warnings":null},{"id":650,"sourceNodeId":167,"sourcePortId":1315,"targetNodeId":168,"targetPortId":1316,"travelTime":{"lock":true,"time":8,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":54,"warning":null,"timeFormatter":null,"consecutiveTime":114},"sourceArrival":{"lock":false,"time":6,"warning":null,"timeFormatter":null,"consecutiveTime":186},"targetDeparture":{"lock":false,"time":58,"warning":null,"timeFormatter":null,"consecutiveTime":178},"targetArrival":{"lock":false,"time":2,"warning":null,"timeFormatter":null,"consecutiveTime":122},"numberOfStops":0,"trainrunId":95,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-2096,"y":706},{"x":-2096,"y":770},{"x":-2096,"y":862},{"x":-2096,"y":926}],"textPositions":{"0":{"x":-2108,"y":724},"1":{"x":-2084,"y":752},"2":{"x":-2084,"y":908},"3":{"x":-2108,"y":880},"4":{"x":-2108,"y":816},"5":{"x":-2108,"y":816},"6":{"x":-2084,"y":816}}},"warnings":null},{"id":651,"sourceNodeId":168,"sourcePortId":1317,"targetNodeId":131,"targetPortId":1318,"travelTime":{"lock":true,"time":24,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":4,"warning":null,"timeFormatter":null,"consecutiveTime":124},"sourceArrival":{"lock":false,"time":56,"warning":null,"timeFormatter":null,"consecutiveTime":176},"targetDeparture":{"lock":false,"time":32,"warning":null,"timeFormatter":null,"consecutiveTime":152},"targetArrival":{"lock":false,"time":28,"warning":null,"timeFormatter":null,"consecutiveTime":148},"numberOfStops":0,"trainrunId":95,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-2014,"y":944},{"x":-1950,"y":944},{"x":-1154,"y":944},{"x":-1090,"y":944}],"textPositions":{"0":{"x":-1996,"y":956},"1":{"x":-1968,"y":932},"2":{"x":-1108,"y":932},"3":{"x":-1136,"y":956},"4":{"x":-1552,"y":932},"5":{"x":-1552,"y":932},"6":{"x":-1552,"y":956}}},"warnings":null},{"id":652,"sourceNodeId":167,"sourcePortId":1319,"targetNodeId":168,"targetPortId":1320,"travelTime":{"lock":true,"time":10,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":19,"warning":null,"timeFormatter":null,"consecutiveTime":379},"sourceArrival":{"lock":false,"time":41,"warning":null,"timeFormatter":null,"consecutiveTime":41},"targetDeparture":{"lock":false,"time":31,"warning":null,"timeFormatter":null,"consecutiveTime":31},"targetArrival":{"lock":false,"time":29,"warning":null,"timeFormatter":null,"consecutiveTime":389},"numberOfStops":0,"trainrunId":89,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-2064,"y":706},{"x":-2064,"y":770},{"x":-2064,"y":862},{"x":-2064,"y":926}],"textPositions":{"0":{"x":-2076,"y":724},"1":{"x":-2052,"y":752},"2":{"x":-2052,"y":908},"3":{"x":-2076,"y":880},"4":{"x":-2076,"y":816},"5":{"x":-2076,"y":816},"6":{"x":-2052,"y":816}}},"warnings":null},{"id":653,"sourceNodeId":168,"sourcePortId":1321,"targetNodeId":132,"targetPortId":1322,"travelTime":{"lock":true,"time":25,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":31,"warning":null,"timeFormatter":null,"consecutiveTime":391},"sourceArrival":{"lock":false,"time":29,"warning":null,"timeFormatter":null,"consecutiveTime":29},"targetDeparture":{"lock":false,"time":4,"warning":null,"timeFormatter":null,"consecutiveTime":4},"targetArrival":{"lock":false,"time":56,"warning":null,"timeFormatter":null,"consecutiveTime":416},"numberOfStops":0,"trainrunId":89,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-2096,"y":1022},{"x":-2096,"y":1086},{"x":-2096,"y":1374},{"x":-2096,"y":1438}],"textPositions":{"0":{"x":-2108,"y":1040},"1":{"x":-2084,"y":1068},"2":{"x":-2084,"y":1420},"3":{"x":-2108,"y":1392},"4":{"x":-2108,"y":1230},"5":{"x":-2108,"y":1230},"6":{"x":-2084,"y":1230}}},"warnings":null},{"id":654,"sourceNodeId":132,"sourcePortId":1323,"targetNodeId":168,"targetPortId":1324,"travelTime":{"lock":true,"time":26,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":29,"warning":null,"timeFormatter":null,"consecutiveTime":149},"sourceArrival":{"lock":false,"time":31,"warning":null,"timeFormatter":null,"consecutiveTime":151},"targetDeparture":{"lock":false,"time":5,"warning":null,"timeFormatter":null,"consecutiveTime":125},"targetArrival":{"lock":false,"time":55,"warning":null,"timeFormatter":null,"consecutiveTime":175},"numberOfStops":0,"trainrunId":96,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-2128,"y":1438},{"x":-2128,"y":1374},{"x":-2128,"y":1086},{"x":-2128,"y":1022}],"textPositions":{"0":{"x":-2116,"y":1420},"1":{"x":-2140,"y":1392},"2":{"x":-2140,"y":1040},"3":{"x":-2116,"y":1068},"4":{"x":-2140,"y":1230},"5":{"x":-2140,"y":1230},"6":{"x":-2116,"y":1230}}},"warnings":null},{"id":655,"sourceNodeId":168,"sourcePortId":1325,"targetNodeId":167,"targetPortId":1326,"travelTime":{"lock":true,"time":8,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":58,"warning":null,"timeFormatter":null,"consecutiveTime":178},"sourceArrival":{"lock":false,"time":2,"warning":null,"timeFormatter":null,"consecutiveTime":122},"targetDeparture":{"lock":false,"time":54,"warning":null,"timeFormatter":null,"consecutiveTime":114},"targetArrival":{"lock":false,"time":6,"warning":null,"timeFormatter":null,"consecutiveTime":186},"numberOfStops":0,"trainrunId":96,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-2128,"y":926},{"x":-2128,"y":862},{"x":-2128,"y":770},{"x":-2128,"y":706}],"textPositions":{"0":{"x":-2116,"y":908},"1":{"x":-2140,"y":880},"2":{"x":-2140,"y":724},"3":{"x":-2116,"y":752},"4":{"x":-2140,"y":816},"5":{"x":-2140,"y":816},"6":{"x":-2116,"y":816}}},"warnings":null},{"id":656,"sourceNodeId":167,"sourcePortId":1327,"targetNodeId":129,"targetPortId":1328,"travelTime":{"lock":true,"time":18,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":8,"warning":null,"timeFormatter":null,"consecutiveTime":188},"sourceArrival":{"lock":false,"time":52,"warning":null,"timeFormatter":null,"consecutiveTime":112},"targetDeparture":{"lock":true,"time":34,"warning":null,"timeFormatter":null,"consecutiveTime":94},"targetArrival":{"lock":true,"time":26,"warning":null,"timeFormatter":null,"consecutiveTime":206},"numberOfStops":0,"trainrunId":96,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-2128,"y":638},{"x":-2128,"y":574},{"x":-2128,"y":446},{"x":-2128,"y":382}],"textPositions":{"0":{"x":-2116,"y":620},"1":{"x":-2140,"y":592},"2":{"x":-2140,"y":400},"3":{"x":-2116,"y":428},"4":{"x":-2140,"y":510},"5":{"x":-2140,"y":510},"6":{"x":-2116,"y":510}}},"warnings":null},{"id":657,"sourceNodeId":129,"sourcePortId":1329,"targetNodeId":178,"targetPortId":1330,"travelTime":{"lock":true,"time":3,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":34,"warning":null,"timeFormatter":null,"consecutiveTime":214},"sourceArrival":{"lock":true,"time":26,"warning":null,"timeFormatter":null,"consecutiveTime":86},"targetDeparture":{"lock":false,"time":23,"warning":null,"timeFormatter":null,"consecutiveTime":83},"targetArrival":{"lock":false,"time":37,"warning":null,"timeFormatter":null,"consecutiveTime":217},"numberOfStops":0,"trainrunId":96,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-2014,"y":176},{"x":-1950,"y":176},{"x":-1762,"y":176},{"x":-1698,"y":176}],"textPositions":{"0":{"x":-1996,"y":188},"1":{"x":-1968,"y":164},"2":{"x":-1716,"y":164},"3":{"x":-1744,"y":188},"4":{"x":-1856,"y":164},"5":{"x":-1856,"y":164},"6":{"x":-1856,"y":188}}},"warnings":null},{"id":658,"sourceNodeId":133,"sourcePortId":1331,"targetNodeId":144,"targetPortId":1332,"travelTime":{"lock":true,"time":8,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":5,"warning":null,"timeFormatter":null,"consecutiveTime":245},"sourceArrival":{"lock":true,"time":55,"warning":null,"timeFormatter":null,"consecutiveTime":55},"targetDeparture":{"lock":false,"time":47,"warning":null,"timeFormatter":null,"consecutiveTime":47},"targetArrival":{"lock":false,"time":13,"warning":null,"timeFormatter":null,"consecutiveTime":253},"numberOfStops":0,"trainrunId":96,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":112,"y":94},{"x":112,"y":30},{"x":112,"y":-290},{"x":112,"y":-354}],"textPositions":{"0":{"x":124,"y":76},"1":{"x":100,"y":48},"2":{"x":100,"y":-336},"3":{"x":124,"y":-308},"4":{"x":100,"y":-130},"5":{"x":100,"y":-130},"6":{"x":124,"y":-130}}},"warnings":null},{"id":659,"sourceNodeId":144,"sourcePortId":1333,"targetNodeId":145,"targetPortId":1334,"travelTime":{"lock":true,"time":6,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":13,"warning":null,"timeFormatter":null,"consecutiveTime":253},"sourceArrival":{"lock":false,"time":47,"warning":null,"timeFormatter":null,"consecutiveTime":47},"targetDeparture":{"lock":false,"time":41,"warning":null,"timeFormatter":null,"consecutiveTime":41},"targetArrival":{"lock":false,"time":19,"warning":null,"timeFormatter":null,"consecutiveTime":259},"numberOfStops":0,"trainrunId":96,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":176,"y":-450},{"x":176,"y":-514},{"x":176,"y":-798},{"x":176,"y":-862}],"textPositions":{"0":{"x":188,"y":-468},"1":{"x":164,"y":-496},"2":{"x":164,"y":-844},"3":{"x":188,"y":-816},"4":{"x":164,"y":-656},"5":{"x":164,"y":-656},"6":{"x":188,"y":-656}}},"warnings":null},{"id":660,"sourceNodeId":145,"sourcePortId":1335,"targetNodeId":146,"targetPortId":1336,"travelTime":{"lock":true,"time":6,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":19,"warning":null,"timeFormatter":null,"consecutiveTime":259},"sourceArrival":{"lock":false,"time":41,"warning":null,"timeFormatter":null,"consecutiveTime":41},"targetDeparture":{"lock":false,"time":35,"warning":null,"timeFormatter":null,"consecutiveTime":35},"targetArrival":{"lock":false,"time":25,"warning":null,"timeFormatter":null,"consecutiveTime":265},"numberOfStops":0,"trainrunId":96,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":176,"y":-930},{"x":176,"y":-994},{"x":176,"y":-1278},{"x":176,"y":-1342}],"textPositions":{"0":{"x":188,"y":-948},"1":{"x":164,"y":-976},"2":{"x":164,"y":-1324},"3":{"x":188,"y":-1296},"4":{"x":164,"y":-1136},"5":{"x":164,"y":-1136},"6":{"x":188,"y":-1136}}},"warnings":null},{"id":661,"sourceNodeId":146,"sourcePortId":1337,"targetNodeId":134,"targetPortId":1338,"travelTime":{"lock":true,"time":7,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":25,"warning":null,"timeFormatter":null,"consecutiveTime":265},"sourceArrival":{"lock":false,"time":35,"warning":null,"timeFormatter":null,"consecutiveTime":35},"targetDeparture":{"lock":true,"time":28,"warning":null,"timeFormatter":null,"consecutiveTime":28},"targetArrival":{"lock":true,"time":32,"warning":null,"timeFormatter":null,"consecutiveTime":272},"numberOfStops":0,"trainrunId":96,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":176,"y":-1410},{"x":176,"y":-1474},{"x":176,"y":-1758},{"x":176,"y":-1822}],"textPositions":{"0":{"x":188,"y":-1428},"1":{"x":164,"y":-1456},"2":{"x":164,"y":-1804},"3":{"x":188,"y":-1776},"4":{"x":164,"y":-1616},"5":{"x":164,"y":-1616},"6":{"x":188,"y":-1616}}},"warnings":null},{"id":662,"sourceNodeId":129,"sourcePortId":1339,"targetNodeId":167,"targetPortId":1340,"travelTime":{"lock":false,"time":19,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":8,"warning":null,"timeFormatter":null,"consecutiveTime":368},"sourceArrival":{"lock":true,"time":52,"warning":null,"timeFormatter":null,"consecutiveTime":52},"targetDeparture":{"lock":true,"time":33,"warning":null,"timeFormatter":null,"consecutiveTime":33},"targetArrival":{"lock":true,"time":27,"warning":null,"timeFormatter":null,"consecutiveTime":387},"numberOfStops":0,"trainrunId":90,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-2032,"y":382},{"x":-2032,"y":446},{"x":-2032,"y":574},{"x":-2032,"y":638}],"textPositions":{"0":{"x":-2044,"y":400},"1":{"x":-2020,"y":428},"2":{"x":-2020,"y":620},"3":{"x":-2044,"y":592},"4":{"x":-2044,"y":510},"5":{"x":-2044,"y":510},"6":{"x":-2020,"y":510}}},"warnings":null},{"id":663,"sourceNodeId":167,"sourcePortId":1341,"targetNodeId":168,"targetPortId":1342,"travelTime":{"lock":true,"time":10,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":28,"warning":null,"timeFormatter":null,"consecutiveTime":388},"sourceArrival":{"lock":false,"time":32,"warning":null,"timeFormatter":null,"consecutiveTime":32},"targetDeparture":{"lock":true,"time":22,"warning":null,"timeFormatter":null,"consecutiveTime":22},"targetArrival":{"lock":true,"time":38,"warning":null,"timeFormatter":null,"consecutiveTime":398},"numberOfStops":0,"trainrunId":90,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-2032,"y":706},{"x":-2032,"y":770},{"x":-2032,"y":862},{"x":-2032,"y":926}],"textPositions":{"0":{"x":-2044,"y":724},"1":{"x":-2020,"y":752},"2":{"x":-2020,"y":908},"3":{"x":-2044,"y":880},"4":{"x":-2044,"y":816},"5":{"x":-2044,"y":816},"6":{"x":-2020,"y":816}}},"warnings":null},{"id":664,"sourceNodeId":168,"sourcePortId":1343,"targetNodeId":131,"targetPortId":1344,"travelTime":{"lock":true,"time":21,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":39,"warning":null,"timeFormatter":null,"consecutiveTime":399},"sourceArrival":{"lock":true,"time":21,"warning":null,"timeFormatter":null,"consecutiveTime":21},"targetDeparture":{"lock":false,"time":0,"warning":null,"timeFormatter":null,"consecutiveTime":0},"targetArrival":{"lock":false,"time":0,"warning":null,"timeFormatter":null,"consecutiveTime":420},"numberOfStops":0,"trainrunId":90,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-2014,"y":976},{"x":-1950,"y":976},{"x":-1154,"y":976},{"x":-1090,"y":976}],"textPositions":{"0":{"x":-1996,"y":988},"1":{"x":-1968,"y":964},"2":{"x":-1108,"y":964},"3":{"x":-1136,"y":988},"4":{"x":-1552,"y":964},"5":{"x":-1552,"y":964},"6":{"x":-1552,"y":988}}},"warnings":null},{"id":665,"sourceNodeId":169,"sourcePortId":1345,"targetNodeId":153,"targetPortId":1346,"travelTime":{"lock":true,"time":9,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":48,"warning":null,"timeFormatter":null,"consecutiveTime":48},"sourceArrival":{"lock":true,"time":12,"warning":null,"timeFormatter":null,"consecutiveTime":252},"targetDeparture":{"lock":true,"time":3,"warning":null,"timeFormatter":null,"consecutiveTime":243},"targetArrival":{"lock":true,"time":57,"warning":null,"timeFormatter":null,"consecutiveTime":57},"numberOfStops":0,"trainrunId":79,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1954,"y":1776},{"x":2018,"y":1776},{"x":2590,"y":1360},{"x":2654,"y":1360}],"textPositions":{"0":{"x":1972,"y":1788},"1":{"x":2000,"y":1764},"2":{"x":2636,"y":1348},"3":{"x":2608,"y":1372},"4":{"x":2304,"y":1556},"5":{"x":2304,"y":1556},"6":{"x":2304,"y":1580}}},"warnings":null},{"id":666,"sourceNodeId":169,"sourcePortId":1347,"targetNodeId":153,"targetPortId":1348,"travelTime":{"lock":true,"time":10,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":18,"warning":null,"timeFormatter":null,"consecutiveTime":18},"sourceArrival":{"lock":false,"time":42,"warning":null,"timeFormatter":null,"consecutiveTime":42},"targetDeparture":{"lock":false,"time":32,"warning":null,"timeFormatter":null,"consecutiveTime":32},"targetArrival":{"lock":false,"time":28,"warning":null,"timeFormatter":null,"consecutiveTime":28},"numberOfStops":0,"trainrunId":80,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1954,"y":1744},{"x":2018,"y":1744},{"x":2590,"y":1328},{"x":2654,"y":1328}],"textPositions":{"0":{"x":1972,"y":1756},"1":{"x":2000,"y":1732},"2":{"x":2636,"y":1316},"3":{"x":2608,"y":1340},"4":{"x":2304,"y":1524},"5":{"x":2304,"y":1524},"6":{"x":2304,"y":1548}}},"warnings":null},{"id":667,"sourceNodeId":169,"sourcePortId":1349,"targetNodeId":142,"targetPortId":1350,"travelTime":{"lock":true,"time":9,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":33,"warning":null,"timeFormatter":null,"consecutiveTime":453},"sourceArrival":{"lock":false,"time":27,"warning":null,"timeFormatter":null,"consecutiveTime":147},"targetDeparture":{"lock":false,"time":18,"warning":null,"timeFormatter":null,"consecutiveTime":138},"targetArrival":{"lock":false,"time":42,"warning":null,"timeFormatter":null,"consecutiveTime":462},"numberOfStops":0,"trainrunId":77,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1854,"y":1776},{"x":1790,"y":1776},{"x":290,"y":1776},{"x":226,"y":1776}],"textPositions":{"0":{"x":1836,"y":1764},"1":{"x":1808,"y":1788},"2":{"x":244,"y":1788},"3":{"x":272,"y":1764},"4":{"x":1040,"y":1764},"5":{"x":1040,"y":1764},"6":{"x":1040,"y":1788}}},"warnings":null},{"id":668,"sourceNodeId":169,"sourcePortId":1351,"targetNodeId":142,"targetPortId":1352,"travelTime":{"lock":true,"time":9,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":33,"warning":null,"timeFormatter":null,"consecutiveTime":273},"sourceArrival":{"lock":false,"time":27,"warning":null,"timeFormatter":null,"consecutiveTime":87},"targetDeparture":{"lock":true,"time":18,"warning":null,"timeFormatter":null,"consecutiveTime":78},"targetArrival":{"lock":true,"time":42,"warning":null,"timeFormatter":null,"consecutiveTime":282},"numberOfStops":0,"trainrunId":75,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1854,"y":1744},{"x":1790,"y":1744},{"x":290,"y":1744},{"x":226,"y":1744}],"textPositions":{"0":{"x":1836,"y":1732},"1":{"x":1808,"y":1756},"2":{"x":244,"y":1756},"3":{"x":272,"y":1732},"4":{"x":1040,"y":1732},"5":{"x":1040,"y":1732},"6":{"x":1040,"y":1756}}},"warnings":null},{"id":669,"sourceNodeId":170,"sourcePortId":1353,"targetNodeId":135,"targetPortId":1354,"travelTime":{"lock":true,"time":11,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":14,"warning":null,"timeFormatter":null,"consecutiveTime":74},"sourceArrival":{"lock":true,"time":46,"warning":null,"timeFormatter":null,"consecutiveTime":226},"targetDeparture":{"lock":true,"time":35,"warning":null,"timeFormatter":null,"consecutiveTime":215},"targetArrival":{"lock":true,"time":25,"warning":null,"timeFormatter":null,"consecutiveTime":85},"numberOfStops":0,"trainrunId":79,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2832,"y":734},{"x":2832,"y":670},{"x":2832,"y":414},{"x":2832,"y":350}],"textPositions":{"0":{"x":2844,"y":716},"1":{"x":2820,"y":688},"2":{"x":2820,"y":368},"3":{"x":2844,"y":396},"4":{"x":2820,"y":542},"5":{"x":2820,"y":542},"6":{"x":2844,"y":542}}},"warnings":null},{"id":670,"sourceNodeId":170,"sourcePortId":1355,"targetNodeId":135,"targetPortId":1356,"travelTime":{"lock":true,"time":7,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":43,"warning":null,"timeFormatter":null,"consecutiveTime":43},"sourceArrival":{"lock":false,"time":17,"warning":null,"timeFormatter":null,"consecutiveTime":17},"targetDeparture":{"lock":true,"time":10,"warning":null,"timeFormatter":null,"consecutiveTime":10},"targetArrival":{"lock":true,"time":50,"warning":null,"timeFormatter":null,"consecutiveTime":50},"numberOfStops":0,"trainrunId":80,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2800,"y":734},{"x":2800,"y":670},{"x":2800,"y":414},{"x":2800,"y":350}],"textPositions":{"0":{"x":2812,"y":716},"1":{"x":2788,"y":688},"2":{"x":2788,"y":368},"3":{"x":2812,"y":396},"4":{"x":2788,"y":542},"5":{"x":2788,"y":542},"6":{"x":2812,"y":542}}},"warnings":null},{"id":671,"sourceNodeId":170,"sourcePortId":1357,"targetNodeId":135,"targetPortId":1358,"travelTime":{"lock":true,"time":8,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":47,"warning":null,"timeFormatter":null,"consecutiveTime":347},"sourceArrival":{"lock":false,"time":13,"warning":null,"timeFormatter":null,"consecutiveTime":13},"targetDeparture":{"lock":true,"time":5,"warning":null,"timeFormatter":null,"consecutiveTime":5},"targetArrival":{"lock":true,"time":55,"warning":null,"timeFormatter":null,"consecutiveTime":355},"numberOfStops":0,"trainrunId":78,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2768,"y":734},{"x":2768,"y":670},{"x":2768,"y":414},{"x":2768,"y":350}],"textPositions":{"0":{"x":2780,"y":716},"1":{"x":2756,"y":688},"2":{"x":2756,"y":368},"3":{"x":2780,"y":396},"4":{"x":2756,"y":542},"5":{"x":2756,"y":542},"6":{"x":2780,"y":542}}},"warnings":null},{"id":672,"sourceNodeId":170,"sourcePortId":1359,"targetNodeId":135,"targetPortId":1360,"travelTime":{"lock":true,"time":8,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":47,"warning":null,"timeFormatter":null,"consecutiveTime":107},"sourceArrival":{"lock":false,"time":13,"warning":null,"timeFormatter":null,"consecutiveTime":13},"targetDeparture":{"lock":true,"time":5,"warning":null,"timeFormatter":null,"consecutiveTime":5},"targetArrival":{"lock":true,"time":55,"warning":null,"timeFormatter":null,"consecutiveTime":115},"numberOfStops":0,"trainrunId":76,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2672,"y":734},{"x":2672,"y":670},{"x":2672,"y":414},{"x":2672,"y":350}],"textPositions":{"0":{"x":2684,"y":716},"1":{"x":2660,"y":688},"2":{"x":2660,"y":368},"3":{"x":2684,"y":396},"4":{"x":2660,"y":542},"5":{"x":2660,"y":542},"6":{"x":2684,"y":542}}},"warnings":null},{"id":673,"sourceNodeId":170,"sourcePortId":1361,"targetNodeId":140,"targetPortId":1362,"travelTime":{"lock":true,"time":47,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":15,"warning":null,"timeFormatter":null,"consecutiveTime":75},"sourceArrival":{"lock":false,"time":45,"warning":null,"timeFormatter":null,"consecutiveTime":285},"targetDeparture":{"lock":true,"time":58,"warning":null,"timeFormatter":null,"consecutiveTime":238},"targetArrival":{"lock":true,"time":2,"warning":null,"timeFormatter":null,"consecutiveTime":122},"numberOfStops":0,"trainrunId":85,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2850,"y":752},{"x":2914,"y":752},{"x":4574,"y":1200},{"x":4638,"y":1200}],"textPositions":{"0":{"x":2868,"y":764},"1":{"x":2896,"y":740},"2":{"x":4620,"y":1188},"3":{"x":4592,"y":1212},"4":{"x":3744,"y":964},"5":{"x":3744,"y":964},"6":{"x":3744,"y":988}}},"warnings":null},{"id":674,"sourceNodeId":170,"sourcePortId":1363,"targetNodeId":140,"targetPortId":1364,"travelTime":{"lock":false,"time":61,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":21,"warning":null,"timeFormatter":null,"consecutiveTime":141},"sourceArrival":{"lock":true,"time":39,"warning":null,"timeFormatter":null,"consecutiveTime":279},"targetDeparture":{"lock":true,"time":38,"warning":null,"timeFormatter":null,"consecutiveTime":218},"targetArrival":{"lock":true,"time":22,"warning":null,"timeFormatter":null,"consecutiveTime":202},"numberOfStops":5,"trainrunId":86,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2850,"y":784},{"x":2914,"y":784},{"x":4574,"y":1232},{"x":4638,"y":1232}],"textPositions":{"0":{"x":2868,"y":796},"1":{"x":2896,"y":772},"2":{"x":4620,"y":1220},"3":{"x":4592,"y":1244},"4":{"x":3744,"y":996},"5":{"x":3744,"y":996},"6":{"x":3744,"y":1020}}},"warnings":null},{"id":675,"sourceNodeId":142,"sourcePortId":1365,"targetNodeId":141,"targetPortId":1366,"travelTime":{"lock":true,"time":19,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":55,"warning":null,"timeFormatter":null,"consecutiveTime":475},"sourceArrival":{"lock":true,"time":5,"warning":null,"timeFormatter":null,"consecutiveTime":125},"targetDeparture":{"lock":false,"time":46,"warning":null,"timeFormatter":null,"consecutiveTime":106},"targetArrival":{"lock":false,"time":14,"warning":null,"timeFormatter":null,"consecutiveTime":494},"numberOfStops":0,"trainrunId":77,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":144,"y":1726},{"x":144,"y":1662},{"x":144,"y":1314},{"x":144,"y":1250}],"textPositions":{"0":{"x":156,"y":1708},"1":{"x":132,"y":1680},"2":{"x":132,"y":1268},"3":{"x":156,"y":1296},"4":{"x":132,"y":1488},"5":{"x":132,"y":1488},"6":{"x":156,"y":1488}}},"warnings":null},{"id":676,"sourceNodeId":141,"sourcePortId":1367,"targetNodeId":143,"targetPortId":1368,"travelTime":{"lock":true,"time":7,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":14,"warning":null,"timeFormatter":null,"consecutiveTime":494},"sourceArrival":{"lock":false,"time":46,"warning":null,"timeFormatter":null,"consecutiveTime":106},"targetDeparture":{"lock":false,"time":39,"warning":null,"timeFormatter":null,"consecutiveTime":99},"targetArrival":{"lock":false,"time":21,"warning":null,"timeFormatter":null,"consecutiveTime":501},"numberOfStops":0,"trainrunId":77,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":144,"y":1182},{"x":144,"y":1118},{"x":144,"y":866},{"x":144,"y":802}],"textPositions":{"0":{"x":156,"y":1164},"1":{"x":132,"y":1136},"2":{"x":132,"y":820},"3":{"x":156,"y":848},"4":{"x":132,"y":992},"5":{"x":132,"y":992},"6":{"x":156,"y":992}}},"warnings":null},{"id":677,"sourceNodeId":143,"sourcePortId":1369,"targetNodeId":133,"targetPortId":1370,"travelTime":{"lock":true,"time":7,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":23,"warning":null,"timeFormatter":null,"consecutiveTime":503},"sourceArrival":{"lock":false,"time":37,"warning":null,"timeFormatter":null,"consecutiveTime":97},"targetDeparture":{"lock":false,"time":30,"warning":null,"timeFormatter":null,"consecutiveTime":90},"targetArrival":{"lock":false,"time":30,"warning":null,"timeFormatter":null,"consecutiveTime":510},"numberOfStops":0,"trainrunId":77,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":112,"y":734},{"x":112,"y":670},{"x":112,"y":414},{"x":112,"y":350}],"textPositions":{"0":{"x":124,"y":716},"1":{"x":100,"y":688},"2":{"x":100,"y":368},"3":{"x":124,"y":396},"4":{"x":100,"y":542},"5":{"x":100,"y":542},"6":{"x":124,"y":542}}},"warnings":null},{"id":678,"sourceNodeId":133,"sourcePortId":1371,"targetNodeId":144,"targetPortId":1372,"travelTime":{"lock":true,"time":10,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":32,"warning":null,"timeFormatter":null,"consecutiveTime":512},"sourceArrival":{"lock":true,"time":28,"warning":null,"timeFormatter":null,"consecutiveTime":88},"targetDeparture":{"lock":false,"time":18,"warning":null,"timeFormatter":null,"consecutiveTime":78},"targetArrival":{"lock":false,"time":42,"warning":null,"timeFormatter":null,"consecutiveTime":522},"numberOfStops":0,"trainrunId":77,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":176,"y":94},{"x":176,"y":30},{"x":176,"y":-290},{"x":176,"y":-354}],"textPositions":{"0":{"x":188,"y":76},"1":{"x":164,"y":48},"2":{"x":164,"y":-336},"3":{"x":188,"y":-308},"4":{"x":164,"y":-130},"5":{"x":164,"y":-130},"6":{"x":188,"y":-130}}},"warnings":null},{"id":679,"sourceNodeId":144,"sourcePortId":1373,"targetNodeId":145,"targetPortId":1374,"travelTime":{"lock":true,"time":5,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":42,"warning":null,"timeFormatter":null,"consecutiveTime":522},"sourceArrival":{"lock":false,"time":18,"warning":null,"timeFormatter":null,"consecutiveTime":78},"targetDeparture":{"lock":false,"time":13,"warning":null,"timeFormatter":null,"consecutiveTime":73},"targetArrival":{"lock":false,"time":47,"warning":null,"timeFormatter":null,"consecutiveTime":527},"numberOfStops":0,"trainrunId":77,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":240,"y":-450},{"x":240,"y":-514},{"x":240,"y":-798},{"x":240,"y":-862}],"textPositions":{"0":{"x":252,"y":-468},"1":{"x":228,"y":-496},"2":{"x":228,"y":-844},"3":{"x":252,"y":-816},"4":{"x":228,"y":-656},"5":{"x":228,"y":-656},"6":{"x":252,"y":-656}}},"warnings":null},{"id":680,"sourceNodeId":145,"sourcePortId":1375,"targetNodeId":146,"targetPortId":1376,"travelTime":{"lock":true,"time":5,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":47,"warning":null,"timeFormatter":null,"consecutiveTime":527},"sourceArrival":{"lock":false,"time":13,"warning":null,"timeFormatter":null,"consecutiveTime":73},"targetDeparture":{"lock":false,"time":8,"warning":null,"timeFormatter":null,"consecutiveTime":68},"targetArrival":{"lock":false,"time":52,"warning":null,"timeFormatter":null,"consecutiveTime":532},"numberOfStops":0,"trainrunId":77,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":240,"y":-930},{"x":240,"y":-994},{"x":240,"y":-1278},{"x":240,"y":-1342}],"textPositions":{"0":{"x":252,"y":-948},"1":{"x":228,"y":-976},"2":{"x":228,"y":-1324},"3":{"x":252,"y":-1296},"4":{"x":228,"y":-1136},"5":{"x":228,"y":-1136},"6":{"x":252,"y":-1136}}},"warnings":null},{"id":681,"sourceNodeId":146,"sourcePortId":1377,"targetNodeId":134,"targetPortId":1378,"travelTime":{"lock":true,"time":5,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":52,"warning":null,"timeFormatter":null,"consecutiveTime":532},"sourceArrival":{"lock":false,"time":8,"warning":null,"timeFormatter":null,"consecutiveTime":68},"targetDeparture":{"lock":true,"time":3,"warning":null,"timeFormatter":null,"consecutiveTime":63},"targetArrival":{"lock":true,"time":57,"warning":null,"timeFormatter":null,"consecutiveTime":537},"numberOfStops":0,"trainrunId":77,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":240,"y":-1410},{"x":240,"y":-1474},{"x":240,"y":-1758},{"x":240,"y":-1822}],"textPositions":{"0":{"x":252,"y":-1428},"1":{"x":228,"y":-1456},"2":{"x":228,"y":-1804},"3":{"x":252,"y":-1776},"4":{"x":228,"y":-1616},"5":{"x":228,"y":-1616},"6":{"x":252,"y":-1616}}},"warnings":null},{"id":682,"sourceNodeId":171,"sourcePortId":1379,"targetNodeId":128,"targetPortId":1380,"travelTime":{"lock":false,"time":49,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":27,"warning":null,"timeFormatter":null,"consecutiveTime":387},"sourceArrival":{"lock":true,"time":33,"warning":null,"timeFormatter":null,"consecutiveTime":153},"targetDeparture":{"lock":true,"time":44,"warning":null,"timeFormatter":null,"consecutiveTime":104},"targetArrival":{"lock":true,"time":16,"warning":null,"timeFormatter":null,"consecutiveTime":436},"numberOfStops":2,"trainrunId":81,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-2562,"y":336},{"x":-2626,"y":336},{"x":-2910,"y":592},{"x":-2974,"y":592}],"textPositions":{"0":{"x":-2580,"y":324},"1":{"x":-2608,"y":348},"2":{"x":-2956,"y":604},"3":{"x":-2928,"y":580},"4":{"x":-2768,"y":452},"5":{"x":-2768,"y":452},"6":{"x":-2768,"y":476}}},"warnings":null},{"id":683,"sourceNodeId":171,"sourcePortId":1381,"targetNodeId":128,"targetPortId":1382,"travelTime":{"lock":true,"time":44,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":54,"warning":null,"timeFormatter":null,"consecutiveTime":414},"sourceArrival":{"lock":false,"time":6,"warning":null,"timeFormatter":null,"consecutiveTime":126},"targetDeparture":{"lock":false,"time":22,"warning":null,"timeFormatter":null,"consecutiveTime":82},"targetArrival":{"lock":false,"time":38,"warning":null,"timeFormatter":null,"consecutiveTime":458},"numberOfStops":0,"trainrunId":88,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-2562,"y":304},{"x":-2626,"y":304},{"x":-2910,"y":560},{"x":-2974,"y":560}],"textPositions":{"0":{"x":-2580,"y":292},"1":{"x":-2608,"y":316},"2":{"x":-2956,"y":572},"3":{"x":-2928,"y":548},"4":{"x":-2768,"y":420},"5":{"x":-2768,"y":420},"6":{"x":-2768,"y":444}}},"warnings":null},{"id":684,"sourceNodeId":172,"sourcePortId":1383,"targetNodeId":178,"targetPortId":1384,"travelTime":{"lock":true,"time":17,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":39,"warning":null,"timeFormatter":null,"consecutiveTime":339},"sourceArrival":{"lock":false,"time":21,"warning":null,"timeFormatter":null,"consecutiveTime":201},"targetDeparture":{"lock":false,"time":4,"warning":null,"timeFormatter":null,"consecutiveTime":184},"targetArrival":{"lock":false,"time":56,"warning":null,"timeFormatter":null,"consecutiveTime":356},"numberOfStops":0,"trainrunId":81,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-610,"y":304},{"x":-674,"y":304},{"x":-1534,"y":304},{"x":-1598,"y":304}],"textPositions":{"0":{"x":-628,"y":292},"1":{"x":-656,"y":316},"2":{"x":-1580,"y":316},"3":{"x":-1552,"y":292},"4":{"x":-1104,"y":292},"5":{"x":-1104,"y":292},"6":{"x":-1104,"y":316}}},"warnings":null},{"id":685,"sourceNodeId":172,"sourcePortId":1385,"targetNodeId":174,"targetPortId":1386,"travelTime":{"lock":true,"time":8,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":43,"warning":null,"timeFormatter":null,"consecutiveTime":343},"sourceArrival":{"lock":false,"time":17,"warning":null,"timeFormatter":null,"consecutiveTime":77},"targetDeparture":{"lock":true,"time":9,"warning":null,"timeFormatter":null,"consecutiveTime":69},"targetArrival":{"lock":true,"time":51,"warning":null,"timeFormatter":null,"consecutiveTime":351},"numberOfStops":0,"trainrunId":86,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-610,"y":336},{"x":-674,"y":336},{"x":-830,"y":368},{"x":-894,"y":368}],"textPositions":{"0":{"x":-628,"y":324},"1":{"x":-656,"y":348},"2":{"x":-876,"y":380},"3":{"x":-848,"y":356},"4":{"x":-752,"y":340},"5":{"x":-752,"y":340},"6":{"x":-752,"y":364}}},"warnings":null},{"id":686,"sourceNodeId":172,"sourcePortId":1387,"targetNodeId":178,"targetPortId":1388,"travelTime":{"lock":true,"time":8,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":47,"warning":null,"timeFormatter":null,"consecutiveTime":347},"sourceArrival":{"lock":false,"time":13,"warning":null,"timeFormatter":null,"consecutiveTime":73},"targetDeparture":{"lock":false,"time":5,"warning":null,"timeFormatter":null,"consecutiveTime":65},"targetArrival":{"lock":false,"time":55,"warning":null,"timeFormatter":null,"consecutiveTime":355},"numberOfStops":0,"trainrunId":90,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-610,"y":272},{"x":-674,"y":272},{"x":-1534,"y":272},{"x":-1598,"y":272}],"textPositions":{"0":{"x":-628,"y":260},"1":{"x":-656,"y":284},"2":{"x":-1580,"y":284},"3":{"x":-1552,"y":260},"4":{"x":-1104,"y":260},"5":{"x":-1104,"y":260},"6":{"x":-1104,"y":284}}},"warnings":null},{"id":687,"sourceNodeId":172,"sourcePortId":1389,"targetNodeId":178,"targetPortId":1390,"travelTime":{"lock":true,"time":12,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":42,"warning":null,"timeFormatter":null,"consecutiveTime":342},"sourceArrival":{"lock":false,"time":18,"warning":null,"timeFormatter":null,"consecutiveTime":78},"targetDeparture":{"lock":false,"time":6,"warning":null,"timeFormatter":null,"consecutiveTime":66},"targetArrival":{"lock":false,"time":54,"warning":null,"timeFormatter":null,"consecutiveTime":354},"numberOfStops":0,"trainrunId":89,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-610,"y":240},{"x":-674,"y":240},{"x":-1534,"y":240},{"x":-1598,"y":240}],"textPositions":{"0":{"x":-628,"y":228},"1":{"x":-656,"y":252},"2":{"x":-1580,"y":252},"3":{"x":-1552,"y":228},"4":{"x":-1104,"y":228},"5":{"x":-1104,"y":228},"6":{"x":-1104,"y":252}}},"warnings":null},{"id":688,"sourceNodeId":172,"sourcePortId":1391,"targetNodeId":178,"targetPortId":1392,"travelTime":{"lock":true,"time":18,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":5,"warning":null,"timeFormatter":null,"consecutiveTime":65},"sourceArrival":{"lock":false,"time":55,"warning":null,"timeFormatter":null,"consecutiveTime":235},"targetDeparture":{"lock":false,"time":37,"warning":null,"timeFormatter":null,"consecutiveTime":217},"targetArrival":{"lock":false,"time":23,"warning":null,"timeFormatter":null,"consecutiveTime":83},"numberOfStops":0,"trainrunId":95,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-610,"y":208},{"x":-674,"y":208},{"x":-1534,"y":208},{"x":-1598,"y":208}],"textPositions":{"0":{"x":-628,"y":196},"1":{"x":-656,"y":220},"2":{"x":-1580,"y":220},"3":{"x":-1552,"y":196},"4":{"x":-1104,"y":196},"5":{"x":-1104,"y":196},"6":{"x":-1104,"y":220}}},"warnings":null},{"id":689,"sourceNodeId":172,"sourcePortId":1393,"targetNodeId":133,"targetPortId":1394,"travelTime":{"lock":true,"time":8,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":54,"warning":null,"timeFormatter":null,"consecutiveTime":234},"sourceArrival":{"lock":false,"time":6,"warning":null,"timeFormatter":null,"consecutiveTime":66},"targetDeparture":{"lock":true,"time":58,"warning":null,"timeFormatter":null,"consecutiveTime":58},"targetArrival":{"lock":true,"time":2,"warning":null,"timeFormatter":null,"consecutiveTime":242},"numberOfStops":0,"trainrunId":96,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-510,"y":176},{"x":-446,"y":176},{"x":-2,"y":176},{"x":62,"y":176}],"textPositions":{"0":{"x":-492,"y":188},"1":{"x":-464,"y":164},"2":{"x":44,"y":164},"3":{"x":16,"y":188},"4":{"x":-224,"y":164},"5":{"x":-224,"y":164},"6":{"x":-224,"y":188}}},"warnings":null},{"id":690,"sourceNodeId":172,"sourcePortId":1395,"targetNodeId":178,"targetPortId":1396,"travelTime":{"lock":true,"time":9,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":17,"warning":null,"timeFormatter":null,"consecutiveTime":377},"sourceArrival":{"lock":false,"time":43,"warning":null,"timeFormatter":null,"consecutiveTime":163},"targetDeparture":{"lock":false,"time":34,"warning":null,"timeFormatter":null,"consecutiveTime":154},"targetArrival":{"lock":false,"time":26,"warning":null,"timeFormatter":null,"consecutiveTime":386},"numberOfStops":0,"trainrunId":88,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-610,"y":144},{"x":-674,"y":144},{"x":-1534,"y":144},{"x":-1598,"y":144}],"textPositions":{"0":{"x":-628,"y":132},"1":{"x":-656,"y":156},"2":{"x":-1580,"y":156},"3":{"x":-1552,"y":132},"4":{"x":-1104,"y":132},"5":{"x":-1104,"y":132},"6":{"x":-1104,"y":156}}},"warnings":null},{"id":691,"sourceNodeId":173,"sourcePortId":1397,"targetNodeId":178,"targetPortId":1398,"travelTime":{"lock":true,"time":10,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":11,"warning":null,"timeFormatter":null,"consecutiveTime":371},"sourceArrival":{"lock":true,"time":49,"warning":null,"timeFormatter":null,"consecutiveTime":49},"targetDeparture":{"lock":false,"time":39,"warning":null,"timeFormatter":null,"consecutiveTime":39},"targetArrival":{"lock":false,"time":21,"warning":null,"timeFormatter":null,"consecutiveTime":381},"numberOfStops":0,"trainrunId":86,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-1346,"y":368},{"x":-1410,"y":368},{"x":-1534,"y":336},{"x":-1598,"y":336}],"textPositions":{"0":{"x":-1364,"y":356},"1":{"x":-1392,"y":380},"2":{"x":-1580,"y":348},"3":{"x":-1552,"y":324},"4":{"x":-1472,"y":340},"5":{"x":-1472,"y":340},"6":{"x":-1472,"y":364}}},"warnings":null},{"id":692,"sourceNodeId":174,"sourcePortId":1399,"targetNodeId":173,"targetPortId":1400,"travelTime":{"lock":true,"time":17,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":52,"warning":null,"timeFormatter":null,"consecutiveTime":352},"sourceArrival":{"lock":true,"time":8,"warning":null,"timeFormatter":null,"consecutiveTime":68},"targetDeparture":{"lock":false,"time":51,"warning":null,"timeFormatter":null,"consecutiveTime":51},"targetArrival":{"lock":false,"time":9,"warning":null,"timeFormatter":null,"consecutiveTime":369},"numberOfStops":1,"trainrunId":86,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-994,"y":368},{"x":-1058,"y":368},{"x":-1182,"y":368},{"x":-1246,"y":368}],"textPositions":{"0":{"x":-1012,"y":356},"1":{"x":-1040,"y":380},"2":{"x":-1228,"y":380},"3":{"x":-1200,"y":356},"4":{"x":-1120,"y":356},"5":{"x":-1120,"y":356},"6":{"x":-1120,"y":380}}},"warnings":null},{"id":693,"sourceNodeId":135,"sourcePortId":1401,"targetNodeId":149,"targetPortId":1402,"travelTime":{"lock":true,"time":8,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":0,"warning":null,"timeFormatter":null,"consecutiveTime":300},"sourceArrival":{"lock":true,"time":0,"warning":null,"timeFormatter":null,"consecutiveTime":60},"targetDeparture":{"lock":false,"time":52,"warning":null,"timeFormatter":null,"consecutiveTime":52},"targetArrival":{"lock":false,"time":8,"warning":null,"timeFormatter":null,"consecutiveTime":308},"numberOfStops":0,"trainrunId":85,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2654,"y":80},{"x":2590,"y":80},{"x":2402,"y":80},{"x":2338,"y":80}],"textPositions":{"0":{"x":2636,"y":68},"1":{"x":2608,"y":92},"2":{"x":2356,"y":92},"3":{"x":2384,"y":68},"4":{"x":2496,"y":68},"5":{"x":2496,"y":68},"6":{"x":2496,"y":92}}},"warnings":null},{"id":694,"sourceNodeId":149,"sourcePortId":1403,"targetNodeId":166,"targetPortId":1404,"travelTime":{"lock":true,"time":6,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":8,"warning":null,"timeFormatter":null,"consecutiveTime":308},"sourceArrival":{"lock":false,"time":52,"warning":null,"timeFormatter":null,"consecutiveTime":52},"targetDeparture":{"lock":false,"time":46,"warning":null,"timeFormatter":null,"consecutiveTime":46},"targetArrival":{"lock":false,"time":14,"warning":null,"timeFormatter":null,"consecutiveTime":314},"numberOfStops":0,"trainrunId":85,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":2238,"y":80},{"x":2174,"y":80},{"x":1954,"y":80},{"x":1890,"y":80}],"textPositions":{"0":{"x":2220,"y":68},"1":{"x":2192,"y":92},"2":{"x":1908,"y":92},"3":{"x":1936,"y":68},"4":{"x":2064,"y":68},"5":{"x":2064,"y":68},"6":{"x":2064,"y":92}}},"warnings":null},{"id":695,"sourceNodeId":166,"sourcePortId":1405,"targetNodeId":148,"targetPortId":1406,"travelTime":{"lock":true,"time":6,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":14,"warning":null,"timeFormatter":null,"consecutiveTime":314},"sourceArrival":{"lock":false,"time":46,"warning":null,"timeFormatter":null,"consecutiveTime":46},"targetDeparture":{"lock":false,"time":40,"warning":null,"timeFormatter":null,"consecutiveTime":40},"targetArrival":{"lock":false,"time":20,"warning":null,"timeFormatter":null,"consecutiveTime":320},"numberOfStops":0,"trainrunId":85,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1790,"y":80},{"x":1726,"y":80},{"x":1506,"y":80},{"x":1442,"y":80}],"textPositions":{"0":{"x":1772,"y":68},"1":{"x":1744,"y":92},"2":{"x":1460,"y":92},"3":{"x":1488,"y":68},"4":{"x":1616,"y":68},"5":{"x":1616,"y":68},"6":{"x":1616,"y":92}}},"warnings":null},{"id":696,"sourceNodeId":148,"sourcePortId":1407,"targetNodeId":147,"targetPortId":1408,"travelTime":{"lock":true,"time":6,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":20,"warning":null,"timeFormatter":null,"consecutiveTime":320},"sourceArrival":{"lock":false,"time":40,"warning":null,"timeFormatter":null,"consecutiveTime":40},"targetDeparture":{"lock":false,"time":34,"warning":null,"timeFormatter":null,"consecutiveTime":34},"targetArrival":{"lock":false,"time":26,"warning":null,"timeFormatter":null,"consecutiveTime":326},"numberOfStops":0,"trainrunId":85,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1342,"y":80},{"x":1278,"y":80},{"x":1122,"y":80},{"x":1058,"y":80}],"textPositions":{"0":{"x":1324,"y":68},"1":{"x":1296,"y":92},"2":{"x":1076,"y":92},"3":{"x":1104,"y":68},"4":{"x":1200,"y":68},"5":{"x":1200,"y":68},"6":{"x":1200,"y":92}}},"warnings":null},{"id":697,"sourceNodeId":147,"sourcePortId":1409,"targetNodeId":144,"targetPortId":1410,"travelTime":{"lock":true,"time":7,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":26,"warning":null,"timeFormatter":null,"consecutiveTime":326},"sourceArrival":{"lock":false,"time":34,"warning":null,"timeFormatter":null,"consecutiveTime":34},"targetDeparture":{"lock":false,"time":27,"warning":null,"timeFormatter":null,"consecutiveTime":27},"targetArrival":{"lock":false,"time":33,"warning":null,"timeFormatter":null,"consecutiveTime":333},"numberOfStops":0,"trainrunId":85,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":958,"y":48},{"x":894,"y":48},{"x":386,"y":-432},{"x":322,"y":-432}],"textPositions":{"0":{"x":940,"y":36},"1":{"x":912,"y":60},"2":{"x":340,"y":-420},"3":{"x":368,"y":-444},"4":{"x":640,"y":-204},"5":{"x":640,"y":-204},"6":{"x":640,"y":-180}}},"warnings":null},{"id":698,"sourceNodeId":144,"sourcePortId":1411,"targetNodeId":145,"targetPortId":1412,"travelTime":{"lock":true,"time":6,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":33,"warning":null,"timeFormatter":null,"consecutiveTime":333},"sourceArrival":{"lock":false,"time":27,"warning":null,"timeFormatter":null,"consecutiveTime":27},"targetDeparture":{"lock":false,"time":21,"warning":null,"timeFormatter":null,"consecutiveTime":21},"targetArrival":{"lock":false,"time":39,"warning":null,"timeFormatter":null,"consecutiveTime":339},"numberOfStops":0,"trainrunId":85,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":112,"y":-450},{"x":112,"y":-514},{"x":112,"y":-798},{"x":112,"y":-862}],"textPositions":{"0":{"x":124,"y":-468},"1":{"x":100,"y":-496},"2":{"x":100,"y":-844},"3":{"x":124,"y":-816},"4":{"x":100,"y":-656},"5":{"x":100,"y":-656},"6":{"x":124,"y":-656}}},"warnings":null},{"id":699,"sourceNodeId":145,"sourcePortId":1413,"targetNodeId":146,"targetPortId":1414,"travelTime":{"lock":true,"time":7,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":39,"warning":null,"timeFormatter":null,"consecutiveTime":339},"sourceArrival":{"lock":false,"time":21,"warning":null,"timeFormatter":null,"consecutiveTime":21},"targetDeparture":{"lock":false,"time":14,"warning":null,"timeFormatter":null,"consecutiveTime":14},"targetArrival":{"lock":false,"time":46,"warning":null,"timeFormatter":null,"consecutiveTime":346},"numberOfStops":0,"trainrunId":85,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":112,"y":-930},{"x":112,"y":-994},{"x":112,"y":-1278},{"x":112,"y":-1342}],"textPositions":{"0":{"x":124,"y":-948},"1":{"x":100,"y":-976},"2":{"x":100,"y":-1324},"3":{"x":124,"y":-1296},"4":{"x":100,"y":-1136},"5":{"x":100,"y":-1136},"6":{"x":124,"y":-1136}}},"warnings":null},{"id":700,"sourceNodeId":146,"sourcePortId":1415,"targetNodeId":134,"targetPortId":1416,"travelTime":{"lock":true,"time":8,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":46,"warning":null,"timeFormatter":null,"consecutiveTime":346},"sourceArrival":{"lock":false,"time":14,"warning":null,"timeFormatter":null,"consecutiveTime":14},"targetDeparture":{"lock":true,"time":6,"warning":null,"timeFormatter":null,"consecutiveTime":6},"targetArrival":{"lock":true,"time":54,"warning":null,"timeFormatter":null,"consecutiveTime":354},"numberOfStops":0,"trainrunId":85,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":112,"y":-1410},{"x":112,"y":-1474},{"x":112,"y":-1758},{"x":112,"y":-1822}],"textPositions":{"0":{"x":124,"y":-1428},"1":{"x":100,"y":-1456},"2":{"x":100,"y":-1804},"3":{"x":124,"y":-1776},"4":{"x":100,"y":-1616},"5":{"x":100,"y":-1616},"6":{"x":124,"y":-1616}}},"warnings":null},{"id":701,"sourceNodeId":175,"sourcePortId":1417,"targetNodeId":130,"targetPortId":1418,"travelTime":{"lock":true,"time":13,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":1,"warning":null,"timeFormatter":null,"consecutiveTime":421},"sourceArrival":{"lock":true,"time":59,"warning":null,"timeFormatter":null,"consecutiveTime":119},"targetDeparture":{"lock":true,"time":46,"warning":null,"timeFormatter":null,"consecutiveTime":106},"targetArrival":{"lock":true,"time":14,"warning":null,"timeFormatter":null,"consecutiveTime":434},"numberOfStops":0,"trainrunId":87,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-1698,"y":-16},{"x":-1762,"y":-16},{"x":-2366,"y":-16},{"x":-2430,"y":-16}],"textPositions":{"0":{"x":-1716,"y":-28},"1":{"x":-1744,"y":-4},"2":{"x":-2412,"y":-4},"3":{"x":-2384,"y":-28},"4":{"x":-2064,"y":-28},"5":{"x":-2064,"y":-28},"6":{"x":-2064,"y":-4}}},"warnings":null},{"id":702,"sourceNodeId":137,"sourcePortId":1419,"targetNodeId":176,"targetPortId":1420,"travelTime":{"lock":true,"time":16,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":5,"warning":null,"timeFormatter":null,"consecutiveTime":245},"sourceArrival":{"lock":true,"time":55,"warning":null,"timeFormatter":null,"consecutiveTime":295},"targetDeparture":{"lock":false,"time":39,"warning":null,"timeFormatter":null,"consecutiveTime":279},"targetArrival":{"lock":false,"time":21,"warning":null,"timeFormatter":null,"consecutiveTime":261},"numberOfStops":0,"trainrunId":87,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":4738,"y":112},{"x":4802,"y":112},{"x":5310,"y":112},{"x":5374,"y":112}],"textPositions":{"0":{"x":4756,"y":124},"1":{"x":4784,"y":100},"2":{"x":5356,"y":100},"3":{"x":5328,"y":124},"4":{"x":5056,"y":100},"5":{"x":5056,"y":100},"6":{"x":5056,"y":124}}},"warnings":null},{"id":703,"sourceNodeId":177,"sourcePortId":1421,"targetNodeId":160,"targetPortId":1422,"travelTime":{"lock":false,"time":30,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":true,"time":31,"warning":null,"timeFormatter":null,"consecutiveTime":451},"sourceArrival":{"lock":true,"time":29,"warning":null,"timeFormatter":null,"consecutiveTime":89},"targetDeparture":{"lock":true,"time":59,"warning":null,"timeFormatter":null,"consecutiveTime":59},"targetArrival":{"lock":true,"time":1,"warning":null,"timeFormatter":null,"consecutiveTime":481},"numberOfStops":1,"trainrunId":81,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-3522,"y":624},{"x":-3586,"y":624},{"x":-3774,"y":688},{"x":-3838,"y":688}],"textPositions":{"0":{"x":-3540,"y":612},"1":{"x":-3568,"y":636},"2":{"x":-3820,"y":700},"3":{"x":-3792,"y":676},"4":{"x":-3680,"y":644},"5":{"x":-3680,"y":644},"6":{"x":-3680,"y":668}}},"warnings":null},{"id":704,"sourceNodeId":177,"sourcePortId":1423,"targetNodeId":160,"targetPortId":1424,"travelTime":{"lock":true,"time":26,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":52,"warning":null,"timeFormatter":null,"consecutiveTime":472},"sourceArrival":{"lock":false,"time":8,"warning":null,"timeFormatter":null,"consecutiveTime":68},"targetDeparture":{"lock":true,"time":42,"warning":null,"timeFormatter":null,"consecutiveTime":42},"targetArrival":{"lock":true,"time":18,"warning":null,"timeFormatter":null,"consecutiveTime":498},"numberOfStops":0,"trainrunId":88,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-3522,"y":560},{"x":-3586,"y":560},{"x":-3774,"y":624},{"x":-3838,"y":624}],"textPositions":{"0":{"x":-3540,"y":548},"1":{"x":-3568,"y":572},"2":{"x":-3820,"y":636},"3":{"x":-3792,"y":612},"4":{"x":-3680,"y":580},"5":{"x":-3680,"y":580},"6":{"x":-3680,"y":604}}},"warnings":null},{"id":705,"sourceNodeId":177,"sourcePortId":1425,"targetNodeId":160,"targetPortId":1426,"travelTime":{"lock":false,"time":26,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":19,"warning":null,"timeFormatter":null,"consecutiveTime":499},"sourceArrival":{"lock":false,"time":41,"warning":null,"timeFormatter":null,"consecutiveTime":41},"targetDeparture":{"lock":true,"time":15,"warning":null,"timeFormatter":null,"consecutiveTime":15},"targetArrival":{"lock":true,"time":45,"warning":null,"timeFormatter":null,"consecutiveTime":525},"numberOfStops":0,"trainrunId":87,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-3522,"y":592},{"x":-3586,"y":592},{"x":-3774,"y":656},{"x":-3838,"y":656}],"textPositions":{"0":{"x":-3540,"y":580},"1":{"x":-3568,"y":604},"2":{"x":-3820,"y":668},"3":{"x":-3792,"y":644},"4":{"x":-3680,"y":612},"5":{"x":-3680,"y":612},"6":{"x":-3680,"y":636}}},"warnings":null},{"id":706,"sourceNodeId":178,"sourcePortId":1427,"targetNodeId":129,"targetPortId":1428,"travelTime":{"lock":true,"time":3,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":21,"warning":null,"timeFormatter":null,"consecutiveTime":381},"sourceArrival":{"lock":false,"time":39,"warning":null,"timeFormatter":null,"consecutiveTime":39},"targetDeparture":{"lock":true,"time":36,"warning":null,"timeFormatter":null,"consecutiveTime":36},"targetArrival":{"lock":true,"time":24,"warning":null,"timeFormatter":null,"consecutiveTime":384},"numberOfStops":0,"trainrunId":86,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-1698,"y":336},{"x":-1762,"y":336},{"x":-1950,"y":336},{"x":-2014,"y":336}],"textPositions":{"0":{"x":-1716,"y":324},"1":{"x":-1744,"y":348},"2":{"x":-1996,"y":348},"3":{"x":-1968,"y":324},"4":{"x":-1856,"y":324},"5":{"x":-1856,"y":324},"6":{"x":-1856,"y":348}}},"warnings":null},{"id":707,"sourceNodeId":178,"sourcePortId":1429,"targetNodeId":129,"targetPortId":1430,"travelTime":{"lock":true,"time":4,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":56,"warning":null,"timeFormatter":null,"consecutiveTime":356},"sourceArrival":{"lock":false,"time":4,"warning":null,"timeFormatter":null,"consecutiveTime":184},"targetDeparture":{"lock":true,"time":0,"warning":null,"timeFormatter":null,"consecutiveTime":180},"targetArrival":{"lock":true,"time":0,"warning":null,"timeFormatter":null,"consecutiveTime":360},"numberOfStops":0,"trainrunId":81,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-1698,"y":304},{"x":-1762,"y":304},{"x":-1950,"y":304},{"x":-2014,"y":304}],"textPositions":{"0":{"x":-1716,"y":292},"1":{"x":-1744,"y":316},"2":{"x":-1996,"y":316},"3":{"x":-1968,"y":292},"4":{"x":-1856,"y":292},"5":{"x":-1856,"y":292},"6":{"x":-1856,"y":316}}},"warnings":null},{"id":708,"sourceNodeId":178,"sourcePortId":1431,"targetNodeId":129,"targetPortId":1432,"travelTime":{"lock":true,"time":3,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":55,"warning":null,"timeFormatter":null,"consecutiveTime":355},"sourceArrival":{"lock":false,"time":5,"warning":null,"timeFormatter":null,"consecutiveTime":65},"targetDeparture":{"lock":false,"time":2,"warning":null,"timeFormatter":null,"consecutiveTime":62},"targetArrival":{"lock":false,"time":58,"warning":null,"timeFormatter":null,"consecutiveTime":358},"numberOfStops":0,"trainrunId":90,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-1698,"y":272},{"x":-1762,"y":272},{"x":-1950,"y":272},{"x":-2014,"y":272}],"textPositions":{"0":{"x":-1716,"y":260},"1":{"x":-1744,"y":284},"2":{"x":-1996,"y":284},"3":{"x":-1968,"y":260},"4":{"x":-1856,"y":260},"5":{"x":-1856,"y":260},"6":{"x":-1856,"y":284}}},"warnings":null},{"id":709,"sourceNodeId":178,"sourcePortId":1433,"targetNodeId":129,"targetPortId":1434,"travelTime":{"lock":true,"time":3,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":54,"warning":null,"timeFormatter":null,"consecutiveTime":354},"sourceArrival":{"lock":false,"time":6,"warning":null,"timeFormatter":null,"consecutiveTime":66},"targetDeparture":{"lock":true,"time":3,"warning":null,"timeFormatter":null,"consecutiveTime":63},"targetArrival":{"lock":true,"time":57,"warning":null,"timeFormatter":null,"consecutiveTime":357},"numberOfStops":0,"trainrunId":89,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-1698,"y":240},{"x":-1762,"y":240},{"x":-1950,"y":240},{"x":-2014,"y":240}],"textPositions":{"0":{"x":-1716,"y":228},"1":{"x":-1744,"y":252},"2":{"x":-1996,"y":252},"3":{"x":-1968,"y":228},"4":{"x":-1856,"y":228},"5":{"x":-1856,"y":228},"6":{"x":-1856,"y":252}}},"warnings":null},{"id":710,"sourceNodeId":178,"sourcePortId":1435,"targetNodeId":129,"targetPortId":1436,"travelTime":{"lock":true,"time":3,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":23,"warning":null,"timeFormatter":null,"consecutiveTime":83},"sourceArrival":{"lock":false,"time":37,"warning":null,"timeFormatter":null,"consecutiveTime":217},"targetDeparture":{"lock":true,"time":34,"warning":null,"timeFormatter":null,"consecutiveTime":214},"targetArrival":{"lock":true,"time":26,"warning":null,"timeFormatter":null,"consecutiveTime":86},"numberOfStops":0,"trainrunId":95,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-1698,"y":208},{"x":-1762,"y":208},{"x":-1950,"y":208},{"x":-2014,"y":208}],"textPositions":{"0":{"x":-1716,"y":196},"1":{"x":-1744,"y":220},"2":{"x":-1996,"y":220},"3":{"x":-1968,"y":196},"4":{"x":-1856,"y":196},"5":{"x":-1856,"y":196},"6":{"x":-1856,"y":220}}},"warnings":null},{"id":711,"sourceNodeId":178,"sourcePortId":1437,"targetNodeId":172,"targetPortId":1438,"travelTime":{"lock":true,"time":17,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":37,"warning":null,"timeFormatter":null,"consecutiveTime":217},"sourceArrival":{"lock":false,"time":23,"warning":null,"timeFormatter":null,"consecutiveTime":83},"targetDeparture":{"lock":false,"time":6,"warning":null,"timeFormatter":null,"consecutiveTime":66},"targetArrival":{"lock":false,"time":54,"warning":null,"timeFormatter":null,"consecutiveTime":234},"numberOfStops":0,"trainrunId":96,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-1598,"y":176},{"x":-1534,"y":176},{"x":-674,"y":176},{"x":-610,"y":176}],"textPositions":{"0":{"x":-1580,"y":188},"1":{"x":-1552,"y":164},"2":{"x":-628,"y":164},"3":{"x":-656,"y":188},"4":{"x":-1104,"y":164},"5":{"x":-1104,"y":164},"6":{"x":-1104,"y":188}}},"warnings":null},{"id":712,"sourceNodeId":178,"sourcePortId":1439,"targetNodeId":129,"targetPortId":1440,"travelTime":{"lock":true,"time":3,"warning":null,"timeFormatter":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":26,"warning":null,"timeFormatter":null,"consecutiveTime":386},"sourceArrival":{"lock":false,"time":34,"warning":null,"timeFormatter":null,"consecutiveTime":154},"targetDeparture":{"lock":false,"time":31,"warning":null,"timeFormatter":null,"consecutiveTime":151},"targetArrival":{"lock":false,"time":29,"warning":null,"timeFormatter":null,"consecutiveTime":389},"numberOfStops":0,"trainrunId":88,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-1698,"y":144},{"x":-1762,"y":144},{"x":-1950,"y":144},{"x":-2014,"y":144}],"textPositions":{"0":{"x":-1716,"y":132},"1":{"x":-1744,"y":156},"2":{"x":-1996,"y":156},"3":{"x":-1968,"y":132},"4":{"x":-1856,"y":132},"5":{"x":-1856,"y":132},"6":{"x":-1856,"y":156}}},"warnings":null}],"trainruns":[{"id":75,"name":"21","categoryId":1,"frequencyId":4,"trainrunTimeCategoryId":0,"labelIds":[3,8,4]},{"id":76,"name":"2","categoryId":1,"frequencyId":4,"trainrunTimeCategoryId":0,"labelIds":[3,8,4]},{"id":77,"name":"26","categoryId":2,"frequencyId":5,"trainrunTimeCategoryId":0,"labelIds":[3,8,4]},{"id":78,"name":"46","categoryId":2,"frequencyId":4,"trainrunTimeCategoryId":0,"labelIds":[3,8,4]},{"id":79,"name":"75","categoryId":2,"frequencyId":3,"trainrunTimeCategoryId":0,"labelIds":[3,8,4]},{"id":80,"name":"70","categoryId":2,"frequencyId":3,"trainrunTimeCategoryId":0,"labelIds":[3,8,4]},{"id":81,"name":"15","categoryId":2,"frequencyId":3,"trainrunTimeCategoryId":0,"labelIds":[3,8,4]},{"id":82,"name":"27","categoryId":2,"frequencyId":3,"trainrunTimeCategoryId":0,"labelIds":[3,8,4]},{"id":83,"name":"26","categoryId":2,"frequencyId":3,"trainrunTimeCategoryId":0,"labelIds":[3,8,4]},{"id":84,"name":"13","categoryId":2,"frequencyId":3,"trainrunTimeCategoryId":0,"labelIds":[3,8,4]},{"id":85,"name":"3","categoryId":1,"frequencyId":4,"trainrunTimeCategoryId":0,"labelIds":[3,8,4]},{"id":86,"name":"35","categoryId":2,"frequencyId":3,"trainrunTimeCategoryId":0,"labelIds":[3,8,4]},{"id":87,"name":"5","categoryId":1,"frequencyId":3,"trainrunTimeCategoryId":0,"labelIds":[3,8,4]},{"id":88,"name":"1","categoryId":1,"frequencyId":3,"trainrunTimeCategoryId":0,"labelIds":[3,8,4]},{"id":89,"name":"8","categoryId":1,"frequencyId":3,"trainrunTimeCategoryId":0,"labelIds":[3,8,4]},{"id":90,"name":"81","categoryId":1,"frequencyId":3,"trainrunTimeCategoryId":0,"labelIds":[3,8,4]},{"id":91,"name":"48","categoryId":2,"frequencyId":3,"trainrunTimeCategoryId":0,"labelIds":[1,9,5]},{"id":92,"name":"","categoryId":1,"frequencyId":3,"trainrunTimeCategoryId":0,"labelIds":[1,9,5]},{"id":93,"name":"36","categoryId":2,"frequencyId":3,"trainrunTimeCategoryId":0,"labelIds":[3,8,4]},{"id":94,"name":"3","categoryId":1,"frequencyId":3,"trainrunTimeCategoryId":0,"labelIds":[3,8,4]},{"id":95,"name":"61","categoryId":1,"frequencyId":3,"trainrunTimeCategoryId":0,"labelIds":[3,8,4]},{"id":96,"name":"6","categoryId":1,"frequencyId":3,"trainrunTimeCategoryId":0,"labelIds":[3,8,4]},{"id":97,"name":"37","categoryId":2,"frequencyId":3,"trainrunTimeCategoryId":0,"labelIds":[3,8,4]}],"resources":[{"id":88,"capacity":2},{"id":89,"capacity":2},{"id":90,"capacity":2},{"id":91,"capacity":2},{"id":92,"capacity":2},{"id":93,"capacity":2},{"id":94,"capacity":2},{"id":95,"capacity":2},{"id":96,"capacity":2},{"id":97,"capacity":2},{"id":98,"capacity":2},{"id":99,"capacity":2},{"id":100,"capacity":2},{"id":101,"capacity":2},{"id":102,"capacity":2},{"id":103,"capacity":2},{"id":104,"capacity":2},{"id":105,"capacity":2},{"id":106,"capacity":2},{"id":107,"capacity":2},{"id":108,"capacity":2},{"id":109,"capacity":2},{"id":110,"capacity":2},{"id":111,"capacity":2},{"id":112,"capacity":2},{"id":113,"capacity":2},{"id":114,"capacity":2},{"id":115,"capacity":2},{"id":116,"capacity":2},{"id":117,"capacity":2},{"id":118,"capacity":2},{"id":119,"capacity":2},{"id":120,"capacity":2},{"id":121,"capacity":2},{"id":122,"capacity":2},{"id":123,"capacity":2},{"id":124,"capacity":2},{"id":125,"capacity":2},{"id":126,"capacity":2},{"id":127,"capacity":2},{"id":128,"capacity":2},{"id":129,"capacity":2},{"id":130,"capacity":2},{"id":131,"capacity":2},{"id":132,"capacity":2},{"id":133,"capacity":2},{"id":134,"capacity":2},{"id":135,"capacity":2},{"id":136,"capacity":2},{"id":137,"capacity":2},{"id":138,"capacity":2},{"id":139,"capacity":2},{"id":140,"capacity":2},{"id":141,"capacity":2},{"id":142,"capacity":2},{"id":143,"capacity":2},{"id":144,"capacity":2},{"id":145,"capacity":2},{"id":146,"capacity":2},{"id":147,"capacity":2},{"id":148,"capacity":2},{"id":149,"capacity":2},{"id":150,"capacity":2},{"id":151,"capacity":2},{"id":152,"capacity":2},{"id":153,"capacity":2},{"id":154,"capacity":2},{"id":155,"capacity":2},{"id":156,"capacity":2},{"id":157,"capacity":2},{"id":158,"capacity":2},{"id":159,"capacity":2},{"id":160,"capacity":2},{"id":161,"capacity":2},{"id":162,"capacity":2},{"id":163,"capacity":2},{"id":164,"capacity":2},{"id":165,"capacity":2},{"id":166,"capacity":2},{"id":167,"capacity":2},{"id":168,"capacity":2},{"id":169,"capacity":2},{"id":170,"capacity":2},{"id":171,"capacity":2},{"id":172,"capacity":2},{"id":173,"capacity":2},{"id":174,"capacity":2},{"id":175,"capacity":2},{"id":176,"capacity":2},{"id":177,"capacity":2},{"id":178,"capacity":2},{"id":179,"capacity":2},{"id":180,"capacity":2},{"id":181,"capacity":2},{"id":182,"capacity":2},{"id":183,"capacity":2},{"id":184,"capacity":2},{"id":185,"capacity":2},{"id":186,"capacity":2},{"id":187,"capacity":2},{"id":188,"capacity":2},{"id":189,"capacity":2},{"id":190,"capacity":2},{"id":191,"capacity":2},{"id":192,"capacity":2},{"id":193,"capacity":2},{"id":194,"capacity":2},{"id":195,"capacity":2},{"id":196,"capacity":2},{"id":197,"capacity":2},{"id":198,"capacity":2},{"id":199,"capacity":2},{"id":200,"capacity":2},{"id":201,"capacity":2},{"id":202,"capacity":2}],"metadata":{"netzgrafikColors":[],"trainrunCategories":[{"id":0,"name":"International","order":0,"colorRef":"EC","shortName":"EC","fachCategory":"HaltezeitIPV","sectionHeadway":2,"nodeHeadwayStop":2,"nodeHeadwayNonStop":2,"minimalTurnaroundTime":4},{"id":1,"name":"InterCity","order":1,"colorRef":"IC","shortName":"IC","fachCategory":"HaltezeitA","sectionHeadway":2,"nodeHeadwayStop":2,"nodeHeadwayNonStop":2,"minimalTurnaroundTime":4},{"id":2,"name":"InterRegio","order":2,"colorRef":"IR","shortName":"IR","fachCategory":"HaltezeitB","sectionHeadway":2,"nodeHeadwayStop":2,"nodeHeadwayNonStop":2,"minimalTurnaroundTime":4},{"id":3,"name":"RegioExpress","order":3,"colorRef":"RE","shortName":"RE","fachCategory":"HaltezeitC","sectionHeadway":2,"nodeHeadwayStop":2,"nodeHeadwayNonStop":2,"minimalTurnaroundTime":4},{"id":4,"name":"RegioUndSBahnverkehr","order":4,"colorRef":"S","shortName":"S","fachCategory":"HaltezeitD","sectionHeadway":2,"nodeHeadwayStop":2,"nodeHeadwayNonStop":2,"minimalTurnaroundTime":4},{"id":5,"name":"GüterExpress","order":5,"colorRef":"GEX","shortName":"GEX","fachCategory":"HaltezeitUncategorized","sectionHeadway":3,"nodeHeadwayStop":3,"nodeHeadwayNonStop":3,"minimalTurnaroundTime":4},{"id":6,"name":"Güterverkehr","order":6,"colorRef":"G","shortName":"G","fachCategory":"HaltezeitUncategorized","sectionHeadway":3,"nodeHeadwayStop":3,"nodeHeadwayNonStop":3,"minimalTurnaroundTime":4}],"trainrunFrequencies":[{"id":0,"name":"verkehrt viertelstündlich","order":0,"offset":0,"frequency":15,"shortName":"15","linePatternRef":"15"},{"id":1,"name":"verkehrt im 20 Minuten Takt","order":0,"offset":0,"frequency":20,"shortName":"20","linePatternRef":"20"},{"id":2,"name":"verkehrt halbstündlich","order":0,"offset":0,"frequency":30,"shortName":"30","linePatternRef":"30"},{"id":3,"name":"verkehrt stündlich","order":0,"offset":0,"frequency":60,"shortName":"60","linePatternRef":"60"},{"id":4,"name":"verkehrt zweistündlich (gerade)","order":0,"offset":0,"frequency":120,"shortName":"120","linePatternRef":"120"},{"id":5,"name":"verkehrt zweistündlich (ungerade)","order":0,"offset":60,"frequency":120,"shortName":"120+","linePatternRef":"120"}],"trainrunTimeCategories":[{"id":0,"name":"verkehrt uneingeschränkt","order":0,"weekday":[1,2,3,4,5,6,7],"shortName":"7/24","linePatternRef":"7/24","dayTimeInterval":[]},{"id":1,"name":"verkehrt zur Hauptverkehrszeit","order":0,"weekday":[1,2,3,4,5,6,7],"shortName":"HVZ","linePatternRef":"HVZ","dayTimeInterval":[{"to":420,"from":360},{"to":1140,"from":960}]},{"id":2,"name":"verkehrt zeitweise","order":0,"weekday":[],"shortName":"zeitweise","linePatternRef":"ZEITWEISE","dayTimeInterval":[]}]},"freeFloatingTexts":[],"labels":[{"id":4,"label":"OK","labelGroupId":1,"labelRef":"Trainrun"},{"id":5,"label":"Zeiten falsch","labelGroupId":3,"labelRef":"Trainrun"}],"labelGroups":[{"id":1,"name":"Standard","labelRef":"Trainrun"},{"id":2,"name":"Standard","labelRef":"Node"},{"id":3,"name":"Standard","labelRef":"Trainrun"}],"filterData":{"filterSettings":[{"id":5,"name":"Neuer Filter","description":"","filterNodeLabels":[],"filterNoteLabels":[],"filterTrainrunLabels":[],"filterArrivalDepartureTime":true,"filterTravelTime":true,"filterTrainrunName":true,"filterConnections":true,"filterShowNonStopTime":true,"filterTrainrunCategory":[{"id":0,"name":"International","order":0,"colorRef":"EC","shortName":"EC","fachCategory":"HaltezeitIPV","sectionHeadway":2,"nodeHeadwayStop":2,"nodeHeadwayNonStop":2,"minimalTurnaroundTime":4},{"id":1,"name":"InterCity","order":1,"colorRef":"IC","shortName":"IC","fachCategory":"HaltezeitA","sectionHeadway":2,"nodeHeadwayStop":2,"nodeHeadwayNonStop":2,"minimalTurnaroundTime":4},{"id":2,"name":"InterRegio","order":2,"colorRef":"IR","shortName":"IR","fachCategory":"HaltezeitB","sectionHeadway":2,"nodeHeadwayStop":2,"nodeHeadwayNonStop":2,"minimalTurnaroundTime":4},{"id":3,"name":"RegioExpress","order":3,"colorRef":"RE","shortName":"RE","fachCategory":"HaltezeitC","sectionHeadway":2,"nodeHeadwayStop":2,"nodeHeadwayNonStop":2,"minimalTurnaroundTime":4},{"id":4,"name":"RegioUndSBahnverkehr","order":4,"colorRef":"S","shortName":"S","fachCategory":"HaltezeitD","sectionHeadway":2,"nodeHeadwayStop":2,"nodeHeadwayNonStop":2,"minimalTurnaroundTime":4},{"id":5,"name":"GüterExpress","order":5,"colorRef":"GEX","shortName":"GEX","fachCategory":"HaltezeitUncategorized","sectionHeadway":3,"nodeHeadwayStop":3,"nodeHeadwayNonStop":3,"minimalTurnaroundTime":4},{"id":6,"name":"Güterverkehr","order":6,"colorRef":"G","shortName":"G","fachCategory":"HaltezeitUncategorized","sectionHeadway":3,"nodeHeadwayStop":3,"nodeHeadwayNonStop":3,"minimalTurnaroundTime":4}],"filterTrainrunFrequency":[{"id":0,"name":"verkehrt viertelstündlich","order":0,"offset":0,"frequency":15,"shortName":"15","linePatternRef":"15"},{"id":1,"name":"verkehrt im 20 Minuten Takt","order":0,"offset":0,"frequency":20,"shortName":"20","linePatternRef":"20"},{"id":2,"name":"verkehrt halbstündlich","order":0,"offset":0,"frequency":30,"shortName":"30","linePatternRef":"30"},{"id":3,"name":"verkehrt stündlich","order":0,"offset":0,"frequency":60,"shortName":"60","linePatternRef":"60"},{"id":4,"name":"verkehrt zweistündlich (gerade)","order":0,"offset":0,"frequency":120,"shortName":"120","linePatternRef":"120"},{"id":5,"name":"verkehrt zweistündlich (ungerade)","order":0,"offset":60,"frequency":120,"shortName":"120+","linePatternRef":"120"}],"filterTrainrunTimeCategory":[{"id":0,"name":"verkehrt uneingeschränkt","order":0,"weekday":[1,2,3,4,5,6,7],"shortName":"7/24","linePatternRef":"7/24","dayTimeInterval":[]},{"id":1,"name":"verkehrt zur Hauptverkehrszeit","order":0,"weekday":[1,2,3,4,5,6,7],"shortName":"HVZ","linePatternRef":"HVZ","dayTimeInterval":[{"to":420,"from":360},{"to":1140,"from":960}]},{"id":2,"name":"verkehrt zeitweise","order":0,"weekday":[],"shortName":"zeitweise","linePatternRef":"ZEITWEISE","dayTimeInterval":[]}],"filterAllEmptyNodes":false,"filterAllNonStopNodes":false,"filterNotes":false,"timeDisplayPrecision":1,"isTemporaryDisableFilteringOfItemsInView":false,"temporaryEmptyAndNonStopFilteringSwitchedOff":false}]}}
+{
+  "nodes": [
+    {
+      "id": 128,
+      "betriebspunktName": "Lausanne",
+      "fullName": "Lausanne",
+      "positionX": -3072,
+      "positionY": 544,
+      "ports": [
+        {
+          "id": 1207,
+          "trainrunSectionId": 596,
+          "positionIndex": 0,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1187,
+          "trainrunSectionId": 586,
+          "positionIndex": 1,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1382,
+          "trainrunSectionId": 683,
+          "positionIndex": 0,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1380,
+          "trainrunSectionId": 682,
+          "positionIndex": 1,
+          "positionAlignment": 3
+        }
+      ],
+      "transitions": [
+        {
+          "id": 345,
+          "port1Id": 1187,
+          "port2Id": 1380,
+          "isNonStopTransit": false
+        },
+        {"id": 347, "port1Id": 1207, "port2Id": 1382, "isNonStopTransit": false}
+      ],
+      "connections": [],
+      "resourceId": 152,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 129,
+      "betriebspunktName": "Bern",
+      "fullName": "Bern",
+      "positionX": -2144,
+      "positionY": 128,
+      "ports": [
+        {
+          "id": 1328,
+          "trainrunSectionId": 656,
+          "positionIndex": 0,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1311,
+          "trainrunSectionId": 648,
+          "positionIndex": 1,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1313,
+          "trainrunSectionId": 649,
+          "positionIndex": 2,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1339,
+          "trainrunSectionId": 662,
+          "positionIndex": 3,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1205,
+          "trainrunSectionId": 595,
+          "positionIndex": 0,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1109,
+          "trainrunSectionId": 547,
+          "positionIndex": 1,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1440,
+          "trainrunSectionId": 712,
+          "positionIndex": 0,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1329,
+          "trainrunSectionId": 657,
+          "positionIndex": 1,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1436,
+          "trainrunSectionId": 710,
+          "positionIndex": 2,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1434,
+          "trainrunSectionId": 709,
+          "positionIndex": 3,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1432,
+          "trainrunSectionId": 708,
+          "positionIndex": 4,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1430,
+          "trainrunSectionId": 707,
+          "positionIndex": 5,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1428,
+          "trainrunSectionId": 706,
+          "positionIndex": 6,
+          "positionAlignment": 3
+        }
+      ],
+      "transitions": [
+        {
+          "id": 315,
+          "port1Id": 1328,
+          "port2Id": 1329,
+          "isNonStopTransit": false
+        },
+        {
+          "id": 376,
+          "port1Id": 1109,
+          "port2Id": 1430,
+          "isNonStopTransit": false
+        },
+        {
+          "id": 378,
+          "port1Id": 1339,
+          "port2Id": 1432,
+          "isNonStopTransit": false
+        },
+        {
+          "id": 380,
+          "port1Id": 1313,
+          "port2Id": 1434,
+          "isNonStopTransit": false
+        },
+        {
+          "id": 382,
+          "port1Id": 1311,
+          "port2Id": 1436,
+          "isNonStopTransit": false
+        },
+        {"id": 386, "port1Id": 1205, "port2Id": 1440, "isNonStopTransit": false}
+      ],
+      "connections": [],
+      "resourceId": 153,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 130,
+      "betriebspunktName": "Biel",
+      "fullName": "Biel",
+      "positionX": -2528,
+      "positionY": -32,
+      "ports": [
+        {
+          "id": 1183,
+          "trainrunSectionId": 584,
+          "positionIndex": 0,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1418,
+          "trainrunSectionId": 701,
+          "positionIndex": 0,
+          "positionAlignment": 3
+        }
+      ],
+      "transitions": [
+        {"id": 366, "port1Id": 1183, "port2Id": 1418, "isNonStopTransit": false}
+      ],
+      "connections": [],
+      "resourceId": 154,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 131,
+      "betriebspunktName": "Interlaken ",
+      "fullName": "Interlaken Ost",
+      "positionX": -1088,
+      "positionY": 928,
+      "ports": [
+        {
+          "id": 1318,
+          "trainrunSectionId": 651,
+          "positionIndex": 0,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1344,
+          "trainrunSectionId": 664,
+          "positionIndex": 1,
+          "positionAlignment": 2
+        }
+      ],
+      "transitions": [],
+      "connections": [],
+      "resourceId": 155,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 132,
+      "betriebspunktName": "Visp",
+      "fullName": "Visp",
+      "positionX": -2144,
+      "positionY": 1440,
+      "ports": [
+        {
+          "id": 1323,
+          "trainrunSectionId": 654,
+          "positionIndex": 0,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1322,
+          "trainrunSectionId": 653,
+          "positionIndex": 1,
+          "positionAlignment": 0
+        }
+      ],
+      "transitions": [],
+      "connections": [],
+      "resourceId": 156,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 133,
+      "betriebspunktName": "Olten",
+      "fullName": "Olten",
+      "positionX": 64,
+      "positionY": 96,
+      "ports": [
+        {
+          "id": 1047,
+          "trainrunSectionId": 516,
+          "positionIndex": 0,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1331,
+          "trainrunSectionId": 658,
+          "positionIndex": 1,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1308,
+          "trainrunSectionId": 646,
+          "positionIndex": 2,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1371,
+          "trainrunSectionId": 678,
+          "positionIndex": 3,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1131,
+          "trainrunSectionId": 558,
+          "positionIndex": 4,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1117,
+          "trainrunSectionId": 551,
+          "positionIndex": 5,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1046,
+          "trainrunSectionId": 515,
+          "positionIndex": 0,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1370,
+          "trainrunSectionId": 677,
+          "positionIndex": 1,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1130,
+          "trainrunSectionId": 557,
+          "positionIndex": 2,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1116,
+          "trainrunSectionId": 550,
+          "positionIndex": 3,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1181,
+          "trainrunSectionId": 583,
+          "positionIndex": 0,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1203,
+          "trainrunSectionId": 594,
+          "positionIndex": 1,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1394,
+          "trainrunSectionId": 689,
+          "positionIndex": 2,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1309,
+          "trainrunSectionId": 647,
+          "positionIndex": 3,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1225,
+          "trainrunSectionId": 605,
+          "positionIndex": 4,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1241,
+          "trainrunSectionId": 613,
+          "positionIndex": 5,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1165,
+          "trainrunSectionId": 575,
+          "positionIndex": 6,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1202,
+          "trainrunSectionId": 593,
+          "positionIndex": 0,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1180,
+          "trainrunSectionId": 582,
+          "positionIndex": 1,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1224,
+          "trainrunSectionId": 604,
+          "positionIndex": 2,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1240,
+          "trainrunSectionId": 612,
+          "positionIndex": 3,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1164,
+          "trainrunSectionId": 574,
+          "positionIndex": 4,
+          "positionAlignment": 3
+        }
+      ],
+      "transitions": [
+        {
+          "id": 210,
+          "port1Id": 1047,
+          "port2Id": 1046,
+          "isNonStopTransit": false
+        },
+        {
+          "id": 236,
+          "port1Id": 1117,
+          "port2Id": 1116,
+          "isNonStopTransit": false
+        },
+        {
+          "id": 242,
+          "port1Id": 1131,
+          "port2Id": 1130,
+          "isNonStopTransit": false
+        },
+        {
+          "id": 253,
+          "port1Id": 1165,
+          "port2Id": 1164,
+          "isNonStopTransit": false
+        },
+        {
+          "id": 259,
+          "port1Id": 1181,
+          "port2Id": 1180,
+          "isNonStopTransit": false
+        },
+        {"id": 264, "port1Id": 1203, "port2Id": 1202, "isNonStopTransit": true},
+        {"id": 270, "port1Id": 1225, "port2Id": 1224, "isNonStopTransit": true},
+        {"id": 276, "port1Id": 1241, "port2Id": 1240, "isNonStopTransit": true},
+        {
+          "id": 308,
+          "port1Id": 1308,
+          "port2Id": 1309,
+          "isNonStopTransit": false
+        },
+        {
+          "id": 340,
+          "port1Id": 1371,
+          "port2Id": 1370,
+          "isNonStopTransit": false
+        },
+        {"id": 353, "port1Id": 1331, "port2Id": 1394, "isNonStopTransit": false}
+      ],
+      "connections": [],
+      "resourceId": 157,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 134,
+      "betriebspunktName": "Basel",
+      "fullName": "Basel",
+      "positionX": 64,
+      "positionY": -1888,
+      "ports": [
+        {
+          "id": 1054,
+          "trainrunSectionId": 519,
+          "positionIndex": 0,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1416,
+          "trainrunSectionId": 700,
+          "positionIndex": 1,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1277,
+          "trainrunSectionId": 631,
+          "positionIndex": 2,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1338,
+          "trainrunSectionId": 661,
+          "positionIndex": 3,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1301,
+          "trainrunSectionId": 643,
+          "positionIndex": 4,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1378,
+          "trainrunSectionId": 681,
+          "positionIndex": 5,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1138,
+          "trainrunSectionId": 561,
+          "positionIndex": 6,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1124,
+          "trainrunSectionId": 554,
+          "positionIndex": 7,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1267,
+          "trainrunSectionId": 626,
+          "positionIndex": 0,
+          "positionAlignment": 3
+        }
+      ],
+      "transitions": [],
+      "connections": [],
+      "resourceId": 158,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 135,
+      "betriebspunktName": "Zürich",
+      "fullName": "Zürich",
+      "positionX": 2656,
+      "positionY": 32,
+      "ports": [
+        {
+          "id": 1255,
+          "trainrunSectionId": 620,
+          "positionIndex": 0,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1254,
+          "trainrunSectionId": 619,
+          "positionIndex": 1,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1360,
+          "trainrunSectionId": 672,
+          "positionIndex": 0,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1149,
+          "trainrunSectionId": 567,
+          "positionIndex": 1,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1153,
+          "trainrunSectionId": 569,
+          "positionIndex": 2,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1358,
+          "trainrunSectionId": 671,
+          "positionIndex": 3,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1356,
+          "trainrunSectionId": 670,
+          "positionIndex": 4,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1354,
+          "trainrunSectionId": 669,
+          "positionIndex": 5,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1195,
+          "trainrunSectionId": 590,
+          "positionIndex": 0,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1401,
+          "trainrunSectionId": 693,
+          "positionIndex": 1,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1292,
+          "trainrunSectionId": 638,
+          "positionIndex": 2,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1173,
+          "trainrunSectionId": 579,
+          "positionIndex": 3,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1217,
+          "trainrunSectionId": 601,
+          "positionIndex": 4,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1233,
+          "trainrunSectionId": 609,
+          "positionIndex": 5,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1157,
+          "trainrunSectionId": 571,
+          "positionIndex": 6,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1276,
+          "trainrunSectionId": 630,
+          "positionIndex": 7,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1300,
+          "trainrunSectionId": 642,
+          "positionIndex": 8,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1191,
+          "trainrunSectionId": 588,
+          "positionIndex": 0,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1172,
+          "trainrunSectionId": 578,
+          "positionIndex": 1,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1213,
+          "trainrunSectionId": 599,
+          "positionIndex": 2,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1229,
+          "trainrunSectionId": 607,
+          "positionIndex": 3,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1139,
+          "trainrunSectionId": 562,
+          "positionIndex": 4,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1245,
+          "trainrunSectionId": 615,
+          "positionIndex": 5,
+          "positionAlignment": 3
+        }
+      ],
+      "transitions": [
+        {
+          "id": 250,
+          "port1Id": 1153,
+          "port2Id": 1157,
+          "isNonStopTransit": false
+        },
+        {
+          "id": 256,
+          "port1Id": 1173,
+          "port2Id": 1172,
+          "isNonStopTransit": false
+        },
+        {
+          "id": 261,
+          "port1Id": 1195,
+          "port2Id": 1191,
+          "isNonStopTransit": false
+        },
+        {
+          "id": 267,
+          "port1Id": 1217,
+          "port2Id": 1213,
+          "isNonStopTransit": false
+        },
+        {
+          "id": 273,
+          "port1Id": 1233,
+          "port2Id": 1229,
+          "isNonStopTransit": false
+        },
+        {
+          "id": 329,
+          "port1Id": 1354,
+          "port2Id": 1245,
+          "isNonStopTransit": false
+        },
+        {"id": 357, "port1Id": 1149, "port2Id": 1401, "isNonStopTransit": false}
+      ],
+      "connections": [],
+      "resourceId": 159,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 136,
+      "betriebspunktName": "Bellinz.",
+      "fullName": "Bellinzona",
+      "positionX": 2592,
+      "positionY": 3232,
+      "ports": [
+        {
+          "id": 1059,
+          "trainrunSectionId": 522,
+          "positionIndex": 0,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1035,
+          "trainrunSectionId": 510,
+          "positionIndex": 1,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1071,
+          "trainrunSectionId": 528,
+          "positionIndex": 2,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1083,
+          "trainrunSectionId": 534,
+          "positionIndex": 3,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1058,
+          "trainrunSectionId": 521,
+          "positionIndex": 0,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1034,
+          "trainrunSectionId": 509,
+          "positionIndex": 1,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1070,
+          "trainrunSectionId": 527,
+          "positionIndex": 0,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1082,
+          "trainrunSectionId": 533,
+          "positionIndex": 1,
+          "positionAlignment": 2
+        }
+      ],
+      "transitions": [
+        {
+          "id": 206,
+          "port1Id": 1035,
+          "port2Id": 1034,
+          "isNonStopTransit": false
+        },
+        {
+          "id": 216,
+          "port1Id": 1059,
+          "port2Id": 1058,
+          "isNonStopTransit": false
+        },
+        {
+          "id": 221,
+          "port1Id": 1071,
+          "port2Id": 1070,
+          "isNonStopTransit": false
+        },
+        {"id": 226, "port1Id": 1083, "port2Id": 1082, "isNonStopTransit": false}
+      ],
+      "connections": [],
+      "resourceId": 160,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 137,
+      "betriebspunktName": "St. Gallen",
+      "fullName": "Sankt Gallen",
+      "positionX": 4640,
+      "positionY": 96,
+      "ports": [
+        {
+          "id": 1145,
+          "trainrunSectionId": 565,
+          "positionIndex": 0,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1212,
+          "trainrunSectionId": 598,
+          "positionIndex": 0,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1167,
+          "trainrunSectionId": 576,
+          "positionIndex": 1,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1144,
+          "trainrunSectionId": 564,
+          "positionIndex": 2,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1419,
+          "trainrunSectionId": 702,
+          "positionIndex": 0,
+          "positionAlignment": 3
+        }
+      ],
+      "transitions": [
+        {
+          "id": 248,
+          "port1Id": 1145,
+          "port2Id": 1144,
+          "isNonStopTransit": false
+        },
+        {"id": 367, "port1Id": 1167, "port2Id": 1419, "isNonStopTransit": false}
+      ],
+      "connections": [],
+      "resourceId": 161,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 138,
+      "betriebspunktName": "Schaffh.",
+      "fullName": "Schaffhausen",
+      "positionX": 2624,
+      "positionY": -1120,
+      "ports": [
+        {
+          "id": 1256,
+          "trainrunSectionId": 620,
+          "positionIndex": 0,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1251,
+          "trainrunSectionId": 618,
+          "positionIndex": 1,
+          "positionAlignment": 1
+        }
+      ],
+      "transitions": [],
+      "connections": [],
+      "resourceId": 162,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 139,
+      "betriebspunktName": "Konstanz",
+      "fullName": "Konstanz",
+      "positionX": 4256,
+      "positionY": -416,
+      "ports": [
+        {
+          "id": 1250,
+          "trainrunSectionId": 617,
+          "positionIndex": 0,
+          "positionAlignment": 1
+        }
+      ],
+      "transitions": [],
+      "connections": [],
+      "resourceId": 163,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 140,
+      "betriebspunktName": "Sargans",
+      "fullName": "Sargans",
+      "positionX": 4640,
+      "positionY": 1184,
+      "ports": [
+        {
+          "id": 1146,
+          "trainrunSectionId": 565,
+          "positionIndex": 0,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1151,
+          "trainrunSectionId": 568,
+          "positionIndex": 0,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1147,
+          "trainrunSectionId": 566,
+          "positionIndex": 1,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1155,
+          "trainrunSectionId": 570,
+          "positionIndex": 2,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1362,
+          "trainrunSectionId": 673,
+          "positionIndex": 0,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1364,
+          "trainrunSectionId": 674,
+          "positionIndex": 1,
+          "positionAlignment": 2
+        }
+      ],
+      "transitions": [
+        {
+          "id": 249,
+          "port1Id": 1146,
+          "port2Id": 1147,
+          "isNonStopTransit": false
+        },
+        {
+          "id": 334,
+          "port1Id": 1151,
+          "port2Id": 1362,
+          "isNonStopTransit": false
+        },
+        {"id": 336, "port1Id": 1155, "port2Id": 1364, "isNonStopTransit": false}
+      ],
+      "connections": [],
+      "resourceId": 164,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 141,
+      "betriebspunktName": "Sursee",
+      "fullName": "Sursee",
+      "positionX": 64,
+      "positionY": 1184,
+      "ports": [
+        {
+          "id": 1043,
+          "trainrunSectionId": 514,
+          "positionIndex": 0,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1105,
+          "trainrunSectionId": 545,
+          "positionIndex": 1,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1367,
+          "trainrunSectionId": 676,
+          "positionIndex": 2,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1127,
+          "trainrunSectionId": 556,
+          "positionIndex": 3,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1113,
+          "trainrunSectionId": 549,
+          "positionIndex": 4,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1042,
+          "trainrunSectionId": 513,
+          "positionIndex": 0,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1104,
+          "trainrunSectionId": 544,
+          "positionIndex": 1,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1366,
+          "trainrunSectionId": 675,
+          "positionIndex": 2,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1126,
+          "trainrunSectionId": 555,
+          "positionIndex": 3,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1112,
+          "trainrunSectionId": 548,
+          "positionIndex": 4,
+          "positionAlignment": 1
+        }
+      ],
+      "transitions": [
+        {"id": 208, "port1Id": 1043, "port2Id": 1042, "isNonStopTransit": true},
+        {
+          "id": 232,
+          "port1Id": 1105,
+          "port2Id": 1104,
+          "isNonStopTransit": false
+        },
+        {
+          "id": 234,
+          "port1Id": 1113,
+          "port2Id": 1112,
+          "isNonStopTransit": false
+        },
+        {"id": 240, "port1Id": 1127, "port2Id": 1126, "isNonStopTransit": true},
+        {"id": 338, "port1Id": 1367, "port2Id": 1366, "isNonStopTransit": true}
+      ],
+      "connections": [],
+      "resourceId": 165,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 142,
+      "betriebspunktName": "Luzern",
+      "fullName": "Luzern",
+      "positionX": 64,
+      "positionY": 1728,
+      "ports": [
+        {
+          "id": 1041,
+          "trainrunSectionId": 513,
+          "positionIndex": 0,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1103,
+          "trainrunSectionId": 544,
+          "positionIndex": 1,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1365,
+          "trainrunSectionId": 675,
+          "positionIndex": 2,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1125,
+          "trainrunSectionId": 555,
+          "positionIndex": 3,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1111,
+          "trainrunSectionId": 548,
+          "positionIndex": 4,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1352,
+          "trainrunSectionId": 668,
+          "positionIndex": 0,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1350,
+          "trainrunSectionId": 667,
+          "positionIndex": 1,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1099,
+          "trainrunSectionId": 542,
+          "positionIndex": 2,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1095,
+          "trainrunSectionId": 540,
+          "positionIndex": 3,
+          "positionAlignment": 3
+        }
+      ],
+      "transitions": [
+        {
+          "id": 327,
+          "port1Id": 1041,
+          "port2Id": 1352,
+          "isNonStopTransit": false
+        },
+        {"id": 337, "port1Id": 1365, "port2Id": 1350, "isNonStopTransit": false}
+      ],
+      "connections": [],
+      "resourceId": 166,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 143,
+      "betriebspunktName": "Zofingen",
+      "fullName": "Zofingen",
+      "positionX": 64,
+      "positionY": 736,
+      "ports": [
+        {
+          "id": 1045,
+          "trainrunSectionId": 515,
+          "positionIndex": 0,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1369,
+          "trainrunSectionId": 677,
+          "positionIndex": 1,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1129,
+          "trainrunSectionId": 557,
+          "positionIndex": 2,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1115,
+          "trainrunSectionId": 550,
+          "positionIndex": 3,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1044,
+          "trainrunSectionId": 514,
+          "positionIndex": 0,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1106,
+          "trainrunSectionId": 545,
+          "positionIndex": 1,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1368,
+          "trainrunSectionId": 676,
+          "positionIndex": 2,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1128,
+          "trainrunSectionId": 556,
+          "positionIndex": 3,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1114,
+          "trainrunSectionId": 549,
+          "positionIndex": 4,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1107,
+          "trainrunSectionId": 546,
+          "positionIndex": 0,
+          "positionAlignment": 2
+        }
+      ],
+      "transitions": [
+        {"id": 209, "port1Id": 1045, "port2Id": 1044, "isNonStopTransit": true},
+        {
+          "id": 233,
+          "port1Id": 1107,
+          "port2Id": 1106,
+          "isNonStopTransit": false
+        },
+        {
+          "id": 235,
+          "port1Id": 1115,
+          "port2Id": 1114,
+          "isNonStopTransit": false
+        },
+        {"id": 241, "port1Id": 1129, "port2Id": 1128, "isNonStopTransit": true},
+        {"id": 339, "port1Id": 1369, "port2Id": 1368, "isNonStopTransit": false}
+      ],
+      "connections": [],
+      "resourceId": 167,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 144,
+      "betriebspunktName": "Gelterk.",
+      "fullName": "Gelterkinden",
+      "positionX": 64,
+      "positionY": -448,
+      "ports": [
+        {
+          "id": 1049,
+          "trainrunSectionId": 517,
+          "positionIndex": 0,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1411,
+          "trainrunSectionId": 698,
+          "positionIndex": 1,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1282,
+          "trainrunSectionId": 633,
+          "positionIndex": 2,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1333,
+          "trainrunSectionId": 659,
+          "positionIndex": 3,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1306,
+          "trainrunSectionId": 645,
+          "positionIndex": 4,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1373,
+          "trainrunSectionId": 679,
+          "positionIndex": 5,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1133,
+          "trainrunSectionId": 559,
+          "positionIndex": 6,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1119,
+          "trainrunSectionId": 552,
+          "positionIndex": 7,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1048,
+          "trainrunSectionId": 516,
+          "positionIndex": 0,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1332,
+          "trainrunSectionId": 658,
+          "positionIndex": 1,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1307,
+          "trainrunSectionId": 646,
+          "positionIndex": 2,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1372,
+          "trainrunSectionId": 678,
+          "positionIndex": 3,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1132,
+          "trainrunSectionId": 558,
+          "positionIndex": 4,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1118,
+          "trainrunSectionId": 551,
+          "positionIndex": 5,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1410,
+          "trainrunSectionId": 697,
+          "positionIndex": 0,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1283,
+          "trainrunSectionId": 634,
+          "positionIndex": 1,
+          "positionAlignment": 3
+        }
+      ],
+      "transitions": [
+        {"id": 211, "port1Id": 1049, "port2Id": 1048, "isNonStopTransit": true},
+        {
+          "id": 237,
+          "port1Id": 1119,
+          "port2Id": 1118,
+          "isNonStopTransit": false
+        },
+        {"id": 243, "port1Id": 1133, "port2Id": 1132, "isNonStopTransit": true},
+        {"id": 297, "port1Id": 1282, "port2Id": 1283, "isNonStopTransit": true},
+        {"id": 307, "port1Id": 1306, "port2Id": 1307, "isNonStopTransit": true},
+        {"id": 316, "port1Id": 1333, "port2Id": 1332, "isNonStopTransit": true},
+        {"id": 341, "port1Id": 1373, "port2Id": 1372, "isNonStopTransit": true},
+        {"id": 362, "port1Id": 1411, "port2Id": 1410, "isNonStopTransit": true}
+      ],
+      "connections": [],
+      "resourceId": 168,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 145,
+      "betriebspunktName": "Sissach",
+      "fullName": "Sissach",
+      "positionX": 64,
+      "positionY": -928,
+      "ports": [
+        {
+          "id": 1051,
+          "trainrunSectionId": 518,
+          "positionIndex": 0,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1413,
+          "trainrunSectionId": 699,
+          "positionIndex": 1,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1280,
+          "trainrunSectionId": 632,
+          "positionIndex": 2,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1335,
+          "trainrunSectionId": 660,
+          "positionIndex": 3,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1304,
+          "trainrunSectionId": 644,
+          "positionIndex": 4,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1375,
+          "trainrunSectionId": 680,
+          "positionIndex": 5,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1135,
+          "trainrunSectionId": 560,
+          "positionIndex": 6,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1121,
+          "trainrunSectionId": 553,
+          "positionIndex": 7,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1050,
+          "trainrunSectionId": 517,
+          "positionIndex": 0,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1412,
+          "trainrunSectionId": 698,
+          "positionIndex": 1,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1281,
+          "trainrunSectionId": 633,
+          "positionIndex": 2,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1334,
+          "trainrunSectionId": 659,
+          "positionIndex": 3,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1305,
+          "trainrunSectionId": 645,
+          "positionIndex": 4,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1374,
+          "trainrunSectionId": 679,
+          "positionIndex": 5,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1134,
+          "trainrunSectionId": 559,
+          "positionIndex": 6,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1120,
+          "trainrunSectionId": 552,
+          "positionIndex": 7,
+          "positionAlignment": 1
+        }
+      ],
+      "transitions": [
+        {"id": 212, "port1Id": 1051, "port2Id": 1050, "isNonStopTransit": true},
+        {
+          "id": 238,
+          "port1Id": 1121,
+          "port2Id": 1120,
+          "isNonStopTransit": false
+        },
+        {"id": 244, "port1Id": 1135, "port2Id": 1134, "isNonStopTransit": true},
+        {"id": 296, "port1Id": 1280, "port2Id": 1281, "isNonStopTransit": true},
+        {"id": 306, "port1Id": 1304, "port2Id": 1305, "isNonStopTransit": true},
+        {"id": 317, "port1Id": 1335, "port2Id": 1334, "isNonStopTransit": true},
+        {"id": 342, "port1Id": 1375, "port2Id": 1374, "isNonStopTransit": true},
+        {"id": 363, "port1Id": 1413, "port2Id": 1412, "isNonStopTransit": true}
+      ],
+      "connections": [],
+      "resourceId": 169,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 146,
+      "betriebspunktName": "Liestal",
+      "fullName": "Liestal",
+      "positionX": 64,
+      "positionY": -1408,
+      "ports": [
+        {
+          "id": 1053,
+          "trainrunSectionId": 519,
+          "positionIndex": 0,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1415,
+          "trainrunSectionId": 700,
+          "positionIndex": 1,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1278,
+          "trainrunSectionId": 631,
+          "positionIndex": 2,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1337,
+          "trainrunSectionId": 661,
+          "positionIndex": 3,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1302,
+          "trainrunSectionId": 643,
+          "positionIndex": 4,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1377,
+          "trainrunSectionId": 681,
+          "positionIndex": 5,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1137,
+          "trainrunSectionId": 561,
+          "positionIndex": 6,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1123,
+          "trainrunSectionId": 554,
+          "positionIndex": 7,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1052,
+          "trainrunSectionId": 518,
+          "positionIndex": 0,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1414,
+          "trainrunSectionId": 699,
+          "positionIndex": 1,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1279,
+          "trainrunSectionId": 632,
+          "positionIndex": 2,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1336,
+          "trainrunSectionId": 660,
+          "positionIndex": 3,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1303,
+          "trainrunSectionId": 644,
+          "positionIndex": 4,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1376,
+          "trainrunSectionId": 680,
+          "positionIndex": 5,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1136,
+          "trainrunSectionId": 560,
+          "positionIndex": 6,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1122,
+          "trainrunSectionId": 553,
+          "positionIndex": 7,
+          "positionAlignment": 1
+        }
+      ],
+      "transitions": [
+        {"id": 213, "port1Id": 1053, "port2Id": 1052, "isNonStopTransit": true},
+        {
+          "id": 239,
+          "port1Id": 1123,
+          "port2Id": 1122,
+          "isNonStopTransit": false
+        },
+        {"id": 245, "port1Id": 1137, "port2Id": 1136, "isNonStopTransit": true},
+        {"id": 295, "port1Id": 1278, "port2Id": 1279, "isNonStopTransit": true},
+        {"id": 305, "port1Id": 1302, "port2Id": 1303, "isNonStopTransit": true},
+        {"id": 318, "port1Id": 1337, "port2Id": 1336, "isNonStopTransit": true},
+        {"id": 343, "port1Id": 1377, "port2Id": 1376, "isNonStopTransit": true},
+        {"id": 364, "port1Id": 1415, "port2Id": 1414, "isNonStopTransit": true}
+      ],
+      "connections": [],
+      "resourceId": 170,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 147,
+      "betriebspunktName": "Aarau",
+      "fullName": "Aarau",
+      "positionX": 960,
+      "positionY": 32,
+      "ports": [
+        {
+          "id": 1409,
+          "trainrunSectionId": 697,
+          "positionIndex": 0,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1284,
+          "trainrunSectionId": 634,
+          "positionIndex": 1,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1201,
+          "trainrunSectionId": 593,
+          "positionIndex": 2,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1179,
+          "trainrunSectionId": 582,
+          "positionIndex": 3,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1223,
+          "trainrunSectionId": 604,
+          "positionIndex": 4,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1239,
+          "trainrunSectionId": 612,
+          "positionIndex": 5,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1163,
+          "trainrunSectionId": 574,
+          "positionIndex": 6,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1200,
+          "trainrunSectionId": 592,
+          "positionIndex": 0,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1408,
+          "trainrunSectionId": 696,
+          "positionIndex": 1,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1285,
+          "trainrunSectionId": 635,
+          "positionIndex": 2,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1178,
+          "trainrunSectionId": 581,
+          "positionIndex": 3,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1222,
+          "trainrunSectionId": 603,
+          "positionIndex": 4,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1238,
+          "trainrunSectionId": 611,
+          "positionIndex": 5,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1162,
+          "trainrunSectionId": 573,
+          "positionIndex": 6,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1293,
+          "trainrunSectionId": 639,
+          "positionIndex": 7,
+          "positionAlignment": 3
+        }
+      ],
+      "transitions": [
+        {"id": 252, "port1Id": 1163, "port2Id": 1162, "isNonStopTransit": true},
+        {
+          "id": 258,
+          "port1Id": 1179,
+          "port2Id": 1178,
+          "isNonStopTransit": false
+        },
+        {"id": 263, "port1Id": 1201, "port2Id": 1200, "isNonStopTransit": true},
+        {"id": 269, "port1Id": 1223, "port2Id": 1222, "isNonStopTransit": true},
+        {"id": 275, "port1Id": 1239, "port2Id": 1238, "isNonStopTransit": true},
+        {"id": 298, "port1Id": 1284, "port2Id": 1285, "isNonStopTransit": true},
+        {"id": 361, "port1Id": 1409, "port2Id": 1408, "isNonStopTransit": true}
+      ],
+      "connections": [],
+      "resourceId": 171,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 148,
+      "betriebspunktName": "Lenzburg",
+      "fullName": "Lenzburg",
+      "positionX": 1344,
+      "positionY": 32,
+      "ports": [
+        {
+          "id": 1199,
+          "trainrunSectionId": 592,
+          "positionIndex": 0,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1407,
+          "trainrunSectionId": 696,
+          "positionIndex": 1,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1286,
+          "trainrunSectionId": 635,
+          "positionIndex": 2,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1177,
+          "trainrunSectionId": 581,
+          "positionIndex": 3,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1221,
+          "trainrunSectionId": 603,
+          "positionIndex": 4,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1237,
+          "trainrunSectionId": 611,
+          "positionIndex": 5,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1161,
+          "trainrunSectionId": 573,
+          "positionIndex": 6,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1294,
+          "trainrunSectionId": 639,
+          "positionIndex": 7,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1258,
+          "trainrunSectionId": 621,
+          "positionIndex": 0,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1406,
+          "trainrunSectionId": 695,
+          "positionIndex": 1,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1287,
+          "trainrunSectionId": 636,
+          "positionIndex": 2,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1260,
+          "trainrunSectionId": 622,
+          "positionIndex": 3,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1262,
+          "trainrunSectionId": 623,
+          "positionIndex": 4,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1264,
+          "trainrunSectionId": 624,
+          "positionIndex": 5,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1266,
+          "trainrunSectionId": 625,
+          "positionIndex": 6,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1295,
+          "trainrunSectionId": 640,
+          "positionIndex": 7,
+          "positionAlignment": 3
+        }
+      ],
+      "transitions": [
+        {"id": 282, "port1Id": 1199, "port2Id": 1258, "isNonStopTransit": true},
+        {"id": 284, "port1Id": 1177, "port2Id": 1260, "isNonStopTransit": true},
+        {"id": 286, "port1Id": 1221, "port2Id": 1262, "isNonStopTransit": true},
+        {"id": 288, "port1Id": 1237, "port2Id": 1264, "isNonStopTransit": true},
+        {"id": 290, "port1Id": 1161, "port2Id": 1266, "isNonStopTransit": true},
+        {"id": 299, "port1Id": 1286, "port2Id": 1287, "isNonStopTransit": true},
+        {
+          "id": 302,
+          "port1Id": 1294,
+          "port2Id": 1295,
+          "isNonStopTransit": false
+        },
+        {"id": 360, "port1Id": 1407, "port2Id": 1406, "isNonStopTransit": true}
+      ],
+      "connections": [],
+      "resourceId": 172,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 149,
+      "betriebspunktName": "Baden",
+      "fullName": "Baden",
+      "positionX": 2240,
+      "positionY": 32,
+      "ports": [
+        {
+          "id": 1197,
+          "trainrunSectionId": 591,
+          "positionIndex": 0,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1403,
+          "trainrunSectionId": 694,
+          "positionIndex": 1,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1290,
+          "trainrunSectionId": 637,
+          "positionIndex": 2,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1175,
+          "trainrunSectionId": 580,
+          "positionIndex": 3,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1219,
+          "trainrunSectionId": 602,
+          "positionIndex": 4,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1235,
+          "trainrunSectionId": 610,
+          "positionIndex": 5,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1159,
+          "trainrunSectionId": 572,
+          "positionIndex": 6,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1274,
+          "trainrunSectionId": 629,
+          "positionIndex": 7,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1298,
+          "trainrunSectionId": 641,
+          "positionIndex": 8,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1196,
+          "trainrunSectionId": 590,
+          "positionIndex": 0,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1402,
+          "trainrunSectionId": 693,
+          "positionIndex": 1,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1291,
+          "trainrunSectionId": 638,
+          "positionIndex": 2,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1174,
+          "trainrunSectionId": 579,
+          "positionIndex": 3,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1218,
+          "trainrunSectionId": 601,
+          "positionIndex": 4,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1234,
+          "trainrunSectionId": 609,
+          "positionIndex": 5,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1158,
+          "trainrunSectionId": 571,
+          "positionIndex": 6,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1275,
+          "trainrunSectionId": 630,
+          "positionIndex": 7,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1299,
+          "trainrunSectionId": 642,
+          "positionIndex": 8,
+          "positionAlignment": 3
+        }
+      ],
+      "transitions": [
+        {"id": 251, "port1Id": 1159, "port2Id": 1158, "isNonStopTransit": true},
+        {"id": 257, "port1Id": 1175, "port2Id": 1174, "isNonStopTransit": true},
+        {"id": 262, "port1Id": 1197, "port2Id": 1196, "isNonStopTransit": true},
+        {"id": 268, "port1Id": 1219, "port2Id": 1218, "isNonStopTransit": true},
+        {"id": 274, "port1Id": 1235, "port2Id": 1234, "isNonStopTransit": true},
+        {
+          "id": 294,
+          "port1Id": 1274,
+          "port2Id": 1275,
+          "isNonStopTransit": false
+        },
+        {"id": 301, "port1Id": 1290, "port2Id": 1291, "isNonStopTransit": true},
+        {"id": 304, "port1Id": 1298, "port2Id": 1299, "isNonStopTransit": true},
+        {"id": 358, "port1Id": 1403, "port2Id": 1402, "isNonStopTransit": true}
+      ],
+      "connections": [],
+      "resourceId": 173,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 150,
+      "betriebspunktName": "Zürich ✈",
+      "fullName": "Zürich Flughafen",
+      "positionX": 3296,
+      "positionY": 32,
+      "ports": [
+        {
+          "id": 1192,
+          "trainrunSectionId": 588,
+          "positionIndex": 0,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1171,
+          "trainrunSectionId": 578,
+          "positionIndex": 1,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1214,
+          "trainrunSectionId": 599,
+          "positionIndex": 2,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1230,
+          "trainrunSectionId": 607,
+          "positionIndex": 3,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1140,
+          "trainrunSectionId": 562,
+          "positionIndex": 4,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1246,
+          "trainrunSectionId": 615,
+          "positionIndex": 5,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1193,
+          "trainrunSectionId": 589,
+          "positionIndex": 0,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1170,
+          "trainrunSectionId": 577,
+          "positionIndex": 1,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1215,
+          "trainrunSectionId": 600,
+          "positionIndex": 2,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1231,
+          "trainrunSectionId": 608,
+          "positionIndex": 3,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1141,
+          "trainrunSectionId": 563,
+          "positionIndex": 4,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1247,
+          "trainrunSectionId": 616,
+          "positionIndex": 5,
+          "positionAlignment": 3
+        }
+      ],
+      "transitions": [
+        {
+          "id": 246,
+          "port1Id": 1140,
+          "port2Id": 1141,
+          "isNonStopTransit": false
+        },
+        {
+          "id": 255,
+          "port1Id": 1171,
+          "port2Id": 1170,
+          "isNonStopTransit": false
+        },
+        {
+          "id": 260,
+          "port1Id": 1192,
+          "port2Id": 1193,
+          "isNonStopTransit": false
+        },
+        {
+          "id": 266,
+          "port1Id": 1214,
+          "port2Id": 1215,
+          "isNonStopTransit": false
+        },
+        {
+          "id": 272,
+          "port1Id": 1230,
+          "port2Id": 1231,
+          "isNonStopTransit": false
+        },
+        {"id": 278, "port1Id": 1246, "port2Id": 1247, "isNonStopTransit": false}
+      ],
+      "connections": [],
+      "resourceId": 174,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 151,
+      "betriebspunktName": "Wintert.",
+      "fullName": "Winterthur",
+      "positionX": 3872,
+      "positionY": 32,
+      "ports": [
+        {
+          "id": 1249,
+          "trainrunSectionId": 617,
+          "positionIndex": 0,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1194,
+          "trainrunSectionId": 589,
+          "positionIndex": 0,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1169,
+          "trainrunSectionId": 577,
+          "positionIndex": 1,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1216,
+          "trainrunSectionId": 600,
+          "positionIndex": 2,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1232,
+          "trainrunSectionId": 608,
+          "positionIndex": 3,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1142,
+          "trainrunSectionId": 563,
+          "positionIndex": 4,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1248,
+          "trainrunSectionId": 616,
+          "positionIndex": 5,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1227,
+          "trainrunSectionId": 606,
+          "positionIndex": 0,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1243,
+          "trainrunSectionId": 614,
+          "positionIndex": 1,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1211,
+          "trainrunSectionId": 598,
+          "positionIndex": 2,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1168,
+          "trainrunSectionId": 576,
+          "positionIndex": 3,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1143,
+          "trainrunSectionId": 564,
+          "positionIndex": 4,
+          "positionAlignment": 3
+        }
+      ],
+      "transitions": [
+        {
+          "id": 247,
+          "port1Id": 1142,
+          "port2Id": 1143,
+          "isNonStopTransit": false
+        },
+        {
+          "id": 254,
+          "port1Id": 1169,
+          "port2Id": 1168,
+          "isNonStopTransit": false
+        },
+        {
+          "id": 265,
+          "port1Id": 1194,
+          "port2Id": 1211,
+          "isNonStopTransit": false
+        },
+        {
+          "id": 271,
+          "port1Id": 1216,
+          "port2Id": 1227,
+          "isNonStopTransit": false
+        },
+        {
+          "id": 277,
+          "port1Id": 1232,
+          "port2Id": 1243,
+          "isNonStopTransit": false
+        },
+        {"id": 279, "port1Id": 1249, "port2Id": 1248, "isNonStopTransit": false}
+      ],
+      "connections": [],
+      "resourceId": 175,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 152,
+      "betriebspunktName": "Chur",
+      "fullName": "Chur",
+      "positionX": 4640,
+      "positionY": 1888,
+      "ports": [
+        {
+          "id": 1152,
+          "trainrunSectionId": 568,
+          "positionIndex": 0,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1148,
+          "trainrunSectionId": 566,
+          "positionIndex": 1,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1156,
+          "trainrunSectionId": 570,
+          "positionIndex": 2,
+          "positionAlignment": 0
+        }
+      ],
+      "transitions": [],
+      "connections": [],
+      "resourceId": 176,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 153,
+      "betriebspunktName": "Zug",
+      "fullName": "Zug",
+      "positionX": 2656,
+      "positionY": 1312,
+      "ports": [
+        {
+          "id": 1067,
+          "trainrunSectionId": 526,
+          "positionIndex": 0,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1093,
+          "trainrunSectionId": 539,
+          "positionIndex": 1,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1101,
+          "trainrunSectionId": 543,
+          "positionIndex": 2,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1097,
+          "trainrunSectionId": 541,
+          "positionIndex": 3,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1066,
+          "trainrunSectionId": 525,
+          "positionIndex": 0,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1092,
+          "trainrunSectionId": 538,
+          "positionIndex": 1,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1348,
+          "trainrunSectionId": 666,
+          "positionIndex": 0,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1346,
+          "trainrunSectionId": 665,
+          "positionIndex": 1,
+          "positionAlignment": 2
+        }
+      ],
+      "transitions": [
+        {
+          "id": 220,
+          "port1Id": 1067,
+          "port2Id": 1066,
+          "isNonStopTransit": false
+        },
+        {
+          "id": 231,
+          "port1Id": 1093,
+          "port2Id": 1092,
+          "isNonStopTransit": false
+        },
+        {
+          "id": 322,
+          "port1Id": 1097,
+          "port2Id": 1346,
+          "isNonStopTransit": false
+        },
+        {"id": 324, "port1Id": 1101, "port2Id": 1348, "isNonStopTransit": false}
+      ],
+      "connections": [],
+      "resourceId": 177,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 154,
+      "betriebspunktName": "Arth-G.",
+      "fullName": "Arth-Goldau",
+      "positionX": 2656,
+      "positionY": 1792,
+      "ports": [
+        {
+          "id": 1065,
+          "trainrunSectionId": 525,
+          "positionIndex": 0,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1091,
+          "trainrunSectionId": 538,
+          "positionIndex": 1,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1064,
+          "trainrunSectionId": 524,
+          "positionIndex": 0,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1038,
+          "trainrunSectionId": 511,
+          "positionIndex": 1,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1078,
+          "trainrunSectionId": 531,
+          "positionIndex": 2,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1090,
+          "trainrunSectionId": 537,
+          "positionIndex": 3,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1039,
+          "trainrunSectionId": 512,
+          "positionIndex": 0,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1079,
+          "trainrunSectionId": 532,
+          "positionIndex": 1,
+          "positionAlignment": 2
+        }
+      ],
+      "transitions": [
+        {
+          "id": 207,
+          "port1Id": 1038,
+          "port2Id": 1039,
+          "isNonStopTransit": false
+        },
+        {
+          "id": 219,
+          "port1Id": 1065,
+          "port2Id": 1064,
+          "isNonStopTransit": false
+        },
+        {
+          "id": 225,
+          "port1Id": 1078,
+          "port2Id": 1079,
+          "isNonStopTransit": false
+        },
+        {"id": 230, "port1Id": 1091, "port2Id": 1090, "isNonStopTransit": false}
+      ],
+      "connections": [],
+      "resourceId": 178,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 155,
+      "betriebspunktName": "Altdorf",
+      "fullName": "Altdorf",
+      "positionX": 2656,
+      "positionY": 2176,
+      "ports": [
+        {
+          "id": 1063,
+          "trainrunSectionId": 524,
+          "positionIndex": 0,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1037,
+          "trainrunSectionId": 511,
+          "positionIndex": 1,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1077,
+          "trainrunSectionId": 531,
+          "positionIndex": 2,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1089,
+          "trainrunSectionId": 537,
+          "positionIndex": 3,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1062,
+          "trainrunSectionId": 523,
+          "positionIndex": 0,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1055,
+          "trainrunSectionId": 520,
+          "positionIndex": 1,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1076,
+          "trainrunSectionId": 530,
+          "positionIndex": 0,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1088,
+          "trainrunSectionId": 536,
+          "positionIndex": 1,
+          "positionAlignment": 2
+        }
+      ],
+      "transitions": [
+        {"id": 214, "port1Id": 1037, "port2Id": 1055, "isNonStopTransit": true},
+        {
+          "id": 218,
+          "port1Id": 1063,
+          "port2Id": 1062,
+          "isNonStopTransit": false
+        },
+        {
+          "id": 224,
+          "port1Id": 1077,
+          "port2Id": 1076,
+          "isNonStopTransit": false
+        },
+        {"id": 229, "port1Id": 1089, "port2Id": 1088, "isNonStopTransit": false}
+      ],
+      "connections": [],
+      "resourceId": 179,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 156,
+      "betriebspunktName": "Lugano",
+      "fullName": "Lugano",
+      "positionX": 2592,
+      "positionY": 3712,
+      "ports": [
+        {
+          "id": 1057,
+          "trainrunSectionId": 521,
+          "positionIndex": 0,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1033,
+          "trainrunSectionId": 509,
+          "positionIndex": 1,
+          "positionAlignment": 0
+        }
+      ],
+      "transitions": [],
+      "connections": [],
+      "resourceId": 180,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 157,
+      "betriebspunktName": "Locarno",
+      "fullName": "Locarno",
+      "positionX": 2208,
+      "positionY": 3232,
+      "ports": [
+        {
+          "id": 1069,
+          "trainrunSectionId": 527,
+          "positionIndex": 0,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1081,
+          "trainrunSectionId": 533,
+          "positionIndex": 1,
+          "positionAlignment": 3
+        }
+      ],
+      "transitions": [],
+      "connections": [],
+      "resourceId": 181,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 158,
+      "betriebspunktName": "Biasca",
+      "fullName": "Biasca",
+      "positionX": 2592,
+      "positionY": 2688,
+      "ports": [
+        {
+          "id": 1073,
+          "trainrunSectionId": 529,
+          "positionIndex": 0,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1085,
+          "trainrunSectionId": 535,
+          "positionIndex": 1,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1061,
+          "trainrunSectionId": 523,
+          "positionIndex": 2,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1056,
+          "trainrunSectionId": 520,
+          "positionIndex": 3,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1060,
+          "trainrunSectionId": 522,
+          "positionIndex": 0,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1036,
+          "trainrunSectionId": 510,
+          "positionIndex": 1,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1072,
+          "trainrunSectionId": 528,
+          "positionIndex": 2,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1084,
+          "trainrunSectionId": 534,
+          "positionIndex": 3,
+          "positionAlignment": 1
+        }
+      ],
+      "transitions": [
+        {"id": 215, "port1Id": 1056, "port2Id": 1036, "isNonStopTransit": true},
+        {"id": 217, "port1Id": 1061, "port2Id": 1060, "isNonStopTransit": true},
+        {
+          "id": 222,
+          "port1Id": 1073,
+          "port2Id": 1072,
+          "isNonStopTransit": false
+        },
+        {"id": 227, "port1Id": 1085, "port2Id": 1084, "isNonStopTransit": false}
+      ],
+      "connections": [],
+      "resourceId": 182,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 159,
+      "betriebspunktName": "Göschn.",
+      "fullName": "Göschenen",
+      "positionX": 2272,
+      "positionY": 2240,
+      "ports": [
+        {
+          "id": 1074,
+          "trainrunSectionId": 529,
+          "positionIndex": 0,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1086,
+          "trainrunSectionId": 535,
+          "positionIndex": 1,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1075,
+          "trainrunSectionId": 530,
+          "positionIndex": 0,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1087,
+          "trainrunSectionId": 536,
+          "positionIndex": 1,
+          "positionAlignment": 3
+        }
+      ],
+      "transitions": [
+        {
+          "id": 223,
+          "port1Id": 1074,
+          "port2Id": 1075,
+          "isNonStopTransit": false
+        },
+        {"id": 228, "port1Id": 1086, "port2Id": 1087, "isNonStopTransit": false}
+      ],
+      "connections": [],
+      "resourceId": 183,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 160,
+      "betriebspunktName": "Genf",
+      "fullName": "Genf",
+      "positionX": -3936,
+      "positionY": 608,
+      "ports": [
+        {
+          "id": 1209,
+          "trainrunSectionId": 597,
+          "positionIndex": 0,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1185,
+          "trainrunSectionId": 585,
+          "positionIndex": 1,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1189,
+          "trainrunSectionId": 587,
+          "positionIndex": 2,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1424,
+          "trainrunSectionId": 704,
+          "positionIndex": 0,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1426,
+          "trainrunSectionId": 705,
+          "positionIndex": 1,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1422,
+          "trainrunSectionId": 703,
+          "positionIndex": 2,
+          "positionAlignment": 3
+        }
+      ],
+      "transitions": [
+        {
+          "id": 369,
+          "port1Id": 1189,
+          "port2Id": 1422,
+          "isNonStopTransit": false
+        },
+        {
+          "id": 371,
+          "port1Id": 1209,
+          "port2Id": 1424,
+          "isNonStopTransit": false
+        },
+        {"id": 373, "port1Id": 1185, "port2Id": 1426, "isNonStopTransit": false}
+      ],
+      "connections": [],
+      "resourceId": 184,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 161,
+      "betriebspunktName": "Genf ✈",
+      "fullName": "Aiport",
+      "positionX": -4352,
+      "positionY": 608,
+      "ports": [
+        {
+          "id": 1210,
+          "trainrunSectionId": 597,
+          "positionIndex": 0,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1186,
+          "trainrunSectionId": 585,
+          "positionIndex": 1,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1190,
+          "trainrunSectionId": 587,
+          "positionIndex": 2,
+          "positionAlignment": 3
+        }
+      ],
+      "transitions": [],
+      "connections": [],
+      "resourceId": 185,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 162,
+      "betriebspunktName": "Romansh.",
+      "fullName": "Romanshorn",
+      "positionX": 4640,
+      "positionY": -192,
+      "ports": [
+        {
+          "id": 1228,
+          "trainrunSectionId": 606,
+          "positionIndex": 0,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1244,
+          "trainrunSectionId": 614,
+          "positionIndex": 1,
+          "positionAlignment": 2
+        }
+      ],
+      "transitions": [],
+      "connections": [],
+      "resourceId": 186,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 163,
+      "betriebspunktName": "Bülach",
+      "fullName": "Bülach",
+      "positionX": 2784,
+      "positionY": -544,
+      "ports": [
+        {
+          "id": 1252,
+          "trainrunSectionId": 618,
+          "positionIndex": 0,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1253,
+          "trainrunSectionId": 619,
+          "positionIndex": 0,
+          "positionAlignment": 1
+        }
+      ],
+      "transitions": [
+        {"id": 280, "port1Id": 1252, "port2Id": 1253, "isNonStopTransit": false}
+      ],
+      "connections": [],
+      "resourceId": 187,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 164,
+      "betriebspunktName": "Reihnf.",
+      "fullName": "Reihnfelden",
+      "positionX": 1056,
+      "positionY": -960,
+      "ports": [
+        {
+          "id": 1268,
+          "trainrunSectionId": 626,
+          "positionIndex": 0,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1269,
+          "trainrunSectionId": 627,
+          "positionIndex": 0,
+          "positionAlignment": 3
+        }
+      ],
+      "transitions": [
+        {"id": 291, "port1Id": 1268, "port2Id": 1269, "isNonStopTransit": false}
+      ],
+      "connections": [],
+      "resourceId": 188,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 165,
+      "betriebspunktName": "Frick",
+      "fullName": "Frick",
+      "positionX": 1792,
+      "positionY": -672,
+      "ports": [
+        {
+          "id": 1271,
+          "trainrunSectionId": 628,
+          "positionIndex": 0,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1270,
+          "trainrunSectionId": 627,
+          "positionIndex": 0,
+          "positionAlignment": 2
+        }
+      ],
+      "transitions": [
+        {"id": 292, "port1Id": 1271, "port2Id": 1270, "isNonStopTransit": false}
+      ],
+      "connections": [],
+      "resourceId": 189,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 166,
+      "betriebspunktName": "Brugg",
+      "fullName": "Brugg",
+      "positionX": 1792,
+      "positionY": 32,
+      "ports": [
+        {
+          "id": 1272,
+          "trainrunSectionId": 628,
+          "positionIndex": 0,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1257,
+          "trainrunSectionId": 621,
+          "positionIndex": 0,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1405,
+          "trainrunSectionId": 695,
+          "positionIndex": 1,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1288,
+          "trainrunSectionId": 636,
+          "positionIndex": 2,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1259,
+          "trainrunSectionId": 622,
+          "positionIndex": 3,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1261,
+          "trainrunSectionId": 623,
+          "positionIndex": 4,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1263,
+          "trainrunSectionId": 624,
+          "positionIndex": 5,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1265,
+          "trainrunSectionId": 625,
+          "positionIndex": 6,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1296,
+          "trainrunSectionId": 640,
+          "positionIndex": 7,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1198,
+          "trainrunSectionId": 591,
+          "positionIndex": 0,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1404,
+          "trainrunSectionId": 694,
+          "positionIndex": 1,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1289,
+          "trainrunSectionId": 637,
+          "positionIndex": 2,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1176,
+          "trainrunSectionId": 580,
+          "positionIndex": 3,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1220,
+          "trainrunSectionId": 602,
+          "positionIndex": 4,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1236,
+          "trainrunSectionId": 610,
+          "positionIndex": 5,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1160,
+          "trainrunSectionId": 572,
+          "positionIndex": 6,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1273,
+          "trainrunSectionId": 629,
+          "positionIndex": 7,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1297,
+          "trainrunSectionId": 641,
+          "positionIndex": 8,
+          "positionAlignment": 3
+        }
+      ],
+      "transitions": [
+        {"id": 281, "port1Id": 1257, "port2Id": 1198, "isNonStopTransit": true},
+        {"id": 283, "port1Id": 1259, "port2Id": 1176, "isNonStopTransit": true},
+        {"id": 285, "port1Id": 1261, "port2Id": 1220, "isNonStopTransit": true},
+        {
+          "id": 287,
+          "port1Id": 1263,
+          "port2Id": 1236,
+          "isNonStopTransit": false
+        },
+        {"id": 289, "port1Id": 1265, "port2Id": 1160, "isNonStopTransit": true},
+        {
+          "id": 293,
+          "port1Id": 1272,
+          "port2Id": 1273,
+          "isNonStopTransit": false
+        },
+        {"id": 300, "port1Id": 1288, "port2Id": 1289, "isNonStopTransit": true},
+        {"id": 303, "port1Id": 1296, "port2Id": 1297, "isNonStopTransit": true},
+        {"id": 359, "port1Id": 1405, "port2Id": 1404, "isNonStopTransit": true}
+      ],
+      "connections": [],
+      "resourceId": 190,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 167,
+      "betriebspunktName": "Thun",
+      "fullName": "Thun",
+      "positionX": -2144,
+      "positionY": 640,
+      "ports": [
+        {
+          "id": 1327,
+          "trainrunSectionId": 656,
+          "positionIndex": 0,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1312,
+          "trainrunSectionId": 648,
+          "positionIndex": 1,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1314,
+          "trainrunSectionId": 649,
+          "positionIndex": 2,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1340,
+          "trainrunSectionId": 662,
+          "positionIndex": 3,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1326,
+          "trainrunSectionId": 655,
+          "positionIndex": 0,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1315,
+          "trainrunSectionId": 650,
+          "positionIndex": 1,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1319,
+          "trainrunSectionId": 652,
+          "positionIndex": 2,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1341,
+          "trainrunSectionId": 663,
+          "positionIndex": 3,
+          "positionAlignment": 1
+        }
+      ],
+      "transitions": [
+        {
+          "id": 309,
+          "port1Id": 1312,
+          "port2Id": 1315,
+          "isNonStopTransit": false
+        },
+        {
+          "id": 311,
+          "port1Id": 1314,
+          "port2Id": 1319,
+          "isNonStopTransit": false
+        },
+        {
+          "id": 314,
+          "port1Id": 1327,
+          "port2Id": 1326,
+          "isNonStopTransit": false
+        },
+        {"id": 319, "port1Id": 1340, "port2Id": 1341, "isNonStopTransit": false}
+      ],
+      "connections": [],
+      "resourceId": 191,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 168,
+      "betriebspunktName": "Spiez",
+      "fullName": "Spiez",
+      "positionX": -2144,
+      "positionY": 928,
+      "ports": [
+        {
+          "id": 1325,
+          "trainrunSectionId": 655,
+          "positionIndex": 0,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1316,
+          "trainrunSectionId": 650,
+          "positionIndex": 1,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1320,
+          "trainrunSectionId": 652,
+          "positionIndex": 2,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1342,
+          "trainrunSectionId": 663,
+          "positionIndex": 3,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1324,
+          "trainrunSectionId": 654,
+          "positionIndex": 0,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1321,
+          "trainrunSectionId": 653,
+          "positionIndex": 1,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1317,
+          "trainrunSectionId": 651,
+          "positionIndex": 0,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1343,
+          "trainrunSectionId": 664,
+          "positionIndex": 1,
+          "positionAlignment": 3
+        }
+      ],
+      "transitions": [
+        {
+          "id": 310,
+          "port1Id": 1316,
+          "port2Id": 1317,
+          "isNonStopTransit": false
+        },
+        {
+          "id": 312,
+          "port1Id": 1320,
+          "port2Id": 1321,
+          "isNonStopTransit": false
+        },
+        {
+          "id": 313,
+          "port1Id": 1325,
+          "port2Id": 1324,
+          "isNonStopTransit": false
+        },
+        {"id": 320, "port1Id": 1342, "port2Id": 1343, "isNonStopTransit": false}
+      ],
+      "connections": [],
+      "resourceId": 192,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 169,
+      "betriebspunktName": "Rothkr.",
+      "fullName": "Rothkreuz",
+      "positionX": 1856,
+      "positionY": 1728,
+      "ports": [
+        {
+          "id": 1351,
+          "trainrunSectionId": 668,
+          "positionIndex": 0,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1349,
+          "trainrunSectionId": 667,
+          "positionIndex": 1,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1100,
+          "trainrunSectionId": 542,
+          "positionIndex": 2,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1096,
+          "trainrunSectionId": 540,
+          "positionIndex": 3,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1347,
+          "trainrunSectionId": 666,
+          "positionIndex": 0,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1345,
+          "trainrunSectionId": 665,
+          "positionIndex": 1,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1040,
+          "trainrunSectionId": 512,
+          "positionIndex": 2,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1080,
+          "trainrunSectionId": 532,
+          "positionIndex": 3,
+          "positionAlignment": 3
+        }
+      ],
+      "transitions": [
+        {
+          "id": 321,
+          "port1Id": 1096,
+          "port2Id": 1345,
+          "isNonStopTransit": false
+        },
+        {"id": 323, "port1Id": 1100, "port2Id": 1347, "isNonStopTransit": true},
+        {"id": 325, "port1Id": 1349, "port2Id": 1080, "isNonStopTransit": true},
+        {"id": 326, "port1Id": 1351, "port2Id": 1040, "isNonStopTransit": true}
+      ],
+      "connections": [],
+      "resourceId": 193,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 170,
+      "betriebspunktName": "Thalwil",
+      "fullName": "Thalwil",
+      "positionX": 2656,
+      "positionY": 736,
+      "ports": [
+        {
+          "id": 1359,
+          "trainrunSectionId": 672,
+          "positionIndex": 0,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1150,
+          "trainrunSectionId": 567,
+          "positionIndex": 1,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1154,
+          "trainrunSectionId": 569,
+          "positionIndex": 2,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1357,
+          "trainrunSectionId": 671,
+          "positionIndex": 3,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1355,
+          "trainrunSectionId": 670,
+          "positionIndex": 4,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1353,
+          "trainrunSectionId": 669,
+          "positionIndex": 5,
+          "positionAlignment": 0
+        },
+        {
+          "id": 1068,
+          "trainrunSectionId": 526,
+          "positionIndex": 0,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1094,
+          "trainrunSectionId": 539,
+          "positionIndex": 1,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1102,
+          "trainrunSectionId": 543,
+          "positionIndex": 2,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1098,
+          "trainrunSectionId": 541,
+          "positionIndex": 3,
+          "positionAlignment": 1
+        },
+        {
+          "id": 1361,
+          "trainrunSectionId": 673,
+          "positionIndex": 0,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1363,
+          "trainrunSectionId": 674,
+          "positionIndex": 1,
+          "positionAlignment": 3
+        }
+      ],
+      "transitions": [
+        {
+          "id": 328,
+          "port1Id": 1353,
+          "port2Id": 1098,
+          "isNonStopTransit": false
+        },
+        {"id": 330, "port1Id": 1355, "port2Id": 1102, "isNonStopTransit": true},
+        {"id": 331, "port1Id": 1357, "port2Id": 1094, "isNonStopTransit": true},
+        {"id": 332, "port1Id": 1359, "port2Id": 1068, "isNonStopTransit": true},
+        {"id": 333, "port1Id": 1150, "port2Id": 1361, "isNonStopTransit": true},
+        {"id": 335, "port1Id": 1154, "port2Id": 1363, "isNonStopTransit": false}
+      ],
+      "connections": [],
+      "resourceId": 194,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 171,
+      "betriebspunktName": "Fribourg",
+      "fullName": "Fribourg",
+      "positionX": -2560,
+      "positionY": 288,
+      "ports": [
+        {
+          "id": 1381,
+          "trainrunSectionId": 683,
+          "positionIndex": 0,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1379,
+          "trainrunSectionId": 682,
+          "positionIndex": 1,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1206,
+          "trainrunSectionId": 595,
+          "positionIndex": 0,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1110,
+          "trainrunSectionId": 547,
+          "positionIndex": 1,
+          "positionAlignment": 3
+        }
+      ],
+      "transitions": [
+        {
+          "id": 344,
+          "port1Id": 1379,
+          "port2Id": 1110,
+          "isNonStopTransit": false
+        },
+        {"id": 346, "port1Id": 1381, "port2Id": 1206, "isNonStopTransit": false}
+      ],
+      "connections": [],
+      "resourceId": 195,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 172,
+      "betriebspunktName": "RTR",
+      "fullName": "Rothrist",
+      "positionX": -608,
+      "positionY": 128,
+      "ports": [
+        {
+          "id": 1395,
+          "trainrunSectionId": 690,
+          "positionIndex": 0,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1438,
+          "trainrunSectionId": 711,
+          "positionIndex": 1,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1391,
+          "trainrunSectionId": 688,
+          "positionIndex": 2,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1389,
+          "trainrunSectionId": 687,
+          "positionIndex": 3,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1387,
+          "trainrunSectionId": 686,
+          "positionIndex": 4,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1383,
+          "trainrunSectionId": 684,
+          "positionIndex": 5,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1385,
+          "trainrunSectionId": 685,
+          "positionIndex": 6,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1204,
+          "trainrunSectionId": 594,
+          "positionIndex": 0,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1393,
+          "trainrunSectionId": 689,
+          "positionIndex": 1,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1310,
+          "trainrunSectionId": 647,
+          "positionIndex": 2,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1226,
+          "trainrunSectionId": 605,
+          "positionIndex": 3,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1242,
+          "trainrunSectionId": 613,
+          "positionIndex": 4,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1166,
+          "trainrunSectionId": 575,
+          "positionIndex": 5,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1108,
+          "trainrunSectionId": 546,
+          "positionIndex": 6,
+          "positionAlignment": 3
+        }
+      ],
+      "transitions": [
+        {"id": 348, "port1Id": 1108, "port2Id": 1383, "isNonStopTransit": true},
+        {"id": 349, "port1Id": 1385, "port2Id": 1166, "isNonStopTransit": true},
+        {"id": 350, "port1Id": 1387, "port2Id": 1242, "isNonStopTransit": true},
+        {"id": 351, "port1Id": 1389, "port2Id": 1226, "isNonStopTransit": true},
+        {"id": 352, "port1Id": 1391, "port2Id": 1310, "isNonStopTransit": true},
+        {"id": 354, "port1Id": 1395, "port2Id": 1204, "isNonStopTransit": true},
+        {"id": 384, "port1Id": 1438, "port2Id": 1393, "isNonStopTransit": true}
+      ],
+      "connections": [],
+      "resourceId": 196,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 173,
+      "betriebspunktName": "Burgdorf",
+      "fullName": "Burgdorf",
+      "positionX": -1344,
+      "positionY": 352,
+      "ports": [
+        {
+          "id": 1397,
+          "trainrunSectionId": 691,
+          "positionIndex": 0,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1400,
+          "trainrunSectionId": 692,
+          "positionIndex": 0,
+          "positionAlignment": 3
+        }
+      ],
+      "transitions": [
+        {"id": 356, "port1Id": 1397, "port2Id": 1400, "isNonStopTransit": false}
+      ],
+      "connections": [],
+      "resourceId": 197,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 174,
+      "betriebspunktName": "Langent.",
+      "fullName": "Langenthal",
+      "positionX": -992,
+      "positionY": 352,
+      "ports": [
+        {
+          "id": 1399,
+          "trainrunSectionId": 692,
+          "positionIndex": 0,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1386,
+          "trainrunSectionId": 685,
+          "positionIndex": 0,
+          "positionAlignment": 3
+        }
+      ],
+      "transitions": [
+        {"id": 355, "port1Id": 1399, "port2Id": 1386, "isNonStopTransit": false}
+      ],
+      "connections": [],
+      "resourceId": 198,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 175,
+      "betriebspunktName": "Solothurn",
+      "fullName": "Solothurn",
+      "positionX": -1696,
+      "positionY": -32,
+      "ports": [
+        {
+          "id": 1417,
+          "trainrunSectionId": 701,
+          "positionIndex": 0,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1182,
+          "trainrunSectionId": 583,
+          "positionIndex": 0,
+          "positionAlignment": 3
+        }
+      ],
+      "transitions": [
+        {"id": 365, "port1Id": 1417, "port2Id": 1182, "isNonStopTransit": false}
+      ],
+      "connections": [],
+      "resourceId": 199,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 176,
+      "betriebspunktName": "Rohrsch.",
+      "fullName": "Rohrschach",
+      "positionX": 5376,
+      "positionY": 96,
+      "ports": [
+        {
+          "id": 1420,
+          "trainrunSectionId": 702,
+          "positionIndex": 0,
+          "positionAlignment": 2
+        }
+      ],
+      "transitions": [],
+      "connections": [],
+      "resourceId": 200,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 177,
+      "betriebspunktName": "Morges",
+      "fullName": "Morges",
+      "positionX": -3520,
+      "positionY": 544,
+      "ports": [
+        {
+          "id": 1423,
+          "trainrunSectionId": 704,
+          "positionIndex": 0,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1425,
+          "trainrunSectionId": 705,
+          "positionIndex": 1,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1421,
+          "trainrunSectionId": 703,
+          "positionIndex": 2,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1184,
+          "trainrunSectionId": 584,
+          "positionIndex": 0,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1208,
+          "trainrunSectionId": 596,
+          "positionIndex": 1,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1188,
+          "trainrunSectionId": 586,
+          "positionIndex": 2,
+          "positionAlignment": 3
+        }
+      ],
+      "transitions": [
+        {
+          "id": 368,
+          "port1Id": 1421,
+          "port2Id": 1188,
+          "isNonStopTransit": false
+        },
+        {"id": 370, "port1Id": 1423, "port2Id": 1208, "isNonStopTransit": true},
+        {"id": 372, "port1Id": 1425, "port2Id": 1184, "isNonStopTransit": false}
+      ],
+      "connections": [],
+      "resourceId": 201,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 178,
+      "betriebspunktName": "BNWD",
+      "fullName": "Bern Wankdorf",
+      "positionX": -1696,
+      "positionY": 128,
+      "ports": [
+        {
+          "id": 1439,
+          "trainrunSectionId": 712,
+          "positionIndex": 0,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1330,
+          "trainrunSectionId": 657,
+          "positionIndex": 1,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1435,
+          "trainrunSectionId": 710,
+          "positionIndex": 2,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1433,
+          "trainrunSectionId": 709,
+          "positionIndex": 3,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1431,
+          "trainrunSectionId": 708,
+          "positionIndex": 4,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1429,
+          "trainrunSectionId": 707,
+          "positionIndex": 5,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1427,
+          "trainrunSectionId": 706,
+          "positionIndex": 6,
+          "positionAlignment": 2
+        },
+        {
+          "id": 1396,
+          "trainrunSectionId": 690,
+          "positionIndex": 0,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1437,
+          "trainrunSectionId": 711,
+          "positionIndex": 1,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1392,
+          "trainrunSectionId": 688,
+          "positionIndex": 2,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1390,
+          "trainrunSectionId": 687,
+          "positionIndex": 3,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1388,
+          "trainrunSectionId": 686,
+          "positionIndex": 4,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1384,
+          "trainrunSectionId": 684,
+          "positionIndex": 5,
+          "positionAlignment": 3
+        },
+        {
+          "id": 1398,
+          "trainrunSectionId": 691,
+          "positionIndex": 6,
+          "positionAlignment": 3
+        }
+      ],
+      "transitions": [
+        {"id": 374, "port1Id": 1427, "port2Id": 1398, "isNonStopTransit": true},
+        {"id": 375, "port1Id": 1429, "port2Id": 1384, "isNonStopTransit": true},
+        {"id": 377, "port1Id": 1431, "port2Id": 1388, "isNonStopTransit": true},
+        {"id": 379, "port1Id": 1433, "port2Id": 1390, "isNonStopTransit": true},
+        {"id": 381, "port1Id": 1435, "port2Id": 1392, "isNonStopTransit": true},
+        {"id": 383, "port1Id": 1330, "port2Id": 1437, "isNonStopTransit": true},
+        {"id": 385, "port1Id": 1439, "port2Id": 1396, "isNonStopTransit": true}
+      ],
+      "connections": [],
+      "resourceId": 202,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    }
+  ],
+  "trainrunSections": [
+    {
+      "id": 509,
+      "sourceNodeId": 156,
+      "sourcePortId": 1033,
+      "targetNodeId": 136,
+      "targetPortId": 1034,
+      "travelTime": {
+        "lock": true,
+        "time": 14,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 2,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 182
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 58,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 178
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 44,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 164
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 16,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 196
+      },
+      "numberOfStops": 0,
+      "trainrunId": 75,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2640, "y": 3710},
+          {"x": 2640, "y": 3646},
+          {"x": 2640, "y": 3390},
+          {"x": 2640, "y": 3326}
+        ],
+        "textPositions": {
+          "0": {"x": 2652, "y": 3692},
+          "1": {"x": 2628, "y": 3664},
+          "2": {"x": 2628, "y": 3344},
+          "3": {"x": 2652, "y": 3372},
+          "4": {"x": 2628, "y": 3518},
+          "5": {"x": 2628, "y": 3518},
+          "6": {"x": 2652, "y": 3518}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 510,
+      "sourceNodeId": 136,
+      "sourcePortId": 1035,
+      "targetNodeId": 158,
+      "targetPortId": 1036,
+      "travelTime": {
+        "lock": true,
+        "time": 6,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 18,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 198
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 42,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 162
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 36,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 156
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 24,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 204
+      },
+      "numberOfStops": 0,
+      "trainrunId": 75,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2640, "y": 3230},
+          {"x": 2640, "y": 3166},
+          {"x": 2640, "y": 2818},
+          {"x": 2640, "y": 2754}
+        ],
+        "textPositions": {
+          "0": {"x": 2652, "y": 3212},
+          "1": {"x": 2628, "y": 3184},
+          "2": {"x": 2628, "y": 2772},
+          "3": {"x": 2652, "y": 2800},
+          "4": {"x": 2628, "y": 2992},
+          "5": {"x": 2628, "y": 2992},
+          "6": {"x": 2652, "y": 2992}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 511,
+      "sourceNodeId": 155,
+      "sourcePortId": 1037,
+      "targetNodeId": 154,
+      "targetPortId": 1038,
+      "travelTime": {
+        "lock": true,
+        "time": 19,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 52,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 232
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 8,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 128
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 49,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 109
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 11,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 251
+      },
+      "numberOfStops": 0,
+      "trainrunId": 75,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2704, "y": 2174},
+          {"x": 2704, "y": 2110},
+          {"x": 2704, "y": 1950},
+          {"x": 2704, "y": 1886}
+        ],
+        "textPositions": {
+          "0": {"x": 2716, "y": 2156},
+          "1": {"x": 2692, "y": 2128},
+          "2": {"x": 2692, "y": 1904},
+          "3": {"x": 2716, "y": 1932},
+          "4": {"x": 2692, "y": 2030},
+          "5": {"x": 2692, "y": 2030},
+          "6": {"x": 2716, "y": 2030}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 512,
+      "sourceNodeId": 154,
+      "sourcePortId": 1039,
+      "targetNodeId": 169,
+      "targetPortId": 1040,
+      "travelTime": {
+        "lock": true,
+        "time": 18,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 15,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 255
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 45,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 105
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 27,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 87
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 33,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 273
+      },
+      "numberOfStops": 0,
+      "trainrunId": 75,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2654, "y": 1808},
+          {"x": 2590, "y": 1808},
+          {"x": 2018, "y": 1808},
+          {"x": 1954, "y": 1808}
+        ],
+        "textPositions": {
+          "0": {"x": 2636, "y": 1796},
+          "1": {"x": 2608, "y": 1820},
+          "2": {"x": 1972, "y": 1820},
+          "3": {"x": 2000, "y": 1796},
+          "4": {"x": 2304, "y": 1796},
+          "5": {"x": 2304, "y": 1796},
+          "6": {"x": 2304, "y": 1820}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 513,
+      "sourceNodeId": 142,
+      "sourcePortId": 1041,
+      "targetNodeId": 141,
+      "targetPortId": 1042,
+      "travelTime": {
+        "lock": true,
+        "time": 19,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 55,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 295
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 5,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 65
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 46,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 46
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 14,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 314
+      },
+      "numberOfStops": 0,
+      "trainrunId": 75,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 80, "y": 1726},
+          {"x": 80, "y": 1662},
+          {"x": 80, "y": 1314},
+          {"x": 80, "y": 1250}
+        ],
+        "textPositions": {
+          "0": {"x": 92, "y": 1708},
+          "1": {"x": 68, "y": 1680},
+          "2": {"x": 68, "y": 1268},
+          "3": {"x": 92, "y": 1296},
+          "4": {"x": 68, "y": 1488},
+          "5": {"x": 68, "y": 1488},
+          "6": {"x": 92, "y": 1488}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 514,
+      "sourceNodeId": 141,
+      "sourcePortId": 1043,
+      "targetNodeId": 143,
+      "targetPortId": 1044,
+      "travelTime": {
+        "lock": true,
+        "time": 9,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 14,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 314
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 46,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 46
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 37,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 37
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 23,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 323
+      },
+      "numberOfStops": 0,
+      "trainrunId": 75,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 80, "y": 1182},
+          {"x": 80, "y": 1118},
+          {"x": 80, "y": 866},
+          {"x": 80, "y": 802}
+        ],
+        "textPositions": {
+          "0": {"x": 92, "y": 1164},
+          "1": {"x": 68, "y": 1136},
+          "2": {"x": 68, "y": 820},
+          "3": {"x": 92, "y": 848},
+          "4": {"x": 68, "y": 992},
+          "5": {"x": 68, "y": 992},
+          "6": {"x": 92, "y": 992}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 515,
+      "sourceNodeId": 143,
+      "sourcePortId": 1045,
+      "targetNodeId": 133,
+      "targetPortId": 1046,
+      "travelTime": {
+        "lock": true,
+        "time": 7,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 23,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 323
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 37,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 37
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 30,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 30
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 30,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 330
+      },
+      "numberOfStops": 0,
+      "trainrunId": 75,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 80, "y": 734},
+          {"x": 80, "y": 670},
+          {"x": 80, "y": 414},
+          {"x": 80, "y": 350}
+        ],
+        "textPositions": {
+          "0": {"x": 92, "y": 716},
+          "1": {"x": 68, "y": 688},
+          "2": {"x": 68, "y": 368},
+          "3": {"x": 92, "y": 396},
+          "4": {"x": 68, "y": 542},
+          "5": {"x": 68, "y": 542},
+          "6": {"x": 92, "y": 542}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 516,
+      "sourceNodeId": 133,
+      "sourcePortId": 1047,
+      "targetNodeId": 144,
+      "targetPortId": 1048,
+      "travelTime": {
+        "lock": true,
+        "time": 10,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 32,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 332
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 28,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 28
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 18,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 18
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 42,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 342
+      },
+      "numberOfStops": 0,
+      "trainrunId": 75,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 80, "y": 94},
+          {"x": 80, "y": 30},
+          {"x": 80, "y": -290},
+          {"x": 80, "y": -354}
+        ],
+        "textPositions": {
+          "0": {"x": 92, "y": 76},
+          "1": {"x": 68, "y": 48},
+          "2": {"x": 68, "y": -336},
+          "3": {"x": 92, "y": -308},
+          "4": {"x": 68, "y": -130},
+          "5": {"x": 68, "y": -130},
+          "6": {"x": 92, "y": -130}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 517,
+      "sourceNodeId": 144,
+      "sourcePortId": 1049,
+      "targetNodeId": 145,
+      "targetPortId": 1050,
+      "travelTime": {
+        "lock": true,
+        "time": 5,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 42,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 342
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 18,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 18
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 13,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 13
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 47,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 347
+      },
+      "numberOfStops": 0,
+      "trainrunId": 75,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 80, "y": -450},
+          {"x": 80, "y": -514},
+          {"x": 80, "y": -798},
+          {"x": 80, "y": -862}
+        ],
+        "textPositions": {
+          "0": {"x": 92, "y": -468},
+          "1": {"x": 68, "y": -496},
+          "2": {"x": 68, "y": -844},
+          "3": {"x": 92, "y": -816},
+          "4": {"x": 68, "y": -656},
+          "5": {"x": 68, "y": -656},
+          "6": {"x": 92, "y": -656}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 518,
+      "sourceNodeId": 145,
+      "sourcePortId": 1051,
+      "targetNodeId": 146,
+      "targetPortId": 1052,
+      "travelTime": {
+        "lock": true,
+        "time": 5,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 47,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 347
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 13,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 13
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 8,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 8
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 52,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 352
+      },
+      "numberOfStops": 0,
+      "trainrunId": 75,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 80, "y": -930},
+          {"x": 80, "y": -994},
+          {"x": 80, "y": -1278},
+          {"x": 80, "y": -1342}
+        ],
+        "textPositions": {
+          "0": {"x": 92, "y": -948},
+          "1": {"x": 68, "y": -976},
+          "2": {"x": 68, "y": -1324},
+          "3": {"x": 92, "y": -1296},
+          "4": {"x": 68, "y": -1136},
+          "5": {"x": 68, "y": -1136},
+          "6": {"x": 92, "y": -1136}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 519,
+      "sourceNodeId": 146,
+      "sourcePortId": 1053,
+      "targetNodeId": 134,
+      "targetPortId": 1054,
+      "travelTime": {
+        "lock": true,
+        "time": 5,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 52,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 352
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 8,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 8
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 3,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 3
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 57,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 357
+      },
+      "numberOfStops": 0,
+      "trainrunId": 75,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 80, "y": -1410},
+          {"x": 80, "y": -1474},
+          {"x": 80, "y": -1758},
+          {"x": 80, "y": -1822}
+        ],
+        "textPositions": {
+          "0": {"x": 92, "y": -1428},
+          "1": {"x": 68, "y": -1456},
+          "2": {"x": 68, "y": -1804},
+          "3": {"x": 92, "y": -1776},
+          "4": {"x": 68, "y": -1616},
+          "5": {"x": 68, "y": -1616},
+          "6": {"x": 92, "y": -1616}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 520,
+      "sourceNodeId": 155,
+      "sourcePortId": 1055,
+      "targetNodeId": 158,
+      "targetPortId": 1056,
+      "travelTime": {
+        "lock": true,
+        "time": 28,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 8,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 128
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 52,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 232
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 24,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 204
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 36,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 156
+      },
+      "numberOfStops": 0,
+      "trainrunId": 75,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2704, "y": 2270},
+          {"x": 2704, "y": 2334},
+          {"x": 2704, "y": 2622},
+          {"x": 2704, "y": 2686}
+        ],
+        "textPositions": {
+          "0": {"x": 2692, "y": 2288},
+          "1": {"x": 2716, "y": 2316},
+          "2": {"x": 2716, "y": 2668},
+          "3": {"x": 2692, "y": 2640},
+          "4": {"x": 2692, "y": 2478},
+          "5": {"x": 2692, "y": 2478},
+          "6": {"x": 2716, "y": 2478}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 521,
+      "sourceNodeId": 156,
+      "sourcePortId": 1057,
+      "targetNodeId": 136,
+      "targetPortId": 1058,
+      "travelTime": {
+        "lock": true,
+        "time": 14,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 2,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 2
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 58,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 118
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 44,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 104
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 16,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 16
+      },
+      "numberOfStops": 0,
+      "trainrunId": 76,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2608, "y": 3710},
+          {"x": 2608, "y": 3646},
+          {"x": 2608, "y": 3390},
+          {"x": 2608, "y": 3326}
+        ],
+        "textPositions": {
+          "0": {"x": 2620, "y": 3692},
+          "1": {"x": 2596, "y": 3664},
+          "2": {"x": 2596, "y": 3344},
+          "3": {"x": 2620, "y": 3372},
+          "4": {"x": 2596, "y": 3518},
+          "5": {"x": 2596, "y": 3518},
+          "6": {"x": 2620, "y": 3518}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 522,
+      "sourceNodeId": 136,
+      "sourcePortId": 1059,
+      "targetNodeId": 158,
+      "targetPortId": 1060,
+      "travelTime": {
+        "lock": true,
+        "time": 6,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 18,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 18
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 42,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 102
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 36,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 96
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 24,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 24
+      },
+      "numberOfStops": 0,
+      "trainrunId": 76,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2608, "y": 3230},
+          {"x": 2608, "y": 3166},
+          {"x": 2608, "y": 2818},
+          {"x": 2608, "y": 2754}
+        ],
+        "textPositions": {
+          "0": {"x": 2620, "y": 3212},
+          "1": {"x": 2596, "y": 3184},
+          "2": {"x": 2596, "y": 2772},
+          "3": {"x": 2620, "y": 2800},
+          "4": {"x": 2596, "y": 2992},
+          "5": {"x": 2596, "y": 2992},
+          "6": {"x": 2620, "y": 2992}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 523,
+      "sourceNodeId": 158,
+      "sourcePortId": 1061,
+      "targetNodeId": 155,
+      "targetPortId": 1062,
+      "travelTime": {
+        "lock": true,
+        "time": 28,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 24,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 24
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 36,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 96
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 8,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 68
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 52,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 52
+      },
+      "numberOfStops": 0,
+      "trainrunId": 76,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2672, "y": 2686},
+          {"x": 2672, "y": 2622},
+          {"x": 2672, "y": 2334},
+          {"x": 2672, "y": 2270}
+        ],
+        "textPositions": {
+          "0": {"x": 2684, "y": 2668},
+          "1": {"x": 2660, "y": 2640},
+          "2": {"x": 2660, "y": 2288},
+          "3": {"x": 2684, "y": 2316},
+          "4": {"x": 2660, "y": 2478},
+          "5": {"x": 2660, "y": 2478},
+          "6": {"x": 2684, "y": 2478}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 524,
+      "sourceNodeId": 155,
+      "sourcePortId": 1063,
+      "targetNodeId": 154,
+      "targetPortId": 1064,
+      "travelTime": {
+        "lock": false,
+        "time": 19,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 52,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 52
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 8,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 68
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 49,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 49
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 11,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 71
+      },
+      "numberOfStops": 0,
+      "trainrunId": 76,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2672, "y": 2174},
+          {"x": 2672, "y": 2110},
+          {"x": 2672, "y": 1950},
+          {"x": 2672, "y": 1886}
+        ],
+        "textPositions": {
+          "0": {"x": 2684, "y": 2156},
+          "1": {"x": 2660, "y": 2128},
+          "2": {"x": 2660, "y": 1904},
+          "3": {"x": 2684, "y": 1932},
+          "4": {"x": 2660, "y": 2030},
+          "5": {"x": 2660, "y": 2030},
+          "6": {"x": 2684, "y": 2030}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 525,
+      "sourceNodeId": 154,
+      "sourcePortId": 1065,
+      "targetNodeId": 153,
+      "targetPortId": 1066,
+      "travelTime": {
+        "lock": true,
+        "time": 15,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 15,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 75
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 45,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 45
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 30,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 30
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 30,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 90
+      },
+      "numberOfStops": 0,
+      "trainrunId": 76,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2672, "y": 1790},
+          {"x": 2672, "y": 1726},
+          {"x": 2672, "y": 1470},
+          {"x": 2672, "y": 1406}
+        ],
+        "textPositions": {
+          "0": {"x": 2684, "y": 1772},
+          "1": {"x": 2660, "y": 1744},
+          "2": {"x": 2660, "y": 1424},
+          "3": {"x": 2684, "y": 1452},
+          "4": {"x": 2660, "y": 1598},
+          "5": {"x": 2660, "y": 1598},
+          "6": {"x": 2684, "y": 1598}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 526,
+      "sourceNodeId": 153,
+      "sourcePortId": 1067,
+      "targetNodeId": 170,
+      "targetPortId": 1068,
+      "travelTime": {
+        "lock": true,
+        "time": 16,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 31,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 91
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 29,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 29
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 13,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 13
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 47,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 107
+      },
+      "numberOfStops": 0,
+      "trainrunId": 76,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2672, "y": 1310},
+          {"x": 2672, "y": 1246},
+          {"x": 2672, "y": 894},
+          {"x": 2672, "y": 830}
+        ],
+        "textPositions": {
+          "0": {"x": 2684, "y": 1292},
+          "1": {"x": 2660, "y": 1264},
+          "2": {"x": 2660, "y": 848},
+          "3": {"x": 2684, "y": 876},
+          "4": {"x": 2660, "y": 1070},
+          "5": {"x": 2660, "y": 1070},
+          "6": {"x": 2684, "y": 1070}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 527,
+      "sourceNodeId": 157,
+      "sourcePortId": 1069,
+      "targetNodeId": 136,
+      "targetPortId": 1070,
+      "travelTime": {
+        "lock": true,
+        "time": 23,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 33,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 273
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 27,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 327
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 4,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 304
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 56,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 296
+      },
+      "numberOfStops": 0,
+      "trainrunId": 77,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2306, "y": 3248},
+          {"x": 2370, "y": 3248},
+          {"x": 2526, "y": 3248},
+          {"x": 2590, "y": 3248}
+        ],
+        "textPositions": {
+          "0": {"x": 2324, "y": 3260},
+          "1": {"x": 2352, "y": 3236},
+          "2": {"x": 2572, "y": 3236},
+          "3": {"x": 2544, "y": 3260},
+          "4": {"x": 2448, "y": 3236},
+          "5": {"x": 2448, "y": 3236},
+          "6": {"x": 2448, "y": 3260}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 528,
+      "sourceNodeId": 136,
+      "sourcePortId": 1071,
+      "targetNodeId": 158,
+      "targetPortId": 1072,
+      "travelTime": {
+        "lock": true,
+        "time": 15,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 0,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 300
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 0,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 300
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 45,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 285
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 15,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 315
+      },
+      "numberOfStops": 0,
+      "trainrunId": 77,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2672, "y": 3230},
+          {"x": 2672, "y": 3166},
+          {"x": 2672, "y": 2818},
+          {"x": 2672, "y": 2754}
+        ],
+        "textPositions": {
+          "0": {"x": 2684, "y": 3212},
+          "1": {"x": 2660, "y": 3184},
+          "2": {"x": 2660, "y": 2772},
+          "3": {"x": 2684, "y": 2800},
+          "4": {"x": 2660, "y": 2992},
+          "5": {"x": 2660, "y": 2992},
+          "6": {"x": 2684, "y": 2992}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 529,
+      "sourceNodeId": 158,
+      "sourcePortId": 1073,
+      "targetNodeId": 159,
+      "targetPortId": 1074,
+      "travelTime": {
+        "lock": true,
+        "time": 53,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 16,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 316
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 44,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 284
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 51,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 231
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 9,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 369
+      },
+      "numberOfStops": 5,
+      "trainrunId": 77,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2608, "y": 2686},
+          {"x": 2608, "y": 2622},
+          {"x": 2288, "y": 2398},
+          {"x": 2288, "y": 2334}
+        ],
+        "textPositions": {
+          "0": {"x": 2620, "y": 2668},
+          "1": {"x": 2596, "y": 2640},
+          "2": {"x": 2276, "y": 2352},
+          "3": {"x": 2300, "y": 2380},
+          "4": {"x": 2460, "y": 2510},
+          "5": {"x": 2460, "y": 2510},
+          "6": {"x": 2436, "y": 2510}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 530,
+      "sourceNodeId": 159,
+      "sourcePortId": 1075,
+      "targetNodeId": 155,
+      "targetPortId": 1076,
+      "travelTime": {
+        "lock": true,
+        "time": 32,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 10,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 370
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 50,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 230
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 18,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 198
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 42,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 402
+      },
+      "numberOfStops": 1,
+      "trainrunId": 77,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2370, "y": 2256},
+          {"x": 2434, "y": 2256},
+          {"x": 2590, "y": 2192},
+          {"x": 2654, "y": 2192}
+        ],
+        "textPositions": {
+          "0": {"x": 2388, "y": 2268},
+          "1": {"x": 2416, "y": 2244},
+          "2": {"x": 2636, "y": 2180},
+          "3": {"x": 2608, "y": 2204},
+          "4": {"x": 2512, "y": 2212},
+          "5": {"x": 2512, "y": 2212},
+          "6": {"x": 2512, "y": 2236}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 531,
+      "sourceNodeId": 155,
+      "sourcePortId": 1077,
+      "targetNodeId": 154,
+      "targetPortId": 1078,
+      "travelTime": {
+        "lock": true,
+        "time": 23,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 43,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 403
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 17,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 197
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 54,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 174
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 6,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 426
+      },
+      "numberOfStops": 3,
+      "trainrunId": 77,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2736, "y": 2174},
+          {"x": 2736, "y": 2110},
+          {"x": 2736, "y": 1950},
+          {"x": 2736, "y": 1886}
+        ],
+        "textPositions": {
+          "0": {"x": 2748, "y": 2156},
+          "1": {"x": 2724, "y": 2128},
+          "2": {"x": 2724, "y": 1904},
+          "3": {"x": 2748, "y": 1932},
+          "4": {"x": 2724, "y": 2030},
+          "5": {"x": 2724, "y": 2030},
+          "6": {"x": 2748, "y": 2030}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 532,
+      "sourceNodeId": 154,
+      "sourcePortId": 1079,
+      "targetNodeId": 169,
+      "targetPortId": 1080,
+      "travelTime": {
+        "lock": true,
+        "time": 18,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 15,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 435
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 45,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 165
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 27,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 147
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 33,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 453
+      },
+      "numberOfStops": 0,
+      "trainrunId": 77,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2654, "y": 1840},
+          {"x": 2590, "y": 1840},
+          {"x": 2018, "y": 1840},
+          {"x": 1954, "y": 1840}
+        ],
+        "textPositions": {
+          "0": {"x": 2636, "y": 1828},
+          "1": {"x": 2608, "y": 1852},
+          "2": {"x": 1972, "y": 1852},
+          "3": {"x": 2000, "y": 1828},
+          "4": {"x": 2304, "y": 1828},
+          "5": {"x": 2304, "y": 1828},
+          "6": {"x": 2304, "y": 1852}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 533,
+      "sourceNodeId": 157,
+      "sourcePortId": 1081,
+      "targetNodeId": 136,
+      "targetPortId": 1082,
+      "travelTime": {
+        "lock": true,
+        "time": 23,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 33,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 153
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 27,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 207
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 4,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 184
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 56,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 176
+      },
+      "numberOfStops": 3,
+      "trainrunId": 78,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2306, "y": 3280},
+          {"x": 2370, "y": 3280},
+          {"x": 2526, "y": 3280},
+          {"x": 2590, "y": 3280}
+        ],
+        "textPositions": {
+          "0": {"x": 2324, "y": 3292},
+          "1": {"x": 2352, "y": 3268},
+          "2": {"x": 2572, "y": 3268},
+          "3": {"x": 2544, "y": 3292},
+          "4": {"x": 2448, "y": 3268},
+          "5": {"x": 2448, "y": 3268},
+          "6": {"x": 2448, "y": 3292}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 534,
+      "sourceNodeId": 136,
+      "sourcePortId": 1083,
+      "targetNodeId": 158,
+      "targetPortId": 1084,
+      "travelTime": {
+        "lock": true,
+        "time": 15,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 0,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 180
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 0,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 180
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 45,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 165
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 15,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 195
+      },
+      "numberOfStops": 1,
+      "trainrunId": 78,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2704, "y": 3230},
+          {"x": 2704, "y": 3166},
+          {"x": 2704, "y": 2818},
+          {"x": 2704, "y": 2754}
+        ],
+        "textPositions": {
+          "0": {"x": 2716, "y": 3212},
+          "1": {"x": 2692, "y": 3184},
+          "2": {"x": 2692, "y": 2772},
+          "3": {"x": 2716, "y": 2800},
+          "4": {"x": 2692, "y": 2992},
+          "5": {"x": 2692, "y": 2992},
+          "6": {"x": 2716, "y": 2992}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 535,
+      "sourceNodeId": 158,
+      "sourcePortId": 1085,
+      "targetNodeId": 159,
+      "targetPortId": 1086,
+      "travelTime": {
+        "lock": true,
+        "time": 53,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 16,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 196
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 44,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 164
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 51,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 111
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 9,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 249
+      },
+      "numberOfStops": 5,
+      "trainrunId": 78,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2640, "y": 2686},
+          {"x": 2640, "y": 2622},
+          {"x": 2320, "y": 2398},
+          {"x": 2320, "y": 2334}
+        ],
+        "textPositions": {
+          "0": {"x": 2652, "y": 2668},
+          "1": {"x": 2628, "y": 2640},
+          "2": {"x": 2308, "y": 2352},
+          "3": {"x": 2332, "y": 2380},
+          "4": {"x": 2492, "y": 2510},
+          "5": {"x": 2492, "y": 2510},
+          "6": {"x": 2468, "y": 2510}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 536,
+      "sourceNodeId": 159,
+      "sourcePortId": 1087,
+      "targetNodeId": 155,
+      "targetPortId": 1088,
+      "travelTime": {
+        "lock": true,
+        "time": 32,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 10,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 250
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 50,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 110
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 18,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 78
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 42,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 282
+      },
+      "numberOfStops": 1,
+      "trainrunId": 78,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2370, "y": 2288},
+          {"x": 2434, "y": 2288},
+          {"x": 2590, "y": 2224},
+          {"x": 2654, "y": 2224}
+        ],
+        "textPositions": {
+          "0": {"x": 2388, "y": 2300},
+          "1": {"x": 2416, "y": 2276},
+          "2": {"x": 2636, "y": 2212},
+          "3": {"x": 2608, "y": 2236},
+          "4": {"x": 2512, "y": 2244},
+          "5": {"x": 2512, "y": 2244},
+          "6": {"x": 2512, "y": 2268}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 537,
+      "sourceNodeId": 155,
+      "sourcePortId": 1089,
+      "targetNodeId": 154,
+      "targetPortId": 1090,
+      "travelTime": {
+        "lock": false,
+        "time": 23,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 43,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 283
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 17,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 77
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 54,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 54
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 6,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 306
+      },
+      "numberOfStops": 3,
+      "trainrunId": 78,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2768, "y": 2174},
+          {"x": 2768, "y": 2110},
+          {"x": 2768, "y": 1950},
+          {"x": 2768, "y": 1886}
+        ],
+        "textPositions": {
+          "0": {"x": 2780, "y": 2156},
+          "1": {"x": 2756, "y": 2128},
+          "2": {"x": 2756, "y": 1904},
+          "3": {"x": 2780, "y": 1932},
+          "4": {"x": 2756, "y": 2030},
+          "5": {"x": 2756, "y": 2030},
+          "6": {"x": 2780, "y": 2030}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 538,
+      "sourceNodeId": 154,
+      "sourcePortId": 1091,
+      "targetNodeId": 153,
+      "targetPortId": 1092,
+      "travelTime": {
+        "lock": true,
+        "time": 15,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 15,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 315
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 45,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 45
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 30,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 30
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 30,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 330
+      },
+      "numberOfStops": 0,
+      "trainrunId": 78,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2704, "y": 1790},
+          {"x": 2704, "y": 1726},
+          {"x": 2704, "y": 1470},
+          {"x": 2704, "y": 1406}
+        ],
+        "textPositions": {
+          "0": {"x": 2716, "y": 1772},
+          "1": {"x": 2692, "y": 1744},
+          "2": {"x": 2692, "y": 1424},
+          "3": {"x": 2716, "y": 1452},
+          "4": {"x": 2692, "y": 1598},
+          "5": {"x": 2692, "y": 1598},
+          "6": {"x": 2716, "y": 1598}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 539,
+      "sourceNodeId": 153,
+      "sourcePortId": 1093,
+      "targetNodeId": 170,
+      "targetPortId": 1094,
+      "travelTime": {
+        "lock": true,
+        "time": 16,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 31,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 331
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 29,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 29
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 13,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 13
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 47,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 347
+      },
+      "numberOfStops": 0,
+      "trainrunId": 78,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2704, "y": 1310},
+          {"x": 2704, "y": 1246},
+          {"x": 2704, "y": 894},
+          {"x": 2704, "y": 830}
+        ],
+        "textPositions": {
+          "0": {"x": 2716, "y": 1292},
+          "1": {"x": 2692, "y": 1264},
+          "2": {"x": 2692, "y": 848},
+          "3": {"x": 2716, "y": 876},
+          "4": {"x": 2692, "y": 1070},
+          "5": {"x": 2692, "y": 1070},
+          "6": {"x": 2716, "y": 1070}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 540,
+      "sourceNodeId": 142,
+      "sourcePortId": 1095,
+      "targetNodeId": 169,
+      "targetPortId": 1096,
+      "travelTime": {
+        "lock": false,
+        "time": 12,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 35,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 35
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 25,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 265
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 13,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 253
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 47,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 47
+      },
+      "numberOfStops": 0,
+      "trainrunId": 79,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 226, "y": 1840},
+          {"x": 290, "y": 1840},
+          {"x": 1790, "y": 1840},
+          {"x": 1854, "y": 1840}
+        ],
+        "textPositions": {
+          "0": {"x": 244, "y": 1852},
+          "1": {"x": 272, "y": 1828},
+          "2": {"x": 1836, "y": 1828},
+          "3": {"x": 1808, "y": 1852},
+          "4": {"x": 1040, "y": 1828},
+          "5": {"x": 1040, "y": 1828},
+          "6": {"x": 1040, "y": 1852}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 541,
+      "sourceNodeId": 153,
+      "sourcePortId": 1097,
+      "targetNodeId": 170,
+      "targetPortId": 1098,
+      "travelTime": {
+        "lock": false,
+        "time": 15,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 58,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 58
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 2,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 242
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 47,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 227
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 13,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 73
+      },
+      "numberOfStops": 1,
+      "trainrunId": 79,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2768, "y": 1310},
+          {"x": 2768, "y": 1246},
+          {"x": 2768, "y": 894},
+          {"x": 2768, "y": 830}
+        ],
+        "textPositions": {
+          "0": {"x": 2780, "y": 1292},
+          "1": {"x": 2756, "y": 1264},
+          "2": {"x": 2756, "y": 848},
+          "3": {"x": 2780, "y": 876},
+          "4": {"x": 2756, "y": 1070},
+          "5": {"x": 2756, "y": 1070},
+          "6": {"x": 2780, "y": 1070}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 542,
+      "sourceNodeId": 142,
+      "sourcePortId": 1099,
+      "targetNodeId": 169,
+      "targetPortId": 1100,
+      "travelTime": {
+        "lock": true,
+        "time": 9,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 9,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 9
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 51,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 51
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 42,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 42
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 18,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 18
+      },
+      "numberOfStops": 0,
+      "trainrunId": 80,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 226, "y": 1808},
+          {"x": 290, "y": 1808},
+          {"x": 1790, "y": 1808},
+          {"x": 1854, "y": 1808}
+        ],
+        "textPositions": {
+          "0": {"x": 244, "y": 1820},
+          "1": {"x": 272, "y": 1796},
+          "2": {"x": 1836, "y": 1796},
+          "3": {"x": 1808, "y": 1820},
+          "4": {"x": 1040, "y": 1796},
+          "5": {"x": 1040, "y": 1796},
+          "6": {"x": 1040, "y": 1820}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 543,
+      "sourceNodeId": 153,
+      "sourcePortId": 1101,
+      "targetNodeId": 170,
+      "targetPortId": 1102,
+      "travelTime": {
+        "lock": true,
+        "time": 14,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 29,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 29
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 31,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 31
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 17,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 17
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 43,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 43
+      },
+      "numberOfStops": 0,
+      "trainrunId": 80,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2736, "y": 1310},
+          {"x": 2736, "y": 1246},
+          {"x": 2736, "y": 894},
+          {"x": 2736, "y": 830}
+        ],
+        "textPositions": {
+          "0": {"x": 2748, "y": 1292},
+          "1": {"x": 2724, "y": 1264},
+          "2": {"x": 2724, "y": 848},
+          "3": {"x": 2748, "y": 876},
+          "4": {"x": 2724, "y": 1070},
+          "5": {"x": 2724, "y": 1070},
+          "6": {"x": 2748, "y": 1070}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 544,
+      "sourceNodeId": 142,
+      "sourcePortId": 1103,
+      "targetNodeId": 141,
+      "targetPortId": 1104,
+      "travelTime": {
+        "lock": true,
+        "time": 19,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 59,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 299
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 1,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 241
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 42,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 222
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 18,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 318
+      },
+      "numberOfStops": 0,
+      "trainrunId": 81,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 112, "y": 1726},
+          {"x": 112, "y": 1662},
+          {"x": 112, "y": 1314},
+          {"x": 112, "y": 1250}
+        ],
+        "textPositions": {
+          "0": {"x": 124, "y": 1708},
+          "1": {"x": 100, "y": 1680},
+          "2": {"x": 100, "y": 1268},
+          "3": {"x": 124, "y": 1296},
+          "4": {"x": 100, "y": 1488},
+          "5": {"x": 100, "y": 1488},
+          "6": {"x": 124, "y": 1488}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 545,
+      "sourceNodeId": 141,
+      "sourcePortId": 1105,
+      "targetNodeId": 143,
+      "targetPortId": 1106,
+      "travelTime": {
+        "lock": true,
+        "time": 12,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 19,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 319
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 41,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 221
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 29,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 209
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 31,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 331
+      },
+      "numberOfStops": 0,
+      "trainrunId": 81,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 112, "y": 1182},
+          {"x": 112, "y": 1118},
+          {"x": 112, "y": 866},
+          {"x": 112, "y": 802}
+        ],
+        "textPositions": {
+          "0": {"x": 124, "y": 1164},
+          "1": {"x": 100, "y": 1136},
+          "2": {"x": 100, "y": 820},
+          "3": {"x": 124, "y": 848},
+          "4": {"x": 100, "y": 992},
+          "5": {"x": 100, "y": 992},
+          "6": {"x": 124, "y": 992}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 546,
+      "sourceNodeId": 143,
+      "sourcePortId": 1107,
+      "targetNodeId": 172,
+      "targetPortId": 1108,
+      "travelTime": {
+        "lock": true,
+        "time": 6,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 32,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 332
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 28,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 208
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 22,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 202
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 38,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 338
+      },
+      "numberOfStops": 0,
+      "trainrunId": 81,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 62, "y": 752},
+          {"x": -2, "y": 752},
+          {"x": -446, "y": 336},
+          {"x": -510, "y": 336}
+        ],
+        "textPositions": {
+          "0": {"x": 44, "y": 740},
+          "1": {"x": 16, "y": 764},
+          "2": {"x": -492, "y": 348},
+          "3": {"x": -464, "y": 324},
+          "4": {"x": -224, "y": 532},
+          "5": {"x": -224, "y": 532},
+          "6": {"x": -224, "y": 556}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 547,
+      "sourceNodeId": 129,
+      "sourcePortId": 1109,
+      "targetNodeId": 171,
+      "targetPortId": 1110,
+      "travelTime": {
+        "lock": false,
+        "time": 22,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 4,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 364
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 56,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 176
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 34,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 154
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 26,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 386
+      },
+      "numberOfStops": 0,
+      "trainrunId": 81,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -2146, "y": 176},
+          {"x": -2210, "y": 176},
+          {"x": -2398, "y": 336},
+          {"x": -2462, "y": 336}
+        ],
+        "textPositions": {
+          "0": {"x": -2164, "y": 164},
+          "1": {"x": -2192, "y": 188},
+          "2": {"x": -2444, "y": 348},
+          "3": {"x": -2416, "y": 324},
+          "4": {"x": -2304, "y": 244},
+          "5": {"x": -2304, "y": 244},
+          "6": {"x": -2304, "y": 268}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 548,
+      "sourceNodeId": 142,
+      "sourcePortId": 1111,
+      "targetNodeId": 141,
+      "targetPortId": 1112,
+      "travelTime": {
+        "lock": true,
+        "time": 18,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 30,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 90
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 30,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 90
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 12,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 72
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 48,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 108
+      },
+      "numberOfStops": 0,
+      "trainrunId": 82,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 208, "y": 1726},
+          {"x": 208, "y": 1662},
+          {"x": 208, "y": 1314},
+          {"x": 208, "y": 1250}
+        ],
+        "textPositions": {
+          "0": {"x": 220, "y": 1708},
+          "1": {"x": 196, "y": 1680},
+          "2": {"x": 196, "y": 1268},
+          "3": {"x": 220, "y": 1296},
+          "4": {"x": 196, "y": 1488},
+          "5": {"x": 196, "y": 1488},
+          "6": {"x": 220, "y": 1488}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 549,
+      "sourceNodeId": 141,
+      "sourcePortId": 1113,
+      "targetNodeId": 143,
+      "targetPortId": 1114,
+      "travelTime": {
+        "lock": true,
+        "time": 13,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 49,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 109
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 11,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 71
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 58,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 58
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 2,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 122
+      },
+      "numberOfStops": 0,
+      "trainrunId": 82,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 208, "y": 1182},
+          {"x": 208, "y": 1118},
+          {"x": 208, "y": 866},
+          {"x": 208, "y": 802}
+        ],
+        "textPositions": {
+          "0": {"x": 220, "y": 1164},
+          "1": {"x": 196, "y": 1136},
+          "2": {"x": 196, "y": 820},
+          "3": {"x": 220, "y": 848},
+          "4": {"x": 196, "y": 992},
+          "5": {"x": 196, "y": 992},
+          "6": {"x": 220, "y": 992}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 550,
+      "sourceNodeId": 143,
+      "sourcePortId": 1115,
+      "targetNodeId": 133,
+      "targetPortId": 1116,
+      "travelTime": {
+        "lock": true,
+        "time": 7,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 4,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 124
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 56,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 56
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 49,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 49
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 11,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 131
+      },
+      "numberOfStops": 0,
+      "trainrunId": 82,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 176, "y": 734},
+          {"x": 176, "y": 670},
+          {"x": 176, "y": 414},
+          {"x": 176, "y": 350}
+        ],
+        "textPositions": {
+          "0": {"x": 188, "y": 716},
+          "1": {"x": 164, "y": 688},
+          "2": {"x": 164, "y": 368},
+          "3": {"x": 188, "y": 396},
+          "4": {"x": 164, "y": 542},
+          "5": {"x": 164, "y": 542},
+          "6": {"x": 188, "y": 542}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 551,
+      "sourceNodeId": 133,
+      "sourcePortId": 1117,
+      "targetNodeId": 144,
+      "targetPortId": 1118,
+      "travelTime": {
+        "lock": true,
+        "time": 10,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 12,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 132
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 48,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 48
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 38,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 38
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 22,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 142
+      },
+      "numberOfStops": 0,
+      "trainrunId": 82,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 240, "y": 94},
+          {"x": 240, "y": 30},
+          {"x": 240, "y": -290},
+          {"x": 240, "y": -354}
+        ],
+        "textPositions": {
+          "0": {"x": 252, "y": 76},
+          "1": {"x": 228, "y": 48},
+          "2": {"x": 228, "y": -336},
+          "3": {"x": 252, "y": -308},
+          "4": {"x": 228, "y": -130},
+          "5": {"x": 228, "y": -130},
+          "6": {"x": 252, "y": -130}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 552,
+      "sourceNodeId": 144,
+      "sourcePortId": 1119,
+      "targetNodeId": 145,
+      "targetPortId": 1120,
+      "travelTime": {
+        "lock": true,
+        "time": 4,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 23,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 143
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 37,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 37
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 33,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 33
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 27,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 147
+      },
+      "numberOfStops": 0,
+      "trainrunId": 82,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 304, "y": -450},
+          {"x": 304, "y": -514},
+          {"x": 304, "y": -798},
+          {"x": 304, "y": -862}
+        ],
+        "textPositions": {
+          "0": {"x": 316, "y": -468},
+          "1": {"x": 292, "y": -496},
+          "2": {"x": 292, "y": -844},
+          "3": {"x": 316, "y": -816},
+          "4": {"x": 292, "y": -656},
+          "5": {"x": 292, "y": -656},
+          "6": {"x": 316, "y": -656}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 553,
+      "sourceNodeId": 145,
+      "sourcePortId": 1121,
+      "targetNodeId": 146,
+      "targetPortId": 1122,
+      "travelTime": {
+        "lock": true,
+        "time": 5,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 28,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 148
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 32,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 32
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 27,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 27
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 33,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 153
+      },
+      "numberOfStops": 0,
+      "trainrunId": 82,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 304, "y": -930},
+          {"x": 304, "y": -994},
+          {"x": 304, "y": -1278},
+          {"x": 304, "y": -1342}
+        ],
+        "textPositions": {
+          "0": {"x": 316, "y": -948},
+          "1": {"x": 292, "y": -976},
+          "2": {"x": 292, "y": -1324},
+          "3": {"x": 316, "y": -1296},
+          "4": {"x": 292, "y": -1136},
+          "5": {"x": 292, "y": -1136},
+          "6": {"x": 316, "y": -1136}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 554,
+      "sourceNodeId": 146,
+      "sourcePortId": 1123,
+      "targetNodeId": 134,
+      "targetPortId": 1124,
+      "travelTime": {
+        "lock": true,
+        "time": 10,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 34,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 154
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 26,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 26
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 16,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 16
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 44,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 164
+      },
+      "numberOfStops": 0,
+      "trainrunId": 82,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 304, "y": -1410},
+          {"x": 304, "y": -1474},
+          {"x": 304, "y": -1758},
+          {"x": 304, "y": -1822}
+        ],
+        "textPositions": {
+          "0": {"x": 316, "y": -1428},
+          "1": {"x": 292, "y": -1456},
+          "2": {"x": 292, "y": -1804},
+          "3": {"x": 316, "y": -1776},
+          "4": {"x": 292, "y": -1616},
+          "5": {"x": 292, "y": -1616},
+          "6": {"x": 316, "y": -1616}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 555,
+      "sourceNodeId": 142,
+      "sourcePortId": 1125,
+      "targetNodeId": 141,
+      "targetPortId": 1126,
+      "travelTime": {
+        "lock": true,
+        "time": 19,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 55,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 115
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 5,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 65
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 46,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 46
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 14,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 134
+      },
+      "numberOfStops": 0,
+      "trainrunId": 83,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 176, "y": 1726},
+          {"x": 176, "y": 1662},
+          {"x": 176, "y": 1314},
+          {"x": 176, "y": 1250}
+        ],
+        "textPositions": {
+          "0": {"x": 188, "y": 1708},
+          "1": {"x": 164, "y": 1680},
+          "2": {"x": 164, "y": 1268},
+          "3": {"x": 188, "y": 1296},
+          "4": {"x": 164, "y": 1488},
+          "5": {"x": 164, "y": 1488},
+          "6": {"x": 188, "y": 1488}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 556,
+      "sourceNodeId": 141,
+      "sourcePortId": 1127,
+      "targetNodeId": 143,
+      "targetPortId": 1128,
+      "travelTime": {
+        "lock": true,
+        "time": 8,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 14,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 134
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 46,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 46
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 38,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 38
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 22,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 142
+      },
+      "numberOfStops": 0,
+      "trainrunId": 83,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 176, "y": 1182},
+          {"x": 176, "y": 1118},
+          {"x": 176, "y": 866},
+          {"x": 176, "y": 802}
+        ],
+        "textPositions": {
+          "0": {"x": 188, "y": 1164},
+          "1": {"x": 164, "y": 1136},
+          "2": {"x": 164, "y": 820},
+          "3": {"x": 188, "y": 848},
+          "4": {"x": 164, "y": 992},
+          "5": {"x": 164, "y": 992},
+          "6": {"x": 188, "y": 992}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 557,
+      "sourceNodeId": 143,
+      "sourcePortId": 1129,
+      "targetNodeId": 133,
+      "targetPortId": 1130,
+      "travelTime": {
+        "lock": true,
+        "time": 8,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 22,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 142
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 38,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 38
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 30,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 30
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 30,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 150
+      },
+      "numberOfStops": 0,
+      "trainrunId": 83,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 144, "y": 734},
+          {"x": 144, "y": 670},
+          {"x": 144, "y": 414},
+          {"x": 144, "y": 350}
+        ],
+        "textPositions": {
+          "0": {"x": 156, "y": 716},
+          "1": {"x": 132, "y": 688},
+          "2": {"x": 132, "y": 368},
+          "3": {"x": 156, "y": 396},
+          "4": {"x": 132, "y": 542},
+          "5": {"x": 132, "y": 542},
+          "6": {"x": 156, "y": 542}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 558,
+      "sourceNodeId": 133,
+      "sourcePortId": 1131,
+      "targetNodeId": 144,
+      "targetPortId": 1132,
+      "travelTime": {
+        "lock": true,
+        "time": 10,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 32,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 152
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 28,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 28
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 18,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 18
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 42,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 162
+      },
+      "numberOfStops": 0,
+      "trainrunId": 83,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 208, "y": 94},
+          {"x": 208, "y": 30},
+          {"x": 208, "y": -290},
+          {"x": 208, "y": -354}
+        ],
+        "textPositions": {
+          "0": {"x": 220, "y": 76},
+          "1": {"x": 196, "y": 48},
+          "2": {"x": 196, "y": -336},
+          "3": {"x": 220, "y": -308},
+          "4": {"x": 196, "y": -130},
+          "5": {"x": 196, "y": -130},
+          "6": {"x": 220, "y": -130}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 559,
+      "sourceNodeId": 144,
+      "sourcePortId": 1133,
+      "targetNodeId": 145,
+      "targetPortId": 1134,
+      "travelTime": {
+        "lock": true,
+        "time": 5,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 42,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 162
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 18,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 18
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 13,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 13
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 47,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 167
+      },
+      "numberOfStops": 0,
+      "trainrunId": 83,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 272, "y": -450},
+          {"x": 272, "y": -514},
+          {"x": 272, "y": -798},
+          {"x": 272, "y": -862}
+        ],
+        "textPositions": {
+          "0": {"x": 284, "y": -468},
+          "1": {"x": 260, "y": -496},
+          "2": {"x": 260, "y": -844},
+          "3": {"x": 284, "y": -816},
+          "4": {"x": 260, "y": -656},
+          "5": {"x": 260, "y": -656},
+          "6": {"x": 284, "y": -656}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 560,
+      "sourceNodeId": 145,
+      "sourcePortId": 1135,
+      "targetNodeId": 146,
+      "targetPortId": 1136,
+      "travelTime": {
+        "lock": true,
+        "time": 5,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 47,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 167
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 13,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 13
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 8,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 8
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 52,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 172
+      },
+      "numberOfStops": 0,
+      "trainrunId": 83,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 272, "y": -930},
+          {"x": 272, "y": -994},
+          {"x": 272, "y": -1278},
+          {"x": 272, "y": -1342}
+        ],
+        "textPositions": {
+          "0": {"x": 284, "y": -948},
+          "1": {"x": 260, "y": -976},
+          "2": {"x": 260, "y": -1324},
+          "3": {"x": 284, "y": -1296},
+          "4": {"x": 260, "y": -1136},
+          "5": {"x": 260, "y": -1136},
+          "6": {"x": 284, "y": -1136}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 561,
+      "sourceNodeId": 146,
+      "sourcePortId": 1137,
+      "targetNodeId": 134,
+      "targetPortId": 1138,
+      "travelTime": {
+        "lock": true,
+        "time": 5,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 52,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 172
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 8,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 8
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 3,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 3
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 57,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 177
+      },
+      "numberOfStops": 0,
+      "trainrunId": 83,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 272, "y": -1410},
+          {"x": 272, "y": -1474},
+          {"x": 272, "y": -1758},
+          {"x": 272, "y": -1822}
+        ],
+        "textPositions": {
+          "0": {"x": 284, "y": -1428},
+          "1": {"x": 260, "y": -1456},
+          "2": {"x": 260, "y": -1804},
+          "3": {"x": 284, "y": -1776},
+          "4": {"x": 260, "y": -1616},
+          "5": {"x": 260, "y": -1616},
+          "6": {"x": 284, "y": -1616}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 562,
+      "sourceNodeId": 135,
+      "sourcePortId": 1139,
+      "targetNodeId": 150,
+      "targetPortId": 1140,
+      "travelTime": {
+        "lock": true,
+        "time": 12,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 9,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 9
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 51,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 291
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 39,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 279
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 21,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 21
+      },
+      "numberOfStops": 1,
+      "trainrunId": 84,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2850, "y": 176},
+          {"x": 2914, "y": 176},
+          {"x": 3230, "y": 176},
+          {"x": 3294, "y": 176}
+        ],
+        "textPositions": {
+          "0": {"x": 2868, "y": 188},
+          "1": {"x": 2896, "y": 164},
+          "2": {"x": 3276, "y": 164},
+          "3": {"x": 3248, "y": 188},
+          "4": {"x": 3072, "y": 164},
+          "5": {"x": 3072, "y": 164},
+          "6": {"x": 3072, "y": 188}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 563,
+      "sourceNodeId": 150,
+      "sourcePortId": 1141,
+      "targetNodeId": 151,
+      "targetPortId": 1142,
+      "travelTime": {
+        "lock": true,
+        "time": 13,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 23,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 23
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 37,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 277
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 24,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 264
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 36,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 36
+      },
+      "numberOfStops": 0,
+      "trainrunId": 84,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 3394, "y": 176},
+          {"x": 3458, "y": 176},
+          {"x": 3806, "y": 176},
+          {"x": 3870, "y": 176}
+        ],
+        "textPositions": {
+          "0": {"x": 3412, "y": 188},
+          "1": {"x": 3440, "y": 164},
+          "2": {"x": 3852, "y": 164},
+          "3": {"x": 3824, "y": 188},
+          "4": {"x": 3632, "y": 164},
+          "5": {"x": 3632, "y": 164},
+          "6": {"x": 3632, "y": 188}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 564,
+      "sourceNodeId": 151,
+      "sourcePortId": 1143,
+      "targetNodeId": 137,
+      "targetPortId": 1144,
+      "travelTime": {
+        "lock": true,
+        "time": 44,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 38,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 38
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 22,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 262
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 38,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 218
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 22,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 82
+      },
+      "numberOfStops": 4,
+      "trainrunId": 84,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 3970, "y": 176},
+          {"x": 4034, "y": 176},
+          {"x": 4574, "y": 176},
+          {"x": 4638, "y": 176}
+        ],
+        "textPositions": {
+          "0": {"x": 3988, "y": 188},
+          "1": {"x": 4016, "y": 164},
+          "2": {"x": 4620, "y": 164},
+          "3": {"x": 4592, "y": 188},
+          "4": {"x": 4304, "y": 164},
+          "5": {"x": 4304, "y": 164},
+          "6": {"x": 4304, "y": 188}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 565,
+      "sourceNodeId": 137,
+      "sourcePortId": 1145,
+      "targetNodeId": 140,
+      "targetPortId": 1146,
+      "travelTime": {
+        "lock": true,
+        "time": 61,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 24,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 84
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 36,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 216
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 35,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 155
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 25,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 145
+      },
+      "numberOfStops": 5,
+      "trainrunId": 84,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 4656, "y": 222},
+          {"x": 4656, "y": 286},
+          {"x": 4656, "y": 1118},
+          {"x": 4656, "y": 1182}
+        ],
+        "textPositions": {
+          "0": {"x": 4644, "y": 240},
+          "1": {"x": 4668, "y": 268},
+          "2": {"x": 4668, "y": 1164},
+          "3": {"x": 4644, "y": 1136},
+          "4": {"x": 4644, "y": 702},
+          "5": {"x": 4644, "y": 702},
+          "6": {"x": 4668, "y": 702}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 566,
+      "sourceNodeId": 140,
+      "sourcePortId": 1147,
+      "targetNodeId": 152,
+      "targetPortId": 1148,
+      "travelTime": {
+        "lock": true,
+        "time": 22,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 26,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 146
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 34,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 154
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 12,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 132
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 48,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 168
+      },
+      "numberOfStops": 2,
+      "trainrunId": 84,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 4688, "y": 1278},
+          {"x": 4688, "y": 1342},
+          {"x": 4688, "y": 1822},
+          {"x": 4688, "y": 1886}
+        ],
+        "textPositions": {
+          "0": {"x": 4676, "y": 1296},
+          "1": {"x": 4700, "y": 1324},
+          "2": {"x": 4700, "y": 1868},
+          "3": {"x": 4676, "y": 1840},
+          "4": {"x": 4676, "y": 1582},
+          "5": {"x": 4676, "y": 1582},
+          "6": {"x": 4700, "y": 1582}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 567,
+      "sourceNodeId": 135,
+      "sourcePortId": 1149,
+      "targetNodeId": 170,
+      "targetPortId": 1150,
+      "travelTime": {
+        "lock": false,
+        "time": 8,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 7,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 67
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 53,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 293
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 45,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 285
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 15,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 75
+      },
+      "numberOfStops": 0,
+      "trainrunId": 85,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2704, "y": 350},
+          {"x": 2704, "y": 414},
+          {"x": 2704, "y": 670},
+          {"x": 2704, "y": 734}
+        ],
+        "textPositions": {
+          "0": {"x": 2692, "y": 368},
+          "1": {"x": 2716, "y": 396},
+          "2": {"x": 2716, "y": 716},
+          "3": {"x": 2692, "y": 688},
+          "4": {"x": 2692, "y": 542},
+          "5": {"x": 2692, "y": 542},
+          "6": {"x": 2716, "y": 542}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 568,
+      "sourceNodeId": 140,
+      "sourcePortId": 1151,
+      "targetNodeId": 152,
+      "targetPortId": 1152,
+      "travelTime": {
+        "lock": true,
+        "time": 19,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 3,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 123
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 57,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 237
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 38,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 218
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 22,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 142
+      },
+      "numberOfStops": 1,
+      "trainrunId": 85,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 4656, "y": 1278},
+          {"x": 4656, "y": 1342},
+          {"x": 4656, "y": 1822},
+          {"x": 4656, "y": 1886}
+        ],
+        "textPositions": {
+          "0": {"x": 4644, "y": 1296},
+          "1": {"x": 4668, "y": 1324},
+          "2": {"x": 4668, "y": 1868},
+          "3": {"x": 4644, "y": 1840},
+          "4": {"x": 4644, "y": 1582},
+          "5": {"x": 4644, "y": 1582},
+          "6": {"x": 4668, "y": 1582}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 569,
+      "sourceNodeId": 135,
+      "sourcePortId": 1153,
+      "targetNodeId": 170,
+      "targetPortId": 1154,
+      "travelTime": {
+        "lock": true,
+        "time": 8,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 12,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 132
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 48,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 288
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 40,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 280
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 20,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 140
+      },
+      "numberOfStops": 0,
+      "trainrunId": 86,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2736, "y": 350},
+          {"x": 2736, "y": 414},
+          {"x": 2736, "y": 670},
+          {"x": 2736, "y": 734}
+        ],
+        "textPositions": {
+          "0": {"x": 2724, "y": 368},
+          "1": {"x": 2748, "y": 396},
+          "2": {"x": 2748, "y": 716},
+          "3": {"x": 2724, "y": 688},
+          "4": {"x": 2724, "y": 542},
+          "5": {"x": 2724, "y": 542},
+          "6": {"x": 2748, "y": 542}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 570,
+      "sourceNodeId": 140,
+      "sourcePortId": 1155,
+      "targetNodeId": 152,
+      "targetPortId": 1156,
+      "travelTime": {
+        "lock": true,
+        "time": 20,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 23,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 203
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 37,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 217
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 17,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 197
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 43,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 223
+      },
+      "numberOfStops": 1,
+      "trainrunId": 86,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 4720, "y": 1278},
+          {"x": 4720, "y": 1342},
+          {"x": 4720, "y": 1822},
+          {"x": 4720, "y": 1886}
+        ],
+        "textPositions": {
+          "0": {"x": 4708, "y": 1296},
+          "1": {"x": 4732, "y": 1324},
+          "2": {"x": 4732, "y": 1868},
+          "3": {"x": 4708, "y": 1840},
+          "4": {"x": 4708, "y": 1582},
+          "5": {"x": 4708, "y": 1582},
+          "6": {"x": 4732, "y": 1582}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 571,
+      "sourceNodeId": 135,
+      "sourcePortId": 1157,
+      "targetNodeId": 149,
+      "targetPortId": 1158,
+      "travelTime": {
+        "lock": true,
+        "time": 7,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 54,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 294
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 6,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 126
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 59,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 119
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 1,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 301
+      },
+      "numberOfStops": 1,
+      "trainrunId": 86,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2654, "y": 240},
+          {"x": 2590, "y": 240},
+          {"x": 2402, "y": 240},
+          {"x": 2338, "y": 240}
+        ],
+        "textPositions": {
+          "0": {"x": 2636, "y": 228},
+          "1": {"x": 2608, "y": 252},
+          "2": {"x": 2356, "y": 252},
+          "3": {"x": 2384, "y": 228},
+          "4": {"x": 2496, "y": 228},
+          "5": {"x": 2496, "y": 228},
+          "6": {"x": 2496, "y": 252}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 572,
+      "sourceNodeId": 149,
+      "sourcePortId": 1159,
+      "targetNodeId": 166,
+      "targetPortId": 1160,
+      "travelTime": {
+        "lock": true,
+        "time": 7,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 1,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 301
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 59,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 119
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 52,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 112
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 8,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 308
+      },
+      "numberOfStops": 0,
+      "trainrunId": 86,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2238, "y": 240},
+          {"x": 2174, "y": 240},
+          {"x": 1954, "y": 240},
+          {"x": 1890, "y": 240}
+        ],
+        "textPositions": {
+          "0": {"x": 2220, "y": 228},
+          "1": {"x": 2192, "y": 252},
+          "2": {"x": 1908, "y": 252},
+          "3": {"x": 1936, "y": 228},
+          "4": {"x": 2064, "y": 228},
+          "5": {"x": 2064, "y": 228},
+          "6": {"x": 2064, "y": 252}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 573,
+      "sourceNodeId": 148,
+      "sourcePortId": 1161,
+      "targetNodeId": 147,
+      "targetPortId": 1162,
+      "travelTime": {
+        "lock": true,
+        "time": 7,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 15,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 315
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 45,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 105
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 38,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 98
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 22,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 322
+      },
+      "numberOfStops": 0,
+      "trainrunId": 86,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1342, "y": 240},
+          {"x": 1278, "y": 240},
+          {"x": 1122, "y": 240},
+          {"x": 1058, "y": 240}
+        ],
+        "textPositions": {
+          "0": {"x": 1324, "y": 228},
+          "1": {"x": 1296, "y": 252},
+          "2": {"x": 1076, "y": 252},
+          "3": {"x": 1104, "y": 228},
+          "4": {"x": 1200, "y": 228},
+          "5": {"x": 1200, "y": 228},
+          "6": {"x": 1200, "y": 252}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 574,
+      "sourceNodeId": 147,
+      "sourcePortId": 1163,
+      "targetNodeId": 133,
+      "targetPortId": 1164,
+      "travelTime": {
+        "lock": true,
+        "time": 8,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 22,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 322
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 38,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 98
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 30,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 90
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 30,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 330
+      },
+      "numberOfStops": 0,
+      "trainrunId": 86,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 958, "y": 240},
+          {"x": 894, "y": 240},
+          {"x": 322, "y": 240},
+          {"x": 258, "y": 240}
+        ],
+        "textPositions": {
+          "0": {"x": 940, "y": 228},
+          "1": {"x": 912, "y": 252},
+          "2": {"x": 276, "y": 252},
+          "3": {"x": 304, "y": 228},
+          "4": {"x": 608, "y": 228},
+          "5": {"x": 608, "y": 228},
+          "6": {"x": 608, "y": 252}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 575,
+      "sourceNodeId": 133,
+      "sourcePortId": 1165,
+      "targetNodeId": 172,
+      "targetPortId": 1166,
+      "travelTime": {
+        "lock": true,
+        "time": 7,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 36,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 336
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 24,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 84
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 17,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 77
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 43,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 343
+      },
+      "numberOfStops": 0,
+      "trainrunId": 86,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 62, "y": 304},
+          {"x": -2, "y": 304},
+          {"x": -446, "y": 304},
+          {"x": -510, "y": 304}
+        ],
+        "textPositions": {
+          "0": {"x": 44, "y": 292},
+          "1": {"x": 16, "y": 316},
+          "2": {"x": -492, "y": 316},
+          "3": {"x": -464, "y": 292},
+          "4": {"x": -224, "y": 292},
+          "5": {"x": -224, "y": 292},
+          "6": {"x": -224, "y": 316}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 576,
+      "sourceNodeId": 137,
+      "sourcePortId": 1167,
+      "targetNodeId": 151,
+      "targetPortId": 1168,
+      "travelTime": {
+        "lock": true,
+        "time": 33,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 58,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 298
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 2,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 242
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 29,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 209
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 31,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 331
+      },
+      "numberOfStops": 0,
+      "trainrunId": 87,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 4638, "y": 144},
+          {"x": 4574, "y": 144},
+          {"x": 4034, "y": 144},
+          {"x": 3970, "y": 144}
+        ],
+        "textPositions": {
+          "0": {"x": 4620, "y": 132},
+          "1": {"x": 4592, "y": 156},
+          "2": {"x": 3988, "y": 156},
+          "3": {"x": 4016, "y": 132},
+          "4": {"x": 4304, "y": 132},
+          "5": {"x": 4304, "y": 132},
+          "6": {"x": 4304, "y": 156}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 577,
+      "sourceNodeId": 151,
+      "sourcePortId": 1169,
+      "targetNodeId": 150,
+      "targetPortId": 1170,
+      "travelTime": {
+        "lock": true,
+        "time": 14,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 33,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 333
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 27,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 207
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 13,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 193
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 47,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 347
+      },
+      "numberOfStops": 0,
+      "trainrunId": 87,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 3870, "y": 80},
+          {"x": 3806, "y": 80},
+          {"x": 3458, "y": 80},
+          {"x": 3394, "y": 80}
+        ],
+        "textPositions": {
+          "0": {"x": 3852, "y": 68},
+          "1": {"x": 3824, "y": 92},
+          "2": {"x": 3412, "y": 92},
+          "3": {"x": 3440, "y": 68},
+          "4": {"x": 3632, "y": 68},
+          "5": {"x": 3632, "y": 68},
+          "6": {"x": 3632, "y": 92}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 578,
+      "sourceNodeId": 150,
+      "sourcePortId": 1171,
+      "targetNodeId": 135,
+      "targetPortId": 1172,
+      "travelTime": {
+        "lock": true,
+        "time": 9,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 48,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 348
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 12,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 192
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 3,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 183
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 57,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 357
+      },
+      "numberOfStops": 0,
+      "trainrunId": 87,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 3294, "y": 80},
+          {"x": 3230, "y": 80},
+          {"x": 2914, "y": 80},
+          {"x": 2850, "y": 80}
+        ],
+        "textPositions": {
+          "0": {"x": 3276, "y": 68},
+          "1": {"x": 3248, "y": 92},
+          "2": {"x": 2868, "y": 92},
+          "3": {"x": 2896, "y": 68},
+          "4": {"x": 3072, "y": 68},
+          "5": {"x": 3072, "y": 68},
+          "6": {"x": 3072, "y": 92}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 579,
+      "sourceNodeId": 135,
+      "sourcePortId": 1173,
+      "targetNodeId": 149,
+      "targetPortId": 1174,
+      "travelTime": {
+        "lock": true,
+        "time": 10,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 4,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 364
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 56,
+        "warning": {
+          "title": "Source Arrival Warning",
+          "description": "Source arrival time cannot be reached"
+        },
+        "timeFormatter": null,
+        "consecutiveTime": 176
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 50,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 170
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 10,
+        "warning": {
+          "title": "Target Arrival Warning",
+          "description": "Target arrival time cannot be reached"
+        },
+        "timeFormatter": null,
+        "consecutiveTime": 370
+      },
+      "numberOfStops": 0,
+      "trainrunId": 87,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2654, "y": 144},
+          {"x": 2590, "y": 144},
+          {"x": 2402, "y": 144},
+          {"x": 2338, "y": 144}
+        ],
+        "textPositions": {
+          "0": {"x": 2636, "y": 132},
+          "1": {"x": 2608, "y": 156},
+          "2": {"x": 2356, "y": 156},
+          "3": {"x": 2384, "y": 132},
+          "4": {"x": 2496, "y": 132},
+          "5": {"x": 2496, "y": 132},
+          "6": {"x": 2496, "y": 156}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 580,
+      "sourceNodeId": 149,
+      "sourcePortId": 1175,
+      "targetNodeId": 166,
+      "targetPortId": 1176,
+      "travelTime": {
+        "lock": true,
+        "time": 7,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 10,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 370
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 50,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 170
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 43,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 163
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 17,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 377
+      },
+      "numberOfStops": 0,
+      "trainrunId": 87,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2238, "y": 144},
+          {"x": 2174, "y": 144},
+          {"x": 1954, "y": 144},
+          {"x": 1890, "y": 144}
+        ],
+        "textPositions": {
+          "0": {"x": 2220, "y": 132},
+          "1": {"x": 2192, "y": 156},
+          "2": {"x": 1908, "y": 156},
+          "3": {"x": 1936, "y": 132},
+          "4": {"x": 2064, "y": 132},
+          "5": {"x": 2064, "y": 132},
+          "6": {"x": 2064, "y": 156}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 581,
+      "sourceNodeId": 148,
+      "sourcePortId": 1177,
+      "targetNodeId": 147,
+      "targetPortId": 1178,
+      "travelTime": {
+        "lock": true,
+        "time": 5,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 24,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 384
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 36,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 156
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 31,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 151
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 29,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 389
+      },
+      "numberOfStops": 0,
+      "trainrunId": 87,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1342, "y": 144},
+          {"x": 1278, "y": 144},
+          {"x": 1122, "y": 144},
+          {"x": 1058, "y": 144}
+        ],
+        "textPositions": {
+          "0": {"x": 1324, "y": 132},
+          "1": {"x": 1296, "y": 156},
+          "2": {"x": 1076, "y": 156},
+          "3": {"x": 1104, "y": 132},
+          "4": {"x": 1200, "y": 132},
+          "5": {"x": 1200, "y": 132},
+          "6": {"x": 1200, "y": 156}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 582,
+      "sourceNodeId": 147,
+      "sourcePortId": 1179,
+      "targetNodeId": 133,
+      "targetPortId": 1180,
+      "travelTime": {
+        "lock": true,
+        "time": 9,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 31,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 391
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 29,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 149
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 20,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 140
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 40,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 400
+      },
+      "numberOfStops": 0,
+      "trainrunId": 87,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 958, "y": 144},
+          {"x": 894, "y": 144},
+          {"x": 322, "y": 144},
+          {"x": 258, "y": 144}
+        ],
+        "textPositions": {
+          "0": {"x": 940, "y": 132},
+          "1": {"x": 912, "y": 156},
+          "2": {"x": 276, "y": 156},
+          "3": {"x": 304, "y": 132},
+          "4": {"x": 608, "y": 132},
+          "5": {"x": 608, "y": 132},
+          "6": {"x": 608, "y": 156}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 583,
+      "sourceNodeId": 133,
+      "sourcePortId": 1181,
+      "targetNodeId": 175,
+      "targetPortId": 1182,
+      "travelTime": {
+        "lock": true,
+        "time": 17,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 42,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 402
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 18,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 138
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 1,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 121
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 59,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 419
+      },
+      "numberOfStops": 0,
+      "trainrunId": 87,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 62, "y": 112},
+          {"x": -2, "y": 112},
+          {"x": -1534, "y": -16},
+          {"x": -1598, "y": -16}
+        ],
+        "textPositions": {
+          "0": {"x": 44, "y": 100},
+          "1": {"x": 16, "y": 124},
+          "2": {"x": -1580, "y": -4},
+          "3": {"x": -1552, "y": -28},
+          "4": {"x": -768, "y": 36},
+          "5": {"x": -768, "y": 36},
+          "6": {"x": -768, "y": 60}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 584,
+      "sourceNodeId": 130,
+      "sourcePortId": 1183,
+      "targetNodeId": 177,
+      "targetPortId": 1184,
+      "travelTime": {
+        "lock": false,
+        "time": 61,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 17,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 437
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 43,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 103
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 42,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 42
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 18,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 498
+      },
+      "numberOfStops": 2,
+      "trainrunId": 87,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -2530, "y": -16},
+          {"x": -2594, "y": -16},
+          {"x": -3358, "y": 560},
+          {"x": -3422, "y": 560}
+        ],
+        "textPositions": {
+          "0": {"x": -2548, "y": -28},
+          "1": {"x": -2576, "y": -4},
+          "2": {"x": -3404, "y": 572},
+          "3": {"x": -3376, "y": 548},
+          "4": {"x": -2976, "y": 260},
+          "5": {"x": -2976, "y": 260},
+          "6": {"x": -2976, "y": 284}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 585,
+      "sourceNodeId": 160,
+      "sourcePortId": 1185,
+      "targetNodeId": 161,
+      "targetPortId": 1186,
+      "travelTime": {
+        "lock": true,
+        "time": 8,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 48,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 528
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 12,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 12
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 4,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 4
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 56,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 536
+      },
+      "numberOfStops": 0,
+      "trainrunId": 87,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -3938, "y": 656},
+          {"x": -4002, "y": 656},
+          {"x": -4190, "y": 656},
+          {"x": -4254, "y": 656}
+        ],
+        "textPositions": {
+          "0": {"x": -3956, "y": 644},
+          "1": {"x": -3984, "y": 668},
+          "2": {"x": -4236, "y": 668},
+          "3": {"x": -4208, "y": 644},
+          "4": {"x": -4096, "y": 644},
+          "5": {"x": -4096, "y": 644},
+          "6": {"x": -4096, "y": 668}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 586,
+      "sourceNodeId": 128,
+      "sourcePortId": 1187,
+      "targetNodeId": 177,
+      "targetPortId": 1188,
+      "travelTime": {
+        "lock": false,
+        "time": 11,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 19,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 439
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 41,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 101
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 30,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 90
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 30,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 450
+      },
+      "numberOfStops": 0,
+      "trainrunId": 81,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -3074, "y": 592},
+          {"x": -3138, "y": 592},
+          {"x": -3358, "y": 624},
+          {"x": -3422, "y": 624}
+        ],
+        "textPositions": {
+          "0": {"x": -3092, "y": 580},
+          "1": {"x": -3120, "y": 604},
+          "2": {"x": -3404, "y": 636},
+          "3": {"x": -3376, "y": 612},
+          "4": {"x": -3248, "y": 596},
+          "5": {"x": -3248, "y": 596},
+          "6": {"x": -3248, "y": 620}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 587,
+      "sourceNodeId": 160,
+      "sourcePortId": 1189,
+      "targetNodeId": 161,
+      "targetPortId": 1190,
+      "travelTime": {
+        "lock": false,
+        "time": 8,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 4,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 484
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 56,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 56
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 48,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 48
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 12,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 492
+      },
+      "numberOfStops": 0,
+      "trainrunId": 81,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -3938, "y": 688},
+          {"x": -4002, "y": 688},
+          {"x": -4190, "y": 688},
+          {"x": -4254, "y": 688}
+        ],
+        "textPositions": {
+          "0": {"x": -3956, "y": 676},
+          "1": {"x": -3984, "y": 700},
+          "2": {"x": -4236, "y": 700},
+          "3": {"x": -4208, "y": 676},
+          "4": {"x": -4096, "y": 676},
+          "5": {"x": -4096, "y": 676},
+          "6": {"x": -4096, "y": 700}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 588,
+      "sourceNodeId": 135,
+      "sourcePortId": 1191,
+      "targetNodeId": 150,
+      "targetPortId": 1192,
+      "travelTime": {
+        "lock": true,
+        "time": 12,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 39,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 219
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 21,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 321
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 9,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 309
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 51,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 231
+      },
+      "numberOfStops": 1,
+      "trainrunId": 88,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2850, "y": 48},
+          {"x": 2914, "y": 48},
+          {"x": 3230, "y": 48},
+          {"x": 3294, "y": 48}
+        ],
+        "textPositions": {
+          "0": {"x": 2868, "y": 60},
+          "1": {"x": 2896, "y": 36},
+          "2": {"x": 3276, "y": 36},
+          "3": {"x": 3248, "y": 60},
+          "4": {"x": 3072, "y": 36},
+          "5": {"x": 3072, "y": 36},
+          "6": {"x": 3072, "y": 60}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 589,
+      "sourceNodeId": 150,
+      "sourcePortId": 1193,
+      "targetNodeId": 151,
+      "targetPortId": 1194,
+      "travelTime": {
+        "lock": true,
+        "time": 13,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 53,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 233
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 7,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 307
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 54,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 294
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 6,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 246
+      },
+      "numberOfStops": 0,
+      "trainrunId": 88,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 3394, "y": 48},
+          {"x": 3458, "y": 48},
+          {"x": 3806, "y": 48},
+          {"x": 3870, "y": 48}
+        ],
+        "textPositions": {
+          "0": {"x": 3412, "y": 60},
+          "1": {"x": 3440, "y": 36},
+          "2": {"x": 3852, "y": 36},
+          "3": {"x": 3824, "y": 60},
+          "4": {"x": 3632, "y": 36},
+          "5": {"x": 3632, "y": 36},
+          "6": {"x": 3632, "y": 60}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 590,
+      "sourceNodeId": 135,
+      "sourcePortId": 1195,
+      "targetNodeId": 149,
+      "targetPortId": 1196,
+      "travelTime": {
+        "lock": true,
+        "time": 5,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 46,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 346
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 14,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 194
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 9,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 189
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 51,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 351
+      },
+      "numberOfStops": 0,
+      "trainrunId": 88,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2654, "y": 48},
+          {"x": 2590, "y": 48},
+          {"x": 2402, "y": 48},
+          {"x": 2338, "y": 48}
+        ],
+        "textPositions": {
+          "0": {"x": 2636, "y": 36},
+          "1": {"x": 2608, "y": 60},
+          "2": {"x": 2356, "y": 60},
+          "3": {"x": 2384, "y": 36},
+          "4": {"x": 2496, "y": 36},
+          "5": {"x": 2496, "y": 36},
+          "6": {"x": 2496, "y": 60}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 591,
+      "sourceNodeId": 149,
+      "sourcePortId": 1197,
+      "targetNodeId": 166,
+      "targetPortId": 1198,
+      "travelTime": {
+        "lock": true,
+        "time": 5,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 51,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 351
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 9,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 189
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 4,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 184
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 56,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 356
+      },
+      "numberOfStops": 0,
+      "trainrunId": 88,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2238, "y": 48},
+          {"x": 2174, "y": 48},
+          {"x": 1954, "y": 48},
+          {"x": 1890, "y": 48}
+        ],
+        "textPositions": {
+          "0": {"x": 2220, "y": 36},
+          "1": {"x": 2192, "y": 60},
+          "2": {"x": 1908, "y": 60},
+          "3": {"x": 1936, "y": 36},
+          "4": {"x": 2064, "y": 36},
+          "5": {"x": 2064, "y": 36},
+          "6": {"x": 2064, "y": 60}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 592,
+      "sourceNodeId": 148,
+      "sourcePortId": 1199,
+      "targetNodeId": 147,
+      "targetPortId": 1200,
+      "travelTime": {
+        "lock": true,
+        "time": 4,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 1,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 361
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 59,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 179
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 55,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 175
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 5,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 365
+      },
+      "numberOfStops": 0,
+      "trainrunId": 88,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1342, "y": 48},
+          {"x": 1278, "y": 48},
+          {"x": 1122, "y": 48},
+          {"x": 1058, "y": 48}
+        ],
+        "textPositions": {
+          "0": {"x": 1324, "y": 36},
+          "1": {"x": 1296, "y": 60},
+          "2": {"x": 1076, "y": 60},
+          "3": {"x": 1104, "y": 36},
+          "4": {"x": 1200, "y": 36},
+          "5": {"x": 1200, "y": 36},
+          "6": {"x": 1200, "y": 60}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 593,
+      "sourceNodeId": 147,
+      "sourcePortId": 1201,
+      "targetNodeId": 133,
+      "targetPortId": 1202,
+      "travelTime": {
+        "lock": true,
+        "time": 5,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 5,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 365
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 55,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 175
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 50,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 170
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 10,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 370
+      },
+      "numberOfStops": 0,
+      "trainrunId": 88,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 958, "y": 112},
+          {"x": 894, "y": 112},
+          {"x": 322, "y": 112},
+          {"x": 258, "y": 112}
+        ],
+        "textPositions": {
+          "0": {"x": 940, "y": 100},
+          "1": {"x": 912, "y": 124},
+          "2": {"x": 276, "y": 124},
+          "3": {"x": 304, "y": 100},
+          "4": {"x": 608, "y": 100},
+          "5": {"x": 608, "y": 100},
+          "6": {"x": 608, "y": 124}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 594,
+      "sourceNodeId": 133,
+      "sourcePortId": 1203,
+      "targetNodeId": 172,
+      "targetPortId": 1204,
+      "travelTime": {
+        "lock": true,
+        "time": 7,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 10,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 370
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 50,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 170
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 43,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 163
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 17,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 377
+      },
+      "numberOfStops": 0,
+      "trainrunId": 88,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 62, "y": 144},
+          {"x": -2, "y": 144},
+          {"x": -446, "y": 144},
+          {"x": -510, "y": 144}
+        ],
+        "textPositions": {
+          "0": {"x": 44, "y": 132},
+          "1": {"x": 16, "y": 156},
+          "2": {"x": -492, "y": 156},
+          "3": {"x": -464, "y": 132},
+          "4": {"x": -224, "y": 132},
+          "5": {"x": -224, "y": 132},
+          "6": {"x": -224, "y": 156}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 595,
+      "sourceNodeId": 129,
+      "sourcePortId": 1205,
+      "targetNodeId": 171,
+      "targetPortId": 1206,
+      "travelTime": {
+        "lock": true,
+        "time": 22,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 30,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 390
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 30,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 150
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 8,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 128
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 52,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 412
+      },
+      "numberOfStops": 0,
+      "trainrunId": 88,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -2146, "y": 144},
+          {"x": -2210, "y": 144},
+          {"x": -2398, "y": 304},
+          {"x": -2462, "y": 304}
+        ],
+        "textPositions": {
+          "0": {"x": -2164, "y": 132},
+          "1": {"x": -2192, "y": 156},
+          "2": {"x": -2444, "y": 316},
+          "3": {"x": -2416, "y": 292},
+          "4": {"x": -2304, "y": 212},
+          "5": {"x": -2304, "y": 212},
+          "6": {"x": -2304, "y": 236}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 596,
+      "sourceNodeId": 128,
+      "sourcePortId": 1207,
+      "targetNodeId": 177,
+      "targetPortId": 1208,
+      "travelTime": {
+        "lock": true,
+        "time": 9,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 43,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 463
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 17,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 77
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 8,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 68
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 52,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 472
+      },
+      "numberOfStops": 0,
+      "trainrunId": 88,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -3074, "y": 560},
+          {"x": -3138, "y": 560},
+          {"x": -3358, "y": 592},
+          {"x": -3422, "y": 592}
+        ],
+        "textPositions": {
+          "0": {"x": -3092, "y": 548},
+          "1": {"x": -3120, "y": 572},
+          "2": {"x": -3404, "y": 604},
+          "3": {"x": -3376, "y": 580},
+          "4": {"x": -3248, "y": 564},
+          "5": {"x": -3248, "y": 564},
+          "6": {"x": -3248, "y": 588}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 597,
+      "sourceNodeId": 160,
+      "sourcePortId": 1209,
+      "targetNodeId": 161,
+      "targetPortId": 1210,
+      "travelTime": {
+        "lock": true,
+        "time": 7,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 21,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 501
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 39,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 39
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 32,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 32
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 28,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 508
+      },
+      "numberOfStops": 0,
+      "trainrunId": 88,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -3938, "y": 624},
+          {"x": -4002, "y": 624},
+          {"x": -4190, "y": 624},
+          {"x": -4254, "y": 624}
+        ],
+        "textPositions": {
+          "0": {"x": -3956, "y": 612},
+          "1": {"x": -3984, "y": 636},
+          "2": {"x": -4236, "y": 636},
+          "3": {"x": -4208, "y": 612},
+          "4": {"x": -4096, "y": 612},
+          "5": {"x": -4096, "y": 612},
+          "6": {"x": -4096, "y": 636}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 598,
+      "sourceNodeId": 151,
+      "sourcePortId": 1211,
+      "targetNodeId": 137,
+      "targetPortId": 1212,
+      "travelTime": {
+        "lock": false,
+        "time": 44,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 8,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 248
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 52,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 292
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 8,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 248
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 52,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 292
+      },
+      "numberOfStops": 4,
+      "trainrunId": 88,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 3970, "y": 112},
+          {"x": 4034, "y": 112},
+          {"x": 4574, "y": 112},
+          {"x": 4638, "y": 112}
+        ],
+        "textPositions": {
+          "0": {"x": 3988, "y": 124},
+          "1": {"x": 4016, "y": 100},
+          "2": {"x": 4620, "y": 100},
+          "3": {"x": 4592, "y": 124},
+          "4": {"x": 4304, "y": 100},
+          "5": {"x": 4304, "y": 100},
+          "6": {"x": 4304, "y": 124}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 599,
+      "sourceNodeId": 135,
+      "sourcePortId": 1213,
+      "targetNodeId": 150,
+      "targetPortId": 1214,
+      "travelTime": {
+        "lock": true,
+        "time": 9,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 5,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 125
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 55,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 295
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 46,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 286
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 14,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 134
+      },
+      "numberOfStops": 0,
+      "trainrunId": 89,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2850, "y": 112},
+          {"x": 2914, "y": 112},
+          {"x": 3230, "y": 112},
+          {"x": 3294, "y": 112}
+        ],
+        "textPositions": {
+          "0": {"x": 2868, "y": 124},
+          "1": {"x": 2896, "y": 100},
+          "2": {"x": 3276, "y": 100},
+          "3": {"x": 3248, "y": 124},
+          "4": {"x": 3072, "y": 100},
+          "5": {"x": 3072, "y": 100},
+          "6": {"x": 3072, "y": 124}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 600,
+      "sourceNodeId": 150,
+      "sourcePortId": 1215,
+      "targetNodeId": 151,
+      "targetPortId": 1216,
+      "travelTime": {
+        "lock": true,
+        "time": 13,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 16,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 136
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 44,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 284
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 31,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 271
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 29,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 149
+      },
+      "numberOfStops": 0,
+      "trainrunId": 89,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 3394, "y": 112},
+          {"x": 3458, "y": 112},
+          {"x": 3806, "y": 112},
+          {"x": 3870, "y": 112}
+        ],
+        "textPositions": {
+          "0": {"x": 3412, "y": 124},
+          "1": {"x": 3440, "y": 100},
+          "2": {"x": 3852, "y": 100},
+          "3": {"x": 3824, "y": 124},
+          "4": {"x": 3632, "y": 100},
+          "5": {"x": 3632, "y": 100},
+          "6": {"x": 3632, "y": 124}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 601,
+      "sourceNodeId": 135,
+      "sourcePortId": 1217,
+      "targetNodeId": 149,
+      "targetPortId": 1218,
+      "travelTime": {
+        "lock": true,
+        "time": 6,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 2,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 302
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 58,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 118
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 52,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 112
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 8,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 308
+      },
+      "numberOfStops": 0,
+      "trainrunId": 89,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2654, "y": 176},
+          {"x": 2590, "y": 176},
+          {"x": 2402, "y": 176},
+          {"x": 2338, "y": 176}
+        ],
+        "textPositions": {
+          "0": {"x": 2636, "y": 164},
+          "1": {"x": 2608, "y": 188},
+          "2": {"x": 2356, "y": 188},
+          "3": {"x": 2384, "y": 164},
+          "4": {"x": 2496, "y": 164},
+          "5": {"x": 2496, "y": 164},
+          "6": {"x": 2496, "y": 188}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 602,
+      "sourceNodeId": 149,
+      "sourcePortId": 1219,
+      "targetNodeId": 166,
+      "targetPortId": 1220,
+      "travelTime": {
+        "lock": true,
+        "time": 6,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 8,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 308
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 52,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 112
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 46,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 106
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 14,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 314
+      },
+      "numberOfStops": 0,
+      "trainrunId": 89,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2238, "y": 176},
+          {"x": 2174, "y": 176},
+          {"x": 1954, "y": 176},
+          {"x": 1890, "y": 176}
+        ],
+        "textPositions": {
+          "0": {"x": 2220, "y": 164},
+          "1": {"x": 2192, "y": 188},
+          "2": {"x": 1908, "y": 188},
+          "3": {"x": 1936, "y": 164},
+          "4": {"x": 2064, "y": 164},
+          "5": {"x": 2064, "y": 164},
+          "6": {"x": 2064, "y": 188}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 603,
+      "sourceNodeId": 148,
+      "sourcePortId": 1221,
+      "targetNodeId": 147,
+      "targetPortId": 1222,
+      "travelTime": {
+        "lock": true,
+        "time": 5,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 20,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 320
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 40,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 100
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 35,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 95
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 25,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 325
+      },
+      "numberOfStops": 0,
+      "trainrunId": 89,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1342, "y": 176},
+          {"x": 1278, "y": 176},
+          {"x": 1122, "y": 176},
+          {"x": 1058, "y": 176}
+        ],
+        "textPositions": {
+          "0": {"x": 1324, "y": 164},
+          "1": {"x": 1296, "y": 188},
+          "2": {"x": 1076, "y": 188},
+          "3": {"x": 1104, "y": 164},
+          "4": {"x": 1200, "y": 164},
+          "5": {"x": 1200, "y": 164},
+          "6": {"x": 1200, "y": 188}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 604,
+      "sourceNodeId": 147,
+      "sourcePortId": 1223,
+      "targetNodeId": 133,
+      "targetPortId": 1224,
+      "travelTime": {
+        "lock": true,
+        "time": 5,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 25,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 325
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 35,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 95
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 30,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 90
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 30,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 330
+      },
+      "numberOfStops": 0,
+      "trainrunId": 89,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 958, "y": 176},
+          {"x": 894, "y": 176},
+          {"x": 322, "y": 176},
+          {"x": 258, "y": 176}
+        ],
+        "textPositions": {
+          "0": {"x": 940, "y": 164},
+          "1": {"x": 912, "y": 188},
+          "2": {"x": 276, "y": 188},
+          "3": {"x": 304, "y": 164},
+          "4": {"x": 608, "y": 164},
+          "5": {"x": 608, "y": 164},
+          "6": {"x": 608, "y": 188}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 605,
+      "sourceNodeId": 133,
+      "sourcePortId": 1225,
+      "targetNodeId": 172,
+      "targetPortId": 1226,
+      "travelTime": {
+        "lock": true,
+        "time": 7,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 30,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 330
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 30,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 90
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 23,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 83
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 37,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 337
+      },
+      "numberOfStops": 0,
+      "trainrunId": 89,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 62, "y": 240},
+          {"x": -2, "y": 240},
+          {"x": -446, "y": 240},
+          {"x": -510, "y": 240}
+        ],
+        "textPositions": {
+          "0": {"x": 44, "y": 228},
+          "1": {"x": 16, "y": 252},
+          "2": {"x": -492, "y": 252},
+          "3": {"x": -464, "y": 228},
+          "4": {"x": -224, "y": 228},
+          "5": {"x": -224, "y": 228},
+          "6": {"x": -224, "y": 252}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 606,
+      "sourceNodeId": 151,
+      "sourcePortId": 1227,
+      "targetNodeId": 162,
+      "targetPortId": 1228,
+      "travelTime": {
+        "lock": true,
+        "time": 51,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 31,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 151
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 29,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 269
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 38,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 218
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 22,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 202
+      },
+      "numberOfStops": 0,
+      "trainrunId": 89,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 3970, "y": 48},
+          {"x": 4034, "y": 48},
+          {"x": 4574, "y": -176},
+          {"x": 4638, "y": -176}
+        ],
+        "textPositions": {
+          "0": {"x": 3988, "y": 60},
+          "1": {"x": 4016, "y": 36},
+          "2": {"x": 4620, "y": -188},
+          "3": {"x": 4592, "y": -164},
+          "4": {"x": 4304, "y": -76},
+          "5": {"x": 4304, "y": -76},
+          "6": {"x": 4304, "y": -52}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 607,
+      "sourceNodeId": 135,
+      "sourcePortId": 1229,
+      "targetNodeId": 150,
+      "targetPortId": 1230,
+      "travelTime": {
+        "lock": true,
+        "time": 9,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 5,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 125
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 55,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 295
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 46,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 286
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 14,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 134
+      },
+      "numberOfStops": 0,
+      "trainrunId": 90,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2850, "y": 144},
+          {"x": 2914, "y": 144},
+          {"x": 3230, "y": 144},
+          {"x": 3294, "y": 144}
+        ],
+        "textPositions": {
+          "0": {"x": 2868, "y": 156},
+          "1": {"x": 2896, "y": 132},
+          "2": {"x": 3276, "y": 132},
+          "3": {"x": 3248, "y": 156},
+          "4": {"x": 3072, "y": 132},
+          "5": {"x": 3072, "y": 132},
+          "6": {"x": 3072, "y": 156}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 608,
+      "sourceNodeId": 150,
+      "sourcePortId": 1231,
+      "targetNodeId": 151,
+      "targetPortId": 1232,
+      "travelTime": {
+        "lock": true,
+        "time": 13,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 16,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 136
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 44,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 284
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 31,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 271
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 29,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 149
+      },
+      "numberOfStops": 0,
+      "trainrunId": 90,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 3394, "y": 144},
+          {"x": 3458, "y": 144},
+          {"x": 3806, "y": 144},
+          {"x": 3870, "y": 144}
+        ],
+        "textPositions": {
+          "0": {"x": 3412, "y": 156},
+          "1": {"x": 3440, "y": 132},
+          "2": {"x": 3852, "y": 132},
+          "3": {"x": 3824, "y": 156},
+          "4": {"x": 3632, "y": 132},
+          "5": {"x": 3632, "y": 132},
+          "6": {"x": 3632, "y": 156}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 609,
+      "sourceNodeId": 135,
+      "sourcePortId": 1233,
+      "targetNodeId": 149,
+      "targetPortId": 1234,
+      "travelTime": {
+        "lock": true,
+        "time": 15,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 2,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 302
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 58,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 118
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 43,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 103
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 17,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 317
+      },
+      "numberOfStops": 0,
+      "trainrunId": 90,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2654, "y": 208},
+          {"x": 2590, "y": 208},
+          {"x": 2402, "y": 208},
+          {"x": 2338, "y": 208}
+        ],
+        "textPositions": {
+          "0": {"x": 2636, "y": 196},
+          "1": {"x": 2608, "y": 220},
+          "2": {"x": 2356, "y": 220},
+          "3": {"x": 2384, "y": 196},
+          "4": {"x": 2496, "y": 196},
+          "5": {"x": 2496, "y": 196},
+          "6": {"x": 2496, "y": 220}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 610,
+      "sourceNodeId": 149,
+      "sourcePortId": 1235,
+      "targetNodeId": 166,
+      "targetPortId": 1236,
+      "travelTime": {
+        "lock": true,
+        "time": 6,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 17,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 317
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 43,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 103
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 37,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 97
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 23,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 323
+      },
+      "numberOfStops": 0,
+      "trainrunId": 90,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2238, "y": 208},
+          {"x": 2174, "y": 208},
+          {"x": 1954, "y": 208},
+          {"x": 1890, "y": 208}
+        ],
+        "textPositions": {
+          "0": {"x": 2220, "y": 196},
+          "1": {"x": 2192, "y": 220},
+          "2": {"x": 1908, "y": 220},
+          "3": {"x": 1936, "y": 196},
+          "4": {"x": 2064, "y": 196},
+          "5": {"x": 2064, "y": 196},
+          "6": {"x": 2064, "y": 220}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 611,
+      "sourceNodeId": 148,
+      "sourcePortId": 1237,
+      "targetNodeId": 147,
+      "targetPortId": 1238,
+      "travelTime": {
+        "lock": true,
+        "time": 5,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 30,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 330
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 30,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 90
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 25,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 85
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 35,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 335
+      },
+      "numberOfStops": 0,
+      "trainrunId": 90,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1342, "y": 208},
+          {"x": 1278, "y": 208},
+          {"x": 1122, "y": 208},
+          {"x": 1058, "y": 208}
+        ],
+        "textPositions": {
+          "0": {"x": 1324, "y": 196},
+          "1": {"x": 1296, "y": 220},
+          "2": {"x": 1076, "y": 220},
+          "3": {"x": 1104, "y": 196},
+          "4": {"x": 1200, "y": 196},
+          "5": {"x": 1200, "y": 196},
+          "6": {"x": 1200, "y": 220}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 612,
+      "sourceNodeId": 147,
+      "sourcePortId": 1239,
+      "targetNodeId": 133,
+      "targetPortId": 1240,
+      "travelTime": {
+        "lock": true,
+        "time": 5,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 35,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 335
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 25,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 85
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 20,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 80
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 40,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 340
+      },
+      "numberOfStops": 0,
+      "trainrunId": 90,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 958, "y": 208},
+          {"x": 894, "y": 208},
+          {"x": 322, "y": 208},
+          {"x": 258, "y": 208}
+        ],
+        "textPositions": {
+          "0": {"x": 940, "y": 196},
+          "1": {"x": 912, "y": 220},
+          "2": {"x": 276, "y": 220},
+          "3": {"x": 304, "y": 196},
+          "4": {"x": 608, "y": 196},
+          "5": {"x": 608, "y": 196},
+          "6": {"x": 608, "y": 220}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 613,
+      "sourceNodeId": 133,
+      "sourcePortId": 1241,
+      "targetNodeId": 172,
+      "targetPortId": 1242,
+      "travelTime": {
+        "lock": true,
+        "time": 7,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 40,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 340
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 20,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 80
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 13,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 73
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 47,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 347
+      },
+      "numberOfStops": 0,
+      "trainrunId": 90,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 62, "y": 272},
+          {"x": -2, "y": 272},
+          {"x": -446, "y": 272},
+          {"x": -510, "y": 272}
+        ],
+        "textPositions": {
+          "0": {"x": 44, "y": 260},
+          "1": {"x": 16, "y": 284},
+          "2": {"x": -492, "y": 284},
+          "3": {"x": -464, "y": 260},
+          "4": {"x": -224, "y": 260},
+          "5": {"x": -224, "y": 260},
+          "6": {"x": -224, "y": 284}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 614,
+      "sourceNodeId": 151,
+      "sourcePortId": 1243,
+      "targetNodeId": 162,
+      "targetPortId": 1244,
+      "travelTime": {
+        "lock": true,
+        "time": 41,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 31,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 151
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 29,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 269
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 48,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 228
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 12,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 192
+      },
+      "numberOfStops": 0,
+      "trainrunId": 90,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 3970, "y": 80},
+          {"x": 4034, "y": 80},
+          {"x": 4574, "y": -144},
+          {"x": 4638, "y": -144}
+        ],
+        "textPositions": {
+          "0": {"x": 3988, "y": 92},
+          "1": {"x": 4016, "y": 68},
+          "2": {"x": 4620, "y": -156},
+          "3": {"x": 4592, "y": -132},
+          "4": {"x": 4304, "y": -44},
+          "5": {"x": 4304, "y": -44},
+          "6": {"x": 4304, "y": -20}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 615,
+      "sourceNodeId": 135,
+      "sourcePortId": 1245,
+      "targetNodeId": 150,
+      "targetPortId": 1246,
+      "travelTime": {
+        "lock": true,
+        "time": 9,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 35,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 95
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 25,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 205
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 16,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 196
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 44,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 104
+      },
+      "numberOfStops": 0,
+      "trainrunId": 79,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2850, "y": 208},
+          {"x": 2914, "y": 208},
+          {"x": 3230, "y": 208},
+          {"x": 3294, "y": 208}
+        ],
+        "textPositions": {
+          "0": {"x": 2868, "y": 220},
+          "1": {"x": 2896, "y": 196},
+          "2": {"x": 3276, "y": 196},
+          "3": {"x": 3248, "y": 220},
+          "4": {"x": 3072, "y": 196},
+          "5": {"x": 3072, "y": 196},
+          "6": {"x": 3072, "y": 220}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 616,
+      "sourceNodeId": 150,
+      "sourcePortId": 1247,
+      "targetNodeId": 151,
+      "targetPortId": 1248,
+      "travelTime": {
+        "lock": false,
+        "time": 13,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 46,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 106
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 14,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 194
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 1,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 181
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 59,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 119
+      },
+      "numberOfStops": 0,
+      "trainrunId": 79,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 3394, "y": 208},
+          {"x": 3458, "y": 208},
+          {"x": 3806, "y": 208},
+          {"x": 3870, "y": 208}
+        ],
+        "textPositions": {
+          "0": {"x": 3412, "y": 220},
+          "1": {"x": 3440, "y": 196},
+          "2": {"x": 3852, "y": 196},
+          "3": {"x": 3824, "y": 220},
+          "4": {"x": 3632, "y": 196},
+          "5": {"x": 3632, "y": 196},
+          "6": {"x": 3632, "y": 220}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 617,
+      "sourceNodeId": 151,
+      "sourcePortId": 1249,
+      "targetNodeId": 139,
+      "targetPortId": 1250,
+      "travelTime": {
+        "lock": false,
+        "time": 49,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 1,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 121
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 59,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 179
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 10,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 130
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 50,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 170
+      },
+      "numberOfStops": 2,
+      "trainrunId": 79,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 3888, "y": 30},
+          {"x": 3888, "y": -34},
+          {"x": 4272, "y": -286},
+          {"x": 4272, "y": -350}
+        ],
+        "textPositions": {
+          "0": {"x": 3900, "y": 12},
+          "1": {"x": 3876, "y": -16},
+          "2": {"x": 4260, "y": -332},
+          "3": {"x": 4284, "y": -304},
+          "4": {"x": 4068, "y": -160},
+          "5": {"x": 4068, "y": -160},
+          "6": {"x": 4092, "y": -160}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 618,
+      "sourceNodeId": 138,
+      "sourcePortId": 1251,
+      "targetNodeId": 163,
+      "targetPortId": 1252,
+      "travelTime": {
+        "lock": true,
+        "time": 1,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 0,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 0
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 0,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 60
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 59,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 59
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 1,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "numberOfStops": 0,
+      "trainrunId": 91,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2672, "y": -1054},
+          {"x": 2672, "y": -990},
+          {"x": 2800, "y": -610},
+          {"x": 2800, "y": -546}
+        ],
+        "textPositions": {
+          "0": {"x": 2660, "y": -1036},
+          "1": {"x": 2684, "y": -1008},
+          "2": {"x": 2812, "y": -564},
+          "3": {"x": 2788, "y": -592},
+          "4": {"x": 2748, "y": -800},
+          "5": {"x": 2748, "y": -800},
+          "6": {"x": 2724, "y": -800}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 619,
+      "sourceNodeId": 163,
+      "sourcePortId": 1253,
+      "targetNodeId": 135,
+      "targetPortId": 1254,
+      "travelTime": {
+        "lock": true,
+        "time": 1,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 3,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 3
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 57,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 57
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 56,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 56
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 4,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 4
+      },
+      "numberOfStops": 0,
+      "trainrunId": 91,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2800, "y": -478},
+          {"x": 2800, "y": -414},
+          {"x": 2704, "y": -34},
+          {"x": 2704, "y": 30}
+        ],
+        "textPositions": {
+          "0": {"x": 2788, "y": -460},
+          "1": {"x": 2812, "y": -432},
+          "2": {"x": 2716, "y": 12},
+          "3": {"x": 2692, "y": -16},
+          "4": {"x": 2740, "y": -224},
+          "5": {"x": 2740, "y": -224},
+          "6": {"x": 2764, "y": -224}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 620,
+      "sourceNodeId": 135,
+      "sourcePortId": 1255,
+      "targetNodeId": 138,
+      "targetPortId": 1256,
+      "travelTime": {
+        "lock": true,
+        "time": 1,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 0,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 120
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 0,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 60
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 59,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 59
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 1,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 121
+      },
+      "numberOfStops": 0,
+      "trainrunId": 92,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2672, "y": 30},
+          {"x": 2672, "y": -34},
+          {"x": 2640, "y": -990},
+          {"x": 2640, "y": -1054}
+        ],
+        "textPositions": {
+          "0": {"x": 2684, "y": 12},
+          "1": {"x": 2660, "y": -16},
+          "2": {"x": 2628, "y": -1036},
+          "3": {"x": 2652, "y": -1008},
+          "4": {"x": 2668, "y": -512},
+          "5": {"x": 2668, "y": -512},
+          "6": {"x": 2644, "y": -512}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 621,
+      "sourceNodeId": 166,
+      "sourcePortId": 1257,
+      "targetNodeId": 148,
+      "targetPortId": 1258,
+      "travelTime": {
+        "lock": true,
+        "time": 5,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 56,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 356
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 4,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 184
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 59,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 179
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 1,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 361
+      },
+      "numberOfStops": 0,
+      "trainrunId": 88,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1790, "y": 48},
+          {"x": 1726, "y": 48},
+          {"x": 1506, "y": 48},
+          {"x": 1442, "y": 48}
+        ],
+        "textPositions": {
+          "0": {"x": 1772, "y": 36},
+          "1": {"x": 1744, "y": 60},
+          "2": {"x": 1460, "y": 60},
+          "3": {"x": 1488, "y": 36},
+          "4": {"x": 1616, "y": 36},
+          "5": {"x": 1616, "y": 36},
+          "6": {"x": 1616, "y": 60}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 622,
+      "sourceNodeId": 166,
+      "sourcePortId": 1259,
+      "targetNodeId": 148,
+      "targetPortId": 1260,
+      "travelTime": {
+        "lock": true,
+        "time": 7,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 17,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 377
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 43,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 163
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 36,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 156
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 24,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 384
+      },
+      "numberOfStops": 0,
+      "trainrunId": 87,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1790, "y": 144},
+          {"x": 1726, "y": 144},
+          {"x": 1506, "y": 144},
+          {"x": 1442, "y": 144}
+        ],
+        "textPositions": {
+          "0": {"x": 1772, "y": 132},
+          "1": {"x": 1744, "y": 156},
+          "2": {"x": 1460, "y": 156},
+          "3": {"x": 1488, "y": 132},
+          "4": {"x": 1616, "y": 132},
+          "5": {"x": 1616, "y": 132},
+          "6": {"x": 1616, "y": 156}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 623,
+      "sourceNodeId": 166,
+      "sourcePortId": 1261,
+      "targetNodeId": 148,
+      "targetPortId": 1262,
+      "travelTime": {
+        "lock": true,
+        "time": 6,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 14,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 314
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 46,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 106
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 40,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 100
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 20,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 320
+      },
+      "numberOfStops": 0,
+      "trainrunId": 89,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1790, "y": 176},
+          {"x": 1726, "y": 176},
+          {"x": 1506, "y": 176},
+          {"x": 1442, "y": 176}
+        ],
+        "textPositions": {
+          "0": {"x": 1772, "y": 164},
+          "1": {"x": 1744, "y": 188},
+          "2": {"x": 1460, "y": 188},
+          "3": {"x": 1488, "y": 164},
+          "4": {"x": 1616, "y": 164},
+          "5": {"x": 1616, "y": 164},
+          "6": {"x": 1616, "y": 188}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 624,
+      "sourceNodeId": 166,
+      "sourcePortId": 1263,
+      "targetNodeId": 148,
+      "targetPortId": 1264,
+      "travelTime": {
+        "lock": true,
+        "time": 5,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 25,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 325
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 35,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 95
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 30,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 90
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 30,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 330
+      },
+      "numberOfStops": 0,
+      "trainrunId": 90,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1790, "y": 208},
+          {"x": 1726, "y": 208},
+          {"x": 1506, "y": 208},
+          {"x": 1442, "y": 208}
+        ],
+        "textPositions": {
+          "0": {"x": 1772, "y": 196},
+          "1": {"x": 1744, "y": 220},
+          "2": {"x": 1460, "y": 220},
+          "3": {"x": 1488, "y": 196},
+          "4": {"x": 1616, "y": 196},
+          "5": {"x": 1616, "y": 196},
+          "6": {"x": 1616, "y": 220}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 625,
+      "sourceNodeId": 166,
+      "sourcePortId": 1265,
+      "targetNodeId": 148,
+      "targetPortId": 1266,
+      "travelTime": {
+        "lock": true,
+        "time": 7,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 8,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 308
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 52,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 112
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 45,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 105
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 15,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 315
+      },
+      "numberOfStops": 0,
+      "trainrunId": 86,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1790, "y": 240},
+          {"x": 1726, "y": 240},
+          {"x": 1506, "y": 240},
+          {"x": 1442, "y": 240}
+        ],
+        "textPositions": {
+          "0": {"x": 1772, "y": 228},
+          "1": {"x": 1744, "y": 252},
+          "2": {"x": 1460, "y": 252},
+          "3": {"x": 1488, "y": 228},
+          "4": {"x": 1616, "y": 228},
+          "5": {"x": 1616, "y": 228},
+          "6": {"x": 1616, "y": 252}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 626,
+      "sourceNodeId": 134,
+      "sourcePortId": 1267,
+      "targetNodeId": 164,
+      "targetPortId": 1268,
+      "travelTime": {
+        "lock": true,
+        "time": 13,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 11,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 11
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 49,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 169
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 36,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 156
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 24,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 24
+      },
+      "numberOfStops": 0,
+      "trainrunId": 93,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 322, "y": -1872},
+          {"x": 386, "y": -1872},
+          {"x": 990, "y": -944},
+          {"x": 1054, "y": -944}
+        ],
+        "textPositions": {
+          "0": {"x": 340, "y": -1860},
+          "1": {"x": 368, "y": -1884},
+          "2": {"x": 1036, "y": -956},
+          "3": {"x": 1008, "y": -932},
+          "4": {"x": 688, "y": -1420},
+          "5": {"x": 688, "y": -1420},
+          "6": {"x": 688, "y": -1396}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 627,
+      "sourceNodeId": 164,
+      "sourcePortId": 1269,
+      "targetNodeId": 165,
+      "targetPortId": 1270,
+      "travelTime": {
+        "lock": true,
+        "time": 9,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 25,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 25
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 35,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 155
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 26,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 146
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 34,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 34
+      },
+      "numberOfStops": 0,
+      "trainrunId": 93,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1154, "y": -944},
+          {"x": 1218, "y": -944},
+          {"x": 1726, "y": -656},
+          {"x": 1790, "y": -656}
+        ],
+        "textPositions": {
+          "0": {"x": 1172, "y": -932},
+          "1": {"x": 1200, "y": -956},
+          "2": {"x": 1772, "y": -668},
+          "3": {"x": 1744, "y": -644},
+          "4": {"x": 1472, "y": -812},
+          "5": {"x": 1472, "y": -812},
+          "6": {"x": 1472, "y": -788}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 628,
+      "sourceNodeId": 165,
+      "sourcePortId": 1271,
+      "targetNodeId": 166,
+      "targetPortId": 1272,
+      "travelTime": {
+        "lock": true,
+        "time": 22,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 35,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 35
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 25,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 145
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 3,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 123
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 57,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 57
+      },
+      "numberOfStops": 0,
+      "trainrunId": 93,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1808, "y": -606},
+          {"x": 1808, "y": -542},
+          {"x": 1808, "y": -34},
+          {"x": 1808, "y": 30}
+        ],
+        "textPositions": {
+          "0": {"x": 1796, "y": -588},
+          "1": {"x": 1820, "y": -560},
+          "2": {"x": 1820, "y": 12},
+          "3": {"x": 1796, "y": -16},
+          "4": {"x": 1796, "y": -288},
+          "5": {"x": 1796, "y": -288},
+          "6": {"x": 1820, "y": -288}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 629,
+      "sourceNodeId": 166,
+      "sourcePortId": 1273,
+      "targetNodeId": 149,
+      "targetPortId": 1274,
+      "travelTime": {
+        "lock": true,
+        "time": 7,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 0,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 60
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 0,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 120
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 53,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 113
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 7,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 67
+      },
+      "numberOfStops": 0,
+      "trainrunId": 93,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1890, "y": 272},
+          {"x": 1954, "y": 272},
+          {"x": 2174, "y": 272},
+          {"x": 2238, "y": 272}
+        ],
+        "textPositions": {
+          "0": {"x": 1908, "y": 284},
+          "1": {"x": 1936, "y": 260},
+          "2": {"x": 2220, "y": 260},
+          "3": {"x": 2192, "y": 284},
+          "4": {"x": 2064, "y": 260},
+          "5": {"x": 2064, "y": 260},
+          "6": {"x": 2064, "y": 284}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 630,
+      "sourceNodeId": 149,
+      "sourcePortId": 1275,
+      "targetNodeId": 135,
+      "targetPortId": 1276,
+      "travelTime": {
+        "lock": true,
+        "time": 16,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 8,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 68
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 52,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 112
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 36,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 96
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 24,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 84
+      },
+      "numberOfStops": 0,
+      "trainrunId": 93,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2338, "y": 272},
+          {"x": 2402, "y": 272},
+          {"x": 2590, "y": 272},
+          {"x": 2654, "y": 272}
+        ],
+        "textPositions": {
+          "0": {"x": 2356, "y": 284},
+          "1": {"x": 2384, "y": 260},
+          "2": {"x": 2636, "y": 260},
+          "3": {"x": 2608, "y": 284},
+          "4": {"x": 2496, "y": 260},
+          "5": {"x": 2496, "y": 260},
+          "6": {"x": 2496, "y": 284}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 631,
+      "sourceNodeId": 134,
+      "sourcePortId": 1277,
+      "targetNodeId": 146,
+      "targetPortId": 1278,
+      "travelTime": {
+        "lock": true,
+        "time": 5,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 6,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 6
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 54,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 174
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 49,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 169
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 11,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 11
+      },
+      "numberOfStops": 0,
+      "trainrunId": 94,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 144, "y": -1822},
+          {"x": 144, "y": -1758},
+          {"x": 144, "y": -1474},
+          {"x": 144, "y": -1410}
+        ],
+        "textPositions": {
+          "0": {"x": 132, "y": -1804},
+          "1": {"x": 156, "y": -1776},
+          "2": {"x": 156, "y": -1428},
+          "3": {"x": 132, "y": -1456},
+          "4": {"x": 132, "y": -1616},
+          "5": {"x": 132, "y": -1616},
+          "6": {"x": 156, "y": -1616}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 632,
+      "sourceNodeId": 146,
+      "sourcePortId": 1279,
+      "targetNodeId": 145,
+      "targetPortId": 1280,
+      "travelTime": {
+        "lock": true,
+        "time": 6,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 11,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 11
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 49,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 169
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 43,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 163
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 17,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 17
+      },
+      "numberOfStops": 0,
+      "trainrunId": 94,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 144, "y": -1342},
+          {"x": 144, "y": -1278},
+          {"x": 144, "y": -994},
+          {"x": 144, "y": -930}
+        ],
+        "textPositions": {
+          "0": {"x": 132, "y": -1324},
+          "1": {"x": 156, "y": -1296},
+          "2": {"x": 156, "y": -948},
+          "3": {"x": 132, "y": -976},
+          "4": {"x": 132, "y": -1136},
+          "5": {"x": 132, "y": -1136},
+          "6": {"x": 156, "y": -1136}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 633,
+      "sourceNodeId": 145,
+      "sourcePortId": 1281,
+      "targetNodeId": 144,
+      "targetPortId": 1282,
+      "travelTime": {
+        "lock": true,
+        "time": 6,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 17,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 17
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 43,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 163
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 37,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 157
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 23,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 23
+      },
+      "numberOfStops": 0,
+      "trainrunId": 94,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 144, "y": -862},
+          {"x": 144, "y": -798},
+          {"x": 144, "y": -514},
+          {"x": 144, "y": -450}
+        ],
+        "textPositions": {
+          "0": {"x": 132, "y": -844},
+          "1": {"x": 156, "y": -816},
+          "2": {"x": 156, "y": -468},
+          "3": {"x": 132, "y": -496},
+          "4": {"x": 132, "y": -656},
+          "5": {"x": 132, "y": -656},
+          "6": {"x": 156, "y": -656}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 634,
+      "sourceNodeId": 144,
+      "sourcePortId": 1283,
+      "targetNodeId": 147,
+      "targetPortId": 1284,
+      "travelTime": {
+        "lock": true,
+        "time": 10,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 23,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 23
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 37,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 157
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 27,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 147
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 33,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 33
+      },
+      "numberOfStops": 0,
+      "trainrunId": 94,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 322, "y": -400},
+          {"x": 386, "y": -400},
+          {"x": 894, "y": 80},
+          {"x": 958, "y": 80}
+        ],
+        "textPositions": {
+          "0": {"x": 340, "y": -388},
+          "1": {"x": 368, "y": -412},
+          "2": {"x": 940, "y": 68},
+          "3": {"x": 912, "y": 92},
+          "4": {"x": 640, "y": -172},
+          "5": {"x": 640, "y": -172},
+          "6": {"x": 640, "y": -148}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 635,
+      "sourceNodeId": 147,
+      "sourcePortId": 1285,
+      "targetNodeId": 148,
+      "targetPortId": 1286,
+      "travelTime": {
+        "lock": true,
+        "time": 7,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 33,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 33
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 27,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 147
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 20,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 140
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 40,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 40
+      },
+      "numberOfStops": 0,
+      "trainrunId": 94,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1058, "y": 112},
+          {"x": 1122, "y": 112},
+          {"x": 1278, "y": 112},
+          {"x": 1342, "y": 112}
+        ],
+        "textPositions": {
+          "0": {"x": 1076, "y": 124},
+          "1": {"x": 1104, "y": 100},
+          "2": {"x": 1324, "y": 100},
+          "3": {"x": 1296, "y": 124},
+          "4": {"x": 1200, "y": 100},
+          "5": {"x": 1200, "y": 100},
+          "6": {"x": 1200, "y": 124}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 636,
+      "sourceNodeId": 148,
+      "sourcePortId": 1287,
+      "targetNodeId": 166,
+      "targetPortId": 1288,
+      "travelTime": {
+        "lock": true,
+        "time": 6,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 40,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 40
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 20,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 140
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 14,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 134
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 46,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 46
+      },
+      "numberOfStops": 0,
+      "trainrunId": 94,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1442, "y": 112},
+          {"x": 1506, "y": 112},
+          {"x": 1726, "y": 112},
+          {"x": 1790, "y": 112}
+        ],
+        "textPositions": {
+          "0": {"x": 1460, "y": 124},
+          "1": {"x": 1488, "y": 100},
+          "2": {"x": 1772, "y": 100},
+          "3": {"x": 1744, "y": 124},
+          "4": {"x": 1616, "y": 100},
+          "5": {"x": 1616, "y": 100},
+          "6": {"x": 1616, "y": 124}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 637,
+      "sourceNodeId": 166,
+      "sourcePortId": 1289,
+      "targetNodeId": 149,
+      "targetPortId": 1290,
+      "travelTime": {
+        "lock": true,
+        "time": 6,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 46,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 46
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 14,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 134
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 8,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 128
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 52,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 52
+      },
+      "numberOfStops": 0,
+      "trainrunId": 94,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1890, "y": 112},
+          {"x": 1954, "y": 112},
+          {"x": 2174, "y": 112},
+          {"x": 2238, "y": 112}
+        ],
+        "textPositions": {
+          "0": {"x": 1908, "y": 124},
+          "1": {"x": 1936, "y": 100},
+          "2": {"x": 2220, "y": 100},
+          "3": {"x": 2192, "y": 124},
+          "4": {"x": 2064, "y": 100},
+          "5": {"x": 2064, "y": 100},
+          "6": {"x": 2064, "y": 124}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 638,
+      "sourceNodeId": 149,
+      "sourcePortId": 1291,
+      "targetNodeId": 135,
+      "targetPortId": 1292,
+      "travelTime": {
+        "lock": true,
+        "time": 8,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 52,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 52
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 8,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 128
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 0,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 120
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 0,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 60
+      },
+      "numberOfStops": 0,
+      "trainrunId": 94,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2338, "y": 112},
+          {"x": 2402, "y": 112},
+          {"x": 2590, "y": 112},
+          {"x": 2654, "y": 112}
+        ],
+        "textPositions": {
+          "0": {"x": 2356, "y": 124},
+          "1": {"x": 2384, "y": 100},
+          "2": {"x": 2636, "y": 100},
+          "3": {"x": 2608, "y": 124},
+          "4": {"x": 2496, "y": 100},
+          "5": {"x": 2496, "y": 100},
+          "6": {"x": 2496, "y": 124}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 639,
+      "sourceNodeId": 147,
+      "sourcePortId": 1293,
+      "targetNodeId": 148,
+      "targetPortId": 1294,
+      "travelTime": {
+        "lock": true,
+        "time": 6,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 54,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 54
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 6,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 126
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 0,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 120
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 0,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 60
+      },
+      "numberOfStops": 0,
+      "trainrunId": 97,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1058, "y": 272},
+          {"x": 1122, "y": 272},
+          {"x": 1278, "y": 272},
+          {"x": 1342, "y": 272}
+        ],
+        "textPositions": {
+          "0": {"x": 1076, "y": 284},
+          "1": {"x": 1104, "y": 260},
+          "2": {"x": 1324, "y": 260},
+          "3": {"x": 1296, "y": 284},
+          "4": {"x": 1200, "y": 260},
+          "5": {"x": 1200, "y": 260},
+          "6": {"x": 1200, "y": 284}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 640,
+      "sourceNodeId": 148,
+      "sourcePortId": 1295,
+      "targetNodeId": 166,
+      "targetPortId": 1296,
+      "travelTime": {
+        "lock": true,
+        "time": 6,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 2,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 62
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 58,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 118
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 52,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 112
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 8,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 68
+      },
+      "numberOfStops": 0,
+      "trainrunId": 97,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1442, "y": 272},
+          {"x": 1506, "y": 272},
+          {"x": 1726, "y": 272},
+          {"x": 1790, "y": 272}
+        ],
+        "textPositions": {
+          "0": {"x": 1460, "y": 284},
+          "1": {"x": 1488, "y": 260},
+          "2": {"x": 1772, "y": 260},
+          "3": {"x": 1744, "y": 284},
+          "4": {"x": 1616, "y": 260},
+          "5": {"x": 1616, "y": 260},
+          "6": {"x": 1616, "y": 284}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 641,
+      "sourceNodeId": 166,
+      "sourcePortId": 1297,
+      "targetNodeId": 149,
+      "targetPortId": 1298,
+      "travelTime": {
+        "lock": true,
+        "time": 7,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 8,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 68
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 52,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 112
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 45,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 105
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 15,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 75
+      },
+      "numberOfStops": 0,
+      "trainrunId": 97,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1890, "y": 304},
+          {"x": 1954, "y": 304},
+          {"x": 2174, "y": 304},
+          {"x": 2238, "y": 304}
+        ],
+        "textPositions": {
+          "0": {"x": 1908, "y": 316},
+          "1": {"x": 1936, "y": 292},
+          "2": {"x": 2220, "y": 292},
+          "3": {"x": 2192, "y": 316},
+          "4": {"x": 2064, "y": 292},
+          "5": {"x": 2064, "y": 292},
+          "6": {"x": 2064, "y": 316}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 642,
+      "sourceNodeId": 149,
+      "sourcePortId": 1299,
+      "targetNodeId": 135,
+      "targetPortId": 1300,
+      "travelTime": {
+        "lock": true,
+        "time": 7,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 15,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 75
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 45,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 105
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 38,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 98
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 22,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 82
+      },
+      "numberOfStops": 0,
+      "trainrunId": 97,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2338, "y": 304},
+          {"x": 2402, "y": 304},
+          {"x": 2590, "y": 304},
+          {"x": 2654, "y": 304}
+        ],
+        "textPositions": {
+          "0": {"x": 2356, "y": 316},
+          "1": {"x": 2384, "y": 292},
+          "2": {"x": 2636, "y": 292},
+          "3": {"x": 2608, "y": 316},
+          "4": {"x": 2496, "y": 292},
+          "5": {"x": 2496, "y": 292},
+          "6": {"x": 2496, "y": 316}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 643,
+      "sourceNodeId": 134,
+      "sourcePortId": 1301,
+      "targetNodeId": 146,
+      "targetPortId": 1302,
+      "travelTime": {
+        "lock": true,
+        "time": 7,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 28,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 28
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 32,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 272
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 25,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 265
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 35,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 35
+      },
+      "numberOfStops": 0,
+      "trainrunId": 95,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 208, "y": -1822},
+          {"x": 208, "y": -1758},
+          {"x": 208, "y": -1474},
+          {"x": 208, "y": -1410}
+        ],
+        "textPositions": {
+          "0": {"x": 196, "y": -1804},
+          "1": {"x": 220, "y": -1776},
+          "2": {"x": 220, "y": -1428},
+          "3": {"x": 196, "y": -1456},
+          "4": {"x": 196, "y": -1616},
+          "5": {"x": 196, "y": -1616},
+          "6": {"x": 220, "y": -1616}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 644,
+      "sourceNodeId": 146,
+      "sourcePortId": 1303,
+      "targetNodeId": 145,
+      "targetPortId": 1304,
+      "travelTime": {
+        "lock": true,
+        "time": 6,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 35,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 35
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 25,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 265
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 19,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 259
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 41,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 41
+      },
+      "numberOfStops": 0,
+      "trainrunId": 95,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 208, "y": -1342},
+          {"x": 208, "y": -1278},
+          {"x": 208, "y": -994},
+          {"x": 208, "y": -930}
+        ],
+        "textPositions": {
+          "0": {"x": 196, "y": -1324},
+          "1": {"x": 220, "y": -1296},
+          "2": {"x": 220, "y": -948},
+          "3": {"x": 196, "y": -976},
+          "4": {"x": 196, "y": -1136},
+          "5": {"x": 196, "y": -1136},
+          "6": {"x": 220, "y": -1136}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 645,
+      "sourceNodeId": 145,
+      "sourcePortId": 1305,
+      "targetNodeId": 144,
+      "targetPortId": 1306,
+      "travelTime": {
+        "lock": true,
+        "time": 6,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 41,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 41
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 19,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 259
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 13,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 253
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 47,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 47
+      },
+      "numberOfStops": 0,
+      "trainrunId": 95,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 208, "y": -862},
+          {"x": 208, "y": -798},
+          {"x": 208, "y": -514},
+          {"x": 208, "y": -450}
+        ],
+        "textPositions": {
+          "0": {"x": 196, "y": -844},
+          "1": {"x": 220, "y": -816},
+          "2": {"x": 220, "y": -468},
+          "3": {"x": 196, "y": -496},
+          "4": {"x": 196, "y": -656},
+          "5": {"x": 196, "y": -656},
+          "6": {"x": 220, "y": -656}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 646,
+      "sourceNodeId": 144,
+      "sourcePortId": 1307,
+      "targetNodeId": 133,
+      "targetPortId": 1308,
+      "travelTime": {
+        "lock": true,
+        "time": 8,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 47,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 47
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 13,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 253
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 5,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 245
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 55,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 55
+      },
+      "numberOfStops": 0,
+      "trainrunId": 95,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 144, "y": -354},
+          {"x": 144, "y": -290},
+          {"x": 144, "y": 30},
+          {"x": 144, "y": 94}
+        ],
+        "textPositions": {
+          "0": {"x": 132, "y": -336},
+          "1": {"x": 156, "y": -308},
+          "2": {"x": 156, "y": 76},
+          "3": {"x": 132, "y": 48},
+          "4": {"x": 132, "y": -130},
+          "5": {"x": 132, "y": -130},
+          "6": {"x": 156, "y": -130}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 647,
+      "sourceNodeId": 133,
+      "sourcePortId": 1309,
+      "targetNodeId": 172,
+      "targetPortId": 1310,
+      "travelTime": {
+        "lock": true,
+        "time": 7,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 58,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 58
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 2,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 242
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 55,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 235
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 5,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 65
+      },
+      "numberOfStops": 0,
+      "trainrunId": 95,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 62, "y": 208},
+          {"x": -2, "y": 208},
+          {"x": -446, "y": 208},
+          {"x": -510, "y": 208}
+        ],
+        "textPositions": {
+          "0": {"x": 44, "y": 196},
+          "1": {"x": 16, "y": 220},
+          "2": {"x": -492, "y": 220},
+          "3": {"x": -464, "y": 196},
+          "4": {"x": -224, "y": 196},
+          "5": {"x": -224, "y": 196},
+          "6": {"x": -224, "y": 220}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 648,
+      "sourceNodeId": 129,
+      "sourcePortId": 1311,
+      "targetNodeId": 167,
+      "targetPortId": 1312,
+      "travelTime": {
+        "lock": true,
+        "time": 18,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 34,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 94
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 26,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 206
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 8,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 188
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 52,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 112
+      },
+      "numberOfStops": 0,
+      "trainrunId": 95,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -2096, "y": 382},
+          {"x": -2096, "y": 446},
+          {"x": -2096, "y": 574},
+          {"x": -2096, "y": 638}
+        ],
+        "textPositions": {
+          "0": {"x": -2108, "y": 400},
+          "1": {"x": -2084, "y": 428},
+          "2": {"x": -2084, "y": 620},
+          "3": {"x": -2108, "y": 592},
+          "4": {"x": -2108, "y": 510},
+          "5": {"x": -2108, "y": 510},
+          "6": {"x": -2084, "y": 510}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 649,
+      "sourceNodeId": 129,
+      "sourcePortId": 1313,
+      "targetNodeId": 167,
+      "targetPortId": 1314,
+      "travelTime": {
+        "lock": true,
+        "time": 18,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 59,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 359
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 1,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 61
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 43,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 43
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 17,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 377
+      },
+      "numberOfStops": 0,
+      "trainrunId": 89,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -2064, "y": 382},
+          {"x": -2064, "y": 446},
+          {"x": -2064, "y": 574},
+          {"x": -2064, "y": 638}
+        ],
+        "textPositions": {
+          "0": {"x": -2076, "y": 400},
+          "1": {"x": -2052, "y": 428},
+          "2": {"x": -2052, "y": 620},
+          "3": {"x": -2076, "y": 592},
+          "4": {"x": -2076, "y": 510},
+          "5": {"x": -2076, "y": 510},
+          "6": {"x": -2052, "y": 510}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 650,
+      "sourceNodeId": 167,
+      "sourcePortId": 1315,
+      "targetNodeId": 168,
+      "targetPortId": 1316,
+      "travelTime": {
+        "lock": true,
+        "time": 8,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 54,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 114
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 6,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 186
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 58,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 178
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 2,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 122
+      },
+      "numberOfStops": 0,
+      "trainrunId": 95,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -2096, "y": 706},
+          {"x": -2096, "y": 770},
+          {"x": -2096, "y": 862},
+          {"x": -2096, "y": 926}
+        ],
+        "textPositions": {
+          "0": {"x": -2108, "y": 724},
+          "1": {"x": -2084, "y": 752},
+          "2": {"x": -2084, "y": 908},
+          "3": {"x": -2108, "y": 880},
+          "4": {"x": -2108, "y": 816},
+          "5": {"x": -2108, "y": 816},
+          "6": {"x": -2084, "y": 816}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 651,
+      "sourceNodeId": 168,
+      "sourcePortId": 1317,
+      "targetNodeId": 131,
+      "targetPortId": 1318,
+      "travelTime": {
+        "lock": true,
+        "time": 24,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 4,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 124
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 56,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 176
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 32,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 152
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 28,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 148
+      },
+      "numberOfStops": 0,
+      "trainrunId": 95,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -2014, "y": 944},
+          {"x": -1950, "y": 944},
+          {"x": -1154, "y": 944},
+          {"x": -1090, "y": 944}
+        ],
+        "textPositions": {
+          "0": {"x": -1996, "y": 956},
+          "1": {"x": -1968, "y": 932},
+          "2": {"x": -1108, "y": 932},
+          "3": {"x": -1136, "y": 956},
+          "4": {"x": -1552, "y": 932},
+          "5": {"x": -1552, "y": 932},
+          "6": {"x": -1552, "y": 956}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 652,
+      "sourceNodeId": 167,
+      "sourcePortId": 1319,
+      "targetNodeId": 168,
+      "targetPortId": 1320,
+      "travelTime": {
+        "lock": true,
+        "time": 10,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 19,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 379
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 41,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 41
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 31,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 31
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 29,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 389
+      },
+      "numberOfStops": 0,
+      "trainrunId": 89,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -2064, "y": 706},
+          {"x": -2064, "y": 770},
+          {"x": -2064, "y": 862},
+          {"x": -2064, "y": 926}
+        ],
+        "textPositions": {
+          "0": {"x": -2076, "y": 724},
+          "1": {"x": -2052, "y": 752},
+          "2": {"x": -2052, "y": 908},
+          "3": {"x": -2076, "y": 880},
+          "4": {"x": -2076, "y": 816},
+          "5": {"x": -2076, "y": 816},
+          "6": {"x": -2052, "y": 816}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 653,
+      "sourceNodeId": 168,
+      "sourcePortId": 1321,
+      "targetNodeId": 132,
+      "targetPortId": 1322,
+      "travelTime": {
+        "lock": true,
+        "time": 25,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 31,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 391
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 29,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 29
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 4,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 4
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 56,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 416
+      },
+      "numberOfStops": 0,
+      "trainrunId": 89,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -2096, "y": 1022},
+          {"x": -2096, "y": 1086},
+          {"x": -2096, "y": 1374},
+          {"x": -2096, "y": 1438}
+        ],
+        "textPositions": {
+          "0": {"x": -2108, "y": 1040},
+          "1": {"x": -2084, "y": 1068},
+          "2": {"x": -2084, "y": 1420},
+          "3": {"x": -2108, "y": 1392},
+          "4": {"x": -2108, "y": 1230},
+          "5": {"x": -2108, "y": 1230},
+          "6": {"x": -2084, "y": 1230}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 654,
+      "sourceNodeId": 132,
+      "sourcePortId": 1323,
+      "targetNodeId": 168,
+      "targetPortId": 1324,
+      "travelTime": {
+        "lock": true,
+        "time": 26,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 29,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 149
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 31,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 151
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 5,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 125
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 55,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 175
+      },
+      "numberOfStops": 0,
+      "trainrunId": 96,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -2128, "y": 1438},
+          {"x": -2128, "y": 1374},
+          {"x": -2128, "y": 1086},
+          {"x": -2128, "y": 1022}
+        ],
+        "textPositions": {
+          "0": {"x": -2116, "y": 1420},
+          "1": {"x": -2140, "y": 1392},
+          "2": {"x": -2140, "y": 1040},
+          "3": {"x": -2116, "y": 1068},
+          "4": {"x": -2140, "y": 1230},
+          "5": {"x": -2140, "y": 1230},
+          "6": {"x": -2116, "y": 1230}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 655,
+      "sourceNodeId": 168,
+      "sourcePortId": 1325,
+      "targetNodeId": 167,
+      "targetPortId": 1326,
+      "travelTime": {
+        "lock": true,
+        "time": 8,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 58,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 178
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 2,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 122
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 54,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 114
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 6,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 186
+      },
+      "numberOfStops": 0,
+      "trainrunId": 96,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -2128, "y": 926},
+          {"x": -2128, "y": 862},
+          {"x": -2128, "y": 770},
+          {"x": -2128, "y": 706}
+        ],
+        "textPositions": {
+          "0": {"x": -2116, "y": 908},
+          "1": {"x": -2140, "y": 880},
+          "2": {"x": -2140, "y": 724},
+          "3": {"x": -2116, "y": 752},
+          "4": {"x": -2140, "y": 816},
+          "5": {"x": -2140, "y": 816},
+          "6": {"x": -2116, "y": 816}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 656,
+      "sourceNodeId": 167,
+      "sourcePortId": 1327,
+      "targetNodeId": 129,
+      "targetPortId": 1328,
+      "travelTime": {
+        "lock": true,
+        "time": 18,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 8,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 188
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 52,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 112
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 34,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 94
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 26,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 206
+      },
+      "numberOfStops": 0,
+      "trainrunId": 96,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -2128, "y": 638},
+          {"x": -2128, "y": 574},
+          {"x": -2128, "y": 446},
+          {"x": -2128, "y": 382}
+        ],
+        "textPositions": {
+          "0": {"x": -2116, "y": 620},
+          "1": {"x": -2140, "y": 592},
+          "2": {"x": -2140, "y": 400},
+          "3": {"x": -2116, "y": 428},
+          "4": {"x": -2140, "y": 510},
+          "5": {"x": -2140, "y": 510},
+          "6": {"x": -2116, "y": 510}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 657,
+      "sourceNodeId": 129,
+      "sourcePortId": 1329,
+      "targetNodeId": 178,
+      "targetPortId": 1330,
+      "travelTime": {
+        "lock": true,
+        "time": 3,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 34,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 214
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 26,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 86
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 23,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 83
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 37,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 217
+      },
+      "numberOfStops": 0,
+      "trainrunId": 96,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -2014, "y": 176},
+          {"x": -1950, "y": 176},
+          {"x": -1762, "y": 176},
+          {"x": -1698, "y": 176}
+        ],
+        "textPositions": {
+          "0": {"x": -1996, "y": 188},
+          "1": {"x": -1968, "y": 164},
+          "2": {"x": -1716, "y": 164},
+          "3": {"x": -1744, "y": 188},
+          "4": {"x": -1856, "y": 164},
+          "5": {"x": -1856, "y": 164},
+          "6": {"x": -1856, "y": 188}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 658,
+      "sourceNodeId": 133,
+      "sourcePortId": 1331,
+      "targetNodeId": 144,
+      "targetPortId": 1332,
+      "travelTime": {
+        "lock": true,
+        "time": 8,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 5,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 245
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 55,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 55
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 47,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 47
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 13,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 253
+      },
+      "numberOfStops": 0,
+      "trainrunId": 96,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 112, "y": 94},
+          {"x": 112, "y": 30},
+          {"x": 112, "y": -290},
+          {"x": 112, "y": -354}
+        ],
+        "textPositions": {
+          "0": {"x": 124, "y": 76},
+          "1": {"x": 100, "y": 48},
+          "2": {"x": 100, "y": -336},
+          "3": {"x": 124, "y": -308},
+          "4": {"x": 100, "y": -130},
+          "5": {"x": 100, "y": -130},
+          "6": {"x": 124, "y": -130}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 659,
+      "sourceNodeId": 144,
+      "sourcePortId": 1333,
+      "targetNodeId": 145,
+      "targetPortId": 1334,
+      "travelTime": {
+        "lock": true,
+        "time": 6,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 13,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 253
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 47,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 47
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 41,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 41
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 19,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 259
+      },
+      "numberOfStops": 0,
+      "trainrunId": 96,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 176, "y": -450},
+          {"x": 176, "y": -514},
+          {"x": 176, "y": -798},
+          {"x": 176, "y": -862}
+        ],
+        "textPositions": {
+          "0": {"x": 188, "y": -468},
+          "1": {"x": 164, "y": -496},
+          "2": {"x": 164, "y": -844},
+          "3": {"x": 188, "y": -816},
+          "4": {"x": 164, "y": -656},
+          "5": {"x": 164, "y": -656},
+          "6": {"x": 188, "y": -656}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 660,
+      "sourceNodeId": 145,
+      "sourcePortId": 1335,
+      "targetNodeId": 146,
+      "targetPortId": 1336,
+      "travelTime": {
+        "lock": true,
+        "time": 6,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 19,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 259
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 41,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 41
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 35,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 35
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 25,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 265
+      },
+      "numberOfStops": 0,
+      "trainrunId": 96,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 176, "y": -930},
+          {"x": 176, "y": -994},
+          {"x": 176, "y": -1278},
+          {"x": 176, "y": -1342}
+        ],
+        "textPositions": {
+          "0": {"x": 188, "y": -948},
+          "1": {"x": 164, "y": -976},
+          "2": {"x": 164, "y": -1324},
+          "3": {"x": 188, "y": -1296},
+          "4": {"x": 164, "y": -1136},
+          "5": {"x": 164, "y": -1136},
+          "6": {"x": 188, "y": -1136}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 661,
+      "sourceNodeId": 146,
+      "sourcePortId": 1337,
+      "targetNodeId": 134,
+      "targetPortId": 1338,
+      "travelTime": {
+        "lock": true,
+        "time": 7,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 25,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 265
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 35,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 35
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 28,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 28
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 32,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 272
+      },
+      "numberOfStops": 0,
+      "trainrunId": 96,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 176, "y": -1410},
+          {"x": 176, "y": -1474},
+          {"x": 176, "y": -1758},
+          {"x": 176, "y": -1822}
+        ],
+        "textPositions": {
+          "0": {"x": 188, "y": -1428},
+          "1": {"x": 164, "y": -1456},
+          "2": {"x": 164, "y": -1804},
+          "3": {"x": 188, "y": -1776},
+          "4": {"x": 164, "y": -1616},
+          "5": {"x": 164, "y": -1616},
+          "6": {"x": 188, "y": -1616}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 662,
+      "sourceNodeId": 129,
+      "sourcePortId": 1339,
+      "targetNodeId": 167,
+      "targetPortId": 1340,
+      "travelTime": {
+        "lock": false,
+        "time": 19,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 8,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 368
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 52,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 52
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 33,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 33
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 27,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 387
+      },
+      "numberOfStops": 0,
+      "trainrunId": 90,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -2032, "y": 382},
+          {"x": -2032, "y": 446},
+          {"x": -2032, "y": 574},
+          {"x": -2032, "y": 638}
+        ],
+        "textPositions": {
+          "0": {"x": -2044, "y": 400},
+          "1": {"x": -2020, "y": 428},
+          "2": {"x": -2020, "y": 620},
+          "3": {"x": -2044, "y": 592},
+          "4": {"x": -2044, "y": 510},
+          "5": {"x": -2044, "y": 510},
+          "6": {"x": -2020, "y": 510}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 663,
+      "sourceNodeId": 167,
+      "sourcePortId": 1341,
+      "targetNodeId": 168,
+      "targetPortId": 1342,
+      "travelTime": {
+        "lock": true,
+        "time": 10,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 28,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 388
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 32,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 32
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 22,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 22
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 38,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 398
+      },
+      "numberOfStops": 0,
+      "trainrunId": 90,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -2032, "y": 706},
+          {"x": -2032, "y": 770},
+          {"x": -2032, "y": 862},
+          {"x": -2032, "y": 926}
+        ],
+        "textPositions": {
+          "0": {"x": -2044, "y": 724},
+          "1": {"x": -2020, "y": 752},
+          "2": {"x": -2020, "y": 908},
+          "3": {"x": -2044, "y": 880},
+          "4": {"x": -2044, "y": 816},
+          "5": {"x": -2044, "y": 816},
+          "6": {"x": -2020, "y": 816}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 664,
+      "sourceNodeId": 168,
+      "sourcePortId": 1343,
+      "targetNodeId": 131,
+      "targetPortId": 1344,
+      "travelTime": {
+        "lock": true,
+        "time": 21,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 39,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 399
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 21,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 21
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 0,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 0
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 0,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 420
+      },
+      "numberOfStops": 0,
+      "trainrunId": 90,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -2014, "y": 976},
+          {"x": -1950, "y": 976},
+          {"x": -1154, "y": 976},
+          {"x": -1090, "y": 976}
+        ],
+        "textPositions": {
+          "0": {"x": -1996, "y": 988},
+          "1": {"x": -1968, "y": 964},
+          "2": {"x": -1108, "y": 964},
+          "3": {"x": -1136, "y": 988},
+          "4": {"x": -1552, "y": 964},
+          "5": {"x": -1552, "y": 964},
+          "6": {"x": -1552, "y": 988}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 665,
+      "sourceNodeId": 169,
+      "sourcePortId": 1345,
+      "targetNodeId": 153,
+      "targetPortId": 1346,
+      "travelTime": {
+        "lock": true,
+        "time": 9,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 48,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 48
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 12,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 252
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 3,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 243
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 57,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 57
+      },
+      "numberOfStops": 0,
+      "trainrunId": 79,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1954, "y": 1776},
+          {"x": 2018, "y": 1776},
+          {"x": 2590, "y": 1360},
+          {"x": 2654, "y": 1360}
+        ],
+        "textPositions": {
+          "0": {"x": 1972, "y": 1788},
+          "1": {"x": 2000, "y": 1764},
+          "2": {"x": 2636, "y": 1348},
+          "3": {"x": 2608, "y": 1372},
+          "4": {"x": 2304, "y": 1556},
+          "5": {"x": 2304, "y": 1556},
+          "6": {"x": 2304, "y": 1580}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 666,
+      "sourceNodeId": 169,
+      "sourcePortId": 1347,
+      "targetNodeId": 153,
+      "targetPortId": 1348,
+      "travelTime": {
+        "lock": true,
+        "time": 10,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 18,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 18
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 42,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 42
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 32,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 32
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 28,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 28
+      },
+      "numberOfStops": 0,
+      "trainrunId": 80,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1954, "y": 1744},
+          {"x": 2018, "y": 1744},
+          {"x": 2590, "y": 1328},
+          {"x": 2654, "y": 1328}
+        ],
+        "textPositions": {
+          "0": {"x": 1972, "y": 1756},
+          "1": {"x": 2000, "y": 1732},
+          "2": {"x": 2636, "y": 1316},
+          "3": {"x": 2608, "y": 1340},
+          "4": {"x": 2304, "y": 1524},
+          "5": {"x": 2304, "y": 1524},
+          "6": {"x": 2304, "y": 1548}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 667,
+      "sourceNodeId": 169,
+      "sourcePortId": 1349,
+      "targetNodeId": 142,
+      "targetPortId": 1350,
+      "travelTime": {
+        "lock": true,
+        "time": 9,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 33,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 453
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 27,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 147
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 18,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 138
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 42,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 462
+      },
+      "numberOfStops": 0,
+      "trainrunId": 77,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1854, "y": 1776},
+          {"x": 1790, "y": 1776},
+          {"x": 290, "y": 1776},
+          {"x": 226, "y": 1776}
+        ],
+        "textPositions": {
+          "0": {"x": 1836, "y": 1764},
+          "1": {"x": 1808, "y": 1788},
+          "2": {"x": 244, "y": 1788},
+          "3": {"x": 272, "y": 1764},
+          "4": {"x": 1040, "y": 1764},
+          "5": {"x": 1040, "y": 1764},
+          "6": {"x": 1040, "y": 1788}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 668,
+      "sourceNodeId": 169,
+      "sourcePortId": 1351,
+      "targetNodeId": 142,
+      "targetPortId": 1352,
+      "travelTime": {
+        "lock": true,
+        "time": 9,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 33,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 273
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 27,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 87
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 18,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 78
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 42,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 282
+      },
+      "numberOfStops": 0,
+      "trainrunId": 75,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1854, "y": 1744},
+          {"x": 1790, "y": 1744},
+          {"x": 290, "y": 1744},
+          {"x": 226, "y": 1744}
+        ],
+        "textPositions": {
+          "0": {"x": 1836, "y": 1732},
+          "1": {"x": 1808, "y": 1756},
+          "2": {"x": 244, "y": 1756},
+          "3": {"x": 272, "y": 1732},
+          "4": {"x": 1040, "y": 1732},
+          "5": {"x": 1040, "y": 1732},
+          "6": {"x": 1040, "y": 1756}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 669,
+      "sourceNodeId": 170,
+      "sourcePortId": 1353,
+      "targetNodeId": 135,
+      "targetPortId": 1354,
+      "travelTime": {
+        "lock": true,
+        "time": 11,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 14,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 74
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 46,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 226
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 35,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 215
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 25,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 85
+      },
+      "numberOfStops": 0,
+      "trainrunId": 79,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2832, "y": 734},
+          {"x": 2832, "y": 670},
+          {"x": 2832, "y": 414},
+          {"x": 2832, "y": 350}
+        ],
+        "textPositions": {
+          "0": {"x": 2844, "y": 716},
+          "1": {"x": 2820, "y": 688},
+          "2": {"x": 2820, "y": 368},
+          "3": {"x": 2844, "y": 396},
+          "4": {"x": 2820, "y": 542},
+          "5": {"x": 2820, "y": 542},
+          "6": {"x": 2844, "y": 542}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 670,
+      "sourceNodeId": 170,
+      "sourcePortId": 1355,
+      "targetNodeId": 135,
+      "targetPortId": 1356,
+      "travelTime": {
+        "lock": true,
+        "time": 7,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 43,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 43
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 17,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 17
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 10,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 10
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 50,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 50
+      },
+      "numberOfStops": 0,
+      "trainrunId": 80,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2800, "y": 734},
+          {"x": 2800, "y": 670},
+          {"x": 2800, "y": 414},
+          {"x": 2800, "y": 350}
+        ],
+        "textPositions": {
+          "0": {"x": 2812, "y": 716},
+          "1": {"x": 2788, "y": 688},
+          "2": {"x": 2788, "y": 368},
+          "3": {"x": 2812, "y": 396},
+          "4": {"x": 2788, "y": 542},
+          "5": {"x": 2788, "y": 542},
+          "6": {"x": 2812, "y": 542}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 671,
+      "sourceNodeId": 170,
+      "sourcePortId": 1357,
+      "targetNodeId": 135,
+      "targetPortId": 1358,
+      "travelTime": {
+        "lock": true,
+        "time": 8,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 47,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 347
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 13,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 13
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 5,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 5
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 55,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 355
+      },
+      "numberOfStops": 0,
+      "trainrunId": 78,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2768, "y": 734},
+          {"x": 2768, "y": 670},
+          {"x": 2768, "y": 414},
+          {"x": 2768, "y": 350}
+        ],
+        "textPositions": {
+          "0": {"x": 2780, "y": 716},
+          "1": {"x": 2756, "y": 688},
+          "2": {"x": 2756, "y": 368},
+          "3": {"x": 2780, "y": 396},
+          "4": {"x": 2756, "y": 542},
+          "5": {"x": 2756, "y": 542},
+          "6": {"x": 2780, "y": 542}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 672,
+      "sourceNodeId": 170,
+      "sourcePortId": 1359,
+      "targetNodeId": 135,
+      "targetPortId": 1360,
+      "travelTime": {
+        "lock": true,
+        "time": 8,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 47,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 107
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 13,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 13
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 5,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 5
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 55,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 115
+      },
+      "numberOfStops": 0,
+      "trainrunId": 76,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2672, "y": 734},
+          {"x": 2672, "y": 670},
+          {"x": 2672, "y": 414},
+          {"x": 2672, "y": 350}
+        ],
+        "textPositions": {
+          "0": {"x": 2684, "y": 716},
+          "1": {"x": 2660, "y": 688},
+          "2": {"x": 2660, "y": 368},
+          "3": {"x": 2684, "y": 396},
+          "4": {"x": 2660, "y": 542},
+          "5": {"x": 2660, "y": 542},
+          "6": {"x": 2684, "y": 542}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 673,
+      "sourceNodeId": 170,
+      "sourcePortId": 1361,
+      "targetNodeId": 140,
+      "targetPortId": 1362,
+      "travelTime": {
+        "lock": true,
+        "time": 47,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 15,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 75
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 45,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 285
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 58,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 238
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 2,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 122
+      },
+      "numberOfStops": 0,
+      "trainrunId": 85,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2850, "y": 752},
+          {"x": 2914, "y": 752},
+          {"x": 4574, "y": 1200},
+          {"x": 4638, "y": 1200}
+        ],
+        "textPositions": {
+          "0": {"x": 2868, "y": 764},
+          "1": {"x": 2896, "y": 740},
+          "2": {"x": 4620, "y": 1188},
+          "3": {"x": 4592, "y": 1212},
+          "4": {"x": 3744, "y": 964},
+          "5": {"x": 3744, "y": 964},
+          "6": {"x": 3744, "y": 988}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 674,
+      "sourceNodeId": 170,
+      "sourcePortId": 1363,
+      "targetNodeId": 140,
+      "targetPortId": 1364,
+      "travelTime": {
+        "lock": false,
+        "time": 61,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 21,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 141
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 39,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 279
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 38,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 218
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 22,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 202
+      },
+      "numberOfStops": 5,
+      "trainrunId": 86,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2850, "y": 784},
+          {"x": 2914, "y": 784},
+          {"x": 4574, "y": 1232},
+          {"x": 4638, "y": 1232}
+        ],
+        "textPositions": {
+          "0": {"x": 2868, "y": 796},
+          "1": {"x": 2896, "y": 772},
+          "2": {"x": 4620, "y": 1220},
+          "3": {"x": 4592, "y": 1244},
+          "4": {"x": 3744, "y": 996},
+          "5": {"x": 3744, "y": 996},
+          "6": {"x": 3744, "y": 1020}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 675,
+      "sourceNodeId": 142,
+      "sourcePortId": 1365,
+      "targetNodeId": 141,
+      "targetPortId": 1366,
+      "travelTime": {
+        "lock": true,
+        "time": 19,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 55,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 475
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 5,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 125
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 46,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 106
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 14,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 494
+      },
+      "numberOfStops": 0,
+      "trainrunId": 77,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 144, "y": 1726},
+          {"x": 144, "y": 1662},
+          {"x": 144, "y": 1314},
+          {"x": 144, "y": 1250}
+        ],
+        "textPositions": {
+          "0": {"x": 156, "y": 1708},
+          "1": {"x": 132, "y": 1680},
+          "2": {"x": 132, "y": 1268},
+          "3": {"x": 156, "y": 1296},
+          "4": {"x": 132, "y": 1488},
+          "5": {"x": 132, "y": 1488},
+          "6": {"x": 156, "y": 1488}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 676,
+      "sourceNodeId": 141,
+      "sourcePortId": 1367,
+      "targetNodeId": 143,
+      "targetPortId": 1368,
+      "travelTime": {
+        "lock": true,
+        "time": 7,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 14,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 494
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 46,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 106
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 39,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 99
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 21,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 501
+      },
+      "numberOfStops": 0,
+      "trainrunId": 77,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 144, "y": 1182},
+          {"x": 144, "y": 1118},
+          {"x": 144, "y": 866},
+          {"x": 144, "y": 802}
+        ],
+        "textPositions": {
+          "0": {"x": 156, "y": 1164},
+          "1": {"x": 132, "y": 1136},
+          "2": {"x": 132, "y": 820},
+          "3": {"x": 156, "y": 848},
+          "4": {"x": 132, "y": 992},
+          "5": {"x": 132, "y": 992},
+          "6": {"x": 156, "y": 992}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 677,
+      "sourceNodeId": 143,
+      "sourcePortId": 1369,
+      "targetNodeId": 133,
+      "targetPortId": 1370,
+      "travelTime": {
+        "lock": true,
+        "time": 7,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 23,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 503
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 37,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 97
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 30,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 90
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 30,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 510
+      },
+      "numberOfStops": 0,
+      "trainrunId": 77,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 112, "y": 734},
+          {"x": 112, "y": 670},
+          {"x": 112, "y": 414},
+          {"x": 112, "y": 350}
+        ],
+        "textPositions": {
+          "0": {"x": 124, "y": 716},
+          "1": {"x": 100, "y": 688},
+          "2": {"x": 100, "y": 368},
+          "3": {"x": 124, "y": 396},
+          "4": {"x": 100, "y": 542},
+          "5": {"x": 100, "y": 542},
+          "6": {"x": 124, "y": 542}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 678,
+      "sourceNodeId": 133,
+      "sourcePortId": 1371,
+      "targetNodeId": 144,
+      "targetPortId": 1372,
+      "travelTime": {
+        "lock": true,
+        "time": 10,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 32,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 512
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 28,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 88
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 18,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 78
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 42,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 522
+      },
+      "numberOfStops": 0,
+      "trainrunId": 77,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 176, "y": 94},
+          {"x": 176, "y": 30},
+          {"x": 176, "y": -290},
+          {"x": 176, "y": -354}
+        ],
+        "textPositions": {
+          "0": {"x": 188, "y": 76},
+          "1": {"x": 164, "y": 48},
+          "2": {"x": 164, "y": -336},
+          "3": {"x": 188, "y": -308},
+          "4": {"x": 164, "y": -130},
+          "5": {"x": 164, "y": -130},
+          "6": {"x": 188, "y": -130}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 679,
+      "sourceNodeId": 144,
+      "sourcePortId": 1373,
+      "targetNodeId": 145,
+      "targetPortId": 1374,
+      "travelTime": {
+        "lock": true,
+        "time": 5,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 42,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 522
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 18,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 78
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 13,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 73
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 47,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 527
+      },
+      "numberOfStops": 0,
+      "trainrunId": 77,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 240, "y": -450},
+          {"x": 240, "y": -514},
+          {"x": 240, "y": -798},
+          {"x": 240, "y": -862}
+        ],
+        "textPositions": {
+          "0": {"x": 252, "y": -468},
+          "1": {"x": 228, "y": -496},
+          "2": {"x": 228, "y": -844},
+          "3": {"x": 252, "y": -816},
+          "4": {"x": 228, "y": -656},
+          "5": {"x": 228, "y": -656},
+          "6": {"x": 252, "y": -656}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 680,
+      "sourceNodeId": 145,
+      "sourcePortId": 1375,
+      "targetNodeId": 146,
+      "targetPortId": 1376,
+      "travelTime": {
+        "lock": true,
+        "time": 5,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 47,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 527
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 13,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 73
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 8,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 68
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 52,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 532
+      },
+      "numberOfStops": 0,
+      "trainrunId": 77,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 240, "y": -930},
+          {"x": 240, "y": -994},
+          {"x": 240, "y": -1278},
+          {"x": 240, "y": -1342}
+        ],
+        "textPositions": {
+          "0": {"x": 252, "y": -948},
+          "1": {"x": 228, "y": -976},
+          "2": {"x": 228, "y": -1324},
+          "3": {"x": 252, "y": -1296},
+          "4": {"x": 228, "y": -1136},
+          "5": {"x": 228, "y": -1136},
+          "6": {"x": 252, "y": -1136}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 681,
+      "sourceNodeId": 146,
+      "sourcePortId": 1377,
+      "targetNodeId": 134,
+      "targetPortId": 1378,
+      "travelTime": {
+        "lock": true,
+        "time": 5,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 52,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 532
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 8,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 68
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 3,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 63
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 57,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 537
+      },
+      "numberOfStops": 0,
+      "trainrunId": 77,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 240, "y": -1410},
+          {"x": 240, "y": -1474},
+          {"x": 240, "y": -1758},
+          {"x": 240, "y": -1822}
+        ],
+        "textPositions": {
+          "0": {"x": 252, "y": -1428},
+          "1": {"x": 228, "y": -1456},
+          "2": {"x": 228, "y": -1804},
+          "3": {"x": 252, "y": -1776},
+          "4": {"x": 228, "y": -1616},
+          "5": {"x": 228, "y": -1616},
+          "6": {"x": 252, "y": -1616}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 682,
+      "sourceNodeId": 171,
+      "sourcePortId": 1379,
+      "targetNodeId": 128,
+      "targetPortId": 1380,
+      "travelTime": {
+        "lock": false,
+        "time": 49,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 27,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 387
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 33,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 153
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 44,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 104
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 16,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 436
+      },
+      "numberOfStops": 2,
+      "trainrunId": 81,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -2562, "y": 336},
+          {"x": -2626, "y": 336},
+          {"x": -2910, "y": 592},
+          {"x": -2974, "y": 592}
+        ],
+        "textPositions": {
+          "0": {"x": -2580, "y": 324},
+          "1": {"x": -2608, "y": 348},
+          "2": {"x": -2956, "y": 604},
+          "3": {"x": -2928, "y": 580},
+          "4": {"x": -2768, "y": 452},
+          "5": {"x": -2768, "y": 452},
+          "6": {"x": -2768, "y": 476}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 683,
+      "sourceNodeId": 171,
+      "sourcePortId": 1381,
+      "targetNodeId": 128,
+      "targetPortId": 1382,
+      "travelTime": {
+        "lock": true,
+        "time": 44,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 54,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 414
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 6,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 126
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 22,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 82
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 38,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 458
+      },
+      "numberOfStops": 0,
+      "trainrunId": 88,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -2562, "y": 304},
+          {"x": -2626, "y": 304},
+          {"x": -2910, "y": 560},
+          {"x": -2974, "y": 560}
+        ],
+        "textPositions": {
+          "0": {"x": -2580, "y": 292},
+          "1": {"x": -2608, "y": 316},
+          "2": {"x": -2956, "y": 572},
+          "3": {"x": -2928, "y": 548},
+          "4": {"x": -2768, "y": 420},
+          "5": {"x": -2768, "y": 420},
+          "6": {"x": -2768, "y": 444}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 684,
+      "sourceNodeId": 172,
+      "sourcePortId": 1383,
+      "targetNodeId": 178,
+      "targetPortId": 1384,
+      "travelTime": {
+        "lock": true,
+        "time": 17,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 39,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 339
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 21,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 201
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 4,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 184
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 56,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 356
+      },
+      "numberOfStops": 0,
+      "trainrunId": 81,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -610, "y": 304},
+          {"x": -674, "y": 304},
+          {"x": -1534, "y": 304},
+          {"x": -1598, "y": 304}
+        ],
+        "textPositions": {
+          "0": {"x": -628, "y": 292},
+          "1": {"x": -656, "y": 316},
+          "2": {"x": -1580, "y": 316},
+          "3": {"x": -1552, "y": 292},
+          "4": {"x": -1104, "y": 292},
+          "5": {"x": -1104, "y": 292},
+          "6": {"x": -1104, "y": 316}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 685,
+      "sourceNodeId": 172,
+      "sourcePortId": 1385,
+      "targetNodeId": 174,
+      "targetPortId": 1386,
+      "travelTime": {
+        "lock": true,
+        "time": 8,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 43,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 343
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 17,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 77
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 9,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 69
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 51,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 351
+      },
+      "numberOfStops": 0,
+      "trainrunId": 86,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -610, "y": 336},
+          {"x": -674, "y": 336},
+          {"x": -830, "y": 368},
+          {"x": -894, "y": 368}
+        ],
+        "textPositions": {
+          "0": {"x": -628, "y": 324},
+          "1": {"x": -656, "y": 348},
+          "2": {"x": -876, "y": 380},
+          "3": {"x": -848, "y": 356},
+          "4": {"x": -752, "y": 340},
+          "5": {"x": -752, "y": 340},
+          "6": {"x": -752, "y": 364}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 686,
+      "sourceNodeId": 172,
+      "sourcePortId": 1387,
+      "targetNodeId": 178,
+      "targetPortId": 1388,
+      "travelTime": {
+        "lock": true,
+        "time": 8,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 47,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 347
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 13,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 73
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 5,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 65
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 55,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 355
+      },
+      "numberOfStops": 0,
+      "trainrunId": 90,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -610, "y": 272},
+          {"x": -674, "y": 272},
+          {"x": -1534, "y": 272},
+          {"x": -1598, "y": 272}
+        ],
+        "textPositions": {
+          "0": {"x": -628, "y": 260},
+          "1": {"x": -656, "y": 284},
+          "2": {"x": -1580, "y": 284},
+          "3": {"x": -1552, "y": 260},
+          "4": {"x": -1104, "y": 260},
+          "5": {"x": -1104, "y": 260},
+          "6": {"x": -1104, "y": 284}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 687,
+      "sourceNodeId": 172,
+      "sourcePortId": 1389,
+      "targetNodeId": 178,
+      "targetPortId": 1390,
+      "travelTime": {
+        "lock": true,
+        "time": 12,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 42,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 342
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 18,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 78
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 6,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 66
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 54,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 354
+      },
+      "numberOfStops": 0,
+      "trainrunId": 89,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -610, "y": 240},
+          {"x": -674, "y": 240},
+          {"x": -1534, "y": 240},
+          {"x": -1598, "y": 240}
+        ],
+        "textPositions": {
+          "0": {"x": -628, "y": 228},
+          "1": {"x": -656, "y": 252},
+          "2": {"x": -1580, "y": 252},
+          "3": {"x": -1552, "y": 228},
+          "4": {"x": -1104, "y": 228},
+          "5": {"x": -1104, "y": 228},
+          "6": {"x": -1104, "y": 252}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 688,
+      "sourceNodeId": 172,
+      "sourcePortId": 1391,
+      "targetNodeId": 178,
+      "targetPortId": 1392,
+      "travelTime": {
+        "lock": true,
+        "time": 18,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 5,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 65
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 55,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 235
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 37,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 217
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 23,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 83
+      },
+      "numberOfStops": 0,
+      "trainrunId": 95,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -610, "y": 208},
+          {"x": -674, "y": 208},
+          {"x": -1534, "y": 208},
+          {"x": -1598, "y": 208}
+        ],
+        "textPositions": {
+          "0": {"x": -628, "y": 196},
+          "1": {"x": -656, "y": 220},
+          "2": {"x": -1580, "y": 220},
+          "3": {"x": -1552, "y": 196},
+          "4": {"x": -1104, "y": 196},
+          "5": {"x": -1104, "y": 196},
+          "6": {"x": -1104, "y": 220}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 689,
+      "sourceNodeId": 172,
+      "sourcePortId": 1393,
+      "targetNodeId": 133,
+      "targetPortId": 1394,
+      "travelTime": {
+        "lock": true,
+        "time": 8,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 54,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 234
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 6,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 66
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 58,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 58
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 2,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 242
+      },
+      "numberOfStops": 0,
+      "trainrunId": 96,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -510, "y": 176},
+          {"x": -446, "y": 176},
+          {"x": -2, "y": 176},
+          {"x": 62, "y": 176}
+        ],
+        "textPositions": {
+          "0": {"x": -492, "y": 188},
+          "1": {"x": -464, "y": 164},
+          "2": {"x": 44, "y": 164},
+          "3": {"x": 16, "y": 188},
+          "4": {"x": -224, "y": 164},
+          "5": {"x": -224, "y": 164},
+          "6": {"x": -224, "y": 188}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 690,
+      "sourceNodeId": 172,
+      "sourcePortId": 1395,
+      "targetNodeId": 178,
+      "targetPortId": 1396,
+      "travelTime": {
+        "lock": true,
+        "time": 9,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 17,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 377
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 43,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 163
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 34,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 154
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 26,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 386
+      },
+      "numberOfStops": 0,
+      "trainrunId": 88,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -610, "y": 144},
+          {"x": -674, "y": 144},
+          {"x": -1534, "y": 144},
+          {"x": -1598, "y": 144}
+        ],
+        "textPositions": {
+          "0": {"x": -628, "y": 132},
+          "1": {"x": -656, "y": 156},
+          "2": {"x": -1580, "y": 156},
+          "3": {"x": -1552, "y": 132},
+          "4": {"x": -1104, "y": 132},
+          "5": {"x": -1104, "y": 132},
+          "6": {"x": -1104, "y": 156}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 691,
+      "sourceNodeId": 173,
+      "sourcePortId": 1397,
+      "targetNodeId": 178,
+      "targetPortId": 1398,
+      "travelTime": {
+        "lock": true,
+        "time": 10,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 11,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 371
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 49,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 49
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 39,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 39
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 21,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 381
+      },
+      "numberOfStops": 0,
+      "trainrunId": 86,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -1346, "y": 368},
+          {"x": -1410, "y": 368},
+          {"x": -1534, "y": 336},
+          {"x": -1598, "y": 336}
+        ],
+        "textPositions": {
+          "0": {"x": -1364, "y": 356},
+          "1": {"x": -1392, "y": 380},
+          "2": {"x": -1580, "y": 348},
+          "3": {"x": -1552, "y": 324},
+          "4": {"x": -1472, "y": 340},
+          "5": {"x": -1472, "y": 340},
+          "6": {"x": -1472, "y": 364}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 692,
+      "sourceNodeId": 174,
+      "sourcePortId": 1399,
+      "targetNodeId": 173,
+      "targetPortId": 1400,
+      "travelTime": {
+        "lock": true,
+        "time": 17,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 52,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 352
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 8,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 68
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 51,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 51
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 9,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 369
+      },
+      "numberOfStops": 1,
+      "trainrunId": 86,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -994, "y": 368},
+          {"x": -1058, "y": 368},
+          {"x": -1182, "y": 368},
+          {"x": -1246, "y": 368}
+        ],
+        "textPositions": {
+          "0": {"x": -1012, "y": 356},
+          "1": {"x": -1040, "y": 380},
+          "2": {"x": -1228, "y": 380},
+          "3": {"x": -1200, "y": 356},
+          "4": {"x": -1120, "y": 356},
+          "5": {"x": -1120, "y": 356},
+          "6": {"x": -1120, "y": 380}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 693,
+      "sourceNodeId": 135,
+      "sourcePortId": 1401,
+      "targetNodeId": 149,
+      "targetPortId": 1402,
+      "travelTime": {
+        "lock": true,
+        "time": 8,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 0,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 300
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 0,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 60
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 52,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 52
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 8,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 308
+      },
+      "numberOfStops": 0,
+      "trainrunId": 85,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2654, "y": 80},
+          {"x": 2590, "y": 80},
+          {"x": 2402, "y": 80},
+          {"x": 2338, "y": 80}
+        ],
+        "textPositions": {
+          "0": {"x": 2636, "y": 68},
+          "1": {"x": 2608, "y": 92},
+          "2": {"x": 2356, "y": 92},
+          "3": {"x": 2384, "y": 68},
+          "4": {"x": 2496, "y": 68},
+          "5": {"x": 2496, "y": 68},
+          "6": {"x": 2496, "y": 92}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 694,
+      "sourceNodeId": 149,
+      "sourcePortId": 1403,
+      "targetNodeId": 166,
+      "targetPortId": 1404,
+      "travelTime": {
+        "lock": true,
+        "time": 6,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 8,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 308
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 52,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 52
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 46,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 46
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 14,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 314
+      },
+      "numberOfStops": 0,
+      "trainrunId": 85,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 2238, "y": 80},
+          {"x": 2174, "y": 80},
+          {"x": 1954, "y": 80},
+          {"x": 1890, "y": 80}
+        ],
+        "textPositions": {
+          "0": {"x": 2220, "y": 68},
+          "1": {"x": 2192, "y": 92},
+          "2": {"x": 1908, "y": 92},
+          "3": {"x": 1936, "y": 68},
+          "4": {"x": 2064, "y": 68},
+          "5": {"x": 2064, "y": 68},
+          "6": {"x": 2064, "y": 92}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 695,
+      "sourceNodeId": 166,
+      "sourcePortId": 1405,
+      "targetNodeId": 148,
+      "targetPortId": 1406,
+      "travelTime": {
+        "lock": true,
+        "time": 6,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 14,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 314
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 46,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 46
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 40,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 40
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 20,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 320
+      },
+      "numberOfStops": 0,
+      "trainrunId": 85,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1790, "y": 80},
+          {"x": 1726, "y": 80},
+          {"x": 1506, "y": 80},
+          {"x": 1442, "y": 80}
+        ],
+        "textPositions": {
+          "0": {"x": 1772, "y": 68},
+          "1": {"x": 1744, "y": 92},
+          "2": {"x": 1460, "y": 92},
+          "3": {"x": 1488, "y": 68},
+          "4": {"x": 1616, "y": 68},
+          "5": {"x": 1616, "y": 68},
+          "6": {"x": 1616, "y": 92}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 696,
+      "sourceNodeId": 148,
+      "sourcePortId": 1407,
+      "targetNodeId": 147,
+      "targetPortId": 1408,
+      "travelTime": {
+        "lock": true,
+        "time": 6,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 20,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 320
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 40,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 40
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 34,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 34
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 26,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 326
+      },
+      "numberOfStops": 0,
+      "trainrunId": 85,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1342, "y": 80},
+          {"x": 1278, "y": 80},
+          {"x": 1122, "y": 80},
+          {"x": 1058, "y": 80}
+        ],
+        "textPositions": {
+          "0": {"x": 1324, "y": 68},
+          "1": {"x": 1296, "y": 92},
+          "2": {"x": 1076, "y": 92},
+          "3": {"x": 1104, "y": 68},
+          "4": {"x": 1200, "y": 68},
+          "5": {"x": 1200, "y": 68},
+          "6": {"x": 1200, "y": 92}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 697,
+      "sourceNodeId": 147,
+      "sourcePortId": 1409,
+      "targetNodeId": 144,
+      "targetPortId": 1410,
+      "travelTime": {
+        "lock": true,
+        "time": 7,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 26,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 326
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 34,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 34
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 27,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 27
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 33,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 333
+      },
+      "numberOfStops": 0,
+      "trainrunId": 85,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 958, "y": 48},
+          {"x": 894, "y": 48},
+          {"x": 386, "y": -432},
+          {"x": 322, "y": -432}
+        ],
+        "textPositions": {
+          "0": {"x": 940, "y": 36},
+          "1": {"x": 912, "y": 60},
+          "2": {"x": 340, "y": -420},
+          "3": {"x": 368, "y": -444},
+          "4": {"x": 640, "y": -204},
+          "5": {"x": 640, "y": -204},
+          "6": {"x": 640, "y": -180}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 698,
+      "sourceNodeId": 144,
+      "sourcePortId": 1411,
+      "targetNodeId": 145,
+      "targetPortId": 1412,
+      "travelTime": {
+        "lock": true,
+        "time": 6,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 33,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 333
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 27,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 27
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 21,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 21
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 39,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 339
+      },
+      "numberOfStops": 0,
+      "trainrunId": 85,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 112, "y": -450},
+          {"x": 112, "y": -514},
+          {"x": 112, "y": -798},
+          {"x": 112, "y": -862}
+        ],
+        "textPositions": {
+          "0": {"x": 124, "y": -468},
+          "1": {"x": 100, "y": -496},
+          "2": {"x": 100, "y": -844},
+          "3": {"x": 124, "y": -816},
+          "4": {"x": 100, "y": -656},
+          "5": {"x": 100, "y": -656},
+          "6": {"x": 124, "y": -656}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 699,
+      "sourceNodeId": 145,
+      "sourcePortId": 1413,
+      "targetNodeId": 146,
+      "targetPortId": 1414,
+      "travelTime": {
+        "lock": true,
+        "time": 7,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 39,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 339
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 21,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 21
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 14,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 14
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 46,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 346
+      },
+      "numberOfStops": 0,
+      "trainrunId": 85,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 112, "y": -930},
+          {"x": 112, "y": -994},
+          {"x": 112, "y": -1278},
+          {"x": 112, "y": -1342}
+        ],
+        "textPositions": {
+          "0": {"x": 124, "y": -948},
+          "1": {"x": 100, "y": -976},
+          "2": {"x": 100, "y": -1324},
+          "3": {"x": 124, "y": -1296},
+          "4": {"x": 100, "y": -1136},
+          "5": {"x": 100, "y": -1136},
+          "6": {"x": 124, "y": -1136}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 700,
+      "sourceNodeId": 146,
+      "sourcePortId": 1415,
+      "targetNodeId": 134,
+      "targetPortId": 1416,
+      "travelTime": {
+        "lock": true,
+        "time": 8,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 46,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 346
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 14,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 14
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 6,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 6
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 54,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 354
+      },
+      "numberOfStops": 0,
+      "trainrunId": 85,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 112, "y": -1410},
+          {"x": 112, "y": -1474},
+          {"x": 112, "y": -1758},
+          {"x": 112, "y": -1822}
+        ],
+        "textPositions": {
+          "0": {"x": 124, "y": -1428},
+          "1": {"x": 100, "y": -1456},
+          "2": {"x": 100, "y": -1804},
+          "3": {"x": 124, "y": -1776},
+          "4": {"x": 100, "y": -1616},
+          "5": {"x": 100, "y": -1616},
+          "6": {"x": 124, "y": -1616}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 701,
+      "sourceNodeId": 175,
+      "sourcePortId": 1417,
+      "targetNodeId": 130,
+      "targetPortId": 1418,
+      "travelTime": {
+        "lock": true,
+        "time": 13,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 1,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 421
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 59,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 119
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 46,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 106
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 14,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 434
+      },
+      "numberOfStops": 0,
+      "trainrunId": 87,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -1698, "y": -16},
+          {"x": -1762, "y": -16},
+          {"x": -2366, "y": -16},
+          {"x": -2430, "y": -16}
+        ],
+        "textPositions": {
+          "0": {"x": -1716, "y": -28},
+          "1": {"x": -1744, "y": -4},
+          "2": {"x": -2412, "y": -4},
+          "3": {"x": -2384, "y": -28},
+          "4": {"x": -2064, "y": -28},
+          "5": {"x": -2064, "y": -28},
+          "6": {"x": -2064, "y": -4}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 702,
+      "sourceNodeId": 137,
+      "sourcePortId": 1419,
+      "targetNodeId": 176,
+      "targetPortId": 1420,
+      "travelTime": {
+        "lock": true,
+        "time": 16,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 5,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 245
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 55,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 295
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 39,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 279
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 21,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 261
+      },
+      "numberOfStops": 0,
+      "trainrunId": 87,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 4738, "y": 112},
+          {"x": 4802, "y": 112},
+          {"x": 5310, "y": 112},
+          {"x": 5374, "y": 112}
+        ],
+        "textPositions": {
+          "0": {"x": 4756, "y": 124},
+          "1": {"x": 4784, "y": 100},
+          "2": {"x": 5356, "y": 100},
+          "3": {"x": 5328, "y": 124},
+          "4": {"x": 5056, "y": 100},
+          "5": {"x": 5056, "y": 100},
+          "6": {"x": 5056, "y": 124}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 703,
+      "sourceNodeId": 177,
+      "sourcePortId": 1421,
+      "targetNodeId": 160,
+      "targetPortId": 1422,
+      "travelTime": {
+        "lock": false,
+        "time": 30,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": true,
+        "time": 31,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 451
+      },
+      "sourceArrival": {
+        "lock": true,
+        "time": 29,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 89
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 59,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 59
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 1,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 481
+      },
+      "numberOfStops": 1,
+      "trainrunId": 81,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -3522, "y": 624},
+          {"x": -3586, "y": 624},
+          {"x": -3774, "y": 688},
+          {"x": -3838, "y": 688}
+        ],
+        "textPositions": {
+          "0": {"x": -3540, "y": 612},
+          "1": {"x": -3568, "y": 636},
+          "2": {"x": -3820, "y": 700},
+          "3": {"x": -3792, "y": 676},
+          "4": {"x": -3680, "y": 644},
+          "5": {"x": -3680, "y": 644},
+          "6": {"x": -3680, "y": 668}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 704,
+      "sourceNodeId": 177,
+      "sourcePortId": 1423,
+      "targetNodeId": 160,
+      "targetPortId": 1424,
+      "travelTime": {
+        "lock": true,
+        "time": 26,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 52,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 472
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 8,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 68
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 42,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 42
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 18,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 498
+      },
+      "numberOfStops": 0,
+      "trainrunId": 88,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -3522, "y": 560},
+          {"x": -3586, "y": 560},
+          {"x": -3774, "y": 624},
+          {"x": -3838, "y": 624}
+        ],
+        "textPositions": {
+          "0": {"x": -3540, "y": 548},
+          "1": {"x": -3568, "y": 572},
+          "2": {"x": -3820, "y": 636},
+          "3": {"x": -3792, "y": 612},
+          "4": {"x": -3680, "y": 580},
+          "5": {"x": -3680, "y": 580},
+          "6": {"x": -3680, "y": 604}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 705,
+      "sourceNodeId": 177,
+      "sourcePortId": 1425,
+      "targetNodeId": 160,
+      "targetPortId": 1426,
+      "travelTime": {
+        "lock": false,
+        "time": 26,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 19,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 499
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 41,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 41
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 15,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 15
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 45,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 525
+      },
+      "numberOfStops": 0,
+      "trainrunId": 87,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -3522, "y": 592},
+          {"x": -3586, "y": 592},
+          {"x": -3774, "y": 656},
+          {"x": -3838, "y": 656}
+        ],
+        "textPositions": {
+          "0": {"x": -3540, "y": 580},
+          "1": {"x": -3568, "y": 604},
+          "2": {"x": -3820, "y": 668},
+          "3": {"x": -3792, "y": 644},
+          "4": {"x": -3680, "y": 612},
+          "5": {"x": -3680, "y": 612},
+          "6": {"x": -3680, "y": 636}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 706,
+      "sourceNodeId": 178,
+      "sourcePortId": 1427,
+      "targetNodeId": 129,
+      "targetPortId": 1428,
+      "travelTime": {
+        "lock": true,
+        "time": 3,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 21,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 381
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 39,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 39
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 36,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 36
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 24,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 384
+      },
+      "numberOfStops": 0,
+      "trainrunId": 86,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -1698, "y": 336},
+          {"x": -1762, "y": 336},
+          {"x": -1950, "y": 336},
+          {"x": -2014, "y": 336}
+        ],
+        "textPositions": {
+          "0": {"x": -1716, "y": 324},
+          "1": {"x": -1744, "y": 348},
+          "2": {"x": -1996, "y": 348},
+          "3": {"x": -1968, "y": 324},
+          "4": {"x": -1856, "y": 324},
+          "5": {"x": -1856, "y": 324},
+          "6": {"x": -1856, "y": 348}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 707,
+      "sourceNodeId": 178,
+      "sourcePortId": 1429,
+      "targetNodeId": 129,
+      "targetPortId": 1430,
+      "travelTime": {
+        "lock": true,
+        "time": 4,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 56,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 356
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 4,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 184
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 0,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 180
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 0,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 360
+      },
+      "numberOfStops": 0,
+      "trainrunId": 81,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -1698, "y": 304},
+          {"x": -1762, "y": 304},
+          {"x": -1950, "y": 304},
+          {"x": -2014, "y": 304}
+        ],
+        "textPositions": {
+          "0": {"x": -1716, "y": 292},
+          "1": {"x": -1744, "y": 316},
+          "2": {"x": -1996, "y": 316},
+          "3": {"x": -1968, "y": 292},
+          "4": {"x": -1856, "y": 292},
+          "5": {"x": -1856, "y": 292},
+          "6": {"x": -1856, "y": 316}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 708,
+      "sourceNodeId": 178,
+      "sourcePortId": 1431,
+      "targetNodeId": 129,
+      "targetPortId": 1432,
+      "travelTime": {
+        "lock": true,
+        "time": 3,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 55,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 355
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 5,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 65
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 2,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 62
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 58,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 358
+      },
+      "numberOfStops": 0,
+      "trainrunId": 90,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -1698, "y": 272},
+          {"x": -1762, "y": 272},
+          {"x": -1950, "y": 272},
+          {"x": -2014, "y": 272}
+        ],
+        "textPositions": {
+          "0": {"x": -1716, "y": 260},
+          "1": {"x": -1744, "y": 284},
+          "2": {"x": -1996, "y": 284},
+          "3": {"x": -1968, "y": 260},
+          "4": {"x": -1856, "y": 260},
+          "5": {"x": -1856, "y": 260},
+          "6": {"x": -1856, "y": 284}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 709,
+      "sourceNodeId": 178,
+      "sourcePortId": 1433,
+      "targetNodeId": 129,
+      "targetPortId": 1434,
+      "travelTime": {
+        "lock": true,
+        "time": 3,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 54,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 354
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 6,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 66
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 3,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 63
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 57,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 357
+      },
+      "numberOfStops": 0,
+      "trainrunId": 89,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -1698, "y": 240},
+          {"x": -1762, "y": 240},
+          {"x": -1950, "y": 240},
+          {"x": -2014, "y": 240}
+        ],
+        "textPositions": {
+          "0": {"x": -1716, "y": 228},
+          "1": {"x": -1744, "y": 252},
+          "2": {"x": -1996, "y": 252},
+          "3": {"x": -1968, "y": 228},
+          "4": {"x": -1856, "y": 228},
+          "5": {"x": -1856, "y": 228},
+          "6": {"x": -1856, "y": 252}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 710,
+      "sourceNodeId": 178,
+      "sourcePortId": 1435,
+      "targetNodeId": 129,
+      "targetPortId": 1436,
+      "travelTime": {
+        "lock": true,
+        "time": 3,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 23,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 83
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 37,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 217
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 34,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 214
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 26,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 86
+      },
+      "numberOfStops": 0,
+      "trainrunId": 95,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -1698, "y": 208},
+          {"x": -1762, "y": 208},
+          {"x": -1950, "y": 208},
+          {"x": -2014, "y": 208}
+        ],
+        "textPositions": {
+          "0": {"x": -1716, "y": 196},
+          "1": {"x": -1744, "y": 220},
+          "2": {"x": -1996, "y": 220},
+          "3": {"x": -1968, "y": 196},
+          "4": {"x": -1856, "y": 196},
+          "5": {"x": -1856, "y": 196},
+          "6": {"x": -1856, "y": 220}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 711,
+      "sourceNodeId": 178,
+      "sourcePortId": 1437,
+      "targetNodeId": 172,
+      "targetPortId": 1438,
+      "travelTime": {
+        "lock": true,
+        "time": 17,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 37,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 217
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 23,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 83
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 6,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 66
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 54,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 234
+      },
+      "numberOfStops": 0,
+      "trainrunId": 96,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -1598, "y": 176},
+          {"x": -1534, "y": 176},
+          {"x": -674, "y": 176},
+          {"x": -610, "y": 176}
+        ],
+        "textPositions": {
+          "0": {"x": -1580, "y": 188},
+          "1": {"x": -1552, "y": 164},
+          "2": {"x": -628, "y": 164},
+          "3": {"x": -656, "y": 188},
+          "4": {"x": -1104, "y": 164},
+          "5": {"x": -1104, "y": 164},
+          "6": {"x": -1104, "y": 188}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 712,
+      "sourceNodeId": 178,
+      "sourcePortId": 1439,
+      "targetNodeId": 129,
+      "targetPortId": 1440,
+      "travelTime": {
+        "lock": true,
+        "time": 3,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 26,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 386
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 34,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 154
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 31,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 151
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 29,
+        "warning": null,
+        "timeFormatter": null,
+        "consecutiveTime": 389
+      },
+      "numberOfStops": 0,
+      "trainrunId": 88,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -1698, "y": 144},
+          {"x": -1762, "y": 144},
+          {"x": -1950, "y": 144},
+          {"x": -2014, "y": 144}
+        ],
+        "textPositions": {
+          "0": {"x": -1716, "y": 132},
+          "1": {"x": -1744, "y": 156},
+          "2": {"x": -1996, "y": 156},
+          "3": {"x": -1968, "y": 132},
+          "4": {"x": -1856, "y": 132},
+          "5": {"x": -1856, "y": 132},
+          "6": {"x": -1856, "y": 156}
+        }
+      },
+      "warnings": null
+    }
+  ],
+  "trainruns": [
+    {
+      "id": 75,
+      "name": "21",
+      "categoryId": 1,
+      "frequencyId": 4,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": [3, 8, 4]
+    },
+    {
+      "id": 76,
+      "name": "2",
+      "categoryId": 1,
+      "frequencyId": 4,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": [3, 8, 4]
+    },
+    {
+      "id": 77,
+      "name": "26",
+      "categoryId": 2,
+      "frequencyId": 5,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": [3, 8, 4]
+    },
+    {
+      "id": 78,
+      "name": "46",
+      "categoryId": 2,
+      "frequencyId": 4,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": [3, 8, 4]
+    },
+    {
+      "id": 79,
+      "name": "75",
+      "categoryId": 2,
+      "frequencyId": 3,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": [3, 8, 4]
+    },
+    {
+      "id": 80,
+      "name": "70",
+      "categoryId": 2,
+      "frequencyId": 3,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": [3, 8, 4]
+    },
+    {
+      "id": 81,
+      "name": "15",
+      "categoryId": 2,
+      "frequencyId": 3,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": [3, 8, 4]
+    },
+    {
+      "id": 82,
+      "name": "27",
+      "categoryId": 2,
+      "frequencyId": 3,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": [3, 8, 4]
+    },
+    {
+      "id": 83,
+      "name": "26",
+      "categoryId": 2,
+      "frequencyId": 3,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": [3, 8, 4]
+    },
+    {
+      "id": 84,
+      "name": "13",
+      "categoryId": 2,
+      "frequencyId": 3,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": [3, 8, 4]
+    },
+    {
+      "id": 85,
+      "name": "3",
+      "categoryId": 1,
+      "frequencyId": 4,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": [3, 8, 4]
+    },
+    {
+      "id": 86,
+      "name": "35",
+      "categoryId": 2,
+      "frequencyId": 3,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": [3, 8, 4]
+    },
+    {
+      "id": 87,
+      "name": "5",
+      "categoryId": 1,
+      "frequencyId": 3,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": [3, 8, 4]
+    },
+    {
+      "id": 88,
+      "name": "1",
+      "categoryId": 1,
+      "frequencyId": 3,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": [3, 8, 4]
+    },
+    {
+      "id": 89,
+      "name": "8",
+      "categoryId": 1,
+      "frequencyId": 3,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": [3, 8, 4]
+    },
+    {
+      "id": 90,
+      "name": "81",
+      "categoryId": 1,
+      "frequencyId": 3,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": [3, 8, 4]
+    },
+    {
+      "id": 91,
+      "name": "48",
+      "categoryId": 2,
+      "frequencyId": 3,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": [1, 9, 5]
+    },
+    {
+      "id": 92,
+      "name": "",
+      "categoryId": 1,
+      "frequencyId": 3,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": [1, 9, 5]
+    },
+    {
+      "id": 93,
+      "name": "36",
+      "categoryId": 2,
+      "frequencyId": 3,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": [3, 8, 4]
+    },
+    {
+      "id": 94,
+      "name": "3",
+      "categoryId": 1,
+      "frequencyId": 3,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": [3, 8, 4]
+    },
+    {
+      "id": 95,
+      "name": "61",
+      "categoryId": 1,
+      "frequencyId": 3,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": [3, 8, 4]
+    },
+    {
+      "id": 96,
+      "name": "6",
+      "categoryId": 1,
+      "frequencyId": 3,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": [3, 8, 4]
+    },
+    {
+      "id": 97,
+      "name": "37",
+      "categoryId": 2,
+      "frequencyId": 3,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": [3, 8, 4]
+    }
+  ],
+  "resources": [
+    {"id": 88, "capacity": 2},
+    {"id": 89, "capacity": 2},
+    {"id": 90, "capacity": 2},
+    {"id": 91, "capacity": 2},
+    {"id": 92, "capacity": 2},
+    {"id": 93, "capacity": 2},
+    {"id": 94, "capacity": 2},
+    {"id": 95, "capacity": 2},
+    {"id": 96, "capacity": 2},
+    {"id": 97, "capacity": 2},
+    {"id": 98, "capacity": 2},
+    {"id": 99, "capacity": 2},
+    {"id": 100, "capacity": 2},
+    {"id": 101, "capacity": 2},
+    {"id": 102, "capacity": 2},
+    {"id": 103, "capacity": 2},
+    {"id": 104, "capacity": 2},
+    {"id": 105, "capacity": 2},
+    {"id": 106, "capacity": 2},
+    {"id": 107, "capacity": 2},
+    {"id": 108, "capacity": 2},
+    {"id": 109, "capacity": 2},
+    {"id": 110, "capacity": 2},
+    {"id": 111, "capacity": 2},
+    {"id": 112, "capacity": 2},
+    {"id": 113, "capacity": 2},
+    {"id": 114, "capacity": 2},
+    {"id": 115, "capacity": 2},
+    {"id": 116, "capacity": 2},
+    {"id": 117, "capacity": 2},
+    {"id": 118, "capacity": 2},
+    {"id": 119, "capacity": 2},
+    {"id": 120, "capacity": 2},
+    {"id": 121, "capacity": 2},
+    {"id": 122, "capacity": 2},
+    {"id": 123, "capacity": 2},
+    {"id": 124, "capacity": 2},
+    {"id": 125, "capacity": 2},
+    {"id": 126, "capacity": 2},
+    {"id": 127, "capacity": 2},
+    {"id": 128, "capacity": 2},
+    {"id": 129, "capacity": 2},
+    {"id": 130, "capacity": 2},
+    {"id": 131, "capacity": 2},
+    {"id": 132, "capacity": 2},
+    {"id": 133, "capacity": 2},
+    {"id": 134, "capacity": 2},
+    {"id": 135, "capacity": 2},
+    {"id": 136, "capacity": 2},
+    {"id": 137, "capacity": 2},
+    {"id": 138, "capacity": 2},
+    {"id": 139, "capacity": 2},
+    {"id": 140, "capacity": 2},
+    {"id": 141, "capacity": 2},
+    {"id": 142, "capacity": 2},
+    {"id": 143, "capacity": 2},
+    {"id": 144, "capacity": 2},
+    {"id": 145, "capacity": 2},
+    {"id": 146, "capacity": 2},
+    {"id": 147, "capacity": 2},
+    {"id": 148, "capacity": 2},
+    {"id": 149, "capacity": 2},
+    {"id": 150, "capacity": 2},
+    {"id": 151, "capacity": 2},
+    {"id": 152, "capacity": 2},
+    {"id": 153, "capacity": 2},
+    {"id": 154, "capacity": 2},
+    {"id": 155, "capacity": 2},
+    {"id": 156, "capacity": 2},
+    {"id": 157, "capacity": 2},
+    {"id": 158, "capacity": 2},
+    {"id": 159, "capacity": 2},
+    {"id": 160, "capacity": 2},
+    {"id": 161, "capacity": 2},
+    {"id": 162, "capacity": 2},
+    {"id": 163, "capacity": 2},
+    {"id": 164, "capacity": 2},
+    {"id": 165, "capacity": 2},
+    {"id": 166, "capacity": 2},
+    {"id": 167, "capacity": 2},
+    {"id": 168, "capacity": 2},
+    {"id": 169, "capacity": 2},
+    {"id": 170, "capacity": 2},
+    {"id": 171, "capacity": 2},
+    {"id": 172, "capacity": 2},
+    {"id": 173, "capacity": 2},
+    {"id": 174, "capacity": 2},
+    {"id": 175, "capacity": 2},
+    {"id": 176, "capacity": 2},
+    {"id": 177, "capacity": 2},
+    {"id": 178, "capacity": 2},
+    {"id": 179, "capacity": 2},
+    {"id": 180, "capacity": 2},
+    {"id": 181, "capacity": 2},
+    {"id": 182, "capacity": 2},
+    {"id": 183, "capacity": 2},
+    {"id": 184, "capacity": 2},
+    {"id": 185, "capacity": 2},
+    {"id": 186, "capacity": 2},
+    {"id": 187, "capacity": 2},
+    {"id": 188, "capacity": 2},
+    {"id": 189, "capacity": 2},
+    {"id": 190, "capacity": 2},
+    {"id": 191, "capacity": 2},
+    {"id": 192, "capacity": 2},
+    {"id": 193, "capacity": 2},
+    {"id": 194, "capacity": 2},
+    {"id": 195, "capacity": 2},
+    {"id": 196, "capacity": 2},
+    {"id": 197, "capacity": 2},
+    {"id": 198, "capacity": 2},
+    {"id": 199, "capacity": 2},
+    {"id": 200, "capacity": 2},
+    {"id": 201, "capacity": 2},
+    {"id": 202, "capacity": 2}
+  ],
+  "metadata": {
+    "netzgrafikColors": [],
+    "trainrunCategories": [
+      {
+        "id": 0,
+        "name": "International",
+        "order": 0,
+        "colorRef": "EC",
+        "shortName": "EC",
+        "fachCategory": "HaltezeitIPV",
+        "sectionHeadway": 2,
+        "nodeHeadwayStop": 2,
+        "nodeHeadwayNonStop": 2,
+        "minimalTurnaroundTime": 4
+      },
+      {
+        "id": 1,
+        "name": "InterCity",
+        "order": 1,
+        "colorRef": "IC",
+        "shortName": "IC",
+        "fachCategory": "HaltezeitA",
+        "sectionHeadway": 2,
+        "nodeHeadwayStop": 2,
+        "nodeHeadwayNonStop": 2,
+        "minimalTurnaroundTime": 4
+      },
+      {
+        "id": 2,
+        "name": "InterRegio",
+        "order": 2,
+        "colorRef": "IR",
+        "shortName": "IR",
+        "fachCategory": "HaltezeitB",
+        "sectionHeadway": 2,
+        "nodeHeadwayStop": 2,
+        "nodeHeadwayNonStop": 2,
+        "minimalTurnaroundTime": 4
+      },
+      {
+        "id": 3,
+        "name": "RegioExpress",
+        "order": 3,
+        "colorRef": "RE",
+        "shortName": "RE",
+        "fachCategory": "HaltezeitC",
+        "sectionHeadway": 2,
+        "nodeHeadwayStop": 2,
+        "nodeHeadwayNonStop": 2,
+        "minimalTurnaroundTime": 4
+      },
+      {
+        "id": 4,
+        "name": "RegioUndSBahnverkehr",
+        "order": 4,
+        "colorRef": "S",
+        "shortName": "S",
+        "fachCategory": "HaltezeitD",
+        "sectionHeadway": 2,
+        "nodeHeadwayStop": 2,
+        "nodeHeadwayNonStop": 2,
+        "minimalTurnaroundTime": 4
+      },
+      {
+        "id": 5,
+        "name": "GüterExpress",
+        "order": 5,
+        "colorRef": "GEX",
+        "shortName": "GEX",
+        "fachCategory": "HaltezeitUncategorized",
+        "sectionHeadway": 3,
+        "nodeHeadwayStop": 3,
+        "nodeHeadwayNonStop": 3,
+        "minimalTurnaroundTime": 4
+      },
+      {
+        "id": 6,
+        "name": "Güterverkehr",
+        "order": 6,
+        "colorRef": "G",
+        "shortName": "G",
+        "fachCategory": "HaltezeitUncategorized",
+        "sectionHeadway": 3,
+        "nodeHeadwayStop": 3,
+        "nodeHeadwayNonStop": 3,
+        "minimalTurnaroundTime": 4
+      }
+    ],
+    "trainrunFrequencies": [
+      {
+        "id": 0,
+        "name": "verkehrt viertelstündlich",
+        "order": 0,
+        "offset": 0,
+        "frequency": 15,
+        "shortName": "15",
+        "linePatternRef": "15"
+      },
+      {
+        "id": 1,
+        "name": "verkehrt im 20 Minuten Takt",
+        "order": 0,
+        "offset": 0,
+        "frequency": 20,
+        "shortName": "20",
+        "linePatternRef": "20"
+      },
+      {
+        "id": 2,
+        "name": "verkehrt halbstündlich",
+        "order": 0,
+        "offset": 0,
+        "frequency": 30,
+        "shortName": "30",
+        "linePatternRef": "30"
+      },
+      {
+        "id": 3,
+        "name": "verkehrt stündlich",
+        "order": 0,
+        "offset": 0,
+        "frequency": 60,
+        "shortName": "60",
+        "linePatternRef": "60"
+      },
+      {
+        "id": 4,
+        "name": "verkehrt zweistündlich (gerade)",
+        "order": 0,
+        "offset": 0,
+        "frequency": 120,
+        "shortName": "120",
+        "linePatternRef": "120"
+      },
+      {
+        "id": 5,
+        "name": "verkehrt zweistündlich (ungerade)",
+        "order": 0,
+        "offset": 60,
+        "frequency": 120,
+        "shortName": "120+",
+        "linePatternRef": "120"
+      }
+    ],
+    "trainrunTimeCategories": [
+      {
+        "id": 0,
+        "name": "verkehrt uneingeschränkt",
+        "order": 0,
+        "weekday": [1, 2, 3, 4, 5, 6, 7],
+        "shortName": "7/24",
+        "linePatternRef": "7/24",
+        "dayTimeInterval": []
+      },
+      {
+        "id": 1,
+        "name": "verkehrt zur Hauptverkehrszeit",
+        "order": 0,
+        "weekday": [1, 2, 3, 4, 5, 6, 7],
+        "shortName": "HVZ",
+        "linePatternRef": "HVZ",
+        "dayTimeInterval": [
+          {"to": 420, "from": 360},
+          {"to": 1140, "from": 960}
+        ]
+      },
+      {
+        "id": 2,
+        "name": "verkehrt zeitweise",
+        "order": 0,
+        "weekday": [],
+        "shortName": "zeitweise",
+        "linePatternRef": "ZEITWEISE",
+        "dayTimeInterval": []
+      }
+    ]
+  },
+  "freeFloatingTexts": [],
+  "labels": [
+    {"id": 4, "label": "OK", "labelGroupId": 1, "labelRef": "Trainrun"},
+    {
+      "id": 5,
+      "label": "Zeiten falsch",
+      "labelGroupId": 3,
+      "labelRef": "Trainrun"
+    }
+  ],
+  "labelGroups": [
+    {"id": 1, "name": "Standard", "labelRef": "Trainrun"},
+    {"id": 2, "name": "Standard", "labelRef": "Node"},
+    {"id": 3, "name": "Standard", "labelRef": "Trainrun"}
+  ],
+  "filterData": {
+    "filterSettings": [
+      {
+        "id": 5,
+        "name": "Neuer Filter",
+        "description": "",
+        "filterNodeLabels": [],
+        "filterNoteLabels": [],
+        "filterTrainrunLabels": [],
+        "filterArrivalDepartureTime": true,
+        "filterTravelTime": true,
+        "filterTrainrunName": true,
+        "filterConnections": true,
+        "filterShowNonStopTime": true,
+        "filterTrainrunCategory": [
+          {
+            "id": 0,
+            "name": "International",
+            "order": 0,
+            "colorRef": "EC",
+            "shortName": "EC",
+            "fachCategory": "HaltezeitIPV",
+            "sectionHeadway": 2,
+            "nodeHeadwayStop": 2,
+            "nodeHeadwayNonStop": 2,
+            "minimalTurnaroundTime": 4
+          },
+          {
+            "id": 1,
+            "name": "InterCity",
+            "order": 1,
+            "colorRef": "IC",
+            "shortName": "IC",
+            "fachCategory": "HaltezeitA",
+            "sectionHeadway": 2,
+            "nodeHeadwayStop": 2,
+            "nodeHeadwayNonStop": 2,
+            "minimalTurnaroundTime": 4
+          },
+          {
+            "id": 2,
+            "name": "InterRegio",
+            "order": 2,
+            "colorRef": "IR",
+            "shortName": "IR",
+            "fachCategory": "HaltezeitB",
+            "sectionHeadway": 2,
+            "nodeHeadwayStop": 2,
+            "nodeHeadwayNonStop": 2,
+            "minimalTurnaroundTime": 4
+          },
+          {
+            "id": 3,
+            "name": "RegioExpress",
+            "order": 3,
+            "colorRef": "RE",
+            "shortName": "RE",
+            "fachCategory": "HaltezeitC",
+            "sectionHeadway": 2,
+            "nodeHeadwayStop": 2,
+            "nodeHeadwayNonStop": 2,
+            "minimalTurnaroundTime": 4
+          },
+          {
+            "id": 4,
+            "name": "RegioUndSBahnverkehr",
+            "order": 4,
+            "colorRef": "S",
+            "shortName": "S",
+            "fachCategory": "HaltezeitD",
+            "sectionHeadway": 2,
+            "nodeHeadwayStop": 2,
+            "nodeHeadwayNonStop": 2,
+            "minimalTurnaroundTime": 4
+          },
+          {
+            "id": 5,
+            "name": "GüterExpress",
+            "order": 5,
+            "colorRef": "GEX",
+            "shortName": "GEX",
+            "fachCategory": "HaltezeitUncategorized",
+            "sectionHeadway": 3,
+            "nodeHeadwayStop": 3,
+            "nodeHeadwayNonStop": 3,
+            "minimalTurnaroundTime": 4
+          },
+          {
+            "id": 6,
+            "name": "Güterverkehr",
+            "order": 6,
+            "colorRef": "G",
+            "shortName": "G",
+            "fachCategory": "HaltezeitUncategorized",
+            "sectionHeadway": 3,
+            "nodeHeadwayStop": 3,
+            "nodeHeadwayNonStop": 3,
+            "minimalTurnaroundTime": 4
+          }
+        ],
+        "filterTrainrunFrequency": [
+          {
+            "id": 0,
+            "name": "verkehrt viertelstündlich",
+            "order": 0,
+            "offset": 0,
+            "frequency": 15,
+            "shortName": "15",
+            "linePatternRef": "15"
+          },
+          {
+            "id": 1,
+            "name": "verkehrt im 20 Minuten Takt",
+            "order": 0,
+            "offset": 0,
+            "frequency": 20,
+            "shortName": "20",
+            "linePatternRef": "20"
+          },
+          {
+            "id": 2,
+            "name": "verkehrt halbstündlich",
+            "order": 0,
+            "offset": 0,
+            "frequency": 30,
+            "shortName": "30",
+            "linePatternRef": "30"
+          },
+          {
+            "id": 3,
+            "name": "verkehrt stündlich",
+            "order": 0,
+            "offset": 0,
+            "frequency": 60,
+            "shortName": "60",
+            "linePatternRef": "60"
+          },
+          {
+            "id": 4,
+            "name": "verkehrt zweistündlich (gerade)",
+            "order": 0,
+            "offset": 0,
+            "frequency": 120,
+            "shortName": "120",
+            "linePatternRef": "120"
+          },
+          {
+            "id": 5,
+            "name": "verkehrt zweistündlich (ungerade)",
+            "order": 0,
+            "offset": 60,
+            "frequency": 120,
+            "shortName": "120+",
+            "linePatternRef": "120"
+          }
+        ],
+        "filterTrainrunTimeCategory": [
+          {
+            "id": 0,
+            "name": "verkehrt uneingeschränkt",
+            "order": 0,
+            "weekday": [1, 2, 3, 4, 5, 6, 7],
+            "shortName": "7/24",
+            "linePatternRef": "7/24",
+            "dayTimeInterval": []
+          },
+          {
+            "id": 1,
+            "name": "verkehrt zur Hauptverkehrszeit",
+            "order": 0,
+            "weekday": [1, 2, 3, 4, 5, 6, 7],
+            "shortName": "HVZ",
+            "linePatternRef": "HVZ",
+            "dayTimeInterval": [
+              {"to": 420, "from": 360},
+              {"to": 1140, "from": 960}
+            ]
+          },
+          {
+            "id": 2,
+            "name": "verkehrt zeitweise",
+            "order": 0,
+            "weekday": [],
+            "shortName": "zeitweise",
+            "linePatternRef": "ZEITWEISE",
+            "dayTimeInterval": []
+          }
+        ],
+        "filterAllEmptyNodes": false,
+        "filterAllNonStopNodes": false,
+        "filterNotes": false,
+        "timeDisplayPrecision": 1,
+        "isTemporaryDisableFilteringOfItemsInView": false,
+        "temporaryEmptyAndNonStopFilteringSwitchedOff": false
+      }
+    ]
+  }
+}

--- a/src/app/sample-netzgrafik/Demo_OL_LZ.json.json
+++ b/src/app/sample-netzgrafik/Demo_OL_LZ.json.json
@@ -1,1 +1,3951 @@
-{"nodes":[{"id":0,"betriebspunktName":"BN","fullName":"Bern","positionX":-960,"positionY":32,"ports":[{"id":118,"trainrunSectionId":101,"positionIndex":0,"positionAlignment":3},{"id":137,"trainrunSectionId":110,"positionIndex":1,"positionAlignment":3},{"id":94,"trainrunSectionId":90,"positionIndex":2,"positionAlignment":3},{"id":104,"trainrunSectionId":95,"positionIndex":3,"positionAlignment":3},{"id":86,"trainrunSectionId":86,"positionIndex":4,"positionAlignment":3},{"id":126,"trainrunSectionId":105,"positionIndex":5,"positionAlignment":3},{"id":214,"trainrunSectionId":141,"positionIndex":6,"positionAlignment":3},{"id":143,"trainrunSectionId":113,"positionIndex":7,"positionAlignment":3},{"id":147,"trainrunSectionId":115,"positionIndex":8,"positionAlignment":3},{"id":181,"trainrunSectionId":132,"positionIndex":9,"positionAlignment":3}],"transitions":[],"connections":[],"resourceId":65,"perronkanten":10,"connectionTime":5,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":0,"warnings":null,"labelIds":[41]},{"id":1,"betriebspunktName":"OL","fullName":"Olten","positionX":832,"positionY":32,"ports":[{"id":141,"trainrunSectionId":112,"positionIndex":0,"positionAlignment":0},{"id":108,"trainrunSectionId":97,"positionIndex":1,"positionAlignment":0},{"id":166,"trainrunSectionId":124,"positionIndex":2,"positionAlignment":0},{"id":174,"trainrunSectionId":128,"positionIndex":3,"positionAlignment":0},{"id":167,"trainrunSectionId":125,"positionIndex":0,"positionAlignment":1},{"id":175,"trainrunSectionId":129,"positionIndex":1,"positionAlignment":1},{"id":153,"trainrunSectionId":118,"positionIndex":2,"positionAlignment":1},{"id":161,"trainrunSectionId":122,"positionIndex":3,"positionAlignment":1},{"id":159,"trainrunSectionId":121,"positionIndex":4,"positionAlignment":1},{"id":185,"trainrunSectionId":134,"positionIndex":5,"positionAlignment":1},{"id":121,"trainrunSectionId":102,"positionIndex":0,"positionAlignment":2},{"id":140,"trainrunSectionId":111,"positionIndex":1,"positionAlignment":2},{"id":97,"trainrunSectionId":91,"positionIndex":2,"positionAlignment":2},{"id":107,"trainrunSectionId":96,"positionIndex":3,"positionAlignment":2},{"id":210,"trainrunSectionId":139,"positionIndex":4,"positionAlignment":2},{"id":129,"trainrunSectionId":106,"positionIndex":5,"positionAlignment":2},{"id":146,"trainrunSectionId":136,"positionIndex":6,"positionAlignment":2},{"id":150,"trainrunSectionId":137,"positionIndex":7,"positionAlignment":2},{"id":184,"trainrunSectionId":138,"positionIndex":8,"positionAlignment":2},{"id":122,"trainrunSectionId":103,"positionIndex":0,"positionAlignment":3},{"id":98,"trainrunSectionId":92,"positionIndex":1,"positionAlignment":3},{"id":151,"trainrunSectionId":117,"positionIndex":2,"positionAlignment":3}],"transitions":[{"id":102,"port1Id":97,"port2Id":98,"isNonStopTransit":true},{"id":104,"port1Id":108,"port2Id":107,"isNonStopTransit":false},{"id":109,"port1Id":121,"port2Id":122,"isNonStopTransit":true},{"id":114,"port1Id":141,"port2Id":140,"isNonStopTransit":false},{"id":117,"port1Id":150,"port2Id":151,"isNonStopTransit":false},{"id":121,"port1Id":166,"port2Id":167,"isNonStopTransit":false},{"id":124,"port1Id":174,"port2Id":175,"isNonStopTransit":false},{"id":128,"port1Id":185,"port2Id":184,"isNonStopTransit":true}],"connections":[],"resourceId":66,"perronkanten":10,"connectionTime":5,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[2,3]},{"id":2,"betriebspunktName":"ZUE","fullName":"Zuerich","positionX":2464,"positionY":32,"ports":[{"id":123,"trainrunSectionId":103,"positionIndex":0,"positionAlignment":2},{"id":99,"trainrunSectionId":92,"positionIndex":1,"positionAlignment":2},{"id":152,"trainrunSectionId":117,"positionIndex":2,"positionAlignment":2}],"transitions":[],"connections":[],"resourceId":67,"perronkanten":10,"connectionTime":5,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[42]},{"id":3,"betriebspunktName":"LZ","fullName":"Luzern","positionX":832,"positionY":1440,"ports":[{"id":93,"trainrunSectionId":89,"positionIndex":0,"positionAlignment":0},{"id":172,"trainrunSectionId":127,"positionIndex":1,"positionAlignment":0},{"id":180,"trainrunSectionId":131,"positionIndex":2,"positionAlignment":0},{"id":158,"trainrunSectionId":120,"positionIndex":3,"positionAlignment":0}],"transitions":[],"connections":[],"resourceId":68,"perronkanten":10,"connectionTime":5,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[40]},{"id":4,"betriebspunktName":"ZF","fullName":"Zofingen","positionX":832,"positionY":576,"ports":[{"id":168,"trainrunSectionId":125,"positionIndex":0,"positionAlignment":0},{"id":176,"trainrunSectionId":129,"positionIndex":1,"positionAlignment":0},{"id":154,"trainrunSectionId":118,"positionIndex":2,"positionAlignment":0},{"id":162,"trainrunSectionId":122,"positionIndex":3,"positionAlignment":0},{"id":160,"trainrunSectionId":121,"positionIndex":4,"positionAlignment":0},{"id":186,"trainrunSectionId":134,"positionIndex":5,"positionAlignment":0},{"id":90,"trainrunSectionId":88,"positionIndex":0,"positionAlignment":1},{"id":169,"trainrunSectionId":126,"positionIndex":1,"positionAlignment":1},{"id":177,"trainrunSectionId":130,"positionIndex":2,"positionAlignment":1},{"id":155,"trainrunSectionId":119,"positionIndex":3,"positionAlignment":1},{"id":163,"trainrunSectionId":123,"positionIndex":4,"positionAlignment":1},{"id":189,"trainrunSectionId":135,"positionIndex":5,"positionAlignment":1},{"id":89,"trainrunSectionId":87,"positionIndex":0,"positionAlignment":2}],"transitions":[{"id":99,"port1Id":90,"port2Id":89,"isNonStopTransit":false},{"id":118,"port1Id":154,"port2Id":155,"isNonStopTransit":false},{"id":120,"port1Id":162,"port2Id":163,"isNonStopTransit":false},{"id":122,"port1Id":168,"port2Id":169,"isNonStopTransit":true},{"id":125,"port1Id":176,"port2Id":177,"isNonStopTransit":false},{"id":130,"port1Id":186,"port2Id":189,"isNonStopTransit":true}],"connections":[{"id":3,"port1Id":89,"port2Id":160},{"id":4,"port1Id":163,"port2Id":89},{"id":5,"port1Id":162,"port2Id":90}],"resourceId":69,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[2,3]},{"id":6,"betriebspunktName":"SS","fullName":"Sursee","positionX":832,"positionY":1024,"ports":[{"id":91,"trainrunSectionId":88,"positionIndex":0,"positionAlignment":0},{"id":170,"trainrunSectionId":126,"positionIndex":1,"positionAlignment":0},{"id":178,"trainrunSectionId":130,"positionIndex":2,"positionAlignment":0},{"id":156,"trainrunSectionId":119,"positionIndex":3,"positionAlignment":0},{"id":164,"trainrunSectionId":123,"positionIndex":4,"positionAlignment":0},{"id":190,"trainrunSectionId":135,"positionIndex":5,"positionAlignment":0},{"id":92,"trainrunSectionId":89,"positionIndex":0,"positionAlignment":1},{"id":171,"trainrunSectionId":127,"positionIndex":1,"positionAlignment":1},{"id":179,"trainrunSectionId":131,"positionIndex":2,"positionAlignment":1},{"id":157,"trainrunSectionId":120,"positionIndex":3,"positionAlignment":1}],"transitions":[{"id":100,"port1Id":91,"port2Id":92,"isNonStopTransit":false},{"id":119,"port1Id":156,"port2Id":157,"isNonStopTransit":false},{"id":123,"port1Id":170,"port2Id":171,"isNonStopTransit":true},{"id":126,"port1Id":178,"port2Id":179,"isNonStopTransit":false}],"connections":[],"resourceId":71,"perronkanten":5,"connectionTime":6,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[40]},{"id":7,"betriebspunktName":"RTR","fullName":"Rothrist","positionX":256,"positionY":32,"ports":[{"id":119,"trainrunSectionId":101,"positionIndex":0,"positionAlignment":2},{"id":138,"trainrunSectionId":110,"positionIndex":1,"positionAlignment":2},{"id":95,"trainrunSectionId":90,"positionIndex":2,"positionAlignment":2},{"id":105,"trainrunSectionId":95,"positionIndex":3,"positionAlignment":2},{"id":87,"trainrunSectionId":86,"positionIndex":4,"positionAlignment":2},{"id":127,"trainrunSectionId":105,"positionIndex":5,"positionAlignment":2},{"id":211,"trainrunSectionId":140,"positionIndex":6,"positionAlignment":2},{"id":203,"trainrunSectionId":114,"positionIndex":7,"positionAlignment":2},{"id":205,"trainrunSectionId":116,"positionIndex":8,"positionAlignment":2},{"id":207,"trainrunSectionId":133,"positionIndex":9,"positionAlignment":2},{"id":120,"trainrunSectionId":102,"positionIndex":0,"positionAlignment":3},{"id":139,"trainrunSectionId":111,"positionIndex":1,"positionAlignment":3},{"id":96,"trainrunSectionId":91,"positionIndex":2,"positionAlignment":3},{"id":106,"trainrunSectionId":96,"positionIndex":3,"positionAlignment":3},{"id":209,"trainrunSectionId":139,"positionIndex":4,"positionAlignment":3},{"id":128,"trainrunSectionId":106,"positionIndex":5,"positionAlignment":3},{"id":204,"trainrunSectionId":136,"positionIndex":6,"positionAlignment":3},{"id":206,"trainrunSectionId":137,"positionIndex":7,"positionAlignment":3},{"id":208,"trainrunSectionId":138,"positionIndex":8,"positionAlignment":3},{"id":88,"trainrunSectionId":87,"positionIndex":9,"positionAlignment":3}],"transitions":[{"id":98,"port1Id":87,"port2Id":88,"isNonStopTransit":true},{"id":101,"port1Id":95,"port2Id":96,"isNonStopTransit":true},{"id":103,"port1Id":105,"port2Id":106,"isNonStopTransit":true},{"id":108,"port1Id":119,"port2Id":120,"isNonStopTransit":true},{"id":110,"port1Id":127,"port2Id":128,"isNonStopTransit":true},{"id":113,"port1Id":138,"port2Id":139,"isNonStopTransit":true},{"id":137,"port1Id":203,"port2Id":204,"isNonStopTransit":true},{"id":138,"port1Id":205,"port2Id":206,"isNonStopTransit":true},{"id":139,"port1Id":207,"port2Id":208,"isNonStopTransit":true},{"id":140,"port1Id":211,"port2Id":209,"isNonStopTransit":true}],"connections":[],"resourceId":72,"perronkanten":5,"connectionTime":5,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[2]},{"id":8,"betriebspunktName":"LTH","fullName":"Langenthal","positionX":-320,"positionY":224,"ports":[{"id":213,"trainrunSectionId":141,"positionIndex":0,"positionAlignment":2},{"id":144,"trainrunSectionId":113,"positionIndex":1,"positionAlignment":2},{"id":148,"trainrunSectionId":115,"positionIndex":2,"positionAlignment":2},{"id":201,"trainrunSectionId":132,"positionIndex":3,"positionAlignment":2},{"id":212,"trainrunSectionId":140,"positionIndex":0,"positionAlignment":3},{"id":145,"trainrunSectionId":114,"positionIndex":1,"positionAlignment":3},{"id":149,"trainrunSectionId":116,"positionIndex":2,"positionAlignment":3},{"id":202,"trainrunSectionId":133,"positionIndex":3,"positionAlignment":3}],"transitions":[{"id":115,"port1Id":144,"port2Id":145,"isNonStopTransit":false},{"id":116,"port1Id":148,"port2Id":149,"isNonStopTransit":false},{"id":136,"port1Id":201,"port2Id":202,"isNonStopTransit":false},{"id":141,"port1Id":213,"port2Id":212,"isNonStopTransit":false}],"connections":[],"resourceId":73,"perronkanten":5,"connectionTime":5,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[1]},{"id":106,"betriebspunktName":"BS","fullName":"Basel","positionX":832,"positionY":-352,"ports":[{"id":142,"trainrunSectionId":112,"positionIndex":0,"positionAlignment":1},{"id":109,"trainrunSectionId":97,"positionIndex":1,"positionAlignment":1},{"id":165,"trainrunSectionId":124,"positionIndex":2,"positionAlignment":1},{"id":173,"trainrunSectionId":128,"positionIndex":3,"positionAlignment":1}],"transitions":[],"connections":[],"resourceId":76,"perronkanten":5,"connectionTime":3,"trainrunCategoryHaltezeiten":{"HaltezeitA":{"no_halt":false,"haltezeit":2},"HaltezeitB":{"no_halt":false,"haltezeit":2},"HaltezeitC":{"no_halt":false,"haltezeit":1},"HaltezeitD":{"no_halt":false,"haltezeit":1},"HaltezeitIPV":{"no_halt":false,"haltezeit":3},"HaltezeitUncategorized":{"no_halt":true,"haltezeit":0}},"symmetryAxis":null,"warnings":null,"labelIds":[2]}],"trainrunSections":[{"id":86,"sourceNodeId":0,"sourcePortId":86,"targetNodeId":7,"targetPortId":87,"travelTime":{"lock":true,"time":23,"warning":null,"consecutiveTime":10},"sourceDeparture":{"lock":false,"time":0,"warning":null,"consecutiveTime":0},"sourceArrival":{"lock":false,"time":0,"warning":null,"consecutiveTime":180},"targetDeparture":{"lock":false,"time":37,"warning":null,"consecutiveTime":157},"targetArrival":{"lock":false,"time":23,"warning":null,"consecutiveTime":23},"numberOfStops":0,"trainrunId":11,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-862,"y":176},{"x":-798,"y":176},{"x":190,"y":176},{"x":254,"y":176}],"textPositions":{"0":{"x":-844,"y":188},"1":{"x":-816,"y":164},"2":{"x":236,"y":164},"3":{"x":208,"y":188},"4":{"x":-304,"y":164},"5":{"x":-304,"y":164},"6":{"x":-304,"y":188}}},"warnings":null},{"id":87,"sourceNodeId":7,"sourcePortId":88,"targetNodeId":4,"targetPortId":89,"travelTime":{"lock":true,"time":5,"warning":null,"consecutiveTime":10},"sourceDeparture":{"lock":false,"time":23,"warning":null,"consecutiveTime":23},"sourceArrival":{"lock":false,"time":37,"warning":null,"consecutiveTime":157},"targetDeparture":{"lock":false,"time":32,"warning":null,"consecutiveTime":152},"targetArrival":{"lock":false,"time":28,"warning":null,"consecutiveTime":28},"numberOfStops":0,"trainrunId":11,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":354,"y":336},{"x":418,"y":336},{"x":766,"y":592},{"x":830,"y":592}],"textPositions":{"0":{"x":372,"y":348},"1":{"x":400,"y":324},"2":{"x":812,"y":580},"3":{"x":784,"y":604},"4":{"x":592,"y":452},"5":{"x":592,"y":452},"6":{"x":592,"y":476}}},"warnings":null},{"id":88,"sourceNodeId":4,"sourcePortId":90,"targetNodeId":6,"targetPortId":91,"travelTime":{"lock":true,"time":13,"warning":null,"consecutiveTime":10},"sourceDeparture":{"lock":false,"time":29,"warning":null,"consecutiveTime":29},"sourceArrival":{"lock":false,"time":31,"warning":null,"consecutiveTime":151},"targetDeparture":{"lock":false,"time":18,"warning":null,"consecutiveTime":138},"targetArrival":{"lock":false,"time":42,"warning":null,"consecutiveTime":42},"numberOfStops":0,"trainrunId":11,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":848,"y":642},{"x":848,"y":706},{"x":848,"y":958},{"x":848,"y":1022}],"textPositions":{"0":{"x":836,"y":660},"1":{"x":860,"y":688},"2":{"x":860,"y":1004},"3":{"x":836,"y":976},"4":{"x":836,"y":832},"5":{"x":836,"y":832},"6":{"x":860,"y":832}}},"warnings":null},{"id":89,"sourceNodeId":6,"sourcePortId":92,"targetNodeId":3,"targetPortId":93,"travelTime":{"lock":true,"time":18,"warning":null,"consecutiveTime":10},"sourceDeparture":{"lock":false,"time":43,"warning":null,"consecutiveTime":43},"sourceArrival":{"lock":false,"time":17,"warning":null,"consecutiveTime":137},"targetDeparture":{"lock":false,"time":59,"warning":null,"consecutiveTime":119},"targetArrival":{"lock":false,"time":1,"warning":null,"consecutiveTime":61},"numberOfStops":0,"trainrunId":11,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":848,"y":1090},{"x":848,"y":1154},{"x":848,"y":1374},{"x":848,"y":1438}],"textPositions":{"0":{"x":836,"y":1108},"1":{"x":860,"y":1136},"2":{"x":860,"y":1420},"3":{"x":836,"y":1392},"4":{"x":836,"y":1264},"5":{"x":836,"y":1264},"6":{"x":860,"y":1264}}},"warnings":null},{"id":90,"sourceNodeId":0,"sourcePortId":94,"targetNodeId":7,"targetPortId":95,"travelTime":{"lock":true,"time":23,"warning":null,"consecutiveTime":10},"sourceDeparture":{"lock":false,"time":31,"warning":null,"consecutiveTime":31},"sourceArrival":{"lock":false,"time":29,"warning":null,"consecutiveTime":149},"targetDeparture":{"lock":false,"time":6,"warning":null,"consecutiveTime":126},"targetArrival":{"lock":false,"time":54,"warning":null,"consecutiveTime":54},"numberOfStops":0,"trainrunId":12,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-862,"y":112},{"x":-798,"y":112},{"x":190,"y":112},{"x":254,"y":112}],"textPositions":{"0":{"x":-844,"y":124},"1":{"x":-816,"y":100},"2":{"x":236,"y":100},"3":{"x":208,"y":124},"4":{"x":-304,"y":100},"5":{"x":-304,"y":100},"6":{"x":-304,"y":124}}},"warnings":null},{"id":91,"sourceNodeId":7,"sourcePortId":96,"targetNodeId":1,"targetPortId":97,"travelTime":{"lock":true,"time":5,"warning":null,"consecutiveTime":10},"sourceDeparture":{"lock":false,"time":54,"warning":null,"consecutiveTime":54},"sourceArrival":{"lock":false,"time":6,"warning":null,"consecutiveTime":126},"targetDeparture":{"lock":false,"time":1,"warning":null,"consecutiveTime":121},"targetArrival":{"lock":false,"time":59,"warning":null,"consecutiveTime":59},"numberOfStops":0,"trainrunId":12,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":354,"y":112},{"x":418,"y":112},{"x":766,"y":112},{"x":830,"y":112}],"textPositions":{"0":{"x":372,"y":124},"1":{"x":400,"y":100},"2":{"x":812,"y":100},"3":{"x":784,"y":124},"4":{"x":592,"y":100},"5":{"x":592,"y":100},"6":{"x":592,"y":124}}},"warnings":null},{"id":92,"sourceNodeId":1,"sourcePortId":98,"targetNodeId":2,"targetPortId":99,"travelTime":{"lock":true,"time":29,"warning":null,"consecutiveTime":10},"sourceDeparture":{"lock":false,"time":59,"warning":null,"consecutiveTime":59},"sourceArrival":{"lock":false,"time":1,"warning":null,"consecutiveTime":121},"targetDeparture":{"lock":false,"time":32,"warning":null,"consecutiveTime":92},"targetArrival":{"lock":false,"time":28,"warning":null,"consecutiveTime":88},"numberOfStops":0,"trainrunId":12,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1026,"y":80},{"x":1090,"y":80},{"x":2398,"y":80},{"x":2462,"y":80}],"textPositions":{"0":{"x":1044,"y":92},"1":{"x":1072,"y":68},"2":{"x":2444,"y":68},"3":{"x":2416,"y":92},"4":{"x":1744,"y":68},"5":{"x":1744,"y":68},"6":{"x":1744,"y":92}}},"warnings":null},{"id":95,"sourceNodeId":0,"sourcePortId":104,"targetNodeId":7,"targetPortId":105,"travelTime":{"lock":true,"time":23,"warning":null,"consecutiveTime":10},"sourceDeparture":{"lock":false,"time":4,"warning":null,"consecutiveTime":4},"sourceArrival":{"lock":false,"time":56,"warning":null,"consecutiveTime":176},"targetDeparture":{"lock":false,"time":33,"warning":null,"consecutiveTime":153},"targetArrival":{"lock":false,"time":27,"warning":null,"consecutiveTime":27},"numberOfStops":0,"trainrunId":14,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-862,"y":144},{"x":-798,"y":144},{"x":190,"y":144},{"x":254,"y":144}],"textPositions":{"0":{"x":-844,"y":156},"1":{"x":-816,"y":132},"2":{"x":236,"y":132},"3":{"x":208,"y":156},"4":{"x":-304,"y":132},"5":{"x":-304,"y":132},"6":{"x":-304,"y":156}}},"warnings":null},{"id":96,"sourceNodeId":7,"sourcePortId":106,"targetNodeId":1,"targetPortId":107,"travelTime":{"lock":true,"time":5,"warning":null,"consecutiveTime":10},"sourceDeparture":{"lock":false,"time":27,"warning":null,"consecutiveTime":27},"sourceArrival":{"lock":false,"time":33,"warning":null,"consecutiveTime":153},"targetDeparture":{"lock":false,"time":28,"warning":null,"consecutiveTime":148},"targetArrival":{"lock":false,"time":32,"warning":null,"consecutiveTime":32},"numberOfStops":0,"trainrunId":14,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":354,"y":144},{"x":418,"y":144},{"x":766,"y":144},{"x":830,"y":144}],"textPositions":{"0":{"x":372,"y":156},"1":{"x":400,"y":132},"2":{"x":812,"y":132},"3":{"x":784,"y":156},"4":{"x":592,"y":132},"5":{"x":592,"y":132},"6":{"x":592,"y":156}}},"warnings":null},{"id":97,"sourceNodeId":1,"sourcePortId":108,"targetNodeId":106,"targetPortId":109,"travelTime":{"lock":true,"time":27,"warning":null,"consecutiveTime":10},"sourceDeparture":{"lock":false,"time":34,"warning":null,"consecutiveTime":34},"sourceArrival":{"lock":false,"time":26,"warning":null,"consecutiveTime":146},"targetDeparture":{"lock":false,"time":59,"warning":null,"consecutiveTime":119},"targetArrival":{"lock":false,"time":1,"warning":null,"consecutiveTime":61},"numberOfStops":0,"trainrunId":14,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":880,"y":30},{"x":880,"y":-34},{"x":880,"y":-222},{"x":880,"y":-286}],"textPositions":{"0":{"x":892,"y":12},"1":{"x":868,"y":-16},"2":{"x":868,"y":-268},"3":{"x":892,"y":-240},"4":{"x":868,"y":-128},"5":{"x":868,"y":-128},"6":{"x":892,"y":-128}}},"warnings":null},{"id":101,"sourceNodeId":0,"sourcePortId":118,"targetNodeId":7,"targetPortId":119,"travelTime":{"lock":true,"time":23,"warning":null,"consecutiveTime":10},"sourceDeparture":{"lock":false,"time":2,"warning":null,"consecutiveTime":2},"sourceArrival":{"lock":false,"time":58,"warning":null,"consecutiveTime":58},"targetDeparture":{"lock":false,"time":35,"warning":null,"consecutiveTime":35},"targetArrival":{"lock":false,"time":25,"warning":null,"consecutiveTime":25},"numberOfStops":0,"trainrunId":16,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-862,"y":48},{"x":-798,"y":48},{"x":190,"y":48},{"x":254,"y":48}],"textPositions":{"0":{"x":-844,"y":60},"1":{"x":-816,"y":36},"2":{"x":236,"y":36},"3":{"x":208,"y":60},"4":{"x":-304,"y":36},"5":{"x":-304,"y":36},"6":{"x":-304,"y":60}}},"warnings":null},{"id":102,"sourceNodeId":7,"sourcePortId":120,"targetNodeId":1,"targetPortId":121,"travelTime":{"lock":true,"time":5,"warning":null,"consecutiveTime":10},"sourceDeparture":{"lock":false,"time":25,"warning":null,"consecutiveTime":25},"sourceArrival":{"lock":false,"time":35,"warning":null,"consecutiveTime":35},"targetDeparture":{"lock":false,"time":30,"warning":null,"consecutiveTime":30},"targetArrival":{"lock":false,"time":30,"warning":null,"consecutiveTime":30},"numberOfStops":0,"trainrunId":16,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":354,"y":48},{"x":418,"y":48},{"x":766,"y":48},{"x":830,"y":48}],"textPositions":{"0":{"x":372,"y":60},"1":{"x":400,"y":36},"2":{"x":812,"y":36},"3":{"x":784,"y":60},"4":{"x":592,"y":36},"5":{"x":592,"y":36},"6":{"x":592,"y":60}}},"warnings":null},{"id":103,"sourceNodeId":1,"sourcePortId":122,"targetNodeId":2,"targetPortId":123,"travelTime":{"lock":true,"time":28,"warning":null,"consecutiveTime":10},"sourceDeparture":{"lock":false,"time":30,"warning":null,"consecutiveTime":30},"sourceArrival":{"lock":false,"time":30,"warning":null,"consecutiveTime":30},"targetDeparture":{"lock":false,"time":2,"warning":null,"consecutiveTime":2},"targetArrival":{"lock":false,"time":58,"warning":null,"consecutiveTime":58},"numberOfStops":0,"trainrunId":16,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1026,"y":48},{"x":1090,"y":48},{"x":2398,"y":48},{"x":2462,"y":48}],"textPositions":{"0":{"x":1044,"y":60},"1":{"x":1072,"y":36},"2":{"x":2444,"y":36},"3":{"x":2416,"y":60},"4":{"x":1744,"y":36},"5":{"x":1744,"y":36},"6":{"x":1744,"y":60}}},"warnings":null},{"id":105,"sourceNodeId":0,"sourcePortId":126,"targetNodeId":7,"targetPortId":127,"travelTime":{"lock":true,"time":23,"warning":null,"consecutiveTime":10},"sourceDeparture":{"lock":false,"time":33,"warning":null,"consecutiveTime":33},"sourceArrival":{"lock":false,"time":27,"warning":null,"consecutiveTime":147},"targetDeparture":{"lock":false,"time":4,"warning":null,"consecutiveTime":124},"targetArrival":{"lock":false,"time":56,"warning":null,"consecutiveTime":56},"numberOfStops":0,"trainrunId":18,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-862,"y":208},{"x":-798,"y":208},{"x":190,"y":208},{"x":254,"y":208}],"textPositions":{"0":{"x":-844,"y":220},"1":{"x":-816,"y":196},"2":{"x":236,"y":196},"3":{"x":208,"y":220},"4":{"x":-304,"y":196},"5":{"x":-304,"y":196},"6":{"x":-304,"y":220}}},"warnings":null},{"id":106,"sourceNodeId":7,"sourcePortId":128,"targetNodeId":1,"targetPortId":129,"travelTime":{"lock":true,"time":5,"warning":null,"consecutiveTime":10},"sourceDeparture":{"lock":false,"time":56,"warning":null,"consecutiveTime":56},"sourceArrival":{"lock":false,"time":4,"warning":null,"consecutiveTime":124},"targetDeparture":{"lock":false,"time":59,"warning":null,"consecutiveTime":119},"targetArrival":{"lock":false,"time":1,"warning":null,"consecutiveTime":61},"numberOfStops":0,"trainrunId":18,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":354,"y":208},{"x":418,"y":208},{"x":766,"y":208},{"x":830,"y":208}],"textPositions":{"0":{"x":372,"y":220},"1":{"x":400,"y":196},"2":{"x":812,"y":196},"3":{"x":784,"y":220},"4":{"x":592,"y":196},"5":{"x":592,"y":196},"6":{"x":592,"y":220}}},"warnings":null},{"id":110,"sourceNodeId":0,"sourcePortId":137,"targetNodeId":7,"targetPortId":138,"travelTime":{"lock":true,"time":22,"warning":null,"consecutiveTime":10},"sourceDeparture":{"lock":false,"time":36,"warning":null,"consecutiveTime":36},"sourceArrival":{"lock":false,"time":24,"warning":null,"consecutiveTime":144},"targetDeparture":{"lock":false,"time":2,"warning":null,"consecutiveTime":122},"targetArrival":{"lock":false,"time":58,"warning":null,"consecutiveTime":58},"numberOfStops":0,"trainrunId":20,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-862,"y":80},{"x":-798,"y":80},{"x":190,"y":80},{"x":254,"y":80}],"textPositions":{"0":{"x":-844,"y":92},"1":{"x":-816,"y":68},"2":{"x":236,"y":68},"3":{"x":208,"y":92},"4":{"x":-304,"y":68},"5":{"x":-304,"y":68},"6":{"x":-304,"y":92}}},"warnings":null},{"id":111,"sourceNodeId":7,"sourcePortId":139,"targetNodeId":1,"targetPortId":140,"travelTime":{"lock":false,"time":5,"warning":null,"consecutiveTime":10},"sourceDeparture":{"lock":false,"time":58,"warning":null,"consecutiveTime":58},"sourceArrival":{"lock":false,"time":2,"warning":null,"consecutiveTime":122},"targetDeparture":{"lock":false,"time":57,"warning":null,"consecutiveTime":117},"targetArrival":{"lock":false,"time":3,"warning":null,"consecutiveTime":63},"numberOfStops":0,"trainrunId":20,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":354,"y":80},{"x":418,"y":80},{"x":766,"y":80},{"x":830,"y":80}],"textPositions":{"0":{"x":372,"y":92},"1":{"x":400,"y":68},"2":{"x":812,"y":68},"3":{"x":784,"y":92},"4":{"x":592,"y":68},"5":{"x":592,"y":68},"6":{"x":592,"y":92}}},"warnings":null},{"id":112,"sourceNodeId":1,"sourcePortId":141,"targetNodeId":106,"targetPortId":142,"travelTime":{"lock":true,"time":27,"warning":null,"consecutiveTime":10},"sourceDeparture":{"lock":false,"time":5,"warning":null,"consecutiveTime":65},"sourceArrival":{"lock":false,"time":55,"warning":null,"consecutiveTime":115},"targetDeparture":{"lock":true,"time":28,"warning":null,"consecutiveTime":88},"targetArrival":{"lock":true,"time":32,"warning":null,"consecutiveTime":92},"numberOfStops":0,"trainrunId":20,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":848,"y":30},{"x":848,"y":-34},{"x":848,"y":-222},{"x":848,"y":-286}],"textPositions":{"0":{"x":860,"y":12},"1":{"x":836,"y":-16},"2":{"x":836,"y":-268},"3":{"x":860,"y":-240},"4":{"x":836,"y":-128},"5":{"x":836,"y":-128},"6":{"x":860,"y":-128}}},"warnings":null},{"id":113,"sourceNodeId":0,"sourcePortId":143,"targetNodeId":8,"targetPortId":144,"travelTime":{"lock":true,"time":33,"warning":null,"consecutiveTime":10},"sourceDeparture":{"lock":false,"time":7,"warning":null,"consecutiveTime":7},"sourceArrival":{"lock":false,"time":53,"warning":null,"consecutiveTime":53},"targetDeparture":{"lock":false,"time":20,"warning":null,"consecutiveTime":20},"targetArrival":{"lock":false,"time":40,"warning":null,"consecutiveTime":40},"numberOfStops":0,"trainrunId":21,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-862,"y":272},{"x":-798,"y":272},{"x":-386,"y":272},{"x":-322,"y":272}],"textPositions":{"0":{"x":-844,"y":284},"1":{"x":-816,"y":260},"2":{"x":-340,"y":260},"3":{"x":-368,"y":284},"4":{"x":-592,"y":260},"5":{"x":-592,"y":260},"6":{"x":-592,"y":284}}},"warnings":null},{"id":114,"sourceNodeId":8,"sourcePortId":145,"targetNodeId":7,"targetPortId":203,"travelTime":{"lock":true,"time":4,"warning":null,"consecutiveTime":10},"sourceDeparture":{"lock":false,"time":42,"warning":null,"consecutiveTime":42},"sourceArrival":{"lock":false,"time":18,"warning":null,"consecutiveTime":18},"targetDeparture":{"lock":false,"time":14,"warning":null,"consecutiveTime":14},"targetArrival":{"lock":false,"time":46,"warning":null,"consecutiveTime":46},"numberOfStops":0,"trainrunId":21,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-222,"y":272},{"x":-158,"y":272},{"x":190,"y":272},{"x":254,"y":272}],"textPositions":{"0":{"x":-204,"y":284},"1":{"x":-176,"y":260},"2":{"x":236,"y":260},"3":{"x":208,"y":284},"4":{"x":16,"y":260},"5":{"x":16,"y":260},"6":{"x":16,"y":284}}},"warnings":null},{"id":115,"sourceNodeId":0,"sourcePortId":147,"targetNodeId":8,"targetPortId":148,"travelTime":{"lock":true,"time":32,"warning":null,"consecutiveTime":10},"sourceDeparture":{"lock":false,"time":38,"warning":null,"consecutiveTime":38},"sourceArrival":{"lock":false,"time":22,"warning":null,"consecutiveTime":262},"targetDeparture":{"lock":false,"time":50,"warning":null,"consecutiveTime":230},"targetArrival":{"lock":false,"time":10,"warning":null,"consecutiveTime":70},"numberOfStops":0,"trainrunId":22,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-862,"y":304},{"x":-798,"y":304},{"x":-386,"y":304},{"x":-322,"y":304}],"textPositions":{"0":{"x":-844,"y":316},"1":{"x":-816,"y":292},"2":{"x":-340,"y":292},"3":{"x":-368,"y":316},"4":{"x":-592,"y":292},"5":{"x":-592,"y":292},"6":{"x":-592,"y":316}}},"warnings":null},{"id":116,"sourceNodeId":8,"sourcePortId":149,"targetNodeId":7,"targetPortId":205,"travelTime":{"lock":true,"time":5,"warning":null,"consecutiveTime":10},"sourceDeparture":{"lock":false,"time":12,"warning":null,"consecutiveTime":72},"sourceArrival":{"lock":false,"time":48,"warning":null,"consecutiveTime":228},"targetDeparture":{"lock":false,"time":43,"warning":null,"consecutiveTime":223},"targetArrival":{"lock":false,"time":17,"warning":null,"consecutiveTime":77},"numberOfStops":0,"trainrunId":22,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-222,"y":304},{"x":-158,"y":304},{"x":190,"y":304},{"x":254,"y":304}],"textPositions":{"0":{"x":-204,"y":316},"1":{"x":-176,"y":292},"2":{"x":236,"y":292},"3":{"x":208,"y":316},"4":{"x":16,"y":292},"5":{"x":16,"y":292},"6":{"x":16,"y":316}}},"warnings":null},{"id":117,"sourceNodeId":1,"sourcePortId":151,"targetNodeId":2,"targetPortId":152,"travelTime":{"lock":true,"time":36,"warning":null,"consecutiveTime":10},"sourceDeparture":{"lock":false,"time":24,"warning":null,"consecutiveTime":84},"sourceArrival":{"lock":false,"time":36,"warning":null,"consecutiveTime":216},"targetDeparture":{"lock":false,"time":0,"warning":null,"consecutiveTime":180},"targetArrival":{"lock":false,"time":0,"warning":null,"consecutiveTime":120},"numberOfStops":0,"trainrunId":22,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1026,"y":112},{"x":1090,"y":112},{"x":2398,"y":112},{"x":2462,"y":112}],"textPositions":{"0":{"x":1044,"y":124},"1":{"x":1072,"y":100},"2":{"x":2444,"y":100},"3":{"x":2416,"y":124},"4":{"x":1744,"y":100},"5":{"x":1744,"y":100},"6":{"x":1744,"y":124}}},"warnings":null},{"id":118,"sourceNodeId":1,"sourcePortId":153,"targetNodeId":4,"targetPortId":154,"travelTime":{"lock":true,"time":6,"warning":null,"consecutiveTime":10},"sourceDeparture":{"lock":false,"time":6,"warning":null,"consecutiveTime":6},"sourceArrival":{"lock":false,"time":54,"warning":null,"consecutiveTime":54},"targetDeparture":{"lock":false,"time":48,"warning":null,"consecutiveTime":48},"targetArrival":{"lock":false,"time":12,"warning":null,"consecutiveTime":12},"numberOfStops":0,"trainrunId":23,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":912,"y":350},{"x":912,"y":414},{"x":912,"y":510},{"x":912,"y":574}],"textPositions":{"0":{"x":900,"y":368},"1":{"x":924,"y":396},"2":{"x":924,"y":556},"3":{"x":900,"y":528},"4":{"x":900,"y":462},"5":{"x":900,"y":462},"6":{"x":924,"y":462}}},"warnings":null},{"id":119,"sourceNodeId":4,"sourcePortId":155,"targetNodeId":6,"targetPortId":156,"travelTime":{"lock":true,"time":17,"warning":null,"consecutiveTime":10},"sourceDeparture":{"lock":false,"time":13,"warning":null,"consecutiveTime":13},"sourceArrival":{"lock":false,"time":47,"warning":null,"consecutiveTime":47},"targetDeparture":{"lock":false,"time":30,"warning":null,"consecutiveTime":30},"targetArrival":{"lock":false,"time":30,"warning":null,"consecutiveTime":30},"numberOfStops":0,"trainrunId":23,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":944,"y":642},{"x":944,"y":706},{"x":944,"y":958},{"x":944,"y":1022}],"textPositions":{"0":{"x":932,"y":660},"1":{"x":956,"y":688},"2":{"x":956,"y":1004},"3":{"x":932,"y":976},"4":{"x":932,"y":832},"5":{"x":932,"y":832},"6":{"x":956,"y":832}}},"warnings":null},{"id":120,"sourceNodeId":6,"sourcePortId":157,"targetNodeId":3,"targetPortId":158,"travelTime":{"lock":true,"time":24,"warning":null,"consecutiveTime":10},"sourceDeparture":{"lock":false,"time":31,"warning":null,"consecutiveTime":31},"sourceArrival":{"lock":false,"time":29,"warning":null,"consecutiveTime":29},"targetDeparture":{"lock":false,"time":5,"warning":null,"consecutiveTime":5},"targetArrival":{"lock":false,"time":55,"warning":null,"consecutiveTime":55},"numberOfStops":0,"trainrunId":23,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":944,"y":1090},{"x":944,"y":1154},{"x":944,"y":1374},{"x":944,"y":1438}],"textPositions":{"0":{"x":932,"y":1108},"1":{"x":956,"y":1136},"2":{"x":956,"y":1420},"3":{"x":932,"y":1392},"4":{"x":932,"y":1264},"5":{"x":932,"y":1264},"6":{"x":956,"y":1264}}},"warnings":null},{"id":121,"sourceNodeId":1,"sourcePortId":159,"targetNodeId":4,"targetPortId":160,"travelTime":{"lock":true,"time":9,"warning":null,"consecutiveTime":10},"sourceDeparture":{"lock":false,"time":12,"warning":null,"consecutiveTime":12},"sourceArrival":{"lock":false,"time":48,"warning":null,"consecutiveTime":48},"targetDeparture":{"lock":false,"time":39,"warning":null,"consecutiveTime":39},"targetArrival":{"lock":false,"time":21,"warning":null,"consecutiveTime":21},"numberOfStops":0,"trainrunId":24,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":976,"y":350},{"x":976,"y":414},{"x":976,"y":510},{"x":976,"y":574}],"textPositions":{"0":{"x":964,"y":368},"1":{"x":988,"y":396},"2":{"x":988,"y":556},"3":{"x":964,"y":528},"4":{"x":964,"y":462},"5":{"x":964,"y":462},"6":{"x":988,"y":462}}},"warnings":null},{"id":122,"sourceNodeId":1,"sourcePortId":161,"targetNodeId":4,"targetPortId":162,"travelTime":{"lock":true,"time":8,"warning":null,"consecutiveTime":10},"sourceDeparture":{"lock":false,"time":36,"warning":null,"consecutiveTime":36},"sourceArrival":{"lock":false,"time":24,"warning":null,"consecutiveTime":144},"targetDeparture":{"lock":false,"time":16,"warning":null,"consecutiveTime":136},"targetArrival":{"lock":false,"time":44,"warning":null,"consecutiveTime":44},"numberOfStops":0,"trainrunId":25,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":944,"y":350},{"x":944,"y":414},{"x":944,"y":510},{"x":944,"y":574}],"textPositions":{"0":{"x":932,"y":368},"1":{"x":956,"y":396},"2":{"x":956,"y":556},"3":{"x":932,"y":528},"4":{"x":932,"y":462},"5":{"x":932,"y":462},"6":{"x":956,"y":462}}},"warnings":null},{"id":123,"sourceNodeId":4,"sourcePortId":163,"targetNodeId":6,"targetPortId":164,"travelTime":{"lock":true,"time":22,"warning":null,"consecutiveTime":10},"sourceDeparture":{"lock":false,"time":45,"warning":null,"consecutiveTime":45},"sourceArrival":{"lock":false,"time":15,"warning":null,"consecutiveTime":135},"targetDeparture":{"lock":false,"time":53,"warning":null,"consecutiveTime":113},"targetArrival":{"lock":false,"time":7,"warning":null,"consecutiveTime":67},"numberOfStops":0,"trainrunId":25,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":976,"y":642},{"x":976,"y":706},{"x":976,"y":958},{"x":976,"y":1022}],"textPositions":{"0":{"x":964,"y":660},"1":{"x":988,"y":688},"2":{"x":988,"y":1004},"3":{"x":964,"y":976},"4":{"x":964,"y":832},"5":{"x":964,"y":832},"6":{"x":988,"y":832}}},"warnings":null},{"id":124,"sourceNodeId":106,"sourcePortId":165,"targetNodeId":1,"targetPortId":166,"travelTime":{"lock":true,"time":25,"warning":null,"consecutiveTime":10},"sourceDeparture":{"lock":false,"time":3,"warning":null,"consecutiveTime":3},"sourceArrival":{"lock":false,"time":57,"warning":null,"consecutiveTime":177},"targetDeparture":{"lock":false,"time":32,"warning":null,"consecutiveTime":152},"targetArrival":{"lock":false,"time":28,"warning":null,"consecutiveTime":28},"numberOfStops":0,"trainrunId":26,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":912,"y":-286},{"x":912,"y":-222},{"x":912,"y":-34},{"x":912,"y":30}],"textPositions":{"0":{"x":900,"y":-268},"1":{"x":924,"y":-240},"2":{"x":924,"y":12},"3":{"x":900,"y":-16},"4":{"x":900,"y":-128},"5":{"x":900,"y":-128},"6":{"x":924,"y":-128}}},"warnings":null},{"id":125,"sourceNodeId":1,"sourcePortId":167,"targetNodeId":4,"targetPortId":168,"travelTime":{"lock":true,"time":6,"warning":null,"consecutiveTime":10},"sourceDeparture":{"lock":false,"time":30,"warning":null,"consecutiveTime":30},"sourceArrival":{"lock":false,"time":30,"warning":null,"consecutiveTime":150},"targetDeparture":{"lock":false,"time":24,"warning":null,"consecutiveTime":144},"targetArrival":{"lock":false,"time":36,"warning":null,"consecutiveTime":36},"numberOfStops":0,"trainrunId":26,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":848,"y":350},{"x":848,"y":414},{"x":848,"y":510},{"x":848,"y":574}],"textPositions":{"0":{"x":836,"y":368},"1":{"x":860,"y":396},"2":{"x":860,"y":556},"3":{"x":836,"y":528},"4":{"x":836,"y":462},"5":{"x":836,"y":462},"6":{"x":860,"y":462}}},"warnings":null},{"id":126,"sourceNodeId":4,"sourcePortId":169,"targetNodeId":6,"targetPortId":170,"travelTime":{"lock":true,"time":10,"warning":null,"consecutiveTime":10},"sourceDeparture":{"lock":false,"time":36,"warning":null,"consecutiveTime":36},"sourceArrival":{"lock":false,"time":24,"warning":null,"consecutiveTime":144},"targetDeparture":{"lock":false,"time":14,"warning":null,"consecutiveTime":134},"targetArrival":{"lock":false,"time":46,"warning":null,"consecutiveTime":46},"numberOfStops":0,"trainrunId":26,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":880,"y":642},{"x":880,"y":706},{"x":880,"y":958},{"x":880,"y":1022}],"textPositions":{"0":{"x":868,"y":660},"1":{"x":892,"y":688},"2":{"x":892,"y":1004},"3":{"x":868,"y":976},"4":{"x":868,"y":832},"5":{"x":868,"y":832},"6":{"x":892,"y":832}}},"warnings":null},{"id":127,"sourceNodeId":6,"sourcePortId":171,"targetNodeId":3,"targetPortId":172,"travelTime":{"lock":true,"time":19,"warning":null,"consecutiveTime":10},"sourceDeparture":{"lock":false,"time":46,"warning":null,"consecutiveTime":46},"sourceArrival":{"lock":false,"time":14,"warning":null,"consecutiveTime":134},"targetDeparture":{"lock":false,"time":55,"warning":null,"consecutiveTime":115},"targetArrival":{"lock":false,"time":5,"warning":null,"consecutiveTime":65},"numberOfStops":0,"trainrunId":26,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":880,"y":1090},{"x":880,"y":1154},{"x":880,"y":1374},{"x":880,"y":1438}],"textPositions":{"0":{"x":868,"y":1108},"1":{"x":892,"y":1136},"2":{"x":892,"y":1420},"3":{"x":868,"y":1392},"4":{"x":868,"y":1264},"5":{"x":868,"y":1264},"6":{"x":892,"y":1264}}},"warnings":null},{"id":128,"sourceNodeId":106,"sourcePortId":173,"targetNodeId":1,"targetPortId":174,"travelTime":{"lock":true,"time":32,"warning":null,"consecutiveTime":10},"sourceDeparture":{"lock":false,"time":16,"warning":null,"consecutiveTime":16},"sourceArrival":{"lock":false,"time":44,"warning":null,"consecutiveTime":164},"targetDeparture":{"lock":false,"time":12,"warning":null,"consecutiveTime":132},"targetArrival":{"lock":false,"time":48,"warning":null,"consecutiveTime":48},"numberOfStops":0,"trainrunId":27,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":944,"y":-286},{"x":944,"y":-222},{"x":944,"y":-34},{"x":944,"y":30}],"textPositions":{"0":{"x":932,"y":-268},"1":{"x":956,"y":-240},"2":{"x":956,"y":12},"3":{"x":932,"y":-16},"4":{"x":932,"y":-128},"5":{"x":932,"y":-128},"6":{"x":956,"y":-128}}},"warnings":null},{"id":129,"sourceNodeId":1,"sourcePortId":175,"targetNodeId":4,"targetPortId":176,"travelTime":{"lock":true,"time":7,"warning":null,"consecutiveTime":10},"sourceDeparture":{"lock":false,"time":49,"warning":null,"consecutiveTime":49},"sourceArrival":{"lock":false,"time":11,"warning":null,"consecutiveTime":131},"targetDeparture":{"lock":false,"time":4,"warning":null,"consecutiveTime":124},"targetArrival":{"lock":false,"time":56,"warning":null,"consecutiveTime":56},"numberOfStops":0,"trainrunId":27,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":880,"y":350},{"x":880,"y":414},{"x":880,"y":510},{"x":880,"y":574}],"textPositions":{"0":{"x":868,"y":368},"1":{"x":892,"y":396},"2":{"x":892,"y":556},"3":{"x":868,"y":528},"4":{"x":868,"y":462},"5":{"x":868,"y":462},"6":{"x":892,"y":462}}},"warnings":null},{"id":130,"sourceNodeId":4,"sourcePortId":177,"targetNodeId":6,"targetPortId":178,"travelTime":{"lock":true,"time":12,"warning":null,"consecutiveTime":10},"sourceDeparture":{"lock":false,"time":58,"warning":null,"consecutiveTime":58},"sourceArrival":{"lock":false,"time":2,"warning":null,"consecutiveTime":122},"targetDeparture":{"lock":false,"time":50,"warning":null,"consecutiveTime":110},"targetArrival":{"lock":false,"time":10,"warning":null,"consecutiveTime":70},"numberOfStops":0,"trainrunId":27,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":912,"y":642},{"x":912,"y":706},{"x":912,"y":958},{"x":912,"y":1022}],"textPositions":{"0":{"x":900,"y":660},"1":{"x":924,"y":688},"2":{"x":924,"y":1004},"3":{"x":900,"y":976},"4":{"x":900,"y":832},"5":{"x":900,"y":832},"6":{"x":924,"y":832}}},"warnings":null},{"id":131,"sourceNodeId":6,"sourcePortId":179,"targetNodeId":3,"targetPortId":180,"travelTime":{"lock":true,"time":18,"warning":null,"consecutiveTime":10},"sourceDeparture":{"lock":false,"time":12,"warning":null,"consecutiveTime":72},"sourceArrival":{"lock":false,"time":48,"warning":null,"consecutiveTime":108},"targetDeparture":{"lock":false,"time":30,"warning":null,"consecutiveTime":90},"targetArrival":{"lock":false,"time":30,"warning":null,"consecutiveTime":90},"numberOfStops":0,"trainrunId":27,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":912,"y":1090},{"x":912,"y":1154},{"x":912,"y":1374},{"x":912,"y":1438}],"textPositions":{"0":{"x":900,"y":1108},"1":{"x":924,"y":1136},"2":{"x":924,"y":1420},"3":{"x":900,"y":1392},"4":{"x":900,"y":1264},"5":{"x":900,"y":1264},"6":{"x":924,"y":1264}}},"warnings":null},{"id":132,"sourceNodeId":0,"sourcePortId":181,"targetNodeId":8,"targetPortId":201,"travelTime":{"lock":true,"time":44,"warning":null,"consecutiveTime":10},"sourceDeparture":{"lock":false,"time":48,"warning":null,"consecutiveTime":48},"sourceArrival":{"lock":false,"time":12,"warning":null,"consecutiveTime":252},"targetDeparture":{"lock":false,"time":28,"warning":null,"consecutiveTime":208},"targetArrival":{"lock":false,"time":32,"warning":null,"consecutiveTime":92},"numberOfStops":0,"trainrunId":28,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-862,"y":336},{"x":-798,"y":336},{"x":-386,"y":336},{"x":-322,"y":336}],"textPositions":{"0":{"x":-844,"y":348},"1":{"x":-816,"y":324},"2":{"x":-340,"y":324},"3":{"x":-368,"y":348},"4":{"x":-592,"y":324},"5":{"x":-592,"y":324},"6":{"x":-592,"y":348}}},"warnings":null},{"id":133,"sourceNodeId":8,"sourcePortId":202,"targetNodeId":7,"targetPortId":207,"travelTime":{"lock":true,"time":6,"warning":null,"consecutiveTime":10},"sourceDeparture":{"lock":false,"time":44,"warning":null,"consecutiveTime":104},"sourceArrival":{"lock":false,"time":16,"warning":null,"consecutiveTime":196},"targetDeparture":{"lock":false,"time":10,"warning":null,"consecutiveTime":190},"targetArrival":{"lock":false,"time":50,"warning":null,"consecutiveTime":110},"numberOfStops":0,"trainrunId":28,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-222,"y":336},{"x":-158,"y":336},{"x":190,"y":336},{"x":254,"y":336}],"textPositions":{"0":{"x":-204,"y":348},"1":{"x":-176,"y":324},"2":{"x":236,"y":324},"3":{"x":208,"y":348},"4":{"x":16,"y":324},"5":{"x":16,"y":324},"6":{"x":16,"y":348}}},"warnings":null},{"id":134,"sourceNodeId":1,"sourcePortId":185,"targetNodeId":4,"targetPortId":186,"travelTime":{"lock":true,"time":13,"warning":null,"consecutiveTime":10},"sourceDeparture":{"lock":false,"time":55,"warning":null,"consecutiveTime":115},"sourceArrival":{"lock":false,"time":5,"warning":null,"consecutiveTime":185},"targetDeparture":{"lock":false,"time":52,"warning":null,"consecutiveTime":172},"targetArrival":{"lock":false,"time":8,"warning":null,"consecutiveTime":128},"numberOfStops":0,"trainrunId":28,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1008,"y":350},{"x":1008,"y":414},{"x":1008,"y":510},{"x":1008,"y":574}],"textPositions":{"0":{"x":996,"y":368},"1":{"x":1020,"y":396},"2":{"x":1020,"y":556},"3":{"x":996,"y":528},"4":{"x":996,"y":462},"5":{"x":996,"y":462},"6":{"x":1020,"y":462}}},"warnings":null},{"id":135,"sourceNodeId":4,"sourcePortId":189,"targetNodeId":6,"targetPortId":190,"travelTime":{"lock":true,"time":20,"warning":null,"consecutiveTime":10},"sourceDeparture":{"lock":false,"time":8,"warning":null,"consecutiveTime":128},"sourceArrival":{"lock":false,"time":52,"warning":null,"consecutiveTime":172},"targetDeparture":{"lock":false,"time":32,"warning":null,"consecutiveTime":152},"targetArrival":{"lock":false,"time":28,"warning":null,"consecutiveTime":148},"numberOfStops":0,"trainrunId":28,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":1008,"y":642},{"x":1008,"y":706},{"x":1008,"y":958},{"x":1008,"y":1022}],"textPositions":{"0":{"x":996,"y":660},"1":{"x":1020,"y":688},"2":{"x":1020,"y":1004},"3":{"x":996,"y":976},"4":{"x":996,"y":832},"5":{"x":996,"y":832},"6":{"x":1020,"y":832}}},"warnings":null},{"id":136,"sourceNodeId":7,"sourcePortId":204,"targetNodeId":1,"targetPortId":146,"travelTime":{"lock":true,"time":4,"warning":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":46,"warning":null,"consecutiveTime":46},"sourceArrival":{"lock":false,"time":14,"warning":null,"consecutiveTime":14},"targetDeparture":{"lock":false,"time":10,"warning":null,"consecutiveTime":10},"targetArrival":{"lock":false,"time":50,"warning":null,"consecutiveTime":50},"numberOfStops":0,"trainrunId":21,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":354,"y":240},{"x":418,"y":240},{"x":766,"y":240},{"x":830,"y":240}],"textPositions":{"0":{"x":372,"y":252},"1":{"x":400,"y":228},"2":{"x":812,"y":228},"3":{"x":784,"y":252},"4":{"x":592,"y":228},"5":{"x":592,"y":228},"6":{"x":592,"y":252}}},"warnings":null},{"id":137,"sourceNodeId":7,"sourcePortId":206,"targetNodeId":1,"targetPortId":150,"travelTime":{"lock":true,"time":5,"warning":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":17,"warning":null,"consecutiveTime":77},"sourceArrival":{"lock":false,"time":43,"warning":null,"consecutiveTime":223},"targetDeparture":{"lock":false,"time":38,"warning":null,"consecutiveTime":218},"targetArrival":{"lock":false,"time":22,"warning":null,"consecutiveTime":82},"numberOfStops":0,"trainrunId":22,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":354,"y":272},{"x":418,"y":272},{"x":766,"y":272},{"x":830,"y":272}],"textPositions":{"0":{"x":372,"y":284},"1":{"x":400,"y":260},"2":{"x":812,"y":260},"3":{"x":784,"y":284},"4":{"x":592,"y":260},"5":{"x":592,"y":260},"6":{"x":592,"y":284}}},"warnings":null},{"id":138,"sourceNodeId":7,"sourcePortId":208,"targetNodeId":1,"targetPortId":184,"travelTime":{"lock":true,"time":5,"warning":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":50,"warning":null,"consecutiveTime":110},"sourceArrival":{"lock":false,"time":10,"warning":null,"consecutiveTime":190},"targetDeparture":{"lock":false,"time":5,"warning":null,"consecutiveTime":185},"targetArrival":{"lock":false,"time":55,"warning":null,"consecutiveTime":115},"numberOfStops":0,"trainrunId":28,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":354,"y":304},{"x":418,"y":304},{"x":766,"y":304},{"x":830,"y":304}],"textPositions":{"0":{"x":372,"y":316},"1":{"x":400,"y":292},"2":{"x":812,"y":292},"3":{"x":784,"y":316},"4":{"x":592,"y":292},"5":{"x":592,"y":292},"6":{"x":592,"y":316}}},"warnings":null},{"id":139,"sourceNodeId":7,"sourcePortId":209,"targetNodeId":1,"targetPortId":210,"travelTime":{"lock":true,"time":1,"warning":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":58,"warning":null,"consecutiveTime":58},"sourceArrival":{"lock":false,"time":2,"warning":null,"consecutiveTime":2},"targetDeparture":{"lock":false,"time":1,"warning":null,"consecutiveTime":1},"targetArrival":{"lock":false,"time":59,"warning":null,"consecutiveTime":59},"numberOfStops":0,"trainrunId":29,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":354,"y":176},{"x":418,"y":176},{"x":766,"y":176},{"x":830,"y":176}],"textPositions":{"0":{"x":372,"y":188},"1":{"x":400,"y":164},"2":{"x":812,"y":164},"3":{"x":784,"y":188},"4":{"x":592,"y":164},"5":{"x":592,"y":164},"6":{"x":592,"y":188}}},"warnings":null},{"id":140,"sourceNodeId":7,"sourcePortId":211,"targetNodeId":8,"targetPortId":212,"travelTime":{"lock":true,"time":1,"warning":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":2,"warning":null,"consecutiveTime":2},"sourceArrival":{"lock":false,"time":58,"warning":null,"consecutiveTime":58},"targetDeparture":{"lock":false,"time":57,"warning":null,"consecutiveTime":57},"targetArrival":{"lock":false,"time":3,"warning":null,"consecutiveTime":3},"numberOfStops":0,"trainrunId":29,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":254,"y":240},{"x":190,"y":240},{"x":-158,"y":240},{"x":-222,"y":240}],"textPositions":{"0":{"x":236,"y":228},"1":{"x":208,"y":252},"2":{"x":-204,"y":252},"3":{"x":-176,"y":228},"4":{"x":16,"y":228},"5":{"x":16,"y":228},"6":{"x":16,"y":252}}},"warnings":null},{"id":141,"sourceNodeId":8,"sourcePortId":213,"targetNodeId":0,"targetPortId":214,"travelTime":{"lock":true,"time":1,"warning":null,"consecutiveTime":1},"sourceDeparture":{"lock":false,"time":5,"warning":null,"consecutiveTime":5},"sourceArrival":{"lock":false,"time":55,"warning":null,"consecutiveTime":55},"targetDeparture":{"lock":false,"time":54,"warning":null,"consecutiveTime":54},"targetArrival":{"lock":false,"time":6,"warning":null,"consecutiveTime":6},"numberOfStops":0,"trainrunId":29,"resourceId":0,"specificTrainrunSectionFrequencyId":null,"path":{"path":[{"x":-322,"y":240},{"x":-386,"y":240},{"x":-798,"y":240},{"x":-862,"y":240}],"textPositions":{"0":{"x":-340,"y":228},"1":{"x":-368,"y":252},"2":{"x":-844,"y":252},"3":{"x":-816,"y":228},"4":{"x":-592,"y":228},"5":{"x":-592,"y":228},"6":{"x":-592,"y":252}}},"warnings":null}],"trainruns":[{"id":11,"name":"15","categoryId":2,"frequencyId":3,"trainrunTimeCategoryId":0,"labelIds":[26]},{"id":12,"name":"8","categoryId":1,"frequencyId":3,"trainrunTimeCategoryId":0,"labelIds":[31]},{"id":14,"name":"E","categoryId":1,"frequencyId":3,"trainrunTimeCategoryId":0,"labelIds":[28]},{"id":16,"name":"1","categoryId":1,"frequencyId":3,"trainrunTimeCategoryId":0,"labelIds":[30]},{"id":18,"name":"16","categoryId":2,"frequencyId":3,"trainrunTimeCategoryId":0,"labelIds":[27]},{"id":20,"name":"61","categoryId":1,"frequencyId":3,"trainrunTimeCategoryId":0,"labelIds":[29]},{"id":21,"name":"17","categoryId":2,"frequencyId":3,"trainrunTimeCategoryId":0,"labelIds":[32]},{"id":22,"name":"35","categoryId":2,"frequencyId":3,"trainrunTimeCategoryId":0,"labelIds":[33]},{"id":23,"name":"","categoryId":3,"frequencyId":3,"trainrunTimeCategoryId":0,"labelIds":[37]},{"id":24,"name":"29a","categoryId":4,"frequencyId":3,"trainrunTimeCategoryId":0,"labelIds":[38]},{"id":25,"name":"29","categoryId":3,"frequencyId":2,"trainrunTimeCategoryId":0,"labelIds":[39]},{"id":26,"name":"26","categoryId":2,"frequencyId":3,"trainrunTimeCategoryId":0,"labelIds":[35]},{"id":27,"name":"27","categoryId":2,"frequencyId":3,"trainrunTimeCategoryId":0,"labelIds":[36]},{"id":28,"name":"X","categoryId":5,"frequencyId":3,"trainrunTimeCategoryId":0,"labelIds":[34]},{"id":29,"name":"X","categoryId":1,"frequencyId":3,"trainrunTimeCategoryId":0,"labelIds":[]}],"resources":[{"id":65,"capacity":10},{"id":66,"capacity":8},{"id":67,"capacity":15},{"id":68,"capacity":10},{"id":69,"capacity":3},{"id":70,"capacity":2},{"id":71,"capacity":3},{"id":72,"capacity":3},{"id":73,"capacity":3},{"id":74,"capacity":2},{"id":75,"capacity":2},{"id":76,"capacity":9},{"id":77,"capacity":2}],"metadata":{"netzgrafikColors":[],"trainrunCategories":[{"id":0,"name":"International","order":0,"colorRef":"EC","shortName":"EC","fachCategory":"HaltezeitIPV","sectionHeadway":2,"nodeHeadwayStop":2,"nodeHeadwayNonStop":2,"minimalTurnaroundTime":8},{"id":1,"name":"InterCity","order":1,"colorRef":"IC","shortName":"IC","fachCategory":"HaltezeitA","sectionHeadway":2,"nodeHeadwayStop":2,"nodeHeadwayNonStop":2,"minimalTurnaroundTime":8},{"id":2,"name":"InterRegio","order":2,"colorRef":"IR","shortName":"IR","fachCategory":"HaltezeitB","sectionHeadway":2,"nodeHeadwayStop":2,"nodeHeadwayNonStop":2,"minimalTurnaroundTime":8},{"id":3,"name":"RegioExpress","order":3,"colorRef":"RE","shortName":"RE","fachCategory":"HaltezeitC","sectionHeadway":2,"nodeHeadwayStop":2,"nodeHeadwayNonStop":2,"minimalTurnaroundTime":8},{"id":4,"name":"RegioUndSBahnverkehr","order":4,"colorRef":"S","shortName":"S","fachCategory":"HaltezeitD","sectionHeadway":2,"nodeHeadwayStop":2,"nodeHeadwayNonStop":2,"minimalTurnaroundTime":8},{"id":5,"name":"GüterExpress","order":5,"colorRef":"GEX","shortName":"GEX","fachCategory":"HaltezeitUncategorized","sectionHeadway":3,"nodeHeadwayStop":3,"nodeHeadwayNonStop":3,"minimalTurnaroundTime":8},{"id":6,"name":"Güterverkehr","order":6,"colorRef":"G","shortName":"G","fachCategory":"HaltezeitUncategorized","sectionHeadway":3,"nodeHeadwayStop":3,"nodeHeadwayNonStop":3,"minimalTurnaroundTime":8}],"trainrunFrequencies":[{"id":0,"name":"verkehrt viertelstündlich","order":0,"offset":0,"frequency":15,"shortName":"15","linePatternRef":"15"},{"id":1,"name":"verkehrt im 20 Minuten Takt","order":0,"offset":0,"frequency":20,"shortName":"20","linePatternRef":"20"},{"id":2,"name":"verkehrt halbstündlich","order":0,"offset":0,"frequency":30,"shortName":"30","linePatternRef":"30"},{"id":3,"name":"verkehrt stündlich","order":0,"offset":0,"frequency":60,"shortName":"60","linePatternRef":"60"},{"id":4,"name":"verkehrt zweistündlich (gerade)","order":0,"offset":0,"frequency":120,"shortName":"120","linePatternRef":"120"},{"id":5,"name":"verkehrt zweistündlich (ungerade)","order":0,"offset":60,"frequency":120,"shortName":"120+","linePatternRef":"120"}],"trainrunTimeCategories":[{"id":0,"name":"verkehrt uneingeschränkt","order":0,"weekday":[1,2,3,4,5,6,7],"shortName":"7/24","linePatternRef":"7/24","dayTimeInterval":[]},{"id":1,"name":"verkehrt zur Hauptverkehrszeit","order":0,"weekday":[1,2,3,4,5,6,7],"shortName":"HVZ","linePatternRef":"HVZ","dayTimeInterval":[{"to":420,"from":360},{"to":1140,"from":960}]},{"id":2,"name":"verkehrt zeitweise","order":0,"weekday":[],"shortName":"zeitweise","linePatternRef":"ZEITWEISE","dayTimeInterval":[]}]},"freeFloatingTexts":[],"labels":[{"id":1,"label":"BLS","labelGroupId":1,"labelRef":"Node"},{"id":2,"label":"SBB","labelGroupId":1,"labelRef":"Node"},{"id":3,"label":"OL-LZ","labelGroupId":1,"labelRef":"Node"},{"id":26,"label":"IR15","labelGroupId":9,"labelRef":"Trainrun"},{"id":27,"label":"IR16","labelGroupId":9,"labelRef":"Trainrun"},{"id":28,"label":"ICE","labelGroupId":9,"labelRef":"Trainrun"},{"id":29,"label":"IC61","labelGroupId":9,"labelRef":"Trainrun"},{"id":30,"label":"IC1","labelGroupId":9,"labelRef":"Trainrun"},{"id":31,"label":"IC8","labelGroupId":9,"labelRef":"Trainrun"},{"id":32,"label":"IR17","labelGroupId":9,"labelRef":"Trainrun"},{"id":33,"label":"IR35","labelGroupId":9,"labelRef":"Trainrun"},{"id":34,"label":"GEXX","labelGroupId":9,"labelRef":"Trainrun"},{"id":35,"label":"IR26","labelGroupId":9,"labelRef":"Trainrun"},{"id":36,"label":"IR27","labelGroupId":9,"labelRef":"Trainrun"},{"id":37,"label":"RE","labelGroupId":9,"labelRef":"Trainrun"},{"id":38,"label":"S29","labelGroupId":9,"labelRef":"Trainrun"},{"id":39,"label":"S29_OL_SS","labelGroupId":9,"labelRef":"Trainrun"},{"id":40,"label":"LZ","labelGroupId":1,"labelRef":"Node"},{"id":41,"label":"BN","labelGroupId":1,"labelRef":"Node"},{"id":42,"label":"ZUE","labelGroupId":1,"labelRef":"Node"}],"labelGroups":[{"id":1,"name":"Standard","labelRef":"Node"},{"id":9,"name":"Standard","labelRef":"Trainrun"}],"filterData":{"filterSettings":[]}}
+{
+  "nodes": [
+    {
+      "id": 0,
+      "betriebspunktName": "BN",
+      "fullName": "Bern",
+      "positionX": -960,
+      "positionY": 32,
+      "ports": [
+        {
+          "id": 118,
+          "trainrunSectionId": 101,
+          "positionIndex": 0,
+          "positionAlignment": 3
+        },
+        {
+          "id": 137,
+          "trainrunSectionId": 110,
+          "positionIndex": 1,
+          "positionAlignment": 3
+        },
+        {
+          "id": 94,
+          "trainrunSectionId": 90,
+          "positionIndex": 2,
+          "positionAlignment": 3
+        },
+        {
+          "id": 104,
+          "trainrunSectionId": 95,
+          "positionIndex": 3,
+          "positionAlignment": 3
+        },
+        {
+          "id": 86,
+          "trainrunSectionId": 86,
+          "positionIndex": 4,
+          "positionAlignment": 3
+        },
+        {
+          "id": 126,
+          "trainrunSectionId": 105,
+          "positionIndex": 5,
+          "positionAlignment": 3
+        },
+        {
+          "id": 214,
+          "trainrunSectionId": 141,
+          "positionIndex": 6,
+          "positionAlignment": 3
+        },
+        {
+          "id": 143,
+          "trainrunSectionId": 113,
+          "positionIndex": 7,
+          "positionAlignment": 3
+        },
+        {
+          "id": 147,
+          "trainrunSectionId": 115,
+          "positionIndex": 8,
+          "positionAlignment": 3
+        },
+        {
+          "id": 181,
+          "trainrunSectionId": 132,
+          "positionIndex": 9,
+          "positionAlignment": 3
+        }
+      ],
+      "transitions": [],
+      "connections": [],
+      "resourceId": 65,
+      "perronkanten": 10,
+      "connectionTime": 5,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": 0,
+      "warnings": null,
+      "labelIds": [41]
+    },
+    {
+      "id": 1,
+      "betriebspunktName": "OL",
+      "fullName": "Olten",
+      "positionX": 832,
+      "positionY": 32,
+      "ports": [
+        {
+          "id": 141,
+          "trainrunSectionId": 112,
+          "positionIndex": 0,
+          "positionAlignment": 0
+        },
+        {
+          "id": 108,
+          "trainrunSectionId": 97,
+          "positionIndex": 1,
+          "positionAlignment": 0
+        },
+        {
+          "id": 166,
+          "trainrunSectionId": 124,
+          "positionIndex": 2,
+          "positionAlignment": 0
+        },
+        {
+          "id": 174,
+          "trainrunSectionId": 128,
+          "positionIndex": 3,
+          "positionAlignment": 0
+        },
+        {
+          "id": 167,
+          "trainrunSectionId": 125,
+          "positionIndex": 0,
+          "positionAlignment": 1
+        },
+        {
+          "id": 175,
+          "trainrunSectionId": 129,
+          "positionIndex": 1,
+          "positionAlignment": 1
+        },
+        {
+          "id": 153,
+          "trainrunSectionId": 118,
+          "positionIndex": 2,
+          "positionAlignment": 1
+        },
+        {
+          "id": 161,
+          "trainrunSectionId": 122,
+          "positionIndex": 3,
+          "positionAlignment": 1
+        },
+        {
+          "id": 159,
+          "trainrunSectionId": 121,
+          "positionIndex": 4,
+          "positionAlignment": 1
+        },
+        {
+          "id": 185,
+          "trainrunSectionId": 134,
+          "positionIndex": 5,
+          "positionAlignment": 1
+        },
+        {
+          "id": 121,
+          "trainrunSectionId": 102,
+          "positionIndex": 0,
+          "positionAlignment": 2
+        },
+        {
+          "id": 140,
+          "trainrunSectionId": 111,
+          "positionIndex": 1,
+          "positionAlignment": 2
+        },
+        {
+          "id": 97,
+          "trainrunSectionId": 91,
+          "positionIndex": 2,
+          "positionAlignment": 2
+        },
+        {
+          "id": 107,
+          "trainrunSectionId": 96,
+          "positionIndex": 3,
+          "positionAlignment": 2
+        },
+        {
+          "id": 210,
+          "trainrunSectionId": 139,
+          "positionIndex": 4,
+          "positionAlignment": 2
+        },
+        {
+          "id": 129,
+          "trainrunSectionId": 106,
+          "positionIndex": 5,
+          "positionAlignment": 2
+        },
+        {
+          "id": 146,
+          "trainrunSectionId": 136,
+          "positionIndex": 6,
+          "positionAlignment": 2
+        },
+        {
+          "id": 150,
+          "trainrunSectionId": 137,
+          "positionIndex": 7,
+          "positionAlignment": 2
+        },
+        {
+          "id": 184,
+          "trainrunSectionId": 138,
+          "positionIndex": 8,
+          "positionAlignment": 2
+        },
+        {
+          "id": 122,
+          "trainrunSectionId": 103,
+          "positionIndex": 0,
+          "positionAlignment": 3
+        },
+        {
+          "id": 98,
+          "trainrunSectionId": 92,
+          "positionIndex": 1,
+          "positionAlignment": 3
+        },
+        {
+          "id": 151,
+          "trainrunSectionId": 117,
+          "positionIndex": 2,
+          "positionAlignment": 3
+        }
+      ],
+      "transitions": [
+        {"id": 102, "port1Id": 97, "port2Id": 98, "isNonStopTransit": true},
+        {"id": 104, "port1Id": 108, "port2Id": 107, "isNonStopTransit": false},
+        {"id": 109, "port1Id": 121, "port2Id": 122, "isNonStopTransit": true},
+        {"id": 114, "port1Id": 141, "port2Id": 140, "isNonStopTransit": false},
+        {"id": 117, "port1Id": 150, "port2Id": 151, "isNonStopTransit": false},
+        {"id": 121, "port1Id": 166, "port2Id": 167, "isNonStopTransit": false},
+        {"id": 124, "port1Id": 174, "port2Id": 175, "isNonStopTransit": false},
+        {"id": 128, "port1Id": 185, "port2Id": 184, "isNonStopTransit": true}
+      ],
+      "connections": [],
+      "resourceId": 66,
+      "perronkanten": 10,
+      "connectionTime": 5,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": [2, 3]
+    },
+    {
+      "id": 2,
+      "betriebspunktName": "ZUE",
+      "fullName": "Zuerich",
+      "positionX": 2464,
+      "positionY": 32,
+      "ports": [
+        {
+          "id": 123,
+          "trainrunSectionId": 103,
+          "positionIndex": 0,
+          "positionAlignment": 2
+        },
+        {
+          "id": 99,
+          "trainrunSectionId": 92,
+          "positionIndex": 1,
+          "positionAlignment": 2
+        },
+        {
+          "id": 152,
+          "trainrunSectionId": 117,
+          "positionIndex": 2,
+          "positionAlignment": 2
+        }
+      ],
+      "transitions": [],
+      "connections": [],
+      "resourceId": 67,
+      "perronkanten": 10,
+      "connectionTime": 5,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": [42]
+    },
+    {
+      "id": 3,
+      "betriebspunktName": "LZ",
+      "fullName": "Luzern",
+      "positionX": 832,
+      "positionY": 1440,
+      "ports": [
+        {
+          "id": 93,
+          "trainrunSectionId": 89,
+          "positionIndex": 0,
+          "positionAlignment": 0
+        },
+        {
+          "id": 172,
+          "trainrunSectionId": 127,
+          "positionIndex": 1,
+          "positionAlignment": 0
+        },
+        {
+          "id": 180,
+          "trainrunSectionId": 131,
+          "positionIndex": 2,
+          "positionAlignment": 0
+        },
+        {
+          "id": 158,
+          "trainrunSectionId": 120,
+          "positionIndex": 3,
+          "positionAlignment": 0
+        }
+      ],
+      "transitions": [],
+      "connections": [],
+      "resourceId": 68,
+      "perronkanten": 10,
+      "connectionTime": 5,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": [40]
+    },
+    {
+      "id": 4,
+      "betriebspunktName": "ZF",
+      "fullName": "Zofingen",
+      "positionX": 832,
+      "positionY": 576,
+      "ports": [
+        {
+          "id": 168,
+          "trainrunSectionId": 125,
+          "positionIndex": 0,
+          "positionAlignment": 0
+        },
+        {
+          "id": 176,
+          "trainrunSectionId": 129,
+          "positionIndex": 1,
+          "positionAlignment": 0
+        },
+        {
+          "id": 154,
+          "trainrunSectionId": 118,
+          "positionIndex": 2,
+          "positionAlignment": 0
+        },
+        {
+          "id": 162,
+          "trainrunSectionId": 122,
+          "positionIndex": 3,
+          "positionAlignment": 0
+        },
+        {
+          "id": 160,
+          "trainrunSectionId": 121,
+          "positionIndex": 4,
+          "positionAlignment": 0
+        },
+        {
+          "id": 186,
+          "trainrunSectionId": 134,
+          "positionIndex": 5,
+          "positionAlignment": 0
+        },
+        {
+          "id": 90,
+          "trainrunSectionId": 88,
+          "positionIndex": 0,
+          "positionAlignment": 1
+        },
+        {
+          "id": 169,
+          "trainrunSectionId": 126,
+          "positionIndex": 1,
+          "positionAlignment": 1
+        },
+        {
+          "id": 177,
+          "trainrunSectionId": 130,
+          "positionIndex": 2,
+          "positionAlignment": 1
+        },
+        {
+          "id": 155,
+          "trainrunSectionId": 119,
+          "positionIndex": 3,
+          "positionAlignment": 1
+        },
+        {
+          "id": 163,
+          "trainrunSectionId": 123,
+          "positionIndex": 4,
+          "positionAlignment": 1
+        },
+        {
+          "id": 189,
+          "trainrunSectionId": 135,
+          "positionIndex": 5,
+          "positionAlignment": 1
+        },
+        {
+          "id": 89,
+          "trainrunSectionId": 87,
+          "positionIndex": 0,
+          "positionAlignment": 2
+        }
+      ],
+      "transitions": [
+        {"id": 99, "port1Id": 90, "port2Id": 89, "isNonStopTransit": false},
+        {"id": 118, "port1Id": 154, "port2Id": 155, "isNonStopTransit": false},
+        {"id": 120, "port1Id": 162, "port2Id": 163, "isNonStopTransit": false},
+        {"id": 122, "port1Id": 168, "port2Id": 169, "isNonStopTransit": true},
+        {"id": 125, "port1Id": 176, "port2Id": 177, "isNonStopTransit": false},
+        {"id": 130, "port1Id": 186, "port2Id": 189, "isNonStopTransit": true}
+      ],
+      "connections": [
+        {"id": 3, "port1Id": 89, "port2Id": 160},
+        {"id": 4, "port1Id": 163, "port2Id": 89},
+        {"id": 5, "port1Id": 162, "port2Id": 90}
+      ],
+      "resourceId": 69,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": [2, 3]
+    },
+    {
+      "id": 6,
+      "betriebspunktName": "SS",
+      "fullName": "Sursee",
+      "positionX": 832,
+      "positionY": 1024,
+      "ports": [
+        {
+          "id": 91,
+          "trainrunSectionId": 88,
+          "positionIndex": 0,
+          "positionAlignment": 0
+        },
+        {
+          "id": 170,
+          "trainrunSectionId": 126,
+          "positionIndex": 1,
+          "positionAlignment": 0
+        },
+        {
+          "id": 178,
+          "trainrunSectionId": 130,
+          "positionIndex": 2,
+          "positionAlignment": 0
+        },
+        {
+          "id": 156,
+          "trainrunSectionId": 119,
+          "positionIndex": 3,
+          "positionAlignment": 0
+        },
+        {
+          "id": 164,
+          "trainrunSectionId": 123,
+          "positionIndex": 4,
+          "positionAlignment": 0
+        },
+        {
+          "id": 190,
+          "trainrunSectionId": 135,
+          "positionIndex": 5,
+          "positionAlignment": 0
+        },
+        {
+          "id": 92,
+          "trainrunSectionId": 89,
+          "positionIndex": 0,
+          "positionAlignment": 1
+        },
+        {
+          "id": 171,
+          "trainrunSectionId": 127,
+          "positionIndex": 1,
+          "positionAlignment": 1
+        },
+        {
+          "id": 179,
+          "trainrunSectionId": 131,
+          "positionIndex": 2,
+          "positionAlignment": 1
+        },
+        {
+          "id": 157,
+          "trainrunSectionId": 120,
+          "positionIndex": 3,
+          "positionAlignment": 1
+        }
+      ],
+      "transitions": [
+        {"id": 100, "port1Id": 91, "port2Id": 92, "isNonStopTransit": false},
+        {"id": 119, "port1Id": 156, "port2Id": 157, "isNonStopTransit": false},
+        {"id": 123, "port1Id": 170, "port2Id": 171, "isNonStopTransit": true},
+        {"id": 126, "port1Id": 178, "port2Id": 179, "isNonStopTransit": false}
+      ],
+      "connections": [],
+      "resourceId": 71,
+      "perronkanten": 5,
+      "connectionTime": 6,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": [40]
+    },
+    {
+      "id": 7,
+      "betriebspunktName": "RTR",
+      "fullName": "Rothrist",
+      "positionX": 256,
+      "positionY": 32,
+      "ports": [
+        {
+          "id": 119,
+          "trainrunSectionId": 101,
+          "positionIndex": 0,
+          "positionAlignment": 2
+        },
+        {
+          "id": 138,
+          "trainrunSectionId": 110,
+          "positionIndex": 1,
+          "positionAlignment": 2
+        },
+        {
+          "id": 95,
+          "trainrunSectionId": 90,
+          "positionIndex": 2,
+          "positionAlignment": 2
+        },
+        {
+          "id": 105,
+          "trainrunSectionId": 95,
+          "positionIndex": 3,
+          "positionAlignment": 2
+        },
+        {
+          "id": 87,
+          "trainrunSectionId": 86,
+          "positionIndex": 4,
+          "positionAlignment": 2
+        },
+        {
+          "id": 127,
+          "trainrunSectionId": 105,
+          "positionIndex": 5,
+          "positionAlignment": 2
+        },
+        {
+          "id": 211,
+          "trainrunSectionId": 140,
+          "positionIndex": 6,
+          "positionAlignment": 2
+        },
+        {
+          "id": 203,
+          "trainrunSectionId": 114,
+          "positionIndex": 7,
+          "positionAlignment": 2
+        },
+        {
+          "id": 205,
+          "trainrunSectionId": 116,
+          "positionIndex": 8,
+          "positionAlignment": 2
+        },
+        {
+          "id": 207,
+          "trainrunSectionId": 133,
+          "positionIndex": 9,
+          "positionAlignment": 2
+        },
+        {
+          "id": 120,
+          "trainrunSectionId": 102,
+          "positionIndex": 0,
+          "positionAlignment": 3
+        },
+        {
+          "id": 139,
+          "trainrunSectionId": 111,
+          "positionIndex": 1,
+          "positionAlignment": 3
+        },
+        {
+          "id": 96,
+          "trainrunSectionId": 91,
+          "positionIndex": 2,
+          "positionAlignment": 3
+        },
+        {
+          "id": 106,
+          "trainrunSectionId": 96,
+          "positionIndex": 3,
+          "positionAlignment": 3
+        },
+        {
+          "id": 209,
+          "trainrunSectionId": 139,
+          "positionIndex": 4,
+          "positionAlignment": 3
+        },
+        {
+          "id": 128,
+          "trainrunSectionId": 106,
+          "positionIndex": 5,
+          "positionAlignment": 3
+        },
+        {
+          "id": 204,
+          "trainrunSectionId": 136,
+          "positionIndex": 6,
+          "positionAlignment": 3
+        },
+        {
+          "id": 206,
+          "trainrunSectionId": 137,
+          "positionIndex": 7,
+          "positionAlignment": 3
+        },
+        {
+          "id": 208,
+          "trainrunSectionId": 138,
+          "positionIndex": 8,
+          "positionAlignment": 3
+        },
+        {
+          "id": 88,
+          "trainrunSectionId": 87,
+          "positionIndex": 9,
+          "positionAlignment": 3
+        }
+      ],
+      "transitions": [
+        {"id": 98, "port1Id": 87, "port2Id": 88, "isNonStopTransit": true},
+        {"id": 101, "port1Id": 95, "port2Id": 96, "isNonStopTransit": true},
+        {"id": 103, "port1Id": 105, "port2Id": 106, "isNonStopTransit": true},
+        {"id": 108, "port1Id": 119, "port2Id": 120, "isNonStopTransit": true},
+        {"id": 110, "port1Id": 127, "port2Id": 128, "isNonStopTransit": true},
+        {"id": 113, "port1Id": 138, "port2Id": 139, "isNonStopTransit": true},
+        {"id": 137, "port1Id": 203, "port2Id": 204, "isNonStopTransit": true},
+        {"id": 138, "port1Id": 205, "port2Id": 206, "isNonStopTransit": true},
+        {"id": 139, "port1Id": 207, "port2Id": 208, "isNonStopTransit": true},
+        {"id": 140, "port1Id": 211, "port2Id": 209, "isNonStopTransit": true}
+      ],
+      "connections": [],
+      "resourceId": 72,
+      "perronkanten": 5,
+      "connectionTime": 5,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": [2]
+    },
+    {
+      "id": 8,
+      "betriebspunktName": "LTH",
+      "fullName": "Langenthal",
+      "positionX": -320,
+      "positionY": 224,
+      "ports": [
+        {
+          "id": 213,
+          "trainrunSectionId": 141,
+          "positionIndex": 0,
+          "positionAlignment": 2
+        },
+        {
+          "id": 144,
+          "trainrunSectionId": 113,
+          "positionIndex": 1,
+          "positionAlignment": 2
+        },
+        {
+          "id": 148,
+          "trainrunSectionId": 115,
+          "positionIndex": 2,
+          "positionAlignment": 2
+        },
+        {
+          "id": 201,
+          "trainrunSectionId": 132,
+          "positionIndex": 3,
+          "positionAlignment": 2
+        },
+        {
+          "id": 212,
+          "trainrunSectionId": 140,
+          "positionIndex": 0,
+          "positionAlignment": 3
+        },
+        {
+          "id": 145,
+          "trainrunSectionId": 114,
+          "positionIndex": 1,
+          "positionAlignment": 3
+        },
+        {
+          "id": 149,
+          "trainrunSectionId": 116,
+          "positionIndex": 2,
+          "positionAlignment": 3
+        },
+        {
+          "id": 202,
+          "trainrunSectionId": 133,
+          "positionIndex": 3,
+          "positionAlignment": 3
+        }
+      ],
+      "transitions": [
+        {"id": 115, "port1Id": 144, "port2Id": 145, "isNonStopTransit": false},
+        {"id": 116, "port1Id": 148, "port2Id": 149, "isNonStopTransit": false},
+        {"id": 136, "port1Id": 201, "port2Id": 202, "isNonStopTransit": false},
+        {"id": 141, "port1Id": 213, "port2Id": 212, "isNonStopTransit": false}
+      ],
+      "connections": [],
+      "resourceId": 73,
+      "perronkanten": 5,
+      "connectionTime": 5,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": [1]
+    },
+    {
+      "id": 106,
+      "betriebspunktName": "BS",
+      "fullName": "Basel",
+      "positionX": 832,
+      "positionY": -352,
+      "ports": [
+        {
+          "id": 142,
+          "trainrunSectionId": 112,
+          "positionIndex": 0,
+          "positionAlignment": 1
+        },
+        {
+          "id": 109,
+          "trainrunSectionId": 97,
+          "positionIndex": 1,
+          "positionAlignment": 1
+        },
+        {
+          "id": 165,
+          "trainrunSectionId": 124,
+          "positionIndex": 2,
+          "positionAlignment": 1
+        },
+        {
+          "id": 173,
+          "trainrunSectionId": 128,
+          "positionIndex": 3,
+          "positionAlignment": 1
+        }
+      ],
+      "transitions": [],
+      "connections": [],
+      "resourceId": 76,
+      "perronkanten": 5,
+      "connectionTime": 3,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitA": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitB": {"no_halt": false, "haltezeit": 2},
+        "HaltezeitC": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitD": {"no_halt": false, "haltezeit": 1},
+        "HaltezeitIPV": {"no_halt": false, "haltezeit": 3},
+        "HaltezeitUncategorized": {"no_halt": true, "haltezeit": 0}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": [2]
+    }
+  ],
+  "trainrunSections": [
+    {
+      "id": 86,
+      "sourceNodeId": 0,
+      "sourcePortId": 86,
+      "targetNodeId": 7,
+      "targetPortId": 87,
+      "travelTime": {
+        "lock": true,
+        "time": 23,
+        "warning": null,
+        "consecutiveTime": 10
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 0,
+        "warning": null,
+        "consecutiveTime": 0
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 0,
+        "warning": null,
+        "consecutiveTime": 180
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 37,
+        "warning": null,
+        "consecutiveTime": 157
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 23,
+        "warning": null,
+        "consecutiveTime": 23
+      },
+      "numberOfStops": 0,
+      "trainrunId": 11,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -862, "y": 176},
+          {"x": -798, "y": 176},
+          {"x": 190, "y": 176},
+          {"x": 254, "y": 176}
+        ],
+        "textPositions": {
+          "0": {"x": -844, "y": 188},
+          "1": {"x": -816, "y": 164},
+          "2": {"x": 236, "y": 164},
+          "3": {"x": 208, "y": 188},
+          "4": {"x": -304, "y": 164},
+          "5": {"x": -304, "y": 164},
+          "6": {"x": -304, "y": 188}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 87,
+      "sourceNodeId": 7,
+      "sourcePortId": 88,
+      "targetNodeId": 4,
+      "targetPortId": 89,
+      "travelTime": {
+        "lock": true,
+        "time": 5,
+        "warning": null,
+        "consecutiveTime": 10
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 23,
+        "warning": null,
+        "consecutiveTime": 23
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 37,
+        "warning": null,
+        "consecutiveTime": 157
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 32,
+        "warning": null,
+        "consecutiveTime": 152
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 28,
+        "warning": null,
+        "consecutiveTime": 28
+      },
+      "numberOfStops": 0,
+      "trainrunId": 11,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 354, "y": 336},
+          {"x": 418, "y": 336},
+          {"x": 766, "y": 592},
+          {"x": 830, "y": 592}
+        ],
+        "textPositions": {
+          "0": {"x": 372, "y": 348},
+          "1": {"x": 400, "y": 324},
+          "2": {"x": 812, "y": 580},
+          "3": {"x": 784, "y": 604},
+          "4": {"x": 592, "y": 452},
+          "5": {"x": 592, "y": 452},
+          "6": {"x": 592, "y": 476}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 88,
+      "sourceNodeId": 4,
+      "sourcePortId": 90,
+      "targetNodeId": 6,
+      "targetPortId": 91,
+      "travelTime": {
+        "lock": true,
+        "time": 13,
+        "warning": null,
+        "consecutiveTime": 10
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 29,
+        "warning": null,
+        "consecutiveTime": 29
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 31,
+        "warning": null,
+        "consecutiveTime": 151
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 18,
+        "warning": null,
+        "consecutiveTime": 138
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 42,
+        "warning": null,
+        "consecutiveTime": 42
+      },
+      "numberOfStops": 0,
+      "trainrunId": 11,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 848, "y": 642},
+          {"x": 848, "y": 706},
+          {"x": 848, "y": 958},
+          {"x": 848, "y": 1022}
+        ],
+        "textPositions": {
+          "0": {"x": 836, "y": 660},
+          "1": {"x": 860, "y": 688},
+          "2": {"x": 860, "y": 1004},
+          "3": {"x": 836, "y": 976},
+          "4": {"x": 836, "y": 832},
+          "5": {"x": 836, "y": 832},
+          "6": {"x": 860, "y": 832}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 89,
+      "sourceNodeId": 6,
+      "sourcePortId": 92,
+      "targetNodeId": 3,
+      "targetPortId": 93,
+      "travelTime": {
+        "lock": true,
+        "time": 18,
+        "warning": null,
+        "consecutiveTime": 10
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 43,
+        "warning": null,
+        "consecutiveTime": 43
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 17,
+        "warning": null,
+        "consecutiveTime": 137
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 59,
+        "warning": null,
+        "consecutiveTime": 119
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 1,
+        "warning": null,
+        "consecutiveTime": 61
+      },
+      "numberOfStops": 0,
+      "trainrunId": 11,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 848, "y": 1090},
+          {"x": 848, "y": 1154},
+          {"x": 848, "y": 1374},
+          {"x": 848, "y": 1438}
+        ],
+        "textPositions": {
+          "0": {"x": 836, "y": 1108},
+          "1": {"x": 860, "y": 1136},
+          "2": {"x": 860, "y": 1420},
+          "3": {"x": 836, "y": 1392},
+          "4": {"x": 836, "y": 1264},
+          "5": {"x": 836, "y": 1264},
+          "6": {"x": 860, "y": 1264}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 90,
+      "sourceNodeId": 0,
+      "sourcePortId": 94,
+      "targetNodeId": 7,
+      "targetPortId": 95,
+      "travelTime": {
+        "lock": true,
+        "time": 23,
+        "warning": null,
+        "consecutiveTime": 10
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 31,
+        "warning": null,
+        "consecutiveTime": 31
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 29,
+        "warning": null,
+        "consecutiveTime": 149
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 6,
+        "warning": null,
+        "consecutiveTime": 126
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 54,
+        "warning": null,
+        "consecutiveTime": 54
+      },
+      "numberOfStops": 0,
+      "trainrunId": 12,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -862, "y": 112},
+          {"x": -798, "y": 112},
+          {"x": 190, "y": 112},
+          {"x": 254, "y": 112}
+        ],
+        "textPositions": {
+          "0": {"x": -844, "y": 124},
+          "1": {"x": -816, "y": 100},
+          "2": {"x": 236, "y": 100},
+          "3": {"x": 208, "y": 124},
+          "4": {"x": -304, "y": 100},
+          "5": {"x": -304, "y": 100},
+          "6": {"x": -304, "y": 124}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 91,
+      "sourceNodeId": 7,
+      "sourcePortId": 96,
+      "targetNodeId": 1,
+      "targetPortId": 97,
+      "travelTime": {
+        "lock": true,
+        "time": 5,
+        "warning": null,
+        "consecutiveTime": 10
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 54,
+        "warning": null,
+        "consecutiveTime": 54
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 6,
+        "warning": null,
+        "consecutiveTime": 126
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 1,
+        "warning": null,
+        "consecutiveTime": 121
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 59,
+        "warning": null,
+        "consecutiveTime": 59
+      },
+      "numberOfStops": 0,
+      "trainrunId": 12,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 354, "y": 112},
+          {"x": 418, "y": 112},
+          {"x": 766, "y": 112},
+          {"x": 830, "y": 112}
+        ],
+        "textPositions": {
+          "0": {"x": 372, "y": 124},
+          "1": {"x": 400, "y": 100},
+          "2": {"x": 812, "y": 100},
+          "3": {"x": 784, "y": 124},
+          "4": {"x": 592, "y": 100},
+          "5": {"x": 592, "y": 100},
+          "6": {"x": 592, "y": 124}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 92,
+      "sourceNodeId": 1,
+      "sourcePortId": 98,
+      "targetNodeId": 2,
+      "targetPortId": 99,
+      "travelTime": {
+        "lock": true,
+        "time": 29,
+        "warning": null,
+        "consecutiveTime": 10
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 59,
+        "warning": null,
+        "consecutiveTime": 59
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 1,
+        "warning": null,
+        "consecutiveTime": 121
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 32,
+        "warning": null,
+        "consecutiveTime": 92
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 28,
+        "warning": null,
+        "consecutiveTime": 88
+      },
+      "numberOfStops": 0,
+      "trainrunId": 12,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1026, "y": 80},
+          {"x": 1090, "y": 80},
+          {"x": 2398, "y": 80},
+          {"x": 2462, "y": 80}
+        ],
+        "textPositions": {
+          "0": {"x": 1044, "y": 92},
+          "1": {"x": 1072, "y": 68},
+          "2": {"x": 2444, "y": 68},
+          "3": {"x": 2416, "y": 92},
+          "4": {"x": 1744, "y": 68},
+          "5": {"x": 1744, "y": 68},
+          "6": {"x": 1744, "y": 92}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 95,
+      "sourceNodeId": 0,
+      "sourcePortId": 104,
+      "targetNodeId": 7,
+      "targetPortId": 105,
+      "travelTime": {
+        "lock": true,
+        "time": 23,
+        "warning": null,
+        "consecutiveTime": 10
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 4,
+        "warning": null,
+        "consecutiveTime": 4
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 56,
+        "warning": null,
+        "consecutiveTime": 176
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 33,
+        "warning": null,
+        "consecutiveTime": 153
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 27,
+        "warning": null,
+        "consecutiveTime": 27
+      },
+      "numberOfStops": 0,
+      "trainrunId": 14,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -862, "y": 144},
+          {"x": -798, "y": 144},
+          {"x": 190, "y": 144},
+          {"x": 254, "y": 144}
+        ],
+        "textPositions": {
+          "0": {"x": -844, "y": 156},
+          "1": {"x": -816, "y": 132},
+          "2": {"x": 236, "y": 132},
+          "3": {"x": 208, "y": 156},
+          "4": {"x": -304, "y": 132},
+          "5": {"x": -304, "y": 132},
+          "6": {"x": -304, "y": 156}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 96,
+      "sourceNodeId": 7,
+      "sourcePortId": 106,
+      "targetNodeId": 1,
+      "targetPortId": 107,
+      "travelTime": {
+        "lock": true,
+        "time": 5,
+        "warning": null,
+        "consecutiveTime": 10
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 27,
+        "warning": null,
+        "consecutiveTime": 27
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 33,
+        "warning": null,
+        "consecutiveTime": 153
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 28,
+        "warning": null,
+        "consecutiveTime": 148
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 32,
+        "warning": null,
+        "consecutiveTime": 32
+      },
+      "numberOfStops": 0,
+      "trainrunId": 14,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 354, "y": 144},
+          {"x": 418, "y": 144},
+          {"x": 766, "y": 144},
+          {"x": 830, "y": 144}
+        ],
+        "textPositions": {
+          "0": {"x": 372, "y": 156},
+          "1": {"x": 400, "y": 132},
+          "2": {"x": 812, "y": 132},
+          "3": {"x": 784, "y": 156},
+          "4": {"x": 592, "y": 132},
+          "5": {"x": 592, "y": 132},
+          "6": {"x": 592, "y": 156}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 97,
+      "sourceNodeId": 1,
+      "sourcePortId": 108,
+      "targetNodeId": 106,
+      "targetPortId": 109,
+      "travelTime": {
+        "lock": true,
+        "time": 27,
+        "warning": null,
+        "consecutiveTime": 10
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 34,
+        "warning": null,
+        "consecutiveTime": 34
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 26,
+        "warning": null,
+        "consecutiveTime": 146
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 59,
+        "warning": null,
+        "consecutiveTime": 119
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 1,
+        "warning": null,
+        "consecutiveTime": 61
+      },
+      "numberOfStops": 0,
+      "trainrunId": 14,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 880, "y": 30},
+          {"x": 880, "y": -34},
+          {"x": 880, "y": -222},
+          {"x": 880, "y": -286}
+        ],
+        "textPositions": {
+          "0": {"x": 892, "y": 12},
+          "1": {"x": 868, "y": -16},
+          "2": {"x": 868, "y": -268},
+          "3": {"x": 892, "y": -240},
+          "4": {"x": 868, "y": -128},
+          "5": {"x": 868, "y": -128},
+          "6": {"x": 892, "y": -128}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 101,
+      "sourceNodeId": 0,
+      "sourcePortId": 118,
+      "targetNodeId": 7,
+      "targetPortId": 119,
+      "travelTime": {
+        "lock": true,
+        "time": 23,
+        "warning": null,
+        "consecutiveTime": 10
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 2,
+        "warning": null,
+        "consecutiveTime": 2
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 58,
+        "warning": null,
+        "consecutiveTime": 58
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 35,
+        "warning": null,
+        "consecutiveTime": 35
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 25,
+        "warning": null,
+        "consecutiveTime": 25
+      },
+      "numberOfStops": 0,
+      "trainrunId": 16,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -862, "y": 48},
+          {"x": -798, "y": 48},
+          {"x": 190, "y": 48},
+          {"x": 254, "y": 48}
+        ],
+        "textPositions": {
+          "0": {"x": -844, "y": 60},
+          "1": {"x": -816, "y": 36},
+          "2": {"x": 236, "y": 36},
+          "3": {"x": 208, "y": 60},
+          "4": {"x": -304, "y": 36},
+          "5": {"x": -304, "y": 36},
+          "6": {"x": -304, "y": 60}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 102,
+      "sourceNodeId": 7,
+      "sourcePortId": 120,
+      "targetNodeId": 1,
+      "targetPortId": 121,
+      "travelTime": {
+        "lock": true,
+        "time": 5,
+        "warning": null,
+        "consecutiveTime": 10
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 25,
+        "warning": null,
+        "consecutiveTime": 25
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 35,
+        "warning": null,
+        "consecutiveTime": 35
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 30,
+        "warning": null,
+        "consecutiveTime": 30
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 30,
+        "warning": null,
+        "consecutiveTime": 30
+      },
+      "numberOfStops": 0,
+      "trainrunId": 16,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 354, "y": 48},
+          {"x": 418, "y": 48},
+          {"x": 766, "y": 48},
+          {"x": 830, "y": 48}
+        ],
+        "textPositions": {
+          "0": {"x": 372, "y": 60},
+          "1": {"x": 400, "y": 36},
+          "2": {"x": 812, "y": 36},
+          "3": {"x": 784, "y": 60},
+          "4": {"x": 592, "y": 36},
+          "5": {"x": 592, "y": 36},
+          "6": {"x": 592, "y": 60}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 103,
+      "sourceNodeId": 1,
+      "sourcePortId": 122,
+      "targetNodeId": 2,
+      "targetPortId": 123,
+      "travelTime": {
+        "lock": true,
+        "time": 28,
+        "warning": null,
+        "consecutiveTime": 10
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 30,
+        "warning": null,
+        "consecutiveTime": 30
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 30,
+        "warning": null,
+        "consecutiveTime": 30
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 2,
+        "warning": null,
+        "consecutiveTime": 2
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 58,
+        "warning": null,
+        "consecutiveTime": 58
+      },
+      "numberOfStops": 0,
+      "trainrunId": 16,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1026, "y": 48},
+          {"x": 1090, "y": 48},
+          {"x": 2398, "y": 48},
+          {"x": 2462, "y": 48}
+        ],
+        "textPositions": {
+          "0": {"x": 1044, "y": 60},
+          "1": {"x": 1072, "y": 36},
+          "2": {"x": 2444, "y": 36},
+          "3": {"x": 2416, "y": 60},
+          "4": {"x": 1744, "y": 36},
+          "5": {"x": 1744, "y": 36},
+          "6": {"x": 1744, "y": 60}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 105,
+      "sourceNodeId": 0,
+      "sourcePortId": 126,
+      "targetNodeId": 7,
+      "targetPortId": 127,
+      "travelTime": {
+        "lock": true,
+        "time": 23,
+        "warning": null,
+        "consecutiveTime": 10
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 33,
+        "warning": null,
+        "consecutiveTime": 33
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 27,
+        "warning": null,
+        "consecutiveTime": 147
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 4,
+        "warning": null,
+        "consecutiveTime": 124
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 56,
+        "warning": null,
+        "consecutiveTime": 56
+      },
+      "numberOfStops": 0,
+      "trainrunId": 18,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -862, "y": 208},
+          {"x": -798, "y": 208},
+          {"x": 190, "y": 208},
+          {"x": 254, "y": 208}
+        ],
+        "textPositions": {
+          "0": {"x": -844, "y": 220},
+          "1": {"x": -816, "y": 196},
+          "2": {"x": 236, "y": 196},
+          "3": {"x": 208, "y": 220},
+          "4": {"x": -304, "y": 196},
+          "5": {"x": -304, "y": 196},
+          "6": {"x": -304, "y": 220}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 106,
+      "sourceNodeId": 7,
+      "sourcePortId": 128,
+      "targetNodeId": 1,
+      "targetPortId": 129,
+      "travelTime": {
+        "lock": true,
+        "time": 5,
+        "warning": null,
+        "consecutiveTime": 10
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 56,
+        "warning": null,
+        "consecutiveTime": 56
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 4,
+        "warning": null,
+        "consecutiveTime": 124
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 59,
+        "warning": null,
+        "consecutiveTime": 119
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 1,
+        "warning": null,
+        "consecutiveTime": 61
+      },
+      "numberOfStops": 0,
+      "trainrunId": 18,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 354, "y": 208},
+          {"x": 418, "y": 208},
+          {"x": 766, "y": 208},
+          {"x": 830, "y": 208}
+        ],
+        "textPositions": {
+          "0": {"x": 372, "y": 220},
+          "1": {"x": 400, "y": 196},
+          "2": {"x": 812, "y": 196},
+          "3": {"x": 784, "y": 220},
+          "4": {"x": 592, "y": 196},
+          "5": {"x": 592, "y": 196},
+          "6": {"x": 592, "y": 220}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 110,
+      "sourceNodeId": 0,
+      "sourcePortId": 137,
+      "targetNodeId": 7,
+      "targetPortId": 138,
+      "travelTime": {
+        "lock": true,
+        "time": 22,
+        "warning": null,
+        "consecutiveTime": 10
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 36,
+        "warning": null,
+        "consecutiveTime": 36
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 24,
+        "warning": null,
+        "consecutiveTime": 144
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 2,
+        "warning": null,
+        "consecutiveTime": 122
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 58,
+        "warning": null,
+        "consecutiveTime": 58
+      },
+      "numberOfStops": 0,
+      "trainrunId": 20,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -862, "y": 80},
+          {"x": -798, "y": 80},
+          {"x": 190, "y": 80},
+          {"x": 254, "y": 80}
+        ],
+        "textPositions": {
+          "0": {"x": -844, "y": 92},
+          "1": {"x": -816, "y": 68},
+          "2": {"x": 236, "y": 68},
+          "3": {"x": 208, "y": 92},
+          "4": {"x": -304, "y": 68},
+          "5": {"x": -304, "y": 68},
+          "6": {"x": -304, "y": 92}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 111,
+      "sourceNodeId": 7,
+      "sourcePortId": 139,
+      "targetNodeId": 1,
+      "targetPortId": 140,
+      "travelTime": {
+        "lock": false,
+        "time": 5,
+        "warning": null,
+        "consecutiveTime": 10
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 58,
+        "warning": null,
+        "consecutiveTime": 58
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 2,
+        "warning": null,
+        "consecutiveTime": 122
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 57,
+        "warning": null,
+        "consecutiveTime": 117
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 3,
+        "warning": null,
+        "consecutiveTime": 63
+      },
+      "numberOfStops": 0,
+      "trainrunId": 20,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 354, "y": 80},
+          {"x": 418, "y": 80},
+          {"x": 766, "y": 80},
+          {"x": 830, "y": 80}
+        ],
+        "textPositions": {
+          "0": {"x": 372, "y": 92},
+          "1": {"x": 400, "y": 68},
+          "2": {"x": 812, "y": 68},
+          "3": {"x": 784, "y": 92},
+          "4": {"x": 592, "y": 68},
+          "5": {"x": 592, "y": 68},
+          "6": {"x": 592, "y": 92}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 112,
+      "sourceNodeId": 1,
+      "sourcePortId": 141,
+      "targetNodeId": 106,
+      "targetPortId": 142,
+      "travelTime": {
+        "lock": true,
+        "time": 27,
+        "warning": null,
+        "consecutiveTime": 10
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 5,
+        "warning": null,
+        "consecutiveTime": 65
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 55,
+        "warning": null,
+        "consecutiveTime": 115
+      },
+      "targetDeparture": {
+        "lock": true,
+        "time": 28,
+        "warning": null,
+        "consecutiveTime": 88
+      },
+      "targetArrival": {
+        "lock": true,
+        "time": 32,
+        "warning": null,
+        "consecutiveTime": 92
+      },
+      "numberOfStops": 0,
+      "trainrunId": 20,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 848, "y": 30},
+          {"x": 848, "y": -34},
+          {"x": 848, "y": -222},
+          {"x": 848, "y": -286}
+        ],
+        "textPositions": {
+          "0": {"x": 860, "y": 12},
+          "1": {"x": 836, "y": -16},
+          "2": {"x": 836, "y": -268},
+          "3": {"x": 860, "y": -240},
+          "4": {"x": 836, "y": -128},
+          "5": {"x": 836, "y": -128},
+          "6": {"x": 860, "y": -128}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 113,
+      "sourceNodeId": 0,
+      "sourcePortId": 143,
+      "targetNodeId": 8,
+      "targetPortId": 144,
+      "travelTime": {
+        "lock": true,
+        "time": 33,
+        "warning": null,
+        "consecutiveTime": 10
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 7,
+        "warning": null,
+        "consecutiveTime": 7
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 53,
+        "warning": null,
+        "consecutiveTime": 53
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 20,
+        "warning": null,
+        "consecutiveTime": 20
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 40,
+        "warning": null,
+        "consecutiveTime": 40
+      },
+      "numberOfStops": 0,
+      "trainrunId": 21,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -862, "y": 272},
+          {"x": -798, "y": 272},
+          {"x": -386, "y": 272},
+          {"x": -322, "y": 272}
+        ],
+        "textPositions": {
+          "0": {"x": -844, "y": 284},
+          "1": {"x": -816, "y": 260},
+          "2": {"x": -340, "y": 260},
+          "3": {"x": -368, "y": 284},
+          "4": {"x": -592, "y": 260},
+          "5": {"x": -592, "y": 260},
+          "6": {"x": -592, "y": 284}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 114,
+      "sourceNodeId": 8,
+      "sourcePortId": 145,
+      "targetNodeId": 7,
+      "targetPortId": 203,
+      "travelTime": {
+        "lock": true,
+        "time": 4,
+        "warning": null,
+        "consecutiveTime": 10
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 42,
+        "warning": null,
+        "consecutiveTime": 42
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 18,
+        "warning": null,
+        "consecutiveTime": 18
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 14,
+        "warning": null,
+        "consecutiveTime": 14
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 46,
+        "warning": null,
+        "consecutiveTime": 46
+      },
+      "numberOfStops": 0,
+      "trainrunId": 21,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -222, "y": 272},
+          {"x": -158, "y": 272},
+          {"x": 190, "y": 272},
+          {"x": 254, "y": 272}
+        ],
+        "textPositions": {
+          "0": {"x": -204, "y": 284},
+          "1": {"x": -176, "y": 260},
+          "2": {"x": 236, "y": 260},
+          "3": {"x": 208, "y": 284},
+          "4": {"x": 16, "y": 260},
+          "5": {"x": 16, "y": 260},
+          "6": {"x": 16, "y": 284}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 115,
+      "sourceNodeId": 0,
+      "sourcePortId": 147,
+      "targetNodeId": 8,
+      "targetPortId": 148,
+      "travelTime": {
+        "lock": true,
+        "time": 32,
+        "warning": null,
+        "consecutiveTime": 10
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 38,
+        "warning": null,
+        "consecutiveTime": 38
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 22,
+        "warning": null,
+        "consecutiveTime": 262
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 50,
+        "warning": null,
+        "consecutiveTime": 230
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 10,
+        "warning": null,
+        "consecutiveTime": 70
+      },
+      "numberOfStops": 0,
+      "trainrunId": 22,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -862, "y": 304},
+          {"x": -798, "y": 304},
+          {"x": -386, "y": 304},
+          {"x": -322, "y": 304}
+        ],
+        "textPositions": {
+          "0": {"x": -844, "y": 316},
+          "1": {"x": -816, "y": 292},
+          "2": {"x": -340, "y": 292},
+          "3": {"x": -368, "y": 316},
+          "4": {"x": -592, "y": 292},
+          "5": {"x": -592, "y": 292},
+          "6": {"x": -592, "y": 316}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 116,
+      "sourceNodeId": 8,
+      "sourcePortId": 149,
+      "targetNodeId": 7,
+      "targetPortId": 205,
+      "travelTime": {
+        "lock": true,
+        "time": 5,
+        "warning": null,
+        "consecutiveTime": 10
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 12,
+        "warning": null,
+        "consecutiveTime": 72
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 48,
+        "warning": null,
+        "consecutiveTime": 228
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 43,
+        "warning": null,
+        "consecutiveTime": 223
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 17,
+        "warning": null,
+        "consecutiveTime": 77
+      },
+      "numberOfStops": 0,
+      "trainrunId": 22,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -222, "y": 304},
+          {"x": -158, "y": 304},
+          {"x": 190, "y": 304},
+          {"x": 254, "y": 304}
+        ],
+        "textPositions": {
+          "0": {"x": -204, "y": 316},
+          "1": {"x": -176, "y": 292},
+          "2": {"x": 236, "y": 292},
+          "3": {"x": 208, "y": 316},
+          "4": {"x": 16, "y": 292},
+          "5": {"x": 16, "y": 292},
+          "6": {"x": 16, "y": 316}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 117,
+      "sourceNodeId": 1,
+      "sourcePortId": 151,
+      "targetNodeId": 2,
+      "targetPortId": 152,
+      "travelTime": {
+        "lock": true,
+        "time": 36,
+        "warning": null,
+        "consecutiveTime": 10
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 24,
+        "warning": null,
+        "consecutiveTime": 84
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 36,
+        "warning": null,
+        "consecutiveTime": 216
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 0,
+        "warning": null,
+        "consecutiveTime": 180
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 0,
+        "warning": null,
+        "consecutiveTime": 120
+      },
+      "numberOfStops": 0,
+      "trainrunId": 22,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1026, "y": 112},
+          {"x": 1090, "y": 112},
+          {"x": 2398, "y": 112},
+          {"x": 2462, "y": 112}
+        ],
+        "textPositions": {
+          "0": {"x": 1044, "y": 124},
+          "1": {"x": 1072, "y": 100},
+          "2": {"x": 2444, "y": 100},
+          "3": {"x": 2416, "y": 124},
+          "4": {"x": 1744, "y": 100},
+          "5": {"x": 1744, "y": 100},
+          "6": {"x": 1744, "y": 124}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 118,
+      "sourceNodeId": 1,
+      "sourcePortId": 153,
+      "targetNodeId": 4,
+      "targetPortId": 154,
+      "travelTime": {
+        "lock": true,
+        "time": 6,
+        "warning": null,
+        "consecutiveTime": 10
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 6,
+        "warning": null,
+        "consecutiveTime": 6
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 54,
+        "warning": null,
+        "consecutiveTime": 54
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 48,
+        "warning": null,
+        "consecutiveTime": 48
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 12,
+        "warning": null,
+        "consecutiveTime": 12
+      },
+      "numberOfStops": 0,
+      "trainrunId": 23,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 912, "y": 350},
+          {"x": 912, "y": 414},
+          {"x": 912, "y": 510},
+          {"x": 912, "y": 574}
+        ],
+        "textPositions": {
+          "0": {"x": 900, "y": 368},
+          "1": {"x": 924, "y": 396},
+          "2": {"x": 924, "y": 556},
+          "3": {"x": 900, "y": 528},
+          "4": {"x": 900, "y": 462},
+          "5": {"x": 900, "y": 462},
+          "6": {"x": 924, "y": 462}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 119,
+      "sourceNodeId": 4,
+      "sourcePortId": 155,
+      "targetNodeId": 6,
+      "targetPortId": 156,
+      "travelTime": {
+        "lock": true,
+        "time": 17,
+        "warning": null,
+        "consecutiveTime": 10
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 13,
+        "warning": null,
+        "consecutiveTime": 13
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 47,
+        "warning": null,
+        "consecutiveTime": 47
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 30,
+        "warning": null,
+        "consecutiveTime": 30
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 30,
+        "warning": null,
+        "consecutiveTime": 30
+      },
+      "numberOfStops": 0,
+      "trainrunId": 23,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 944, "y": 642},
+          {"x": 944, "y": 706},
+          {"x": 944, "y": 958},
+          {"x": 944, "y": 1022}
+        ],
+        "textPositions": {
+          "0": {"x": 932, "y": 660},
+          "1": {"x": 956, "y": 688},
+          "2": {"x": 956, "y": 1004},
+          "3": {"x": 932, "y": 976},
+          "4": {"x": 932, "y": 832},
+          "5": {"x": 932, "y": 832},
+          "6": {"x": 956, "y": 832}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 120,
+      "sourceNodeId": 6,
+      "sourcePortId": 157,
+      "targetNodeId": 3,
+      "targetPortId": 158,
+      "travelTime": {
+        "lock": true,
+        "time": 24,
+        "warning": null,
+        "consecutiveTime": 10
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 31,
+        "warning": null,
+        "consecutiveTime": 31
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 29,
+        "warning": null,
+        "consecutiveTime": 29
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 5,
+        "warning": null,
+        "consecutiveTime": 5
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 55,
+        "warning": null,
+        "consecutiveTime": 55
+      },
+      "numberOfStops": 0,
+      "trainrunId": 23,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 944, "y": 1090},
+          {"x": 944, "y": 1154},
+          {"x": 944, "y": 1374},
+          {"x": 944, "y": 1438}
+        ],
+        "textPositions": {
+          "0": {"x": 932, "y": 1108},
+          "1": {"x": 956, "y": 1136},
+          "2": {"x": 956, "y": 1420},
+          "3": {"x": 932, "y": 1392},
+          "4": {"x": 932, "y": 1264},
+          "5": {"x": 932, "y": 1264},
+          "6": {"x": 956, "y": 1264}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 121,
+      "sourceNodeId": 1,
+      "sourcePortId": 159,
+      "targetNodeId": 4,
+      "targetPortId": 160,
+      "travelTime": {
+        "lock": true,
+        "time": 9,
+        "warning": null,
+        "consecutiveTime": 10
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 12,
+        "warning": null,
+        "consecutiveTime": 12
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 48,
+        "warning": null,
+        "consecutiveTime": 48
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 39,
+        "warning": null,
+        "consecutiveTime": 39
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 21,
+        "warning": null,
+        "consecutiveTime": 21
+      },
+      "numberOfStops": 0,
+      "trainrunId": 24,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 976, "y": 350},
+          {"x": 976, "y": 414},
+          {"x": 976, "y": 510},
+          {"x": 976, "y": 574}
+        ],
+        "textPositions": {
+          "0": {"x": 964, "y": 368},
+          "1": {"x": 988, "y": 396},
+          "2": {"x": 988, "y": 556},
+          "3": {"x": 964, "y": 528},
+          "4": {"x": 964, "y": 462},
+          "5": {"x": 964, "y": 462},
+          "6": {"x": 988, "y": 462}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 122,
+      "sourceNodeId": 1,
+      "sourcePortId": 161,
+      "targetNodeId": 4,
+      "targetPortId": 162,
+      "travelTime": {
+        "lock": true,
+        "time": 8,
+        "warning": null,
+        "consecutiveTime": 10
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 36,
+        "warning": null,
+        "consecutiveTime": 36
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 24,
+        "warning": null,
+        "consecutiveTime": 144
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 16,
+        "warning": null,
+        "consecutiveTime": 136
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 44,
+        "warning": null,
+        "consecutiveTime": 44
+      },
+      "numberOfStops": 0,
+      "trainrunId": 25,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 944, "y": 350},
+          {"x": 944, "y": 414},
+          {"x": 944, "y": 510},
+          {"x": 944, "y": 574}
+        ],
+        "textPositions": {
+          "0": {"x": 932, "y": 368},
+          "1": {"x": 956, "y": 396},
+          "2": {"x": 956, "y": 556},
+          "3": {"x": 932, "y": 528},
+          "4": {"x": 932, "y": 462},
+          "5": {"x": 932, "y": 462},
+          "6": {"x": 956, "y": 462}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 123,
+      "sourceNodeId": 4,
+      "sourcePortId": 163,
+      "targetNodeId": 6,
+      "targetPortId": 164,
+      "travelTime": {
+        "lock": true,
+        "time": 22,
+        "warning": null,
+        "consecutiveTime": 10
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 45,
+        "warning": null,
+        "consecutiveTime": 45
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 15,
+        "warning": null,
+        "consecutiveTime": 135
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 53,
+        "warning": null,
+        "consecutiveTime": 113
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 7,
+        "warning": null,
+        "consecutiveTime": 67
+      },
+      "numberOfStops": 0,
+      "trainrunId": 25,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 976, "y": 642},
+          {"x": 976, "y": 706},
+          {"x": 976, "y": 958},
+          {"x": 976, "y": 1022}
+        ],
+        "textPositions": {
+          "0": {"x": 964, "y": 660},
+          "1": {"x": 988, "y": 688},
+          "2": {"x": 988, "y": 1004},
+          "3": {"x": 964, "y": 976},
+          "4": {"x": 964, "y": 832},
+          "5": {"x": 964, "y": 832},
+          "6": {"x": 988, "y": 832}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 124,
+      "sourceNodeId": 106,
+      "sourcePortId": 165,
+      "targetNodeId": 1,
+      "targetPortId": 166,
+      "travelTime": {
+        "lock": true,
+        "time": 25,
+        "warning": null,
+        "consecutiveTime": 10
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 3,
+        "warning": null,
+        "consecutiveTime": 3
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 57,
+        "warning": null,
+        "consecutiveTime": 177
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 32,
+        "warning": null,
+        "consecutiveTime": 152
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 28,
+        "warning": null,
+        "consecutiveTime": 28
+      },
+      "numberOfStops": 0,
+      "trainrunId": 26,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 912, "y": -286},
+          {"x": 912, "y": -222},
+          {"x": 912, "y": -34},
+          {"x": 912, "y": 30}
+        ],
+        "textPositions": {
+          "0": {"x": 900, "y": -268},
+          "1": {"x": 924, "y": -240},
+          "2": {"x": 924, "y": 12},
+          "3": {"x": 900, "y": -16},
+          "4": {"x": 900, "y": -128},
+          "5": {"x": 900, "y": -128},
+          "6": {"x": 924, "y": -128}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 125,
+      "sourceNodeId": 1,
+      "sourcePortId": 167,
+      "targetNodeId": 4,
+      "targetPortId": 168,
+      "travelTime": {
+        "lock": true,
+        "time": 6,
+        "warning": null,
+        "consecutiveTime": 10
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 30,
+        "warning": null,
+        "consecutiveTime": 30
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 30,
+        "warning": null,
+        "consecutiveTime": 150
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 24,
+        "warning": null,
+        "consecutiveTime": 144
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 36,
+        "warning": null,
+        "consecutiveTime": 36
+      },
+      "numberOfStops": 0,
+      "trainrunId": 26,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 848, "y": 350},
+          {"x": 848, "y": 414},
+          {"x": 848, "y": 510},
+          {"x": 848, "y": 574}
+        ],
+        "textPositions": {
+          "0": {"x": 836, "y": 368},
+          "1": {"x": 860, "y": 396},
+          "2": {"x": 860, "y": 556},
+          "3": {"x": 836, "y": 528},
+          "4": {"x": 836, "y": 462},
+          "5": {"x": 836, "y": 462},
+          "6": {"x": 860, "y": 462}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 126,
+      "sourceNodeId": 4,
+      "sourcePortId": 169,
+      "targetNodeId": 6,
+      "targetPortId": 170,
+      "travelTime": {
+        "lock": true,
+        "time": 10,
+        "warning": null,
+        "consecutiveTime": 10
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 36,
+        "warning": null,
+        "consecutiveTime": 36
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 24,
+        "warning": null,
+        "consecutiveTime": 144
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 14,
+        "warning": null,
+        "consecutiveTime": 134
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 46,
+        "warning": null,
+        "consecutiveTime": 46
+      },
+      "numberOfStops": 0,
+      "trainrunId": 26,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 880, "y": 642},
+          {"x": 880, "y": 706},
+          {"x": 880, "y": 958},
+          {"x": 880, "y": 1022}
+        ],
+        "textPositions": {
+          "0": {"x": 868, "y": 660},
+          "1": {"x": 892, "y": 688},
+          "2": {"x": 892, "y": 1004},
+          "3": {"x": 868, "y": 976},
+          "4": {"x": 868, "y": 832},
+          "5": {"x": 868, "y": 832},
+          "6": {"x": 892, "y": 832}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 127,
+      "sourceNodeId": 6,
+      "sourcePortId": 171,
+      "targetNodeId": 3,
+      "targetPortId": 172,
+      "travelTime": {
+        "lock": true,
+        "time": 19,
+        "warning": null,
+        "consecutiveTime": 10
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 46,
+        "warning": null,
+        "consecutiveTime": 46
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 14,
+        "warning": null,
+        "consecutiveTime": 134
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 55,
+        "warning": null,
+        "consecutiveTime": 115
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 5,
+        "warning": null,
+        "consecutiveTime": 65
+      },
+      "numberOfStops": 0,
+      "trainrunId": 26,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 880, "y": 1090},
+          {"x": 880, "y": 1154},
+          {"x": 880, "y": 1374},
+          {"x": 880, "y": 1438}
+        ],
+        "textPositions": {
+          "0": {"x": 868, "y": 1108},
+          "1": {"x": 892, "y": 1136},
+          "2": {"x": 892, "y": 1420},
+          "3": {"x": 868, "y": 1392},
+          "4": {"x": 868, "y": 1264},
+          "5": {"x": 868, "y": 1264},
+          "6": {"x": 892, "y": 1264}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 128,
+      "sourceNodeId": 106,
+      "sourcePortId": 173,
+      "targetNodeId": 1,
+      "targetPortId": 174,
+      "travelTime": {
+        "lock": true,
+        "time": 32,
+        "warning": null,
+        "consecutiveTime": 10
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 16,
+        "warning": null,
+        "consecutiveTime": 16
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 44,
+        "warning": null,
+        "consecutiveTime": 164
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 12,
+        "warning": null,
+        "consecutiveTime": 132
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 48,
+        "warning": null,
+        "consecutiveTime": 48
+      },
+      "numberOfStops": 0,
+      "trainrunId": 27,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 944, "y": -286},
+          {"x": 944, "y": -222},
+          {"x": 944, "y": -34},
+          {"x": 944, "y": 30}
+        ],
+        "textPositions": {
+          "0": {"x": 932, "y": -268},
+          "1": {"x": 956, "y": -240},
+          "2": {"x": 956, "y": 12},
+          "3": {"x": 932, "y": -16},
+          "4": {"x": 932, "y": -128},
+          "5": {"x": 932, "y": -128},
+          "6": {"x": 956, "y": -128}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 129,
+      "sourceNodeId": 1,
+      "sourcePortId": 175,
+      "targetNodeId": 4,
+      "targetPortId": 176,
+      "travelTime": {
+        "lock": true,
+        "time": 7,
+        "warning": null,
+        "consecutiveTime": 10
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 49,
+        "warning": null,
+        "consecutiveTime": 49
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 11,
+        "warning": null,
+        "consecutiveTime": 131
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 4,
+        "warning": null,
+        "consecutiveTime": 124
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 56,
+        "warning": null,
+        "consecutiveTime": 56
+      },
+      "numberOfStops": 0,
+      "trainrunId": 27,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 880, "y": 350},
+          {"x": 880, "y": 414},
+          {"x": 880, "y": 510},
+          {"x": 880, "y": 574}
+        ],
+        "textPositions": {
+          "0": {"x": 868, "y": 368},
+          "1": {"x": 892, "y": 396},
+          "2": {"x": 892, "y": 556},
+          "3": {"x": 868, "y": 528},
+          "4": {"x": 868, "y": 462},
+          "5": {"x": 868, "y": 462},
+          "6": {"x": 892, "y": 462}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 130,
+      "sourceNodeId": 4,
+      "sourcePortId": 177,
+      "targetNodeId": 6,
+      "targetPortId": 178,
+      "travelTime": {
+        "lock": true,
+        "time": 12,
+        "warning": null,
+        "consecutiveTime": 10
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 58,
+        "warning": null,
+        "consecutiveTime": 58
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 2,
+        "warning": null,
+        "consecutiveTime": 122
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 50,
+        "warning": null,
+        "consecutiveTime": 110
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 10,
+        "warning": null,
+        "consecutiveTime": 70
+      },
+      "numberOfStops": 0,
+      "trainrunId": 27,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 912, "y": 642},
+          {"x": 912, "y": 706},
+          {"x": 912, "y": 958},
+          {"x": 912, "y": 1022}
+        ],
+        "textPositions": {
+          "0": {"x": 900, "y": 660},
+          "1": {"x": 924, "y": 688},
+          "2": {"x": 924, "y": 1004},
+          "3": {"x": 900, "y": 976},
+          "4": {"x": 900, "y": 832},
+          "5": {"x": 900, "y": 832},
+          "6": {"x": 924, "y": 832}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 131,
+      "sourceNodeId": 6,
+      "sourcePortId": 179,
+      "targetNodeId": 3,
+      "targetPortId": 180,
+      "travelTime": {
+        "lock": true,
+        "time": 18,
+        "warning": null,
+        "consecutiveTime": 10
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 12,
+        "warning": null,
+        "consecutiveTime": 72
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 48,
+        "warning": null,
+        "consecutiveTime": 108
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 30,
+        "warning": null,
+        "consecutiveTime": 90
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 30,
+        "warning": null,
+        "consecutiveTime": 90
+      },
+      "numberOfStops": 0,
+      "trainrunId": 27,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 912, "y": 1090},
+          {"x": 912, "y": 1154},
+          {"x": 912, "y": 1374},
+          {"x": 912, "y": 1438}
+        ],
+        "textPositions": {
+          "0": {"x": 900, "y": 1108},
+          "1": {"x": 924, "y": 1136},
+          "2": {"x": 924, "y": 1420},
+          "3": {"x": 900, "y": 1392},
+          "4": {"x": 900, "y": 1264},
+          "5": {"x": 900, "y": 1264},
+          "6": {"x": 924, "y": 1264}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 132,
+      "sourceNodeId": 0,
+      "sourcePortId": 181,
+      "targetNodeId": 8,
+      "targetPortId": 201,
+      "travelTime": {
+        "lock": true,
+        "time": 44,
+        "warning": null,
+        "consecutiveTime": 10
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 48,
+        "warning": null,
+        "consecutiveTime": 48
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 12,
+        "warning": null,
+        "consecutiveTime": 252
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 28,
+        "warning": null,
+        "consecutiveTime": 208
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 32,
+        "warning": null,
+        "consecutiveTime": 92
+      },
+      "numberOfStops": 0,
+      "trainrunId": 28,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -862, "y": 336},
+          {"x": -798, "y": 336},
+          {"x": -386, "y": 336},
+          {"x": -322, "y": 336}
+        ],
+        "textPositions": {
+          "0": {"x": -844, "y": 348},
+          "1": {"x": -816, "y": 324},
+          "2": {"x": -340, "y": 324},
+          "3": {"x": -368, "y": 348},
+          "4": {"x": -592, "y": 324},
+          "5": {"x": -592, "y": 324},
+          "6": {"x": -592, "y": 348}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 133,
+      "sourceNodeId": 8,
+      "sourcePortId": 202,
+      "targetNodeId": 7,
+      "targetPortId": 207,
+      "travelTime": {
+        "lock": true,
+        "time": 6,
+        "warning": null,
+        "consecutiveTime": 10
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 44,
+        "warning": null,
+        "consecutiveTime": 104
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 16,
+        "warning": null,
+        "consecutiveTime": 196
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 10,
+        "warning": null,
+        "consecutiveTime": 190
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 50,
+        "warning": null,
+        "consecutiveTime": 110
+      },
+      "numberOfStops": 0,
+      "trainrunId": 28,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -222, "y": 336},
+          {"x": -158, "y": 336},
+          {"x": 190, "y": 336},
+          {"x": 254, "y": 336}
+        ],
+        "textPositions": {
+          "0": {"x": -204, "y": 348},
+          "1": {"x": -176, "y": 324},
+          "2": {"x": 236, "y": 324},
+          "3": {"x": 208, "y": 348},
+          "4": {"x": 16, "y": 324},
+          "5": {"x": 16, "y": 324},
+          "6": {"x": 16, "y": 348}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 134,
+      "sourceNodeId": 1,
+      "sourcePortId": 185,
+      "targetNodeId": 4,
+      "targetPortId": 186,
+      "travelTime": {
+        "lock": true,
+        "time": 13,
+        "warning": null,
+        "consecutiveTime": 10
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 55,
+        "warning": null,
+        "consecutiveTime": 115
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 5,
+        "warning": null,
+        "consecutiveTime": 185
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 52,
+        "warning": null,
+        "consecutiveTime": 172
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 8,
+        "warning": null,
+        "consecutiveTime": 128
+      },
+      "numberOfStops": 0,
+      "trainrunId": 28,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1008, "y": 350},
+          {"x": 1008, "y": 414},
+          {"x": 1008, "y": 510},
+          {"x": 1008, "y": 574}
+        ],
+        "textPositions": {
+          "0": {"x": 996, "y": 368},
+          "1": {"x": 1020, "y": 396},
+          "2": {"x": 1020, "y": 556},
+          "3": {"x": 996, "y": 528},
+          "4": {"x": 996, "y": 462},
+          "5": {"x": 996, "y": 462},
+          "6": {"x": 1020, "y": 462}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 135,
+      "sourceNodeId": 4,
+      "sourcePortId": 189,
+      "targetNodeId": 6,
+      "targetPortId": 190,
+      "travelTime": {
+        "lock": true,
+        "time": 20,
+        "warning": null,
+        "consecutiveTime": 10
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 8,
+        "warning": null,
+        "consecutiveTime": 128
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 52,
+        "warning": null,
+        "consecutiveTime": 172
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 32,
+        "warning": null,
+        "consecutiveTime": 152
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 28,
+        "warning": null,
+        "consecutiveTime": 148
+      },
+      "numberOfStops": 0,
+      "trainrunId": 28,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 1008, "y": 642},
+          {"x": 1008, "y": 706},
+          {"x": 1008, "y": 958},
+          {"x": 1008, "y": 1022}
+        ],
+        "textPositions": {
+          "0": {"x": 996, "y": 660},
+          "1": {"x": 1020, "y": 688},
+          "2": {"x": 1020, "y": 1004},
+          "3": {"x": 996, "y": 976},
+          "4": {"x": 996, "y": 832},
+          "5": {"x": 996, "y": 832},
+          "6": {"x": 1020, "y": 832}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 136,
+      "sourceNodeId": 7,
+      "sourcePortId": 204,
+      "targetNodeId": 1,
+      "targetPortId": 146,
+      "travelTime": {
+        "lock": true,
+        "time": 4,
+        "warning": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 46,
+        "warning": null,
+        "consecutiveTime": 46
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 14,
+        "warning": null,
+        "consecutiveTime": 14
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 10,
+        "warning": null,
+        "consecutiveTime": 10
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 50,
+        "warning": null,
+        "consecutiveTime": 50
+      },
+      "numberOfStops": 0,
+      "trainrunId": 21,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 354, "y": 240},
+          {"x": 418, "y": 240},
+          {"x": 766, "y": 240},
+          {"x": 830, "y": 240}
+        ],
+        "textPositions": {
+          "0": {"x": 372, "y": 252},
+          "1": {"x": 400, "y": 228},
+          "2": {"x": 812, "y": 228},
+          "3": {"x": 784, "y": 252},
+          "4": {"x": 592, "y": 228},
+          "5": {"x": 592, "y": 228},
+          "6": {"x": 592, "y": 252}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 137,
+      "sourceNodeId": 7,
+      "sourcePortId": 206,
+      "targetNodeId": 1,
+      "targetPortId": 150,
+      "travelTime": {
+        "lock": true,
+        "time": 5,
+        "warning": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 17,
+        "warning": null,
+        "consecutiveTime": 77
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 43,
+        "warning": null,
+        "consecutiveTime": 223
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 38,
+        "warning": null,
+        "consecutiveTime": 218
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 22,
+        "warning": null,
+        "consecutiveTime": 82
+      },
+      "numberOfStops": 0,
+      "trainrunId": 22,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 354, "y": 272},
+          {"x": 418, "y": 272},
+          {"x": 766, "y": 272},
+          {"x": 830, "y": 272}
+        ],
+        "textPositions": {
+          "0": {"x": 372, "y": 284},
+          "1": {"x": 400, "y": 260},
+          "2": {"x": 812, "y": 260},
+          "3": {"x": 784, "y": 284},
+          "4": {"x": 592, "y": 260},
+          "5": {"x": 592, "y": 260},
+          "6": {"x": 592, "y": 284}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 138,
+      "sourceNodeId": 7,
+      "sourcePortId": 208,
+      "targetNodeId": 1,
+      "targetPortId": 184,
+      "travelTime": {
+        "lock": true,
+        "time": 5,
+        "warning": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 50,
+        "warning": null,
+        "consecutiveTime": 110
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 10,
+        "warning": null,
+        "consecutiveTime": 190
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 5,
+        "warning": null,
+        "consecutiveTime": 185
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 55,
+        "warning": null,
+        "consecutiveTime": 115
+      },
+      "numberOfStops": 0,
+      "trainrunId": 28,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 354, "y": 304},
+          {"x": 418, "y": 304},
+          {"x": 766, "y": 304},
+          {"x": 830, "y": 304}
+        ],
+        "textPositions": {
+          "0": {"x": 372, "y": 316},
+          "1": {"x": 400, "y": 292},
+          "2": {"x": 812, "y": 292},
+          "3": {"x": 784, "y": 316},
+          "4": {"x": 592, "y": 292},
+          "5": {"x": 592, "y": 292},
+          "6": {"x": 592, "y": 316}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 139,
+      "sourceNodeId": 7,
+      "sourcePortId": 209,
+      "targetNodeId": 1,
+      "targetPortId": 210,
+      "travelTime": {
+        "lock": true,
+        "time": 1,
+        "warning": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 58,
+        "warning": null,
+        "consecutiveTime": 58
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 2,
+        "warning": null,
+        "consecutiveTime": 2
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 1,
+        "warning": null,
+        "consecutiveTime": 1
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 59,
+        "warning": null,
+        "consecutiveTime": 59
+      },
+      "numberOfStops": 0,
+      "trainrunId": 29,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 354, "y": 176},
+          {"x": 418, "y": 176},
+          {"x": 766, "y": 176},
+          {"x": 830, "y": 176}
+        ],
+        "textPositions": {
+          "0": {"x": 372, "y": 188},
+          "1": {"x": 400, "y": 164},
+          "2": {"x": 812, "y": 164},
+          "3": {"x": 784, "y": 188},
+          "4": {"x": 592, "y": 164},
+          "5": {"x": 592, "y": 164},
+          "6": {"x": 592, "y": 188}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 140,
+      "sourceNodeId": 7,
+      "sourcePortId": 211,
+      "targetNodeId": 8,
+      "targetPortId": 212,
+      "travelTime": {
+        "lock": true,
+        "time": 1,
+        "warning": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 2,
+        "warning": null,
+        "consecutiveTime": 2
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 58,
+        "warning": null,
+        "consecutiveTime": 58
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 57,
+        "warning": null,
+        "consecutiveTime": 57
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 3,
+        "warning": null,
+        "consecutiveTime": 3
+      },
+      "numberOfStops": 0,
+      "trainrunId": 29,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 254, "y": 240},
+          {"x": 190, "y": 240},
+          {"x": -158, "y": 240},
+          {"x": -222, "y": 240}
+        ],
+        "textPositions": {
+          "0": {"x": 236, "y": 228},
+          "1": {"x": 208, "y": 252},
+          "2": {"x": -204, "y": 252},
+          "3": {"x": -176, "y": 228},
+          "4": {"x": 16, "y": 228},
+          "5": {"x": 16, "y": 228},
+          "6": {"x": 16, "y": 252}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 141,
+      "sourceNodeId": 8,
+      "sourcePortId": 213,
+      "targetNodeId": 0,
+      "targetPortId": 214,
+      "travelTime": {
+        "lock": true,
+        "time": 1,
+        "warning": null,
+        "consecutiveTime": 1
+      },
+      "sourceDeparture": {
+        "lock": false,
+        "time": 5,
+        "warning": null,
+        "consecutiveTime": 5
+      },
+      "sourceArrival": {
+        "lock": false,
+        "time": 55,
+        "warning": null,
+        "consecutiveTime": 55
+      },
+      "targetDeparture": {
+        "lock": false,
+        "time": 54,
+        "warning": null,
+        "consecutiveTime": 54
+      },
+      "targetArrival": {
+        "lock": false,
+        "time": 6,
+        "warning": null,
+        "consecutiveTime": 6
+      },
+      "numberOfStops": 0,
+      "trainrunId": 29,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -322, "y": 240},
+          {"x": -386, "y": 240},
+          {"x": -798, "y": 240},
+          {"x": -862, "y": 240}
+        ],
+        "textPositions": {
+          "0": {"x": -340, "y": 228},
+          "1": {"x": -368, "y": 252},
+          "2": {"x": -844, "y": 252},
+          "3": {"x": -816, "y": 228},
+          "4": {"x": -592, "y": 228},
+          "5": {"x": -592, "y": 228},
+          "6": {"x": -592, "y": 252}
+        }
+      },
+      "warnings": null
+    }
+  ],
+  "trainruns": [
+    {
+      "id": 11,
+      "name": "15",
+      "categoryId": 2,
+      "frequencyId": 3,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": [26]
+    },
+    {
+      "id": 12,
+      "name": "8",
+      "categoryId": 1,
+      "frequencyId": 3,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": [31]
+    },
+    {
+      "id": 14,
+      "name": "E",
+      "categoryId": 1,
+      "frequencyId": 3,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": [28]
+    },
+    {
+      "id": 16,
+      "name": "1",
+      "categoryId": 1,
+      "frequencyId": 3,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": [30]
+    },
+    {
+      "id": 18,
+      "name": "16",
+      "categoryId": 2,
+      "frequencyId": 3,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": [27]
+    },
+    {
+      "id": 20,
+      "name": "61",
+      "categoryId": 1,
+      "frequencyId": 3,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": [29]
+    },
+    {
+      "id": 21,
+      "name": "17",
+      "categoryId": 2,
+      "frequencyId": 3,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": [32]
+    },
+    {
+      "id": 22,
+      "name": "35",
+      "categoryId": 2,
+      "frequencyId": 3,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": [33]
+    },
+    {
+      "id": 23,
+      "name": "",
+      "categoryId": 3,
+      "frequencyId": 3,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": [37]
+    },
+    {
+      "id": 24,
+      "name": "29a",
+      "categoryId": 4,
+      "frequencyId": 3,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": [38]
+    },
+    {
+      "id": 25,
+      "name": "29",
+      "categoryId": 3,
+      "frequencyId": 2,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": [39]
+    },
+    {
+      "id": 26,
+      "name": "26",
+      "categoryId": 2,
+      "frequencyId": 3,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": [35]
+    },
+    {
+      "id": 27,
+      "name": "27",
+      "categoryId": 2,
+      "frequencyId": 3,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": [36]
+    },
+    {
+      "id": 28,
+      "name": "X",
+      "categoryId": 5,
+      "frequencyId": 3,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": [34]
+    },
+    {
+      "id": 29,
+      "name": "X",
+      "categoryId": 1,
+      "frequencyId": 3,
+      "trainrunTimeCategoryId": 0,
+      "labelIds": []
+    }
+  ],
+  "resources": [
+    {"id": 65, "capacity": 10},
+    {"id": 66, "capacity": 8},
+    {"id": 67, "capacity": 15},
+    {"id": 68, "capacity": 10},
+    {"id": 69, "capacity": 3},
+    {"id": 70, "capacity": 2},
+    {"id": 71, "capacity": 3},
+    {"id": 72, "capacity": 3},
+    {"id": 73, "capacity": 3},
+    {"id": 74, "capacity": 2},
+    {"id": 75, "capacity": 2},
+    {"id": 76, "capacity": 9},
+    {"id": 77, "capacity": 2}
+  ],
+  "metadata": {
+    "netzgrafikColors": [],
+    "trainrunCategories": [
+      {
+        "id": 0,
+        "name": "International",
+        "order": 0,
+        "colorRef": "EC",
+        "shortName": "EC",
+        "fachCategory": "HaltezeitIPV",
+        "sectionHeadway": 2,
+        "nodeHeadwayStop": 2,
+        "nodeHeadwayNonStop": 2,
+        "minimalTurnaroundTime": 8
+      },
+      {
+        "id": 1,
+        "name": "InterCity",
+        "order": 1,
+        "colorRef": "IC",
+        "shortName": "IC",
+        "fachCategory": "HaltezeitA",
+        "sectionHeadway": 2,
+        "nodeHeadwayStop": 2,
+        "nodeHeadwayNonStop": 2,
+        "minimalTurnaroundTime": 8
+      },
+      {
+        "id": 2,
+        "name": "InterRegio",
+        "order": 2,
+        "colorRef": "IR",
+        "shortName": "IR",
+        "fachCategory": "HaltezeitB",
+        "sectionHeadway": 2,
+        "nodeHeadwayStop": 2,
+        "nodeHeadwayNonStop": 2,
+        "minimalTurnaroundTime": 8
+      },
+      {
+        "id": 3,
+        "name": "RegioExpress",
+        "order": 3,
+        "colorRef": "RE",
+        "shortName": "RE",
+        "fachCategory": "HaltezeitC",
+        "sectionHeadway": 2,
+        "nodeHeadwayStop": 2,
+        "nodeHeadwayNonStop": 2,
+        "minimalTurnaroundTime": 8
+      },
+      {
+        "id": 4,
+        "name": "RegioUndSBahnverkehr",
+        "order": 4,
+        "colorRef": "S",
+        "shortName": "S",
+        "fachCategory": "HaltezeitD",
+        "sectionHeadway": 2,
+        "nodeHeadwayStop": 2,
+        "nodeHeadwayNonStop": 2,
+        "minimalTurnaroundTime": 8
+      },
+      {
+        "id": 5,
+        "name": "GüterExpress",
+        "order": 5,
+        "colorRef": "GEX",
+        "shortName": "GEX",
+        "fachCategory": "HaltezeitUncategorized",
+        "sectionHeadway": 3,
+        "nodeHeadwayStop": 3,
+        "nodeHeadwayNonStop": 3,
+        "minimalTurnaroundTime": 8
+      },
+      {
+        "id": 6,
+        "name": "Güterverkehr",
+        "order": 6,
+        "colorRef": "G",
+        "shortName": "G",
+        "fachCategory": "HaltezeitUncategorized",
+        "sectionHeadway": 3,
+        "nodeHeadwayStop": 3,
+        "nodeHeadwayNonStop": 3,
+        "minimalTurnaroundTime": 8
+      }
+    ],
+    "trainrunFrequencies": [
+      {
+        "id": 0,
+        "name": "verkehrt viertelstündlich",
+        "order": 0,
+        "offset": 0,
+        "frequency": 15,
+        "shortName": "15",
+        "linePatternRef": "15"
+      },
+      {
+        "id": 1,
+        "name": "verkehrt im 20 Minuten Takt",
+        "order": 0,
+        "offset": 0,
+        "frequency": 20,
+        "shortName": "20",
+        "linePatternRef": "20"
+      },
+      {
+        "id": 2,
+        "name": "verkehrt halbstündlich",
+        "order": 0,
+        "offset": 0,
+        "frequency": 30,
+        "shortName": "30",
+        "linePatternRef": "30"
+      },
+      {
+        "id": 3,
+        "name": "verkehrt stündlich",
+        "order": 0,
+        "offset": 0,
+        "frequency": 60,
+        "shortName": "60",
+        "linePatternRef": "60"
+      },
+      {
+        "id": 4,
+        "name": "verkehrt zweistündlich (gerade)",
+        "order": 0,
+        "offset": 0,
+        "frequency": 120,
+        "shortName": "120",
+        "linePatternRef": "120"
+      },
+      {
+        "id": 5,
+        "name": "verkehrt zweistündlich (ungerade)",
+        "order": 0,
+        "offset": 60,
+        "frequency": 120,
+        "shortName": "120+",
+        "linePatternRef": "120"
+      }
+    ],
+    "trainrunTimeCategories": [
+      {
+        "id": 0,
+        "name": "verkehrt uneingeschränkt",
+        "order": 0,
+        "weekday": [1, 2, 3, 4, 5, 6, 7],
+        "shortName": "7/24",
+        "linePatternRef": "7/24",
+        "dayTimeInterval": []
+      },
+      {
+        "id": 1,
+        "name": "verkehrt zur Hauptverkehrszeit",
+        "order": 0,
+        "weekday": [1, 2, 3, 4, 5, 6, 7],
+        "shortName": "HVZ",
+        "linePatternRef": "HVZ",
+        "dayTimeInterval": [
+          {"to": 420, "from": 360},
+          {"to": 1140, "from": 960}
+        ]
+      },
+      {
+        "id": 2,
+        "name": "verkehrt zeitweise",
+        "order": 0,
+        "weekday": [],
+        "shortName": "zeitweise",
+        "linePatternRef": "ZEITWEISE",
+        "dayTimeInterval": []
+      }
+    ]
+  },
+  "freeFloatingTexts": [],
+  "labels": [
+    {"id": 1, "label": "BLS", "labelGroupId": 1, "labelRef": "Node"},
+    {"id": 2, "label": "SBB", "labelGroupId": 1, "labelRef": "Node"},
+    {"id": 3, "label": "OL-LZ", "labelGroupId": 1, "labelRef": "Node"},
+    {"id": 26, "label": "IR15", "labelGroupId": 9, "labelRef": "Trainrun"},
+    {"id": 27, "label": "IR16", "labelGroupId": 9, "labelRef": "Trainrun"},
+    {"id": 28, "label": "ICE", "labelGroupId": 9, "labelRef": "Trainrun"},
+    {"id": 29, "label": "IC61", "labelGroupId": 9, "labelRef": "Trainrun"},
+    {"id": 30, "label": "IC1", "labelGroupId": 9, "labelRef": "Trainrun"},
+    {"id": 31, "label": "IC8", "labelGroupId": 9, "labelRef": "Trainrun"},
+    {"id": 32, "label": "IR17", "labelGroupId": 9, "labelRef": "Trainrun"},
+    {"id": 33, "label": "IR35", "labelGroupId": 9, "labelRef": "Trainrun"},
+    {"id": 34, "label": "GEXX", "labelGroupId": 9, "labelRef": "Trainrun"},
+    {"id": 35, "label": "IR26", "labelGroupId": 9, "labelRef": "Trainrun"},
+    {"id": 36, "label": "IR27", "labelGroupId": 9, "labelRef": "Trainrun"},
+    {"id": 37, "label": "RE", "labelGroupId": 9, "labelRef": "Trainrun"},
+    {"id": 38, "label": "S29", "labelGroupId": 9, "labelRef": "Trainrun"},
+    {"id": 39, "label": "S29_OL_SS", "labelGroupId": 9, "labelRef": "Trainrun"},
+    {"id": 40, "label": "LZ", "labelGroupId": 1, "labelRef": "Node"},
+    {"id": 41, "label": "BN", "labelGroupId": 1, "labelRef": "Node"},
+    {"id": 42, "label": "ZUE", "labelGroupId": 1, "labelRef": "Node"}
+  ],
+  "labelGroups": [
+    {"id": 1, "name": "Standard", "labelRef": "Node"},
+    {"id": 9, "name": "Standard", "labelRef": "Trainrun"}
+  ],
+  "filterData": {"filterSettings": []}
+}

--- a/src/app/sample-netzgrafik/netzgrafik.default.ts
+++ b/src/app/sample-netzgrafik/netzgrafik.default.ts
@@ -208,7 +208,7 @@ export class NetzgrafikDefault {
         analyticsSettings: {
           originDestinationSettings: {
             connectionPenalty: 5,
-          }
+          },
         },
         trainrunCategories: [
           {

--- a/src/app/sample-netzgrafik/netzgrafik.demo.standalone.github.ts
+++ b/src/app/sample-netzgrafik/netzgrafik.demo.standalone.github.ts
@@ -19,40 +19,40 @@ export class NetzgrafikDemoStandaloneGithub {
               id: 1207,
               trainrunSectionId: 596,
               positionIndex: 0,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1187,
               trainrunSectionId: 586,
               positionIndex: 1,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1382,
               trainrunSectionId: 683,
               positionIndex: 0,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1380,
               trainrunSectionId: 682,
               positionIndex: 1,
-              positionAlignment: 3
-            }
+              positionAlignment: 3,
+            },
           ],
           transitions: [
             {
               id: 345,
               port1Id: 1187,
               port2Id: 1380,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 347,
               port1Id: 1207,
               port2Id: 1382,
-              isNonStopTransit: false
-            }
+              isNonStopTransit: false,
+            },
           ],
           connections: [],
           resourceId: 152,
@@ -61,32 +61,32 @@ export class NetzgrafikDemoStandaloneGithub {
           trainrunCategoryHaltezeiten: {
             HaltezeitA: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitB: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitC: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitD: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitIPV: {
               no_halt: false,
-              haltezeit: 3
+              haltezeit: 3,
             },
             HaltezeitUncategorized: {
               no_halt: true,
-              haltezeit: 0
-            }
+              haltezeit: 0,
+            },
           },
           symmetryAxis: null,
           warnings: null,
-          labelIds: []
+          labelIds: [],
         },
         {
           id: 129,
@@ -99,118 +99,118 @@ export class NetzgrafikDemoStandaloneGithub {
               id: 1328,
               trainrunSectionId: 656,
               positionIndex: 0,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1311,
               trainrunSectionId: 648,
               positionIndex: 1,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1313,
               trainrunSectionId: 649,
               positionIndex: 2,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1339,
               trainrunSectionId: 662,
               positionIndex: 3,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1205,
               trainrunSectionId: 595,
               positionIndex: 0,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1109,
               trainrunSectionId: 547,
               positionIndex: 1,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1440,
               trainrunSectionId: 712,
               positionIndex: 0,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1329,
               trainrunSectionId: 657,
               positionIndex: 1,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1436,
               trainrunSectionId: 710,
               positionIndex: 2,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1434,
               trainrunSectionId: 709,
               positionIndex: 3,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1432,
               trainrunSectionId: 708,
               positionIndex: 4,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1430,
               trainrunSectionId: 707,
               positionIndex: 5,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1428,
               trainrunSectionId: 706,
               positionIndex: 6,
-              positionAlignment: 3
-            }
+              positionAlignment: 3,
+            },
           ],
           transitions: [
             {
               id: 315,
               port1Id: 1328,
               port2Id: 1329,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 376,
               port1Id: 1109,
               port2Id: 1430,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 378,
               port1Id: 1339,
               port2Id: 1432,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 380,
               port1Id: 1313,
               port2Id: 1434,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 382,
               port1Id: 1311,
               port2Id: 1436,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 386,
               port1Id: 1205,
               port2Id: 1440,
-              isNonStopTransit: false
-            }
+              isNonStopTransit: false,
+            },
           ],
           connections: [],
           resourceId: 153,
@@ -219,32 +219,32 @@ export class NetzgrafikDemoStandaloneGithub {
           trainrunCategoryHaltezeiten: {
             HaltezeitA: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitB: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitC: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitD: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitIPV: {
               no_halt: false,
-              haltezeit: 3
+              haltezeit: 3,
             },
             HaltezeitUncategorized: {
               no_halt: true,
-              haltezeit: 0
-            }
+              haltezeit: 0,
+            },
           },
           symmetryAxis: null,
           warnings: null,
-          labelIds: []
+          labelIds: [],
         },
         {
           id: 130,
@@ -257,22 +257,22 @@ export class NetzgrafikDemoStandaloneGithub {
               id: 1183,
               trainrunSectionId: 584,
               positionIndex: 0,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1418,
               trainrunSectionId: 701,
               positionIndex: 0,
-              positionAlignment: 3
-            }
+              positionAlignment: 3,
+            },
           ],
           transitions: [
             {
               id: 366,
               port1Id: 1183,
               port2Id: 1418,
-              isNonStopTransit: false
-            }
+              isNonStopTransit: false,
+            },
           ],
           connections: [],
           resourceId: 154,
@@ -281,32 +281,32 @@ export class NetzgrafikDemoStandaloneGithub {
           trainrunCategoryHaltezeiten: {
             HaltezeitA: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitB: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitC: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitD: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitIPV: {
               no_halt: false,
-              haltezeit: 3
+              haltezeit: 3,
             },
             HaltezeitUncategorized: {
               no_halt: true,
-              haltezeit: 0
-            }
+              haltezeit: 0,
+            },
           },
           symmetryAxis: null,
           warnings: null,
-          labelIds: []
+          labelIds: [],
         },
         {
           id: 131,
@@ -319,14 +319,14 @@ export class NetzgrafikDemoStandaloneGithub {
               id: 1318,
               trainrunSectionId: 651,
               positionIndex: 0,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1344,
               trainrunSectionId: 664,
               positionIndex: 1,
-              positionAlignment: 2
-            }
+              positionAlignment: 2,
+            },
           ],
           transitions: [],
           connections: [],
@@ -336,32 +336,32 @@ export class NetzgrafikDemoStandaloneGithub {
           trainrunCategoryHaltezeiten: {
             HaltezeitA: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitB: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitC: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitD: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitIPV: {
               no_halt: false,
-              haltezeit: 3
+              haltezeit: 3,
             },
             HaltezeitUncategorized: {
               no_halt: true,
-              haltezeit: 0
-            }
+              haltezeit: 0,
+            },
           },
           symmetryAxis: null,
           warnings: null,
-          labelIds: []
+          labelIds: [],
         },
         {
           id: 132,
@@ -374,14 +374,14 @@ export class NetzgrafikDemoStandaloneGithub {
               id: 1323,
               trainrunSectionId: 654,
               positionIndex: 0,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1322,
               trainrunSectionId: 653,
               positionIndex: 1,
-              positionAlignment: 0
-            }
+              positionAlignment: 0,
+            },
           ],
           transitions: [],
           connections: [],
@@ -391,32 +391,32 @@ export class NetzgrafikDemoStandaloneGithub {
           trainrunCategoryHaltezeiten: {
             HaltezeitA: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitB: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitC: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitD: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitIPV: {
               no_halt: false,
-              haltezeit: 3
+              haltezeit: 3,
             },
             HaltezeitUncategorized: {
               no_halt: true,
-              haltezeit: 0
-            }
+              haltezeit: 0,
+            },
           },
           symmetryAxis: null,
           warnings: null,
-          labelIds: []
+          labelIds: [],
         },
         {
           id: 133,
@@ -429,202 +429,202 @@ export class NetzgrafikDemoStandaloneGithub {
               id: 1047,
               trainrunSectionId: 516,
               positionIndex: 0,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1331,
               trainrunSectionId: 658,
               positionIndex: 1,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1308,
               trainrunSectionId: 646,
               positionIndex: 2,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1371,
               trainrunSectionId: 678,
               positionIndex: 3,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1131,
               trainrunSectionId: 558,
               positionIndex: 4,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1117,
               trainrunSectionId: 551,
               positionIndex: 5,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1046,
               trainrunSectionId: 515,
               positionIndex: 0,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1370,
               trainrunSectionId: 677,
               positionIndex: 1,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1130,
               trainrunSectionId: 557,
               positionIndex: 2,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1116,
               trainrunSectionId: 550,
               positionIndex: 3,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1181,
               trainrunSectionId: 583,
               positionIndex: 0,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1203,
               trainrunSectionId: 594,
               positionIndex: 1,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1394,
               trainrunSectionId: 689,
               positionIndex: 2,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1309,
               trainrunSectionId: 647,
               positionIndex: 3,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1225,
               trainrunSectionId: 605,
               positionIndex: 4,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1241,
               trainrunSectionId: 613,
               positionIndex: 5,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1165,
               trainrunSectionId: 575,
               positionIndex: 6,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1202,
               trainrunSectionId: 593,
               positionIndex: 0,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1180,
               trainrunSectionId: 582,
               positionIndex: 1,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1224,
               trainrunSectionId: 604,
               positionIndex: 2,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1240,
               trainrunSectionId: 612,
               positionIndex: 3,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1164,
               trainrunSectionId: 574,
               positionIndex: 4,
-              positionAlignment: 3
-            }
+              positionAlignment: 3,
+            },
           ],
           transitions: [
             {
               id: 210,
               port1Id: 1047,
               port2Id: 1046,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 236,
               port1Id: 1117,
               port2Id: 1116,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 242,
               port1Id: 1131,
               port2Id: 1130,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 253,
               port1Id: 1165,
               port2Id: 1164,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 259,
               port1Id: 1181,
               port2Id: 1180,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 264,
               port1Id: 1203,
               port2Id: 1202,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 270,
               port1Id: 1225,
               port2Id: 1224,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 276,
               port1Id: 1241,
               port2Id: 1240,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 308,
               port1Id: 1308,
               port2Id: 1309,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 340,
               port1Id: 1371,
               port2Id: 1370,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 353,
               port1Id: 1331,
               port2Id: 1394,
-              isNonStopTransit: false
-            }
+              isNonStopTransit: false,
+            },
           ],
           connections: [],
           resourceId: 157,
@@ -633,32 +633,32 @@ export class NetzgrafikDemoStandaloneGithub {
           trainrunCategoryHaltezeiten: {
             HaltezeitA: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitB: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitC: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitD: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitIPV: {
               no_halt: false,
-              haltezeit: 3
+              haltezeit: 3,
             },
             HaltezeitUncategorized: {
               no_halt: true,
-              haltezeit: 0
-            }
+              haltezeit: 0,
+            },
           },
           symmetryAxis: null,
           warnings: null,
-          labelIds: []
+          labelIds: [],
         },
         {
           id: 134,
@@ -671,56 +671,56 @@ export class NetzgrafikDemoStandaloneGithub {
               id: 1054,
               trainrunSectionId: 519,
               positionIndex: 0,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1416,
               trainrunSectionId: 700,
               positionIndex: 1,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1277,
               trainrunSectionId: 631,
               positionIndex: 2,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1338,
               trainrunSectionId: 661,
               positionIndex: 3,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1301,
               trainrunSectionId: 643,
               positionIndex: 4,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1378,
               trainrunSectionId: 681,
               positionIndex: 5,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1138,
               trainrunSectionId: 561,
               positionIndex: 6,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1124,
               trainrunSectionId: 554,
               positionIndex: 7,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1267,
               trainrunSectionId: 626,
               positionIndex: 0,
-              positionAlignment: 3
-            }
+              positionAlignment: 3,
+            },
           ],
           transitions: [],
           connections: [],
@@ -730,32 +730,32 @@ export class NetzgrafikDemoStandaloneGithub {
           trainrunCategoryHaltezeiten: {
             HaltezeitA: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitB: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitC: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitD: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitIPV: {
               no_halt: false,
-              haltezeit: 3
+              haltezeit: 3,
             },
             HaltezeitUncategorized: {
               no_halt: true,
-              haltezeit: 0
-            }
+              haltezeit: 0,
+            },
           },
           symmetryAxis: null,
           warnings: null,
-          labelIds: []
+          labelIds: [],
         },
         {
           id: 135,
@@ -768,184 +768,184 @@ export class NetzgrafikDemoStandaloneGithub {
               id: 1255,
               trainrunSectionId: 620,
               positionIndex: 0,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1254,
               trainrunSectionId: 619,
               positionIndex: 1,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1360,
               trainrunSectionId: 672,
               positionIndex: 0,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1149,
               trainrunSectionId: 567,
               positionIndex: 1,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1153,
               trainrunSectionId: 569,
               positionIndex: 2,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1358,
               trainrunSectionId: 671,
               positionIndex: 3,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1356,
               trainrunSectionId: 670,
               positionIndex: 4,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1354,
               trainrunSectionId: 669,
               positionIndex: 5,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1195,
               trainrunSectionId: 590,
               positionIndex: 0,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1401,
               trainrunSectionId: 693,
               positionIndex: 1,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1292,
               trainrunSectionId: 638,
               positionIndex: 2,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1173,
               trainrunSectionId: 579,
               positionIndex: 3,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1217,
               trainrunSectionId: 601,
               positionIndex: 4,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1233,
               trainrunSectionId: 609,
               positionIndex: 5,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1157,
               trainrunSectionId: 571,
               positionIndex: 6,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1276,
               trainrunSectionId: 630,
               positionIndex: 7,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1300,
               trainrunSectionId: 642,
               positionIndex: 8,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1191,
               trainrunSectionId: 588,
               positionIndex: 0,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1172,
               trainrunSectionId: 578,
               positionIndex: 1,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1213,
               trainrunSectionId: 599,
               positionIndex: 2,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1229,
               trainrunSectionId: 607,
               positionIndex: 3,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1139,
               trainrunSectionId: 562,
               positionIndex: 4,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1245,
               trainrunSectionId: 615,
               positionIndex: 5,
-              positionAlignment: 3
-            }
+              positionAlignment: 3,
+            },
           ],
           transitions: [
             {
               id: 250,
               port1Id: 1153,
               port2Id: 1157,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 256,
               port1Id: 1173,
               port2Id: 1172,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 261,
               port1Id: 1195,
               port2Id: 1191,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 267,
               port1Id: 1217,
               port2Id: 1213,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 273,
               port1Id: 1233,
               port2Id: 1229,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 329,
               port1Id: 1354,
               port2Id: 1245,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 357,
               port1Id: 1149,
               port2Id: 1401,
-              isNonStopTransit: false
-            }
+              isNonStopTransit: false,
+            },
           ],
           connections: [],
           resourceId: 159,
@@ -954,32 +954,32 @@ export class NetzgrafikDemoStandaloneGithub {
           trainrunCategoryHaltezeiten: {
             HaltezeitA: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitB: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitC: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitD: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitIPV: {
               no_halt: false,
-              haltezeit: 3
+              haltezeit: 3,
             },
             HaltezeitUncategorized: {
               no_halt: true,
-              haltezeit: 0
-            }
+              haltezeit: 0,
+            },
           },
           symmetryAxis: null,
           warnings: null,
-          labelIds: []
+          labelIds: [],
         },
         {
           id: 136,
@@ -992,76 +992,76 @@ export class NetzgrafikDemoStandaloneGithub {
               id: 1059,
               trainrunSectionId: 522,
               positionIndex: 0,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1035,
               trainrunSectionId: 510,
               positionIndex: 1,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1071,
               trainrunSectionId: 528,
               positionIndex: 2,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1083,
               trainrunSectionId: 534,
               positionIndex: 3,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1058,
               trainrunSectionId: 521,
               positionIndex: 0,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1034,
               trainrunSectionId: 509,
               positionIndex: 1,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1070,
               trainrunSectionId: 527,
               positionIndex: 0,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1082,
               trainrunSectionId: 533,
               positionIndex: 1,
-              positionAlignment: 2
-            }
+              positionAlignment: 2,
+            },
           ],
           transitions: [
             {
               id: 206,
               port1Id: 1035,
               port2Id: 1034,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 216,
               port1Id: 1059,
               port2Id: 1058,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 221,
               port1Id: 1071,
               port2Id: 1070,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 226,
               port1Id: 1083,
               port2Id: 1082,
-              isNonStopTransit: false
-            }
+              isNonStopTransit: false,
+            },
           ],
           connections: [],
           resourceId: 160,
@@ -1070,32 +1070,32 @@ export class NetzgrafikDemoStandaloneGithub {
           trainrunCategoryHaltezeiten: {
             HaltezeitA: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitB: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitC: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitD: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitIPV: {
               no_halt: false,
-              haltezeit: 3
+              haltezeit: 3,
             },
             HaltezeitUncategorized: {
               no_halt: true,
-              haltezeit: 0
-            }
+              haltezeit: 0,
+            },
           },
           symmetryAxis: null,
           warnings: null,
-          labelIds: []
+          labelIds: [],
         },
         {
           id: 137,
@@ -1108,46 +1108,46 @@ export class NetzgrafikDemoStandaloneGithub {
               id: 1145,
               trainrunSectionId: 565,
               positionIndex: 0,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1212,
               trainrunSectionId: 598,
               positionIndex: 0,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1167,
               trainrunSectionId: 576,
               positionIndex: 1,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1144,
               trainrunSectionId: 564,
               positionIndex: 2,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1419,
               trainrunSectionId: 702,
               positionIndex: 0,
-              positionAlignment: 3
-            }
+              positionAlignment: 3,
+            },
           ],
           transitions: [
             {
               id: 248,
               port1Id: 1145,
               port2Id: 1144,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 367,
               port1Id: 1167,
               port2Id: 1419,
-              isNonStopTransit: false
-            }
+              isNonStopTransit: false,
+            },
           ],
           connections: [],
           resourceId: 161,
@@ -1156,32 +1156,32 @@ export class NetzgrafikDemoStandaloneGithub {
           trainrunCategoryHaltezeiten: {
             HaltezeitA: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitB: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitC: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitD: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitIPV: {
               no_halt: false,
-              haltezeit: 3
+              haltezeit: 3,
             },
             HaltezeitUncategorized: {
               no_halt: true,
-              haltezeit: 0
-            }
+              haltezeit: 0,
+            },
           },
           symmetryAxis: null,
           warnings: null,
-          labelIds: []
+          labelIds: [],
         },
         {
           id: 138,
@@ -1194,14 +1194,14 @@ export class NetzgrafikDemoStandaloneGithub {
               id: 1256,
               trainrunSectionId: 620,
               positionIndex: 0,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1251,
               trainrunSectionId: 618,
               positionIndex: 1,
-              positionAlignment: 1
-            }
+              positionAlignment: 1,
+            },
           ],
           transitions: [],
           connections: [],
@@ -1211,32 +1211,32 @@ export class NetzgrafikDemoStandaloneGithub {
           trainrunCategoryHaltezeiten: {
             HaltezeitA: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitB: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitC: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitD: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitIPV: {
               no_halt: false,
-              haltezeit: 3
+              haltezeit: 3,
             },
             HaltezeitUncategorized: {
               no_halt: true,
-              haltezeit: 0
-            }
+              haltezeit: 0,
+            },
           },
           symmetryAxis: null,
           warnings: null,
-          labelIds: []
+          labelIds: [],
         },
         {
           id: 139,
@@ -1249,8 +1249,8 @@ export class NetzgrafikDemoStandaloneGithub {
               id: 1250,
               trainrunSectionId: 617,
               positionIndex: 0,
-              positionAlignment: 1
-            }
+              positionAlignment: 1,
+            },
           ],
           transitions: [],
           connections: [],
@@ -1260,32 +1260,32 @@ export class NetzgrafikDemoStandaloneGithub {
           trainrunCategoryHaltezeiten: {
             HaltezeitA: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitB: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitC: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitD: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitIPV: {
               no_halt: false,
-              haltezeit: 3
+              haltezeit: 3,
             },
             HaltezeitUncategorized: {
               no_halt: true,
-              haltezeit: 0
-            }
+              haltezeit: 0,
+            },
           },
           symmetryAxis: null,
           warnings: null,
-          labelIds: []
+          labelIds: [],
         },
         {
           id: 140,
@@ -1298,58 +1298,58 @@ export class NetzgrafikDemoStandaloneGithub {
               id: 1146,
               trainrunSectionId: 565,
               positionIndex: 0,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1151,
               trainrunSectionId: 568,
               positionIndex: 0,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1147,
               trainrunSectionId: 566,
               positionIndex: 1,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1155,
               trainrunSectionId: 570,
               positionIndex: 2,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1362,
               trainrunSectionId: 673,
               positionIndex: 0,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1364,
               trainrunSectionId: 674,
               positionIndex: 1,
-              positionAlignment: 2
-            }
+              positionAlignment: 2,
+            },
           ],
           transitions: [
             {
               id: 249,
               port1Id: 1146,
               port2Id: 1147,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 334,
               port1Id: 1151,
               port2Id: 1362,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 336,
               port1Id: 1155,
               port2Id: 1364,
-              isNonStopTransit: false
-            }
+              isNonStopTransit: false,
+            },
           ],
           connections: [],
           resourceId: 164,
@@ -1358,32 +1358,32 @@ export class NetzgrafikDemoStandaloneGithub {
           trainrunCategoryHaltezeiten: {
             HaltezeitA: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitB: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitC: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitD: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitIPV: {
               no_halt: false,
-              haltezeit: 3
+              haltezeit: 3,
             },
             HaltezeitUncategorized: {
               no_halt: true,
-              haltezeit: 0
-            }
+              haltezeit: 0,
+            },
           },
           symmetryAxis: null,
           warnings: null,
-          labelIds: []
+          labelIds: [],
         },
         {
           id: 141,
@@ -1396,94 +1396,94 @@ export class NetzgrafikDemoStandaloneGithub {
               id: 1043,
               trainrunSectionId: 514,
               positionIndex: 0,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1105,
               trainrunSectionId: 545,
               positionIndex: 1,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1367,
               trainrunSectionId: 676,
               positionIndex: 2,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1127,
               trainrunSectionId: 556,
               positionIndex: 3,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1113,
               trainrunSectionId: 549,
               positionIndex: 4,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1042,
               trainrunSectionId: 513,
               positionIndex: 0,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1104,
               trainrunSectionId: 544,
               positionIndex: 1,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1366,
               trainrunSectionId: 675,
               positionIndex: 2,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1126,
               trainrunSectionId: 555,
               positionIndex: 3,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1112,
               trainrunSectionId: 548,
               positionIndex: 4,
-              positionAlignment: 1
-            }
+              positionAlignment: 1,
+            },
           ],
           transitions: [
             {
               id: 208,
               port1Id: 1043,
               port2Id: 1042,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 232,
               port1Id: 1105,
               port2Id: 1104,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 234,
               port1Id: 1113,
               port2Id: 1112,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 240,
               port1Id: 1127,
               port2Id: 1126,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 338,
               port1Id: 1367,
               port2Id: 1366,
-              isNonStopTransit: true
-            }
+              isNonStopTransit: true,
+            },
           ],
           connections: [],
           resourceId: 165,
@@ -1492,32 +1492,32 @@ export class NetzgrafikDemoStandaloneGithub {
           trainrunCategoryHaltezeiten: {
             HaltezeitA: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitB: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitC: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitD: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitIPV: {
               no_halt: false,
-              haltezeit: 3
+              haltezeit: 3,
             },
             HaltezeitUncategorized: {
               no_halt: true,
-              haltezeit: 0
-            }
+              haltezeit: 0,
+            },
           },
           symmetryAxis: null,
           warnings: null,
-          labelIds: []
+          labelIds: [],
         },
         {
           id: 142,
@@ -1530,70 +1530,70 @@ export class NetzgrafikDemoStandaloneGithub {
               id: 1041,
               trainrunSectionId: 513,
               positionIndex: 0,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1103,
               trainrunSectionId: 544,
               positionIndex: 1,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1365,
               trainrunSectionId: 675,
               positionIndex: 2,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1125,
               trainrunSectionId: 555,
               positionIndex: 3,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1111,
               trainrunSectionId: 548,
               positionIndex: 4,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1352,
               trainrunSectionId: 668,
               positionIndex: 0,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1350,
               trainrunSectionId: 667,
               positionIndex: 1,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1099,
               trainrunSectionId: 542,
               positionIndex: 2,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1095,
               trainrunSectionId: 540,
               positionIndex: 3,
-              positionAlignment: 3
-            }
+              positionAlignment: 3,
+            },
           ],
           transitions: [
             {
               id: 327,
               port1Id: 1041,
               port2Id: 1352,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 337,
               port1Id: 1365,
               port2Id: 1350,
-              isNonStopTransit: false
-            }
+              isNonStopTransit: false,
+            },
           ],
           connections: [],
           resourceId: 166,
@@ -1602,32 +1602,32 @@ export class NetzgrafikDemoStandaloneGithub {
           trainrunCategoryHaltezeiten: {
             HaltezeitA: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitB: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitC: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitD: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitIPV: {
               no_halt: false,
-              haltezeit: 3
+              haltezeit: 3,
             },
             HaltezeitUncategorized: {
               no_halt: true,
-              haltezeit: 0
-            }
+              haltezeit: 0,
+            },
           },
           symmetryAxis: null,
           warnings: null,
-          labelIds: []
+          labelIds: [],
         },
         {
           id: 143,
@@ -1640,94 +1640,94 @@ export class NetzgrafikDemoStandaloneGithub {
               id: 1045,
               trainrunSectionId: 515,
               positionIndex: 0,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1369,
               trainrunSectionId: 677,
               positionIndex: 1,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1129,
               trainrunSectionId: 557,
               positionIndex: 2,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1115,
               trainrunSectionId: 550,
               positionIndex: 3,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1044,
               trainrunSectionId: 514,
               positionIndex: 0,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1106,
               trainrunSectionId: 545,
               positionIndex: 1,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1368,
               trainrunSectionId: 676,
               positionIndex: 2,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1128,
               trainrunSectionId: 556,
               positionIndex: 3,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1114,
               trainrunSectionId: 549,
               positionIndex: 4,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1107,
               trainrunSectionId: 546,
               positionIndex: 0,
-              positionAlignment: 2
-            }
+              positionAlignment: 2,
+            },
           ],
           transitions: [
             {
               id: 209,
               port1Id: 1045,
               port2Id: 1044,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 233,
               port1Id: 1107,
               port2Id: 1106,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 235,
               port1Id: 1115,
               port2Id: 1114,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 241,
               port1Id: 1129,
               port2Id: 1128,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 339,
               port1Id: 1369,
               port2Id: 1368,
-              isNonStopTransit: false
-            }
+              isNonStopTransit: false,
+            },
           ],
           connections: [],
           resourceId: 167,
@@ -1736,32 +1736,32 @@ export class NetzgrafikDemoStandaloneGithub {
           trainrunCategoryHaltezeiten: {
             HaltezeitA: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitB: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitC: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitD: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitIPV: {
               no_halt: false,
-              haltezeit: 3
+              haltezeit: 3,
             },
             HaltezeitUncategorized: {
               no_halt: true,
-              haltezeit: 0
-            }
+              haltezeit: 0,
+            },
           },
           symmetryAxis: null,
           warnings: null,
-          labelIds: []
+          labelIds: [],
         },
         {
           id: 144,
@@ -1774,148 +1774,148 @@ export class NetzgrafikDemoStandaloneGithub {
               id: 1049,
               trainrunSectionId: 517,
               positionIndex: 0,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1411,
               trainrunSectionId: 698,
               positionIndex: 1,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1282,
               trainrunSectionId: 633,
               positionIndex: 2,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1333,
               trainrunSectionId: 659,
               positionIndex: 3,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1306,
               trainrunSectionId: 645,
               positionIndex: 4,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1373,
               trainrunSectionId: 679,
               positionIndex: 5,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1133,
               trainrunSectionId: 559,
               positionIndex: 6,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1119,
               trainrunSectionId: 552,
               positionIndex: 7,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1048,
               trainrunSectionId: 516,
               positionIndex: 0,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1332,
               trainrunSectionId: 658,
               positionIndex: 1,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1307,
               trainrunSectionId: 646,
               positionIndex: 2,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1372,
               trainrunSectionId: 678,
               positionIndex: 3,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1132,
               trainrunSectionId: 558,
               positionIndex: 4,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1118,
               trainrunSectionId: 551,
               positionIndex: 5,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1410,
               trainrunSectionId: 697,
               positionIndex: 0,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1283,
               trainrunSectionId: 634,
               positionIndex: 1,
-              positionAlignment: 3
-            }
+              positionAlignment: 3,
+            },
           ],
           transitions: [
             {
               id: 211,
               port1Id: 1049,
               port2Id: 1048,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 237,
               port1Id: 1119,
               port2Id: 1118,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 243,
               port1Id: 1133,
               port2Id: 1132,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 297,
               port1Id: 1282,
               port2Id: 1283,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 307,
               port1Id: 1306,
               port2Id: 1307,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 316,
               port1Id: 1333,
               port2Id: 1332,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 341,
               port1Id: 1373,
               port2Id: 1372,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 362,
               port1Id: 1411,
               port2Id: 1410,
-              isNonStopTransit: true
-            }
+              isNonStopTransit: true,
+            },
           ],
           connections: [],
           resourceId: 168,
@@ -1924,32 +1924,32 @@ export class NetzgrafikDemoStandaloneGithub {
           trainrunCategoryHaltezeiten: {
             HaltezeitA: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitB: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitC: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitD: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitIPV: {
               no_halt: false,
-              haltezeit: 3
+              haltezeit: 3,
             },
             HaltezeitUncategorized: {
               no_halt: true,
-              haltezeit: 0
-            }
+              haltezeit: 0,
+            },
           },
           symmetryAxis: null,
           warnings: null,
-          labelIds: []
+          labelIds: [],
         },
         {
           id: 145,
@@ -1962,148 +1962,148 @@ export class NetzgrafikDemoStandaloneGithub {
               id: 1051,
               trainrunSectionId: 518,
               positionIndex: 0,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1413,
               trainrunSectionId: 699,
               positionIndex: 1,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1280,
               trainrunSectionId: 632,
               positionIndex: 2,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1335,
               trainrunSectionId: 660,
               positionIndex: 3,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1304,
               trainrunSectionId: 644,
               positionIndex: 4,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1375,
               trainrunSectionId: 680,
               positionIndex: 5,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1135,
               trainrunSectionId: 560,
               positionIndex: 6,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1121,
               trainrunSectionId: 553,
               positionIndex: 7,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1050,
               trainrunSectionId: 517,
               positionIndex: 0,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1412,
               trainrunSectionId: 698,
               positionIndex: 1,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1281,
               trainrunSectionId: 633,
               positionIndex: 2,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1334,
               trainrunSectionId: 659,
               positionIndex: 3,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1305,
               trainrunSectionId: 645,
               positionIndex: 4,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1374,
               trainrunSectionId: 679,
               positionIndex: 5,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1134,
               trainrunSectionId: 559,
               positionIndex: 6,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1120,
               trainrunSectionId: 552,
               positionIndex: 7,
-              positionAlignment: 1
-            }
+              positionAlignment: 1,
+            },
           ],
           transitions: [
             {
               id: 212,
               port1Id: 1051,
               port2Id: 1050,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 238,
               port1Id: 1121,
               port2Id: 1120,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 244,
               port1Id: 1135,
               port2Id: 1134,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 296,
               port1Id: 1280,
               port2Id: 1281,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 306,
               port1Id: 1304,
               port2Id: 1305,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 317,
               port1Id: 1335,
               port2Id: 1334,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 342,
               port1Id: 1375,
               port2Id: 1374,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 363,
               port1Id: 1413,
               port2Id: 1412,
-              isNonStopTransit: true
-            }
+              isNonStopTransit: true,
+            },
           ],
           connections: [],
           resourceId: 169,
@@ -2112,32 +2112,32 @@ export class NetzgrafikDemoStandaloneGithub {
           trainrunCategoryHaltezeiten: {
             HaltezeitA: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitB: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitC: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitD: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitIPV: {
               no_halt: false,
-              haltezeit: 3
+              haltezeit: 3,
             },
             HaltezeitUncategorized: {
               no_halt: true,
-              haltezeit: 0
-            }
+              haltezeit: 0,
+            },
           },
           symmetryAxis: null,
           warnings: null,
-          labelIds: []
+          labelIds: [],
         },
         {
           id: 146,
@@ -2150,148 +2150,148 @@ export class NetzgrafikDemoStandaloneGithub {
               id: 1053,
               trainrunSectionId: 519,
               positionIndex: 0,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1415,
               trainrunSectionId: 700,
               positionIndex: 1,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1278,
               trainrunSectionId: 631,
               positionIndex: 2,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1337,
               trainrunSectionId: 661,
               positionIndex: 3,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1302,
               trainrunSectionId: 643,
               positionIndex: 4,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1377,
               trainrunSectionId: 681,
               positionIndex: 5,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1137,
               trainrunSectionId: 561,
               positionIndex: 6,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1123,
               trainrunSectionId: 554,
               positionIndex: 7,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1052,
               trainrunSectionId: 518,
               positionIndex: 0,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1414,
               trainrunSectionId: 699,
               positionIndex: 1,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1279,
               trainrunSectionId: 632,
               positionIndex: 2,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1336,
               trainrunSectionId: 660,
               positionIndex: 3,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1303,
               trainrunSectionId: 644,
               positionIndex: 4,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1376,
               trainrunSectionId: 680,
               positionIndex: 5,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1136,
               trainrunSectionId: 560,
               positionIndex: 6,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1122,
               trainrunSectionId: 553,
               positionIndex: 7,
-              positionAlignment: 1
-            }
+              positionAlignment: 1,
+            },
           ],
           transitions: [
             {
               id: 213,
               port1Id: 1053,
               port2Id: 1052,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 239,
               port1Id: 1123,
               port2Id: 1122,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 245,
               port1Id: 1137,
               port2Id: 1136,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 295,
               port1Id: 1278,
               port2Id: 1279,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 305,
               port1Id: 1302,
               port2Id: 1303,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 318,
               port1Id: 1337,
               port2Id: 1336,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 343,
               port1Id: 1377,
               port2Id: 1376,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 364,
               port1Id: 1415,
               port2Id: 1414,
-              isNonStopTransit: true
-            }
+              isNonStopTransit: true,
+            },
           ],
           connections: [],
           resourceId: 170,
@@ -2300,32 +2300,32 @@ export class NetzgrafikDemoStandaloneGithub {
           trainrunCategoryHaltezeiten: {
             HaltezeitA: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitB: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitC: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitD: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitIPV: {
               no_halt: false,
-              haltezeit: 3
+              haltezeit: 3,
             },
             HaltezeitUncategorized: {
               no_halt: true,
-              haltezeit: 0
-            }
+              haltezeit: 0,
+            },
           },
           symmetryAxis: null,
           warnings: null,
-          labelIds: []
+          labelIds: [],
         },
         {
           id: 147,
@@ -2338,136 +2338,136 @@ export class NetzgrafikDemoStandaloneGithub {
               id: 1409,
               trainrunSectionId: 697,
               positionIndex: 0,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1284,
               trainrunSectionId: 634,
               positionIndex: 1,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1201,
               trainrunSectionId: 593,
               positionIndex: 2,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1179,
               trainrunSectionId: 582,
               positionIndex: 3,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1223,
               trainrunSectionId: 604,
               positionIndex: 4,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1239,
               trainrunSectionId: 612,
               positionIndex: 5,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1163,
               trainrunSectionId: 574,
               positionIndex: 6,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1200,
               trainrunSectionId: 592,
               positionIndex: 0,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1408,
               trainrunSectionId: 696,
               positionIndex: 1,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1285,
               trainrunSectionId: 635,
               positionIndex: 2,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1178,
               trainrunSectionId: 581,
               positionIndex: 3,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1222,
               trainrunSectionId: 603,
               positionIndex: 4,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1238,
               trainrunSectionId: 611,
               positionIndex: 5,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1162,
               trainrunSectionId: 573,
               positionIndex: 6,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1293,
               trainrunSectionId: 639,
               positionIndex: 7,
-              positionAlignment: 3
-            }
+              positionAlignment: 3,
+            },
           ],
           transitions: [
             {
               id: 252,
               port1Id: 1163,
               port2Id: 1162,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 258,
               port1Id: 1179,
               port2Id: 1178,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 263,
               port1Id: 1201,
               port2Id: 1200,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 269,
               port1Id: 1223,
               port2Id: 1222,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 275,
               port1Id: 1239,
               port2Id: 1238,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 298,
               port1Id: 1284,
               port2Id: 1285,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 361,
               port1Id: 1409,
               port2Id: 1408,
-              isNonStopTransit: true
-            }
+              isNonStopTransit: true,
+            },
           ],
           connections: [],
           resourceId: 171,
@@ -2476,32 +2476,32 @@ export class NetzgrafikDemoStandaloneGithub {
           trainrunCategoryHaltezeiten: {
             HaltezeitA: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitB: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitC: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitD: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitIPV: {
               no_halt: false,
-              haltezeit: 3
+              haltezeit: 3,
             },
             HaltezeitUncategorized: {
               no_halt: true,
-              haltezeit: 0
-            }
+              haltezeit: 0,
+            },
           },
           symmetryAxis: null,
           warnings: null,
-          labelIds: []
+          labelIds: [],
         },
         {
           id: 148,
@@ -2514,148 +2514,148 @@ export class NetzgrafikDemoStandaloneGithub {
               id: 1199,
               trainrunSectionId: 592,
               positionIndex: 0,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1407,
               trainrunSectionId: 696,
               positionIndex: 1,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1286,
               trainrunSectionId: 635,
               positionIndex: 2,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1177,
               trainrunSectionId: 581,
               positionIndex: 3,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1221,
               trainrunSectionId: 603,
               positionIndex: 4,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1237,
               trainrunSectionId: 611,
               positionIndex: 5,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1161,
               trainrunSectionId: 573,
               positionIndex: 6,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1294,
               trainrunSectionId: 639,
               positionIndex: 7,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1258,
               trainrunSectionId: 621,
               positionIndex: 0,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1406,
               trainrunSectionId: 695,
               positionIndex: 1,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1287,
               trainrunSectionId: 636,
               positionIndex: 2,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1260,
               trainrunSectionId: 622,
               positionIndex: 3,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1262,
               trainrunSectionId: 623,
               positionIndex: 4,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1264,
               trainrunSectionId: 624,
               positionIndex: 5,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1266,
               trainrunSectionId: 625,
               positionIndex: 6,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1295,
               trainrunSectionId: 640,
               positionIndex: 7,
-              positionAlignment: 3
-            }
+              positionAlignment: 3,
+            },
           ],
           transitions: [
             {
               id: 282,
               port1Id: 1199,
               port2Id: 1258,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 284,
               port1Id: 1177,
               port2Id: 1260,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 286,
               port1Id: 1221,
               port2Id: 1262,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 288,
               port1Id: 1237,
               port2Id: 1264,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 290,
               port1Id: 1161,
               port2Id: 1266,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 299,
               port1Id: 1286,
               port2Id: 1287,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 302,
               port1Id: 1294,
               port2Id: 1295,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 360,
               port1Id: 1407,
               port2Id: 1406,
-              isNonStopTransit: true
-            }
+              isNonStopTransit: true,
+            },
           ],
           connections: [],
           resourceId: 172,
@@ -2664,32 +2664,32 @@ export class NetzgrafikDemoStandaloneGithub {
           trainrunCategoryHaltezeiten: {
             HaltezeitA: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitB: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitC: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitD: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitIPV: {
               no_halt: false,
-              haltezeit: 3
+              haltezeit: 3,
             },
             HaltezeitUncategorized: {
               no_halt: true,
-              haltezeit: 0
-            }
+              haltezeit: 0,
+            },
           },
           symmetryAxis: null,
           warnings: null,
-          labelIds: []
+          labelIds: [],
         },
         {
           id: 149,
@@ -2702,166 +2702,166 @@ export class NetzgrafikDemoStandaloneGithub {
               id: 1197,
               trainrunSectionId: 591,
               positionIndex: 0,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1403,
               trainrunSectionId: 694,
               positionIndex: 1,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1290,
               trainrunSectionId: 637,
               positionIndex: 2,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1175,
               trainrunSectionId: 580,
               positionIndex: 3,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1219,
               trainrunSectionId: 602,
               positionIndex: 4,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1235,
               trainrunSectionId: 610,
               positionIndex: 5,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1159,
               trainrunSectionId: 572,
               positionIndex: 6,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1274,
               trainrunSectionId: 629,
               positionIndex: 7,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1298,
               trainrunSectionId: 641,
               positionIndex: 8,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1196,
               trainrunSectionId: 590,
               positionIndex: 0,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1402,
               trainrunSectionId: 693,
               positionIndex: 1,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1291,
               trainrunSectionId: 638,
               positionIndex: 2,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1174,
               trainrunSectionId: 579,
               positionIndex: 3,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1218,
               trainrunSectionId: 601,
               positionIndex: 4,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1234,
               trainrunSectionId: 609,
               positionIndex: 5,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1158,
               trainrunSectionId: 571,
               positionIndex: 6,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1275,
               trainrunSectionId: 630,
               positionIndex: 7,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1299,
               trainrunSectionId: 642,
               positionIndex: 8,
-              positionAlignment: 3
-            }
+              positionAlignment: 3,
+            },
           ],
           transitions: [
             {
               id: 251,
               port1Id: 1159,
               port2Id: 1158,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 257,
               port1Id: 1175,
               port2Id: 1174,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 262,
               port1Id: 1197,
               port2Id: 1196,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 268,
               port1Id: 1219,
               port2Id: 1218,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 274,
               port1Id: 1235,
               port2Id: 1234,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 294,
               port1Id: 1274,
               port2Id: 1275,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 301,
               port1Id: 1290,
               port2Id: 1291,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 304,
               port1Id: 1298,
               port2Id: 1299,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 358,
               port1Id: 1403,
               port2Id: 1402,
-              isNonStopTransit: true
-            }
+              isNonStopTransit: true,
+            },
           ],
           connections: [],
           resourceId: 173,
@@ -2870,32 +2870,32 @@ export class NetzgrafikDemoStandaloneGithub {
           trainrunCategoryHaltezeiten: {
             HaltezeitA: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitB: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitC: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitD: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitIPV: {
               no_halt: false,
-              haltezeit: 3
+              haltezeit: 3,
             },
             HaltezeitUncategorized: {
               no_halt: true,
-              haltezeit: 0
-            }
+              haltezeit: 0,
+            },
           },
           symmetryAxis: null,
           warnings: null,
-          labelIds: []
+          labelIds: [],
         },
         {
           id: 150,
@@ -2908,112 +2908,112 @@ export class NetzgrafikDemoStandaloneGithub {
               id: 1192,
               trainrunSectionId: 588,
               positionIndex: 0,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1171,
               trainrunSectionId: 578,
               positionIndex: 1,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1214,
               trainrunSectionId: 599,
               positionIndex: 2,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1230,
               trainrunSectionId: 607,
               positionIndex: 3,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1140,
               trainrunSectionId: 562,
               positionIndex: 4,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1246,
               trainrunSectionId: 615,
               positionIndex: 5,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1193,
               trainrunSectionId: 589,
               positionIndex: 0,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1170,
               trainrunSectionId: 577,
               positionIndex: 1,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1215,
               trainrunSectionId: 600,
               positionIndex: 2,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1231,
               trainrunSectionId: 608,
               positionIndex: 3,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1141,
               trainrunSectionId: 563,
               positionIndex: 4,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1247,
               trainrunSectionId: 616,
               positionIndex: 5,
-              positionAlignment: 3
-            }
+              positionAlignment: 3,
+            },
           ],
           transitions: [
             {
               id: 246,
               port1Id: 1140,
               port2Id: 1141,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 255,
               port1Id: 1171,
               port2Id: 1170,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 260,
               port1Id: 1192,
               port2Id: 1193,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 266,
               port1Id: 1214,
               port2Id: 1215,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 272,
               port1Id: 1230,
               port2Id: 1231,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 278,
               port1Id: 1246,
               port2Id: 1247,
-              isNonStopTransit: false
-            }
+              isNonStopTransit: false,
+            },
           ],
           connections: [],
           resourceId: 174,
@@ -3022,32 +3022,32 @@ export class NetzgrafikDemoStandaloneGithub {
           trainrunCategoryHaltezeiten: {
             HaltezeitA: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitB: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitC: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitD: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitIPV: {
               no_halt: false,
-              haltezeit: 3
+              haltezeit: 3,
             },
             HaltezeitUncategorized: {
               no_halt: true,
-              haltezeit: 0
-            }
+              haltezeit: 0,
+            },
           },
           symmetryAxis: null,
           warnings: null,
-          labelIds: []
+          labelIds: [],
         },
         {
           id: 151,
@@ -3060,112 +3060,112 @@ export class NetzgrafikDemoStandaloneGithub {
               id: 1249,
               trainrunSectionId: 617,
               positionIndex: 0,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1194,
               trainrunSectionId: 589,
               positionIndex: 0,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1169,
               trainrunSectionId: 577,
               positionIndex: 1,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1216,
               trainrunSectionId: 600,
               positionIndex: 2,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1232,
               trainrunSectionId: 608,
               positionIndex: 3,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1142,
               trainrunSectionId: 563,
               positionIndex: 4,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1248,
               trainrunSectionId: 616,
               positionIndex: 5,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1227,
               trainrunSectionId: 606,
               positionIndex: 0,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1243,
               trainrunSectionId: 614,
               positionIndex: 1,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1211,
               trainrunSectionId: 598,
               positionIndex: 2,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1168,
               trainrunSectionId: 576,
               positionIndex: 3,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1143,
               trainrunSectionId: 564,
               positionIndex: 4,
-              positionAlignment: 3
-            }
+              positionAlignment: 3,
+            },
           ],
           transitions: [
             {
               id: 247,
               port1Id: 1142,
               port2Id: 1143,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 254,
               port1Id: 1169,
               port2Id: 1168,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 265,
               port1Id: 1194,
               port2Id: 1211,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 271,
               port1Id: 1216,
               port2Id: 1227,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 277,
               port1Id: 1232,
               port2Id: 1243,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 279,
               port1Id: 1249,
               port2Id: 1248,
-              isNonStopTransit: false
-            }
+              isNonStopTransit: false,
+            },
           ],
           connections: [],
           resourceId: 175,
@@ -3174,32 +3174,32 @@ export class NetzgrafikDemoStandaloneGithub {
           trainrunCategoryHaltezeiten: {
             HaltezeitA: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitB: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitC: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitD: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitIPV: {
               no_halt: false,
-              haltezeit: 3
+              haltezeit: 3,
             },
             HaltezeitUncategorized: {
               no_halt: true,
-              haltezeit: 0
-            }
+              haltezeit: 0,
+            },
           },
           symmetryAxis: null,
           warnings: null,
-          labelIds: []
+          labelIds: [],
         },
         {
           id: 152,
@@ -3212,20 +3212,20 @@ export class NetzgrafikDemoStandaloneGithub {
               id: 1152,
               trainrunSectionId: 568,
               positionIndex: 0,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1148,
               trainrunSectionId: 566,
               positionIndex: 1,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1156,
               trainrunSectionId: 570,
               positionIndex: 2,
-              positionAlignment: 0
-            }
+              positionAlignment: 0,
+            },
           ],
           transitions: [],
           connections: [],
@@ -3235,32 +3235,32 @@ export class NetzgrafikDemoStandaloneGithub {
           trainrunCategoryHaltezeiten: {
             HaltezeitA: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitB: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitC: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitD: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitIPV: {
               no_halt: false,
-              haltezeit: 3
+              haltezeit: 3,
             },
             HaltezeitUncategorized: {
               no_halt: true,
-              haltezeit: 0
-            }
+              haltezeit: 0,
+            },
           },
           symmetryAxis: null,
           warnings: null,
-          labelIds: []
+          labelIds: [],
         },
         {
           id: 153,
@@ -3273,76 +3273,76 @@ export class NetzgrafikDemoStandaloneGithub {
               id: 1067,
               trainrunSectionId: 526,
               positionIndex: 0,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1093,
               trainrunSectionId: 539,
               positionIndex: 1,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1101,
               trainrunSectionId: 543,
               positionIndex: 2,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1097,
               trainrunSectionId: 541,
               positionIndex: 3,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1066,
               trainrunSectionId: 525,
               positionIndex: 0,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1092,
               trainrunSectionId: 538,
               positionIndex: 1,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1348,
               trainrunSectionId: 666,
               positionIndex: 0,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1346,
               trainrunSectionId: 665,
               positionIndex: 1,
-              positionAlignment: 2
-            }
+              positionAlignment: 2,
+            },
           ],
           transitions: [
             {
               id: 220,
               port1Id: 1067,
               port2Id: 1066,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 231,
               port1Id: 1093,
               port2Id: 1092,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 322,
               port1Id: 1097,
               port2Id: 1346,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 324,
               port1Id: 1101,
               port2Id: 1348,
-              isNonStopTransit: false
-            }
+              isNonStopTransit: false,
+            },
           ],
           connections: [],
           resourceId: 177,
@@ -3351,32 +3351,32 @@ export class NetzgrafikDemoStandaloneGithub {
           trainrunCategoryHaltezeiten: {
             HaltezeitA: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitB: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitC: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitD: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitIPV: {
               no_halt: false,
-              haltezeit: 3
+              haltezeit: 3,
             },
             HaltezeitUncategorized: {
               no_halt: true,
-              haltezeit: 0
-            }
+              haltezeit: 0,
+            },
           },
           symmetryAxis: null,
           warnings: null,
-          labelIds: []
+          labelIds: [],
         },
         {
           id: 154,
@@ -3389,76 +3389,76 @@ export class NetzgrafikDemoStandaloneGithub {
               id: 1065,
               trainrunSectionId: 525,
               positionIndex: 0,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1091,
               trainrunSectionId: 538,
               positionIndex: 1,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1064,
               trainrunSectionId: 524,
               positionIndex: 0,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1038,
               trainrunSectionId: 511,
               positionIndex: 1,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1078,
               trainrunSectionId: 531,
               positionIndex: 2,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1090,
               trainrunSectionId: 537,
               positionIndex: 3,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1039,
               trainrunSectionId: 512,
               positionIndex: 0,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1079,
               trainrunSectionId: 532,
               positionIndex: 1,
-              positionAlignment: 2
-            }
+              positionAlignment: 2,
+            },
           ],
           transitions: [
             {
               id: 207,
               port1Id: 1038,
               port2Id: 1039,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 219,
               port1Id: 1065,
               port2Id: 1064,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 225,
               port1Id: 1078,
               port2Id: 1079,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 230,
               port1Id: 1091,
               port2Id: 1090,
-              isNonStopTransit: false
-            }
+              isNonStopTransit: false,
+            },
           ],
           connections: [],
           resourceId: 178,
@@ -3467,32 +3467,32 @@ export class NetzgrafikDemoStandaloneGithub {
           trainrunCategoryHaltezeiten: {
             HaltezeitA: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitB: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitC: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitD: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitIPV: {
               no_halt: false,
-              haltezeit: 3
+              haltezeit: 3,
             },
             HaltezeitUncategorized: {
               no_halt: true,
-              haltezeit: 0
-            }
+              haltezeit: 0,
+            },
           },
           symmetryAxis: null,
           warnings: null,
-          labelIds: []
+          labelIds: [],
         },
         {
           id: 155,
@@ -3505,76 +3505,76 @@ export class NetzgrafikDemoStandaloneGithub {
               id: 1063,
               trainrunSectionId: 524,
               positionIndex: 0,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1037,
               trainrunSectionId: 511,
               positionIndex: 1,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1077,
               trainrunSectionId: 531,
               positionIndex: 2,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1089,
               trainrunSectionId: 537,
               positionIndex: 3,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1062,
               trainrunSectionId: 523,
               positionIndex: 0,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1055,
               trainrunSectionId: 520,
               positionIndex: 1,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1076,
               trainrunSectionId: 530,
               positionIndex: 0,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1088,
               trainrunSectionId: 536,
               positionIndex: 1,
-              positionAlignment: 2
-            }
+              positionAlignment: 2,
+            },
           ],
           transitions: [
             {
               id: 214,
               port1Id: 1037,
               port2Id: 1055,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 218,
               port1Id: 1063,
               port2Id: 1062,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 224,
               port1Id: 1077,
               port2Id: 1076,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 229,
               port1Id: 1089,
               port2Id: 1088,
-              isNonStopTransit: false
-            }
+              isNonStopTransit: false,
+            },
           ],
           connections: [],
           resourceId: 179,
@@ -3583,32 +3583,32 @@ export class NetzgrafikDemoStandaloneGithub {
           trainrunCategoryHaltezeiten: {
             HaltezeitA: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitB: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitC: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitD: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitIPV: {
               no_halt: false,
-              haltezeit: 3
+              haltezeit: 3,
             },
             HaltezeitUncategorized: {
               no_halt: true,
-              haltezeit: 0
-            }
+              haltezeit: 0,
+            },
           },
           symmetryAxis: null,
           warnings: null,
-          labelIds: []
+          labelIds: [],
         },
         {
           id: 156,
@@ -3621,14 +3621,14 @@ export class NetzgrafikDemoStandaloneGithub {
               id: 1057,
               trainrunSectionId: 521,
               positionIndex: 0,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1033,
               trainrunSectionId: 509,
               positionIndex: 1,
-              positionAlignment: 0
-            }
+              positionAlignment: 0,
+            },
           ],
           transitions: [],
           connections: [],
@@ -3638,32 +3638,32 @@ export class NetzgrafikDemoStandaloneGithub {
           trainrunCategoryHaltezeiten: {
             HaltezeitA: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitB: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitC: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitD: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitIPV: {
               no_halt: false,
-              haltezeit: 3
+              haltezeit: 3,
             },
             HaltezeitUncategorized: {
               no_halt: true,
-              haltezeit: 0
-            }
+              haltezeit: 0,
+            },
           },
           symmetryAxis: null,
           warnings: null,
-          labelIds: []
+          labelIds: [],
         },
         {
           id: 157,
@@ -3676,14 +3676,14 @@ export class NetzgrafikDemoStandaloneGithub {
               id: 1069,
               trainrunSectionId: 527,
               positionIndex: 0,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1081,
               trainrunSectionId: 533,
               positionIndex: 1,
-              positionAlignment: 3
-            }
+              positionAlignment: 3,
+            },
           ],
           transitions: [],
           connections: [],
@@ -3693,32 +3693,32 @@ export class NetzgrafikDemoStandaloneGithub {
           trainrunCategoryHaltezeiten: {
             HaltezeitA: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitB: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitC: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitD: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitIPV: {
               no_halt: false,
-              haltezeit: 3
+              haltezeit: 3,
             },
             HaltezeitUncategorized: {
               no_halt: true,
-              haltezeit: 0
-            }
+              haltezeit: 0,
+            },
           },
           symmetryAxis: null,
           warnings: null,
-          labelIds: []
+          labelIds: [],
         },
         {
           id: 158,
@@ -3731,76 +3731,76 @@ export class NetzgrafikDemoStandaloneGithub {
               id: 1073,
               trainrunSectionId: 529,
               positionIndex: 0,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1085,
               trainrunSectionId: 535,
               positionIndex: 1,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1061,
               trainrunSectionId: 523,
               positionIndex: 2,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1056,
               trainrunSectionId: 520,
               positionIndex: 3,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1060,
               trainrunSectionId: 522,
               positionIndex: 0,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1036,
               trainrunSectionId: 510,
               positionIndex: 1,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1072,
               trainrunSectionId: 528,
               positionIndex: 2,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1084,
               trainrunSectionId: 534,
               positionIndex: 3,
-              positionAlignment: 1
-            }
+              positionAlignment: 1,
+            },
           ],
           transitions: [
             {
               id: 215,
               port1Id: 1056,
               port2Id: 1036,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 217,
               port1Id: 1061,
               port2Id: 1060,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 222,
               port1Id: 1073,
               port2Id: 1072,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 227,
               port1Id: 1085,
               port2Id: 1084,
-              isNonStopTransit: false
-            }
+              isNonStopTransit: false,
+            },
           ],
           connections: [],
           resourceId: 182,
@@ -3809,32 +3809,32 @@ export class NetzgrafikDemoStandaloneGithub {
           trainrunCategoryHaltezeiten: {
             HaltezeitA: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitB: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitC: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitD: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitIPV: {
               no_halt: false,
-              haltezeit: 3
+              haltezeit: 3,
             },
             HaltezeitUncategorized: {
               no_halt: true,
-              haltezeit: 0
-            }
+              haltezeit: 0,
+            },
           },
           symmetryAxis: null,
           warnings: null,
-          labelIds: []
+          labelIds: [],
         },
         {
           id: 159,
@@ -3847,40 +3847,40 @@ export class NetzgrafikDemoStandaloneGithub {
               id: 1074,
               trainrunSectionId: 529,
               positionIndex: 0,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1086,
               trainrunSectionId: 535,
               positionIndex: 1,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1075,
               trainrunSectionId: 530,
               positionIndex: 0,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1087,
               trainrunSectionId: 536,
               positionIndex: 1,
-              positionAlignment: 3
-            }
+              positionAlignment: 3,
+            },
           ],
           transitions: [
             {
               id: 223,
               port1Id: 1074,
               port2Id: 1075,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 228,
               port1Id: 1086,
               port2Id: 1087,
-              isNonStopTransit: false
-            }
+              isNonStopTransit: false,
+            },
           ],
           connections: [],
           resourceId: 183,
@@ -3889,32 +3889,32 @@ export class NetzgrafikDemoStandaloneGithub {
           trainrunCategoryHaltezeiten: {
             HaltezeitA: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitB: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitC: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitD: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitIPV: {
               no_halt: false,
-              haltezeit: 3
+              haltezeit: 3,
             },
             HaltezeitUncategorized: {
               no_halt: true,
-              haltezeit: 0
-            }
+              haltezeit: 0,
+            },
           },
           symmetryAxis: null,
           warnings: null,
-          labelIds: []
+          labelIds: [],
         },
         {
           id: 160,
@@ -3927,58 +3927,58 @@ export class NetzgrafikDemoStandaloneGithub {
               id: 1209,
               trainrunSectionId: 597,
               positionIndex: 0,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1185,
               trainrunSectionId: 585,
               positionIndex: 1,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1189,
               trainrunSectionId: 587,
               positionIndex: 2,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1424,
               trainrunSectionId: 704,
               positionIndex: 0,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1426,
               trainrunSectionId: 705,
               positionIndex: 1,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1422,
               trainrunSectionId: 703,
               positionIndex: 2,
-              positionAlignment: 3
-            }
+              positionAlignment: 3,
+            },
           ],
           transitions: [
             {
               id: 369,
               port1Id: 1189,
               port2Id: 1422,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 371,
               port1Id: 1209,
               port2Id: 1424,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 373,
               port1Id: 1185,
               port2Id: 1426,
-              isNonStopTransit: false
-            }
+              isNonStopTransit: false,
+            },
           ],
           connections: [],
           resourceId: 184,
@@ -3987,32 +3987,32 @@ export class NetzgrafikDemoStandaloneGithub {
           trainrunCategoryHaltezeiten: {
             HaltezeitA: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitB: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitC: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitD: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitIPV: {
               no_halt: false,
-              haltezeit: 3
+              haltezeit: 3,
             },
             HaltezeitUncategorized: {
               no_halt: true,
-              haltezeit: 0
-            }
+              haltezeit: 0,
+            },
           },
           symmetryAxis: null,
           warnings: null,
-          labelIds: []
+          labelIds: [],
         },
         {
           id: 161,
@@ -4025,20 +4025,20 @@ export class NetzgrafikDemoStandaloneGithub {
               id: 1210,
               trainrunSectionId: 597,
               positionIndex: 0,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1186,
               trainrunSectionId: 585,
               positionIndex: 1,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1190,
               trainrunSectionId: 587,
               positionIndex: 2,
-              positionAlignment: 3
-            }
+              positionAlignment: 3,
+            },
           ],
           transitions: [],
           connections: [],
@@ -4048,32 +4048,32 @@ export class NetzgrafikDemoStandaloneGithub {
           trainrunCategoryHaltezeiten: {
             HaltezeitA: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitB: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitC: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitD: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitIPV: {
               no_halt: false,
-              haltezeit: 3
+              haltezeit: 3,
             },
             HaltezeitUncategorized: {
               no_halt: true,
-              haltezeit: 0
-            }
+              haltezeit: 0,
+            },
           },
           symmetryAxis: null,
           warnings: null,
-          labelIds: []
+          labelIds: [],
         },
         {
           id: 162,
@@ -4086,14 +4086,14 @@ export class NetzgrafikDemoStandaloneGithub {
               id: 1228,
               trainrunSectionId: 606,
               positionIndex: 0,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1244,
               trainrunSectionId: 614,
               positionIndex: 1,
-              positionAlignment: 2
-            }
+              positionAlignment: 2,
+            },
           ],
           transitions: [],
           connections: [],
@@ -4103,32 +4103,32 @@ export class NetzgrafikDemoStandaloneGithub {
           trainrunCategoryHaltezeiten: {
             HaltezeitA: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitB: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitC: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitD: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitIPV: {
               no_halt: false,
-              haltezeit: 3
+              haltezeit: 3,
             },
             HaltezeitUncategorized: {
               no_halt: true,
-              haltezeit: 0
-            }
+              haltezeit: 0,
+            },
           },
           symmetryAxis: null,
           warnings: null,
-          labelIds: []
+          labelIds: [],
         },
         {
           id: 163,
@@ -4141,22 +4141,22 @@ export class NetzgrafikDemoStandaloneGithub {
               id: 1252,
               trainrunSectionId: 618,
               positionIndex: 0,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1253,
               trainrunSectionId: 619,
               positionIndex: 0,
-              positionAlignment: 1
-            }
+              positionAlignment: 1,
+            },
           ],
           transitions: [
             {
               id: 280,
               port1Id: 1252,
               port2Id: 1253,
-              isNonStopTransit: false
-            }
+              isNonStopTransit: false,
+            },
           ],
           connections: [],
           resourceId: 187,
@@ -4165,32 +4165,32 @@ export class NetzgrafikDemoStandaloneGithub {
           trainrunCategoryHaltezeiten: {
             HaltezeitA: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitB: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitC: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitD: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitIPV: {
               no_halt: false,
-              haltezeit: 3
+              haltezeit: 3,
             },
             HaltezeitUncategorized: {
               no_halt: true,
-              haltezeit: 0
-            }
+              haltezeit: 0,
+            },
           },
           symmetryAxis: null,
           warnings: null,
-          labelIds: []
+          labelIds: [],
         },
         {
           id: 164,
@@ -4203,22 +4203,22 @@ export class NetzgrafikDemoStandaloneGithub {
               id: 1268,
               trainrunSectionId: 626,
               positionIndex: 0,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1269,
               trainrunSectionId: 627,
               positionIndex: 0,
-              positionAlignment: 3
-            }
+              positionAlignment: 3,
+            },
           ],
           transitions: [
             {
               id: 291,
               port1Id: 1268,
               port2Id: 1269,
-              isNonStopTransit: false
-            }
+              isNonStopTransit: false,
+            },
           ],
           connections: [],
           resourceId: 188,
@@ -4227,32 +4227,32 @@ export class NetzgrafikDemoStandaloneGithub {
           trainrunCategoryHaltezeiten: {
             HaltezeitA: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitB: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitC: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitD: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitIPV: {
               no_halt: false,
-              haltezeit: 3
+              haltezeit: 3,
             },
             HaltezeitUncategorized: {
               no_halt: true,
-              haltezeit: 0
-            }
+              haltezeit: 0,
+            },
           },
           symmetryAxis: null,
           warnings: null,
-          labelIds: []
+          labelIds: [],
         },
         {
           id: 165,
@@ -4265,22 +4265,22 @@ export class NetzgrafikDemoStandaloneGithub {
               id: 1271,
               trainrunSectionId: 628,
               positionIndex: 0,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1270,
               trainrunSectionId: 627,
               positionIndex: 0,
-              positionAlignment: 2
-            }
+              positionAlignment: 2,
+            },
           ],
           transitions: [
             {
               id: 292,
               port1Id: 1271,
               port2Id: 1270,
-              isNonStopTransit: false
-            }
+              isNonStopTransit: false,
+            },
           ],
           connections: [],
           resourceId: 189,
@@ -4289,32 +4289,32 @@ export class NetzgrafikDemoStandaloneGithub {
           trainrunCategoryHaltezeiten: {
             HaltezeitA: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitB: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitC: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitD: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitIPV: {
               no_halt: false,
-              haltezeit: 3
+              haltezeit: 3,
             },
             HaltezeitUncategorized: {
               no_halt: true,
-              haltezeit: 0
-            }
+              haltezeit: 0,
+            },
           },
           symmetryAxis: null,
           warnings: null,
-          labelIds: []
+          labelIds: [],
         },
         {
           id: 166,
@@ -4327,166 +4327,166 @@ export class NetzgrafikDemoStandaloneGithub {
               id: 1272,
               trainrunSectionId: 628,
               positionIndex: 0,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1257,
               trainrunSectionId: 621,
               positionIndex: 0,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1405,
               trainrunSectionId: 695,
               positionIndex: 1,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1288,
               trainrunSectionId: 636,
               positionIndex: 2,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1259,
               trainrunSectionId: 622,
               positionIndex: 3,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1261,
               trainrunSectionId: 623,
               positionIndex: 4,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1263,
               trainrunSectionId: 624,
               positionIndex: 5,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1265,
               trainrunSectionId: 625,
               positionIndex: 6,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1296,
               trainrunSectionId: 640,
               positionIndex: 7,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1198,
               trainrunSectionId: 591,
               positionIndex: 0,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1404,
               trainrunSectionId: 694,
               positionIndex: 1,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1289,
               trainrunSectionId: 637,
               positionIndex: 2,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1176,
               trainrunSectionId: 580,
               positionIndex: 3,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1220,
               trainrunSectionId: 602,
               positionIndex: 4,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1236,
               trainrunSectionId: 610,
               positionIndex: 5,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1160,
               trainrunSectionId: 572,
               positionIndex: 6,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1273,
               trainrunSectionId: 629,
               positionIndex: 7,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1297,
               trainrunSectionId: 641,
               positionIndex: 8,
-              positionAlignment: 3
-            }
+              positionAlignment: 3,
+            },
           ],
           transitions: [
             {
               id: 281,
               port1Id: 1257,
               port2Id: 1198,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 283,
               port1Id: 1259,
               port2Id: 1176,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 285,
               port1Id: 1261,
               port2Id: 1220,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 287,
               port1Id: 1263,
               port2Id: 1236,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 289,
               port1Id: 1265,
               port2Id: 1160,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 293,
               port1Id: 1272,
               port2Id: 1273,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 300,
               port1Id: 1288,
               port2Id: 1289,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 303,
               port1Id: 1296,
               port2Id: 1297,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 359,
               port1Id: 1405,
               port2Id: 1404,
-              isNonStopTransit: true
-            }
+              isNonStopTransit: true,
+            },
           ],
           connections: [],
           resourceId: 190,
@@ -4495,32 +4495,32 @@ export class NetzgrafikDemoStandaloneGithub {
           trainrunCategoryHaltezeiten: {
             HaltezeitA: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitB: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitC: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitD: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitIPV: {
               no_halt: false,
-              haltezeit: 3
+              haltezeit: 3,
             },
             HaltezeitUncategorized: {
               no_halt: true,
-              haltezeit: 0
-            }
+              haltezeit: 0,
+            },
           },
           symmetryAxis: null,
           warnings: null,
-          labelIds: []
+          labelIds: [],
         },
         {
           id: 167,
@@ -4533,76 +4533,76 @@ export class NetzgrafikDemoStandaloneGithub {
               id: 1327,
               trainrunSectionId: 656,
               positionIndex: 0,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1312,
               trainrunSectionId: 648,
               positionIndex: 1,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1314,
               trainrunSectionId: 649,
               positionIndex: 2,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1340,
               trainrunSectionId: 662,
               positionIndex: 3,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1326,
               trainrunSectionId: 655,
               positionIndex: 0,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1315,
               trainrunSectionId: 650,
               positionIndex: 1,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1319,
               trainrunSectionId: 652,
               positionIndex: 2,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1341,
               trainrunSectionId: 663,
               positionIndex: 3,
-              positionAlignment: 1
-            }
+              positionAlignment: 1,
+            },
           ],
           transitions: [
             {
               id: 309,
               port1Id: 1312,
               port2Id: 1315,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 311,
               port1Id: 1314,
               port2Id: 1319,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 314,
               port1Id: 1327,
               port2Id: 1326,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 319,
               port1Id: 1340,
               port2Id: 1341,
-              isNonStopTransit: false
-            }
+              isNonStopTransit: false,
+            },
           ],
           connections: [],
           resourceId: 191,
@@ -4611,32 +4611,32 @@ export class NetzgrafikDemoStandaloneGithub {
           trainrunCategoryHaltezeiten: {
             HaltezeitA: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitB: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitC: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitD: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitIPV: {
               no_halt: false,
-              haltezeit: 3
+              haltezeit: 3,
             },
             HaltezeitUncategorized: {
               no_halt: true,
-              haltezeit: 0
-            }
+              haltezeit: 0,
+            },
           },
           symmetryAxis: null,
           warnings: null,
-          labelIds: []
+          labelIds: [],
         },
         {
           id: 168,
@@ -4649,76 +4649,76 @@ export class NetzgrafikDemoStandaloneGithub {
               id: 1325,
               trainrunSectionId: 655,
               positionIndex: 0,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1316,
               trainrunSectionId: 650,
               positionIndex: 1,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1320,
               trainrunSectionId: 652,
               positionIndex: 2,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1342,
               trainrunSectionId: 663,
               positionIndex: 3,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1324,
               trainrunSectionId: 654,
               positionIndex: 0,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1321,
               trainrunSectionId: 653,
               positionIndex: 1,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1317,
               trainrunSectionId: 651,
               positionIndex: 0,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1343,
               trainrunSectionId: 664,
               positionIndex: 1,
-              positionAlignment: 3
-            }
+              positionAlignment: 3,
+            },
           ],
           transitions: [
             {
               id: 310,
               port1Id: 1316,
               port2Id: 1317,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 312,
               port1Id: 1320,
               port2Id: 1321,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 313,
               port1Id: 1325,
               port2Id: 1324,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 320,
               port1Id: 1342,
               port2Id: 1343,
-              isNonStopTransit: false
-            }
+              isNonStopTransit: false,
+            },
           ],
           connections: [],
           resourceId: 192,
@@ -4727,32 +4727,32 @@ export class NetzgrafikDemoStandaloneGithub {
           trainrunCategoryHaltezeiten: {
             HaltezeitA: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitB: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitC: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitD: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitIPV: {
               no_halt: false,
-              haltezeit: 3
+              haltezeit: 3,
             },
             HaltezeitUncategorized: {
               no_halt: true,
-              haltezeit: 0
-            }
+              haltezeit: 0,
+            },
           },
           symmetryAxis: null,
           warnings: null,
-          labelIds: []
+          labelIds: [],
         },
         {
           id: 169,
@@ -4765,76 +4765,76 @@ export class NetzgrafikDemoStandaloneGithub {
               id: 1351,
               trainrunSectionId: 668,
               positionIndex: 0,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1349,
               trainrunSectionId: 667,
               positionIndex: 1,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1100,
               trainrunSectionId: 542,
               positionIndex: 2,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1096,
               trainrunSectionId: 540,
               positionIndex: 3,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1347,
               trainrunSectionId: 666,
               positionIndex: 0,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1345,
               trainrunSectionId: 665,
               positionIndex: 1,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1040,
               trainrunSectionId: 512,
               positionIndex: 2,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1080,
               trainrunSectionId: 532,
               positionIndex: 3,
-              positionAlignment: 3
-            }
+              positionAlignment: 3,
+            },
           ],
           transitions: [
             {
               id: 321,
               port1Id: 1096,
               port2Id: 1345,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 323,
               port1Id: 1100,
               port2Id: 1347,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 325,
               port1Id: 1349,
               port2Id: 1080,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 326,
               port1Id: 1351,
               port2Id: 1040,
-              isNonStopTransit: true
-            }
+              isNonStopTransit: true,
+            },
           ],
           connections: [],
           resourceId: 193,
@@ -4843,32 +4843,32 @@ export class NetzgrafikDemoStandaloneGithub {
           trainrunCategoryHaltezeiten: {
             HaltezeitA: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitB: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitC: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitD: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitIPV: {
               no_halt: false,
-              haltezeit: 3
+              haltezeit: 3,
             },
             HaltezeitUncategorized: {
               no_halt: true,
-              haltezeit: 0
-            }
+              haltezeit: 0,
+            },
           },
           symmetryAxis: null,
           warnings: null,
-          labelIds: []
+          labelIds: [],
         },
         {
           id: 170,
@@ -4881,112 +4881,112 @@ export class NetzgrafikDemoStandaloneGithub {
               id: 1359,
               trainrunSectionId: 672,
               positionIndex: 0,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1150,
               trainrunSectionId: 567,
               positionIndex: 1,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1154,
               trainrunSectionId: 569,
               positionIndex: 2,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1357,
               trainrunSectionId: 671,
               positionIndex: 3,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1355,
               trainrunSectionId: 670,
               positionIndex: 4,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1353,
               trainrunSectionId: 669,
               positionIndex: 5,
-              positionAlignment: 0
+              positionAlignment: 0,
             },
             {
               id: 1068,
               trainrunSectionId: 526,
               positionIndex: 0,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1094,
               trainrunSectionId: 539,
               positionIndex: 1,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1102,
               trainrunSectionId: 543,
               positionIndex: 2,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1098,
               trainrunSectionId: 541,
               positionIndex: 3,
-              positionAlignment: 1
+              positionAlignment: 1,
             },
             {
               id: 1361,
               trainrunSectionId: 673,
               positionIndex: 0,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1363,
               trainrunSectionId: 674,
               positionIndex: 1,
-              positionAlignment: 3
-            }
+              positionAlignment: 3,
+            },
           ],
           transitions: [
             {
               id: 328,
               port1Id: 1353,
               port2Id: 1098,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 330,
               port1Id: 1355,
               port2Id: 1102,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 331,
               port1Id: 1357,
               port2Id: 1094,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 332,
               port1Id: 1359,
               port2Id: 1068,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 333,
               port1Id: 1150,
               port2Id: 1361,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 335,
               port1Id: 1154,
               port2Id: 1363,
-              isNonStopTransit: false
-            }
+              isNonStopTransit: false,
+            },
           ],
           connections: [],
           resourceId: 194,
@@ -4995,32 +4995,32 @@ export class NetzgrafikDemoStandaloneGithub {
           trainrunCategoryHaltezeiten: {
             HaltezeitA: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitB: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitC: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitD: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitIPV: {
               no_halt: false,
-              haltezeit: 3
+              haltezeit: 3,
             },
             HaltezeitUncategorized: {
               no_halt: true,
-              haltezeit: 0
-            }
+              haltezeit: 0,
+            },
           },
           symmetryAxis: null,
           warnings: null,
-          labelIds: []
+          labelIds: [],
         },
         {
           id: 171,
@@ -5033,40 +5033,40 @@ export class NetzgrafikDemoStandaloneGithub {
               id: 1381,
               trainrunSectionId: 683,
               positionIndex: 0,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1379,
               trainrunSectionId: 682,
               positionIndex: 1,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1206,
               trainrunSectionId: 595,
               positionIndex: 0,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1110,
               trainrunSectionId: 547,
               positionIndex: 1,
-              positionAlignment: 3
-            }
+              positionAlignment: 3,
+            },
           ],
           transitions: [
             {
               id: 344,
               port1Id: 1379,
               port2Id: 1110,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 346,
               port1Id: 1381,
               port2Id: 1206,
-              isNonStopTransit: false
-            }
+              isNonStopTransit: false,
+            },
           ],
           connections: [],
           resourceId: 195,
@@ -5075,32 +5075,32 @@ export class NetzgrafikDemoStandaloneGithub {
           trainrunCategoryHaltezeiten: {
             HaltezeitA: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitB: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitC: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitD: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitIPV: {
               no_halt: false,
-              haltezeit: 3
+              haltezeit: 3,
             },
             HaltezeitUncategorized: {
               no_halt: true,
-              haltezeit: 0
-            }
+              haltezeit: 0,
+            },
           },
           symmetryAxis: null,
           warnings: null,
-          labelIds: []
+          labelIds: [],
         },
         {
           id: 172,
@@ -5113,130 +5113,130 @@ export class NetzgrafikDemoStandaloneGithub {
               id: 1395,
               trainrunSectionId: 690,
               positionIndex: 0,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1438,
               trainrunSectionId: 711,
               positionIndex: 1,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1391,
               trainrunSectionId: 688,
               positionIndex: 2,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1389,
               trainrunSectionId: 687,
               positionIndex: 3,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1387,
               trainrunSectionId: 686,
               positionIndex: 4,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1383,
               trainrunSectionId: 684,
               positionIndex: 5,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1385,
               trainrunSectionId: 685,
               positionIndex: 6,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1204,
               trainrunSectionId: 594,
               positionIndex: 0,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1393,
               trainrunSectionId: 689,
               positionIndex: 1,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1310,
               trainrunSectionId: 647,
               positionIndex: 2,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1226,
               trainrunSectionId: 605,
               positionIndex: 3,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1242,
               trainrunSectionId: 613,
               positionIndex: 4,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1166,
               trainrunSectionId: 575,
               positionIndex: 5,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1108,
               trainrunSectionId: 546,
               positionIndex: 6,
-              positionAlignment: 3
-            }
+              positionAlignment: 3,
+            },
           ],
           transitions: [
             {
               id: 348,
               port1Id: 1108,
               port2Id: 1383,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 349,
               port1Id: 1385,
               port2Id: 1166,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 350,
               port1Id: 1387,
               port2Id: 1242,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 351,
               port1Id: 1389,
               port2Id: 1226,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 352,
               port1Id: 1391,
               port2Id: 1310,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 354,
               port1Id: 1395,
               port2Id: 1204,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 384,
               port1Id: 1438,
               port2Id: 1393,
-              isNonStopTransit: true
-            }
+              isNonStopTransit: true,
+            },
           ],
           connections: [],
           resourceId: 196,
@@ -5245,32 +5245,32 @@ export class NetzgrafikDemoStandaloneGithub {
           trainrunCategoryHaltezeiten: {
             HaltezeitA: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitB: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitC: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitD: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitIPV: {
               no_halt: false,
-              haltezeit: 3
+              haltezeit: 3,
             },
             HaltezeitUncategorized: {
               no_halt: true,
-              haltezeit: 0
-            }
+              haltezeit: 0,
+            },
           },
           symmetryAxis: null,
           warnings: null,
-          labelIds: []
+          labelIds: [],
         },
         {
           id: 173,
@@ -5283,22 +5283,22 @@ export class NetzgrafikDemoStandaloneGithub {
               id: 1397,
               trainrunSectionId: 691,
               positionIndex: 0,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1400,
               trainrunSectionId: 692,
               positionIndex: 0,
-              positionAlignment: 3
-            }
+              positionAlignment: 3,
+            },
           ],
           transitions: [
             {
               id: 356,
               port1Id: 1397,
               port2Id: 1400,
-              isNonStopTransit: false
-            }
+              isNonStopTransit: false,
+            },
           ],
           connections: [],
           resourceId: 197,
@@ -5307,32 +5307,32 @@ export class NetzgrafikDemoStandaloneGithub {
           trainrunCategoryHaltezeiten: {
             HaltezeitA: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitB: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitC: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitD: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitIPV: {
               no_halt: false,
-              haltezeit: 3
+              haltezeit: 3,
             },
             HaltezeitUncategorized: {
               no_halt: true,
-              haltezeit: 0
-            }
+              haltezeit: 0,
+            },
           },
           symmetryAxis: null,
           warnings: null,
-          labelIds: []
+          labelIds: [],
         },
         {
           id: 174,
@@ -5345,22 +5345,22 @@ export class NetzgrafikDemoStandaloneGithub {
               id: 1399,
               trainrunSectionId: 692,
               positionIndex: 0,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1386,
               trainrunSectionId: 685,
               positionIndex: 0,
-              positionAlignment: 3
-            }
+              positionAlignment: 3,
+            },
           ],
           transitions: [
             {
               id: 355,
               port1Id: 1399,
               port2Id: 1386,
-              isNonStopTransit: false
-            }
+              isNonStopTransit: false,
+            },
           ],
           connections: [],
           resourceId: 198,
@@ -5369,32 +5369,32 @@ export class NetzgrafikDemoStandaloneGithub {
           trainrunCategoryHaltezeiten: {
             HaltezeitA: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitB: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitC: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitD: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitIPV: {
               no_halt: false,
-              haltezeit: 3
+              haltezeit: 3,
             },
             HaltezeitUncategorized: {
               no_halt: true,
-              haltezeit: 0
-            }
+              haltezeit: 0,
+            },
           },
           symmetryAxis: null,
           warnings: null,
-          labelIds: []
+          labelIds: [],
         },
         {
           id: 175,
@@ -5407,22 +5407,22 @@ export class NetzgrafikDemoStandaloneGithub {
               id: 1417,
               trainrunSectionId: 701,
               positionIndex: 0,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1182,
               trainrunSectionId: 583,
               positionIndex: 0,
-              positionAlignment: 3
-            }
+              positionAlignment: 3,
+            },
           ],
           transitions: [
             {
               id: 365,
               port1Id: 1417,
               port2Id: 1182,
-              isNonStopTransit: false
-            }
+              isNonStopTransit: false,
+            },
           ],
           connections: [],
           resourceId: 199,
@@ -5431,32 +5431,32 @@ export class NetzgrafikDemoStandaloneGithub {
           trainrunCategoryHaltezeiten: {
             HaltezeitA: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitB: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitC: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitD: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitIPV: {
               no_halt: false,
-              haltezeit: 3
+              haltezeit: 3,
             },
             HaltezeitUncategorized: {
               no_halt: true,
-              haltezeit: 0
-            }
+              haltezeit: 0,
+            },
           },
           symmetryAxis: null,
           warnings: null,
-          labelIds: []
+          labelIds: [],
         },
         {
           id: 176,
@@ -5469,8 +5469,8 @@ export class NetzgrafikDemoStandaloneGithub {
               id: 1420,
               trainrunSectionId: 702,
               positionIndex: 0,
-              positionAlignment: 2
-            }
+              positionAlignment: 2,
+            },
           ],
           transitions: [],
           connections: [],
@@ -5480,32 +5480,32 @@ export class NetzgrafikDemoStandaloneGithub {
           trainrunCategoryHaltezeiten: {
             HaltezeitA: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitB: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitC: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitD: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitIPV: {
               no_halt: false,
-              haltezeit: 3
+              haltezeit: 3,
             },
             HaltezeitUncategorized: {
               no_halt: true,
-              haltezeit: 0
-            }
+              haltezeit: 0,
+            },
           },
           symmetryAxis: null,
           warnings: null,
-          labelIds: []
+          labelIds: [],
         },
         {
           id: 177,
@@ -5518,58 +5518,58 @@ export class NetzgrafikDemoStandaloneGithub {
               id: 1423,
               trainrunSectionId: 704,
               positionIndex: 0,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1425,
               trainrunSectionId: 705,
               positionIndex: 1,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1421,
               trainrunSectionId: 703,
               positionIndex: 2,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1184,
               trainrunSectionId: 584,
               positionIndex: 0,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1208,
               trainrunSectionId: 596,
               positionIndex: 1,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1188,
               trainrunSectionId: 586,
               positionIndex: 2,
-              positionAlignment: 3
-            }
+              positionAlignment: 3,
+            },
           ],
           transitions: [
             {
               id: 368,
               port1Id: 1421,
               port2Id: 1188,
-              isNonStopTransit: false
+              isNonStopTransit: false,
             },
             {
               id: 370,
               port1Id: 1423,
               port2Id: 1208,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 372,
               port1Id: 1425,
               port2Id: 1184,
-              isNonStopTransit: false
-            }
+              isNonStopTransit: false,
+            },
           ],
           connections: [],
           resourceId: 201,
@@ -5578,32 +5578,32 @@ export class NetzgrafikDemoStandaloneGithub {
           trainrunCategoryHaltezeiten: {
             HaltezeitA: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitB: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitC: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitD: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitIPV: {
               no_halt: false,
-              haltezeit: 3
+              haltezeit: 3,
             },
             HaltezeitUncategorized: {
               no_halt: true,
-              haltezeit: 0
-            }
+              haltezeit: 0,
+            },
           },
           symmetryAxis: null,
           warnings: null,
-          labelIds: []
+          labelIds: [],
         },
         {
           id: 178,
@@ -5616,130 +5616,130 @@ export class NetzgrafikDemoStandaloneGithub {
               id: 1439,
               trainrunSectionId: 712,
               positionIndex: 0,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1330,
               trainrunSectionId: 657,
               positionIndex: 1,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1435,
               trainrunSectionId: 710,
               positionIndex: 2,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1433,
               trainrunSectionId: 709,
               positionIndex: 3,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1431,
               trainrunSectionId: 708,
               positionIndex: 4,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1429,
               trainrunSectionId: 707,
               positionIndex: 5,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1427,
               trainrunSectionId: 706,
               positionIndex: 6,
-              positionAlignment: 2
+              positionAlignment: 2,
             },
             {
               id: 1396,
               trainrunSectionId: 690,
               positionIndex: 0,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1437,
               trainrunSectionId: 711,
               positionIndex: 1,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1392,
               trainrunSectionId: 688,
               positionIndex: 2,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1390,
               trainrunSectionId: 687,
               positionIndex: 3,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1388,
               trainrunSectionId: 686,
               positionIndex: 4,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1384,
               trainrunSectionId: 684,
               positionIndex: 5,
-              positionAlignment: 3
+              positionAlignment: 3,
             },
             {
               id: 1398,
               trainrunSectionId: 691,
               positionIndex: 6,
-              positionAlignment: 3
-            }
+              positionAlignment: 3,
+            },
           ],
           transitions: [
             {
               id: 374,
               port1Id: 1427,
               port2Id: 1398,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 375,
               port1Id: 1429,
               port2Id: 1384,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 377,
               port1Id: 1431,
               port2Id: 1388,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 379,
               port1Id: 1433,
               port2Id: 1390,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 381,
               port1Id: 1435,
               port2Id: 1392,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 383,
               port1Id: 1330,
               port2Id: 1437,
-              isNonStopTransit: true
+              isNonStopTransit: true,
             },
             {
               id: 385,
               port1Id: 1439,
               port2Id: 1396,
-              isNonStopTransit: true
-            }
+              isNonStopTransit: true,
+            },
           ],
           connections: [],
           resourceId: 202,
@@ -5748,33 +5748,33 @@ export class NetzgrafikDemoStandaloneGithub {
           trainrunCategoryHaltezeiten: {
             HaltezeitA: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitB: {
               no_halt: false,
-              haltezeit: 2
+              haltezeit: 2,
             },
             HaltezeitC: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitD: {
               no_halt: false,
-              haltezeit: 1
+              haltezeit: 1,
             },
             HaltezeitIPV: {
               no_halt: false,
-              haltezeit: 3
+              haltezeit: 3,
             },
             HaltezeitUncategorized: {
               no_halt: true,
-              haltezeit: 0
-            }
+              haltezeit: 0,
+            },
           },
           symmetryAxis: null,
           warnings: null,
-          labelIds: []
-        }
+          labelIds: [],
+        },
       ],
       trainrunSections: [
         {
@@ -5788,35 +5788,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 14,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 2,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 182
+            consecutiveTime: 182,
           },
           sourceArrival: {
             lock: false,
             time: 58,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 178
+            consecutiveTime: 178,
           },
           targetDeparture: {
             lock: false,
             time: 44,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 164
+            consecutiveTime: 164,
           },
           targetArrival: {
             lock: false,
             time: 16,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 196
+            consecutiveTime: 196,
           },
           numberOfStops: 0,
           trainrunId: 75,
@@ -5826,53 +5826,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2640,
-                y: 3710
+                y: 3710,
               },
               {
                 x: 2640,
-                y: 3646
+                y: 3646,
               },
               {
                 x: 2640,
-                y: 3390
+                y: 3390,
               },
               {
                 x: 2640,
-                y: 3326
-              }
+                y: 3326,
+              },
             ],
             textPositions: {
               0: {
                 x: 2652,
-                y: 3692
+                y: 3692,
               },
               1: {
                 x: 2628,
-                y: 3664
+                y: 3664,
               },
               2: {
                 x: 2628,
-                y: 3344
+                y: 3344,
               },
               3: {
                 x: 2652,
-                y: 3372
+                y: 3372,
               },
               4: {
                 x: 2628,
-                y: 3518
+                y: 3518,
               },
               5: {
                 x: 2628,
-                y: 3518
+                y: 3518,
               },
               6: {
                 x: 2652,
-                y: 3518
-              }
-            }
+                y: 3518,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 510,
@@ -5885,35 +5885,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 6,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 18,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 198
+            consecutiveTime: 198,
           },
           sourceArrival: {
             lock: true,
             time: 42,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 162
+            consecutiveTime: 162,
           },
           targetDeparture: {
             lock: false,
             time: 36,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 156
+            consecutiveTime: 156,
           },
           targetArrival: {
             lock: false,
             time: 24,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 204
+            consecutiveTime: 204,
           },
           numberOfStops: 0,
           trainrunId: 75,
@@ -5923,53 +5923,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2640,
-                y: 3230
+                y: 3230,
               },
               {
                 x: 2640,
-                y: 3166
+                y: 3166,
               },
               {
                 x: 2640,
-                y: 2818
+                y: 2818,
               },
               {
                 x: 2640,
-                y: 2754
-              }
+                y: 2754,
+              },
             ],
             textPositions: {
               0: {
                 x: 2652,
-                y: 3212
+                y: 3212,
               },
               1: {
                 x: 2628,
-                y: 3184
+                y: 3184,
               },
               2: {
                 x: 2628,
-                y: 2772
+                y: 2772,
               },
               3: {
                 x: 2652,
-                y: 2800
+                y: 2800,
               },
               4: {
                 x: 2628,
-                y: 2992
+                y: 2992,
               },
               5: {
                 x: 2628,
-                y: 2992
+                y: 2992,
               },
               6: {
                 x: 2652,
-                y: 2992
-              }
-            }
+                y: 2992,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 511,
@@ -5982,35 +5982,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 19,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 52,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 232
+            consecutiveTime: 232,
           },
           sourceArrival: {
             lock: false,
             time: 8,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 128
+            consecutiveTime: 128,
           },
           targetDeparture: {
             lock: true,
             time: 49,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 109
+            consecutiveTime: 109,
           },
           targetArrival: {
             lock: true,
             time: 11,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 251
+            consecutiveTime: 251,
           },
           numberOfStops: 0,
           trainrunId: 75,
@@ -6020,53 +6020,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2704,
-                y: 2174
+                y: 2174,
               },
               {
                 x: 2704,
-                y: 2110
+                y: 2110,
               },
               {
                 x: 2704,
-                y: 1950
+                y: 1950,
               },
               {
                 x: 2704,
-                y: 1886
-              }
+                y: 1886,
+              },
             ],
             textPositions: {
               0: {
                 x: 2716,
-                y: 2156
+                y: 2156,
               },
               1: {
                 x: 2692,
-                y: 2128
+                y: 2128,
               },
               2: {
                 x: 2692,
-                y: 1904
+                y: 1904,
               },
               3: {
                 x: 2716,
-                y: 1932
+                y: 1932,
               },
               4: {
                 x: 2692,
-                y: 2030
+                y: 2030,
               },
               5: {
                 x: 2692,
-                y: 2030
+                y: 2030,
               },
               6: {
                 x: 2716,
-                y: 2030
-              }
-            }
+                y: 2030,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 512,
@@ -6079,35 +6079,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 18,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 15,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 255
+            consecutiveTime: 255,
           },
           sourceArrival: {
             lock: true,
             time: 45,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 105
+            consecutiveTime: 105,
           },
           targetDeparture: {
             lock: false,
             time: 27,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 87
+            consecutiveTime: 87,
           },
           targetArrival: {
             lock: false,
             time: 33,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 273
+            consecutiveTime: 273,
           },
           numberOfStops: 0,
           trainrunId: 75,
@@ -6117,53 +6117,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2654,
-                y: 1808
+                y: 1808,
               },
               {
                 x: 2590,
-                y: 1808
+                y: 1808,
               },
               {
                 x: 2018,
-                y: 1808
+                y: 1808,
               },
               {
                 x: 1954,
-                y: 1808
-              }
+                y: 1808,
+              },
             ],
             textPositions: {
               0: {
                 x: 2636,
-                y: 1796
+                y: 1796,
               },
               1: {
                 x: 2608,
-                y: 1820
+                y: 1820,
               },
               2: {
                 x: 1972,
-                y: 1820
+                y: 1820,
               },
               3: {
                 x: 2000,
-                y: 1796
+                y: 1796,
               },
               4: {
                 x: 2304,
-                y: 1796
+                y: 1796,
               },
               5: {
                 x: 2304,
-                y: 1796
+                y: 1796,
               },
               6: {
                 x: 2304,
-                y: 1820
-              }
-            }
+                y: 1820,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 513,
@@ -6176,35 +6176,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 19,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 55,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 295
+            consecutiveTime: 295,
           },
           sourceArrival: {
             lock: true,
             time: 5,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 65
+            consecutiveTime: 65,
           },
           targetDeparture: {
             lock: false,
             time: 46,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 46
+            consecutiveTime: 46,
           },
           targetArrival: {
             lock: false,
             time: 14,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 314
+            consecutiveTime: 314,
           },
           numberOfStops: 0,
           trainrunId: 75,
@@ -6214,53 +6214,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 80,
-                y: 1726
+                y: 1726,
               },
               {
                 x: 80,
-                y: 1662
+                y: 1662,
               },
               {
                 x: 80,
-                y: 1314
+                y: 1314,
               },
               {
                 x: 80,
-                y: 1250
-              }
+                y: 1250,
+              },
             ],
             textPositions: {
               0: {
                 x: 92,
-                y: 1708
+                y: 1708,
               },
               1: {
                 x: 68,
-                y: 1680
+                y: 1680,
               },
               2: {
                 x: 68,
-                y: 1268
+                y: 1268,
               },
               3: {
                 x: 92,
-                y: 1296
+                y: 1296,
               },
               4: {
                 x: 68,
-                y: 1488
+                y: 1488,
               },
               5: {
                 x: 68,
-                y: 1488
+                y: 1488,
               },
               6: {
                 x: 92,
-                y: 1488
-              }
-            }
+                y: 1488,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 514,
@@ -6273,35 +6273,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 9,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 14,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 314
+            consecutiveTime: 314,
           },
           sourceArrival: {
             lock: false,
             time: 46,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 46
+            consecutiveTime: 46,
           },
           targetDeparture: {
             lock: false,
             time: 37,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 37
+            consecutiveTime: 37,
           },
           targetArrival: {
             lock: false,
             time: 23,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 323
+            consecutiveTime: 323,
           },
           numberOfStops: 0,
           trainrunId: 75,
@@ -6311,53 +6311,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 80,
-                y: 1182
+                y: 1182,
               },
               {
                 x: 80,
-                y: 1118
+                y: 1118,
               },
               {
                 x: 80,
-                y: 866
+                y: 866,
               },
               {
                 x: 80,
-                y: 802
-              }
+                y: 802,
+              },
             ],
             textPositions: {
               0: {
                 x: 92,
-                y: 1164
+                y: 1164,
               },
               1: {
                 x: 68,
-                y: 1136
+                y: 1136,
               },
               2: {
                 x: 68,
-                y: 820
+                y: 820,
               },
               3: {
                 x: 92,
-                y: 848
+                y: 848,
               },
               4: {
                 x: 68,
-                y: 992
+                y: 992,
               },
               5: {
                 x: 68,
-                y: 992
+                y: 992,
               },
               6: {
                 x: 92,
-                y: 992
-              }
-            }
+                y: 992,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 515,
@@ -6370,35 +6370,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 7,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 23,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 323
+            consecutiveTime: 323,
           },
           sourceArrival: {
             lock: false,
             time: 37,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 37
+            consecutiveTime: 37,
           },
           targetDeparture: {
             lock: true,
             time: 30,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 30
+            consecutiveTime: 30,
           },
           targetArrival: {
             lock: true,
             time: 30,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 330
+            consecutiveTime: 330,
           },
           numberOfStops: 0,
           trainrunId: 75,
@@ -6408,53 +6408,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 80,
-                y: 734
+                y: 734,
               },
               {
                 x: 80,
-                y: 670
+                y: 670,
               },
               {
                 x: 80,
-                y: 414
+                y: 414,
               },
               {
                 x: 80,
-                y: 350
-              }
+                y: 350,
+              },
             ],
             textPositions: {
               0: {
                 x: 92,
-                y: 716
+                y: 716,
               },
               1: {
                 x: 68,
-                y: 688
+                y: 688,
               },
               2: {
                 x: 68,
-                y: 368
+                y: 368,
               },
               3: {
                 x: 92,
-                y: 396
+                y: 396,
               },
               4: {
                 x: 68,
-                y: 542
+                y: 542,
               },
               5: {
                 x: 68,
-                y: 542
+                y: 542,
               },
               6: {
                 x: 92,
-                y: 542
-              }
-            }
+                y: 542,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 516,
@@ -6467,35 +6467,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 10,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 32,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 332
+            consecutiveTime: 332,
           },
           sourceArrival: {
             lock: true,
             time: 28,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 28
+            consecutiveTime: 28,
           },
           targetDeparture: {
             lock: false,
             time: 18,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 18
+            consecutiveTime: 18,
           },
           targetArrival: {
             lock: false,
             time: 42,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 342
+            consecutiveTime: 342,
           },
           numberOfStops: 0,
           trainrunId: 75,
@@ -6505,53 +6505,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 80,
-                y: 94
+                y: 94,
               },
               {
                 x: 80,
-                y: 30
+                y: 30,
               },
               {
                 x: 80,
-                y: -290
+                y: -290,
               },
               {
                 x: 80,
-                y: -354
-              }
+                y: -354,
+              },
             ],
             textPositions: {
               0: {
                 x: 92,
-                y: 76
+                y: 76,
               },
               1: {
                 x: 68,
-                y: 48
+                y: 48,
               },
               2: {
                 x: 68,
-                y: -336
+                y: -336,
               },
               3: {
                 x: 92,
-                y: -308
+                y: -308,
               },
               4: {
                 x: 68,
-                y: -130
+                y: -130,
               },
               5: {
                 x: 68,
-                y: -130
+                y: -130,
               },
               6: {
                 x: 92,
-                y: -130
-              }
-            }
+                y: -130,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 517,
@@ -6564,35 +6564,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 5,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 42,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 342
+            consecutiveTime: 342,
           },
           sourceArrival: {
             lock: false,
             time: 18,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 18
+            consecutiveTime: 18,
           },
           targetDeparture: {
             lock: false,
             time: 13,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 13
+            consecutiveTime: 13,
           },
           targetArrival: {
             lock: false,
             time: 47,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 347
+            consecutiveTime: 347,
           },
           numberOfStops: 0,
           trainrunId: 75,
@@ -6602,53 +6602,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 80,
-                y: -450
+                y: -450,
               },
               {
                 x: 80,
-                y: -514
+                y: -514,
               },
               {
                 x: 80,
-                y: -798
+                y: -798,
               },
               {
                 x: 80,
-                y: -862
-              }
+                y: -862,
+              },
             ],
             textPositions: {
               0: {
                 x: 92,
-                y: -468
+                y: -468,
               },
               1: {
                 x: 68,
-                y: -496
+                y: -496,
               },
               2: {
                 x: 68,
-                y: -844
+                y: -844,
               },
               3: {
                 x: 92,
-                y: -816
+                y: -816,
               },
               4: {
                 x: 68,
-                y: -656
+                y: -656,
               },
               5: {
                 x: 68,
-                y: -656
+                y: -656,
               },
               6: {
                 x: 92,
-                y: -656
-              }
-            }
+                y: -656,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 518,
@@ -6661,35 +6661,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 5,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 47,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 347
+            consecutiveTime: 347,
           },
           sourceArrival: {
             lock: false,
             time: 13,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 13
+            consecutiveTime: 13,
           },
           targetDeparture: {
             lock: false,
             time: 8,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 8
+            consecutiveTime: 8,
           },
           targetArrival: {
             lock: false,
             time: 52,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 352
+            consecutiveTime: 352,
           },
           numberOfStops: 0,
           trainrunId: 75,
@@ -6699,53 +6699,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 80,
-                y: -930
+                y: -930,
               },
               {
                 x: 80,
-                y: -994
+                y: -994,
               },
               {
                 x: 80,
-                y: -1278
+                y: -1278,
               },
               {
                 x: 80,
-                y: -1342
-              }
+                y: -1342,
+              },
             ],
             textPositions: {
               0: {
                 x: 92,
-                y: -948
+                y: -948,
               },
               1: {
                 x: 68,
-                y: -976
+                y: -976,
               },
               2: {
                 x: 68,
-                y: -1324
+                y: -1324,
               },
               3: {
                 x: 92,
-                y: -1296
+                y: -1296,
               },
               4: {
                 x: 68,
-                y: -1136
+                y: -1136,
               },
               5: {
                 x: 68,
-                y: -1136
+                y: -1136,
               },
               6: {
                 x: 92,
-                y: -1136
-              }
-            }
+                y: -1136,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 519,
@@ -6758,35 +6758,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 5,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 52,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 352
+            consecutiveTime: 352,
           },
           sourceArrival: {
             lock: false,
             time: 8,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 8
+            consecutiveTime: 8,
           },
           targetDeparture: {
             lock: true,
             time: 3,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 3
+            consecutiveTime: 3,
           },
           targetArrival: {
             lock: true,
             time: 57,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 357
+            consecutiveTime: 357,
           },
           numberOfStops: 0,
           trainrunId: 75,
@@ -6796,53 +6796,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 80,
-                y: -1410
+                y: -1410,
               },
               {
                 x: 80,
-                y: -1474
+                y: -1474,
               },
               {
                 x: 80,
-                y: -1758
+                y: -1758,
               },
               {
                 x: 80,
-                y: -1822
-              }
+                y: -1822,
+              },
             ],
             textPositions: {
               0: {
                 x: 92,
-                y: -1428
+                y: -1428,
               },
               1: {
                 x: 68,
-                y: -1456
+                y: -1456,
               },
               2: {
                 x: 68,
-                y: -1804
+                y: -1804,
               },
               3: {
                 x: 92,
-                y: -1776
+                y: -1776,
               },
               4: {
                 x: 68,
-                y: -1616
+                y: -1616,
               },
               5: {
                 x: 68,
-                y: -1616
+                y: -1616,
               },
               6: {
                 x: 92,
-                y: -1616
-              }
-            }
+                y: -1616,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 520,
@@ -6855,35 +6855,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 28,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 8,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 128
+            consecutiveTime: 128,
           },
           sourceArrival: {
             lock: true,
             time: 52,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 232
+            consecutiveTime: 232,
           },
           targetDeparture: {
             lock: false,
             time: 24,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 204
+            consecutiveTime: 204,
           },
           targetArrival: {
             lock: false,
             time: 36,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 156
+            consecutiveTime: 156,
           },
           numberOfStops: 0,
           trainrunId: 75,
@@ -6893,53 +6893,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2704,
-                y: 2270
+                y: 2270,
               },
               {
                 x: 2704,
-                y: 2334
+                y: 2334,
               },
               {
                 x: 2704,
-                y: 2622
+                y: 2622,
               },
               {
                 x: 2704,
-                y: 2686
-              }
+                y: 2686,
+              },
             ],
             textPositions: {
               0: {
                 x: 2692,
-                y: 2288
+                y: 2288,
               },
               1: {
                 x: 2716,
-                y: 2316
+                y: 2316,
               },
               2: {
                 x: 2716,
-                y: 2668
+                y: 2668,
               },
               3: {
                 x: 2692,
-                y: 2640
+                y: 2640,
               },
               4: {
                 x: 2692,
-                y: 2478
+                y: 2478,
               },
               5: {
                 x: 2692,
-                y: 2478
+                y: 2478,
               },
               6: {
                 x: 2716,
-                y: 2478
-              }
-            }
+                y: 2478,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 521,
@@ -6952,35 +6952,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 14,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 2,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 2
+            consecutiveTime: 2,
           },
           sourceArrival: {
             lock: true,
             time: 58,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 118
+            consecutiveTime: 118,
           },
           targetDeparture: {
             lock: false,
             time: 44,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 104
+            consecutiveTime: 104,
           },
           targetArrival: {
             lock: false,
             time: 16,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 16
+            consecutiveTime: 16,
           },
           numberOfStops: 0,
           trainrunId: 76,
@@ -6990,53 +6990,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2608,
-                y: 3710
+                y: 3710,
               },
               {
                 x: 2608,
-                y: 3646
+                y: 3646,
               },
               {
                 x: 2608,
-                y: 3390
+                y: 3390,
               },
               {
                 x: 2608,
-                y: 3326
-              }
+                y: 3326,
+              },
             ],
             textPositions: {
               0: {
                 x: 2620,
-                y: 3692
+                y: 3692,
               },
               1: {
                 x: 2596,
-                y: 3664
+                y: 3664,
               },
               2: {
                 x: 2596,
-                y: 3344
+                y: 3344,
               },
               3: {
                 x: 2620,
-                y: 3372
+                y: 3372,
               },
               4: {
                 x: 2596,
-                y: 3518
+                y: 3518,
               },
               5: {
                 x: 2596,
-                y: 3518
+                y: 3518,
               },
               6: {
                 x: 2620,
-                y: 3518
-              }
-            }
+                y: 3518,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 522,
@@ -7049,35 +7049,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 6,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 18,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 18
+            consecutiveTime: 18,
           },
           sourceArrival: {
             lock: true,
             time: 42,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 102
+            consecutiveTime: 102,
           },
           targetDeparture: {
             lock: false,
             time: 36,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 96
+            consecutiveTime: 96,
           },
           targetArrival: {
             lock: false,
             time: 24,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 24
+            consecutiveTime: 24,
           },
           numberOfStops: 0,
           trainrunId: 76,
@@ -7087,53 +7087,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2608,
-                y: 3230
+                y: 3230,
               },
               {
                 x: 2608,
-                y: 3166
+                y: 3166,
               },
               {
                 x: 2608,
-                y: 2818
+                y: 2818,
               },
               {
                 x: 2608,
-                y: 2754
-              }
+                y: 2754,
+              },
             ],
             textPositions: {
               0: {
                 x: 2620,
-                y: 3212
+                y: 3212,
               },
               1: {
                 x: 2596,
-                y: 3184
+                y: 3184,
               },
               2: {
                 x: 2596,
-                y: 2772
+                y: 2772,
               },
               3: {
                 x: 2620,
-                y: 2800
+                y: 2800,
               },
               4: {
                 x: 2596,
-                y: 2992
+                y: 2992,
               },
               5: {
                 x: 2596,
-                y: 2992
+                y: 2992,
               },
               6: {
                 x: 2620,
-                y: 2992
-              }
-            }
+                y: 2992,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 523,
@@ -7146,35 +7146,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 28,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 24,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 24
+            consecutiveTime: 24,
           },
           sourceArrival: {
             lock: false,
             time: 36,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 96
+            consecutiveTime: 96,
           },
           targetDeparture: {
             lock: false,
             time: 8,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 68
+            consecutiveTime: 68,
           },
           targetArrival: {
             lock: false,
             time: 52,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 52
+            consecutiveTime: 52,
           },
           numberOfStops: 0,
           trainrunId: 76,
@@ -7184,53 +7184,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2672,
-                y: 2686
+                y: 2686,
               },
               {
                 x: 2672,
-                y: 2622
+                y: 2622,
               },
               {
                 x: 2672,
-                y: 2334
+                y: 2334,
               },
               {
                 x: 2672,
-                y: 2270
-              }
+                y: 2270,
+              },
             ],
             textPositions: {
               0: {
                 x: 2684,
-                y: 2668
+                y: 2668,
               },
               1: {
                 x: 2660,
-                y: 2640
+                y: 2640,
               },
               2: {
                 x: 2660,
-                y: 2288
+                y: 2288,
               },
               3: {
                 x: 2684,
-                y: 2316
+                y: 2316,
               },
               4: {
                 x: 2660,
-                y: 2478
+                y: 2478,
               },
               5: {
                 x: 2660,
-                y: 2478
+                y: 2478,
               },
               6: {
                 x: 2684,
-                y: 2478
-              }
-            }
+                y: 2478,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 524,
@@ -7243,35 +7243,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 19,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 52,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 52
+            consecutiveTime: 52,
           },
           sourceArrival: {
             lock: false,
             time: 8,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 68
+            consecutiveTime: 68,
           },
           targetDeparture: {
             lock: true,
             time: 49,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 49
+            consecutiveTime: 49,
           },
           targetArrival: {
             lock: true,
             time: 11,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 71
+            consecutiveTime: 71,
           },
           numberOfStops: 0,
           trainrunId: 76,
@@ -7281,53 +7281,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2672,
-                y: 2174
+                y: 2174,
               },
               {
                 x: 2672,
-                y: 2110
+                y: 2110,
               },
               {
                 x: 2672,
-                y: 1950
+                y: 1950,
               },
               {
                 x: 2672,
-                y: 1886
-              }
+                y: 1886,
+              },
             ],
             textPositions: {
               0: {
                 x: 2684,
-                y: 2156
+                y: 2156,
               },
               1: {
                 x: 2660,
-                y: 2128
+                y: 2128,
               },
               2: {
                 x: 2660,
-                y: 1904
+                y: 1904,
               },
               3: {
                 x: 2684,
-                y: 1932
+                y: 1932,
               },
               4: {
                 x: 2660,
-                y: 2030
+                y: 2030,
               },
               5: {
                 x: 2660,
-                y: 2030
+                y: 2030,
               },
               6: {
                 x: 2684,
-                y: 2030
-              }
-            }
+                y: 2030,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 525,
@@ -7340,35 +7340,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 15,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 15,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 75
+            consecutiveTime: 75,
           },
           sourceArrival: {
             lock: true,
             time: 45,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 45
+            consecutiveTime: 45,
           },
           targetDeparture: {
             lock: true,
             time: 30,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 30
+            consecutiveTime: 30,
           },
           targetArrival: {
             lock: true,
             time: 30,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 90
+            consecutiveTime: 90,
           },
           numberOfStops: 0,
           trainrunId: 76,
@@ -7378,53 +7378,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2672,
-                y: 1790
+                y: 1790,
               },
               {
                 x: 2672,
-                y: 1726
+                y: 1726,
               },
               {
                 x: 2672,
-                y: 1470
+                y: 1470,
               },
               {
                 x: 2672,
-                y: 1406
-              }
+                y: 1406,
+              },
             ],
             textPositions: {
               0: {
                 x: 2684,
-                y: 1772
+                y: 1772,
               },
               1: {
                 x: 2660,
-                y: 1744
+                y: 1744,
               },
               2: {
                 x: 2660,
-                y: 1424
+                y: 1424,
               },
               3: {
                 x: 2684,
-                y: 1452
+                y: 1452,
               },
               4: {
                 x: 2660,
-                y: 1598
+                y: 1598,
               },
               5: {
                 x: 2660,
-                y: 1598
+                y: 1598,
               },
               6: {
                 x: 2684,
-                y: 1598
-              }
-            }
+                y: 1598,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 526,
@@ -7437,35 +7437,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 16,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 31,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 91
+            consecutiveTime: 91,
           },
           sourceArrival: {
             lock: true,
             time: 29,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 29
+            consecutiveTime: 29,
           },
           targetDeparture: {
             lock: false,
             time: 13,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 13
+            consecutiveTime: 13,
           },
           targetArrival: {
             lock: false,
             time: 47,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 107
+            consecutiveTime: 107,
           },
           numberOfStops: 0,
           trainrunId: 76,
@@ -7475,53 +7475,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2672,
-                y: 1310
+                y: 1310,
               },
               {
                 x: 2672,
-                y: 1246
+                y: 1246,
               },
               {
                 x: 2672,
-                y: 894
+                y: 894,
               },
               {
                 x: 2672,
-                y: 830
-              }
+                y: 830,
+              },
             ],
             textPositions: {
               0: {
                 x: 2684,
-                y: 1292
+                y: 1292,
               },
               1: {
                 x: 2660,
-                y: 1264
+                y: 1264,
               },
               2: {
                 x: 2660,
-                y: 848
+                y: 848,
               },
               3: {
                 x: 2684,
-                y: 876
+                y: 876,
               },
               4: {
                 x: 2660,
-                y: 1070
+                y: 1070,
               },
               5: {
                 x: 2660,
-                y: 1070
+                y: 1070,
               },
               6: {
                 x: 2684,
-                y: 1070
-              }
-            }
+                y: 1070,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 527,
@@ -7534,35 +7534,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 23,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 33,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 273
+            consecutiveTime: 273,
           },
           sourceArrival: {
             lock: true,
             time: 27,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 327
+            consecutiveTime: 327,
           },
           targetDeparture: {
             lock: true,
             time: 4,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 304
+            consecutiveTime: 304,
           },
           targetArrival: {
             lock: true,
             time: 56,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 296
+            consecutiveTime: 296,
           },
           numberOfStops: 0,
           trainrunId: 77,
@@ -7572,53 +7572,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2306,
-                y: 3248
+                y: 3248,
               },
               {
                 x: 2370,
-                y: 3248
+                y: 3248,
               },
               {
                 x: 2526,
-                y: 3248
+                y: 3248,
               },
               {
                 x: 2590,
-                y: 3248
-              }
+                y: 3248,
+              },
             ],
             textPositions: {
               0: {
                 x: 2324,
-                y: 3260
+                y: 3260,
               },
               1: {
                 x: 2352,
-                y: 3236
+                y: 3236,
               },
               2: {
                 x: 2572,
-                y: 3236
+                y: 3236,
               },
               3: {
                 x: 2544,
-                y: 3260
+                y: 3260,
               },
               4: {
                 x: 2448,
-                y: 3236
+                y: 3236,
               },
               5: {
                 x: 2448,
-                y: 3236
+                y: 3236,
               },
               6: {
                 x: 2448,
-                y: 3260
-              }
-            }
+                y: 3260,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 528,
@@ -7631,35 +7631,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 15,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 0,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 300
+            consecutiveTime: 300,
           },
           sourceArrival: {
             lock: true,
             time: 0,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 300
+            consecutiveTime: 300,
           },
           targetDeparture: {
             lock: true,
             time: 45,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 285
+            consecutiveTime: 285,
           },
           targetArrival: {
             lock: true,
             time: 15,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 315
+            consecutiveTime: 315,
           },
           numberOfStops: 0,
           trainrunId: 77,
@@ -7669,53 +7669,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2672,
-                y: 3230
+                y: 3230,
               },
               {
                 x: 2672,
-                y: 3166
+                y: 3166,
               },
               {
                 x: 2672,
-                y: 2818
+                y: 2818,
               },
               {
                 x: 2672,
-                y: 2754
-              }
+                y: 2754,
+              },
             ],
             textPositions: {
               0: {
                 x: 2684,
-                y: 3212
+                y: 3212,
               },
               1: {
                 x: 2660,
-                y: 3184
+                y: 3184,
               },
               2: {
                 x: 2660,
-                y: 2772
+                y: 2772,
               },
               3: {
                 x: 2684,
-                y: 2800
+                y: 2800,
               },
               4: {
                 x: 2660,
-                y: 2992
+                y: 2992,
               },
               5: {
                 x: 2660,
-                y: 2992
+                y: 2992,
               },
               6: {
                 x: 2684,
-                y: 2992
-              }
-            }
+                y: 2992,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 529,
@@ -7728,35 +7728,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 53,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 16,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 316
+            consecutiveTime: 316,
           },
           sourceArrival: {
             lock: true,
             time: 44,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 284
+            consecutiveTime: 284,
           },
           targetDeparture: {
             lock: true,
             time: 51,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 231
+            consecutiveTime: 231,
           },
           targetArrival: {
             lock: true,
             time: 9,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 369
+            consecutiveTime: 369,
           },
           numberOfStops: 5,
           trainrunId: 77,
@@ -7766,53 +7766,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2608,
-                y: 2686
+                y: 2686,
               },
               {
                 x: 2608,
-                y: 2622
+                y: 2622,
               },
               {
                 x: 2288,
-                y: 2398
+                y: 2398,
               },
               {
                 x: 2288,
-                y: 2334
-              }
+                y: 2334,
+              },
             ],
             textPositions: {
               0: {
                 x: 2620,
-                y: 2668
+                y: 2668,
               },
               1: {
                 x: 2596,
-                y: 2640
+                y: 2640,
               },
               2: {
                 x: 2276,
-                y: 2352
+                y: 2352,
               },
               3: {
                 x: 2300,
-                y: 2380
+                y: 2380,
               },
               4: {
                 x: 2460,
-                y: 2510
+                y: 2510,
               },
               5: {
                 x: 2460,
-                y: 2510
+                y: 2510,
               },
               6: {
                 x: 2436,
-                y: 2510
-              }
-            }
+                y: 2510,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 530,
@@ -7825,35 +7825,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 32,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 10,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 370
+            consecutiveTime: 370,
           },
           sourceArrival: {
             lock: true,
             time: 50,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 230
+            consecutiveTime: 230,
           },
           targetDeparture: {
             lock: false,
             time: 18,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 198
+            consecutiveTime: 198,
           },
           targetArrival: {
             lock: false,
             time: 42,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 402
+            consecutiveTime: 402,
           },
           numberOfStops: 1,
           trainrunId: 77,
@@ -7863,53 +7863,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2370,
-                y: 2256
+                y: 2256,
               },
               {
                 x: 2434,
-                y: 2256
+                y: 2256,
               },
               {
                 x: 2590,
-                y: 2192
+                y: 2192,
               },
               {
                 x: 2654,
-                y: 2192
-              }
+                y: 2192,
+              },
             ],
             textPositions: {
               0: {
                 x: 2388,
-                y: 2268
+                y: 2268,
               },
               1: {
                 x: 2416,
-                y: 2244
+                y: 2244,
               },
               2: {
                 x: 2636,
-                y: 2180
+                y: 2180,
               },
               3: {
                 x: 2608,
-                y: 2204
+                y: 2204,
               },
               4: {
                 x: 2512,
-                y: 2212
+                y: 2212,
               },
               5: {
                 x: 2512,
-                y: 2212
+                y: 2212,
               },
               6: {
                 x: 2512,
-                y: 2236
-              }
-            }
+                y: 2236,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 531,
@@ -7922,35 +7922,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 23,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 43,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 403
+            consecutiveTime: 403,
           },
           sourceArrival: {
             lock: true,
             time: 17,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 197
+            consecutiveTime: 197,
           },
           targetDeparture: {
             lock: true,
             time: 54,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 174
+            consecutiveTime: 174,
           },
           targetArrival: {
             lock: true,
             time: 6,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 426
+            consecutiveTime: 426,
           },
           numberOfStops: 3,
           trainrunId: 77,
@@ -7960,53 +7960,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2736,
-                y: 2174
+                y: 2174,
               },
               {
                 x: 2736,
-                y: 2110
+                y: 2110,
               },
               {
                 x: 2736,
-                y: 1950
+                y: 1950,
               },
               {
                 x: 2736,
-                y: 1886
-              }
+                y: 1886,
+              },
             ],
             textPositions: {
               0: {
                 x: 2748,
-                y: 2156
+                y: 2156,
               },
               1: {
                 x: 2724,
-                y: 2128
+                y: 2128,
               },
               2: {
                 x: 2724,
-                y: 1904
+                y: 1904,
               },
               3: {
                 x: 2748,
-                y: 1932
+                y: 1932,
               },
               4: {
                 x: 2724,
-                y: 2030
+                y: 2030,
               },
               5: {
                 x: 2724,
-                y: 2030
+                y: 2030,
               },
               6: {
                 x: 2748,
-                y: 2030
-              }
-            }
+                y: 2030,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 532,
@@ -8019,35 +8019,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 18,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 15,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 435
+            consecutiveTime: 435,
           },
           sourceArrival: {
             lock: true,
             time: 45,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 165
+            consecutiveTime: 165,
           },
           targetDeparture: {
             lock: false,
             time: 27,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 147
+            consecutiveTime: 147,
           },
           targetArrival: {
             lock: false,
             time: 33,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 453
+            consecutiveTime: 453,
           },
           numberOfStops: 0,
           trainrunId: 77,
@@ -8057,53 +8057,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2654,
-                y: 1840
+                y: 1840,
               },
               {
                 x: 2590,
-                y: 1840
+                y: 1840,
               },
               {
                 x: 2018,
-                y: 1840
+                y: 1840,
               },
               {
                 x: 1954,
-                y: 1840
-              }
+                y: 1840,
+              },
             ],
             textPositions: {
               0: {
                 x: 2636,
-                y: 1828
+                y: 1828,
               },
               1: {
                 x: 2608,
-                y: 1852
+                y: 1852,
               },
               2: {
                 x: 1972,
-                y: 1852
+                y: 1852,
               },
               3: {
                 x: 2000,
-                y: 1828
+                y: 1828,
               },
               4: {
                 x: 2304,
-                y: 1828
+                y: 1828,
               },
               5: {
                 x: 2304,
-                y: 1828
+                y: 1828,
               },
               6: {
                 x: 2304,
-                y: 1852
-              }
-            }
+                y: 1852,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 533,
@@ -8116,35 +8116,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 23,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 33,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 153
+            consecutiveTime: 153,
           },
           sourceArrival: {
             lock: true,
             time: 27,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 207
+            consecutiveTime: 207,
           },
           targetDeparture: {
             lock: true,
             time: 4,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 184
+            consecutiveTime: 184,
           },
           targetArrival: {
             lock: true,
             time: 56,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 176
+            consecutiveTime: 176,
           },
           numberOfStops: 3,
           trainrunId: 78,
@@ -8154,53 +8154,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2306,
-                y: 3280
+                y: 3280,
               },
               {
                 x: 2370,
-                y: 3280
+                y: 3280,
               },
               {
                 x: 2526,
-                y: 3280
+                y: 3280,
               },
               {
                 x: 2590,
-                y: 3280
-              }
+                y: 3280,
+              },
             ],
             textPositions: {
               0: {
                 x: 2324,
-                y: 3292
+                y: 3292,
               },
               1: {
                 x: 2352,
-                y: 3268
+                y: 3268,
               },
               2: {
                 x: 2572,
-                y: 3268
+                y: 3268,
               },
               3: {
                 x: 2544,
-                y: 3292
+                y: 3292,
               },
               4: {
                 x: 2448,
-                y: 3268
+                y: 3268,
               },
               5: {
                 x: 2448,
-                y: 3268
+                y: 3268,
               },
               6: {
                 x: 2448,
-                y: 3292
-              }
-            }
+                y: 3292,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 534,
@@ -8213,35 +8213,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 15,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 0,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 180
+            consecutiveTime: 180,
           },
           sourceArrival: {
             lock: true,
             time: 0,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 180
+            consecutiveTime: 180,
           },
           targetDeparture: {
             lock: true,
             time: 45,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 165
+            consecutiveTime: 165,
           },
           targetArrival: {
             lock: true,
             time: 15,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 195
+            consecutiveTime: 195,
           },
           numberOfStops: 1,
           trainrunId: 78,
@@ -8251,53 +8251,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2704,
-                y: 3230
+                y: 3230,
               },
               {
                 x: 2704,
-                y: 3166
+                y: 3166,
               },
               {
                 x: 2704,
-                y: 2818
+                y: 2818,
               },
               {
                 x: 2704,
-                y: 2754
-              }
+                y: 2754,
+              },
             ],
             textPositions: {
               0: {
                 x: 2716,
-                y: 3212
+                y: 3212,
               },
               1: {
                 x: 2692,
-                y: 3184
+                y: 3184,
               },
               2: {
                 x: 2692,
-                y: 2772
+                y: 2772,
               },
               3: {
                 x: 2716,
-                y: 2800
+                y: 2800,
               },
               4: {
                 x: 2692,
-                y: 2992
+                y: 2992,
               },
               5: {
                 x: 2692,
-                y: 2992
+                y: 2992,
               },
               6: {
                 x: 2716,
-                y: 2992
-              }
-            }
+                y: 2992,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 535,
@@ -8310,35 +8310,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 53,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 16,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 196
+            consecutiveTime: 196,
           },
           sourceArrival: {
             lock: true,
             time: 44,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 164
+            consecutiveTime: 164,
           },
           targetDeparture: {
             lock: true,
             time: 51,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 111
+            consecutiveTime: 111,
           },
           targetArrival: {
             lock: true,
             time: 9,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 249
+            consecutiveTime: 249,
           },
           numberOfStops: 5,
           trainrunId: 78,
@@ -8348,53 +8348,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2640,
-                y: 2686
+                y: 2686,
               },
               {
                 x: 2640,
-                y: 2622
+                y: 2622,
               },
               {
                 x: 2320,
-                y: 2398
+                y: 2398,
               },
               {
                 x: 2320,
-                y: 2334
-              }
+                y: 2334,
+              },
             ],
             textPositions: {
               0: {
                 x: 2652,
-                y: 2668
+                y: 2668,
               },
               1: {
                 x: 2628,
-                y: 2640
+                y: 2640,
               },
               2: {
                 x: 2308,
-                y: 2352
+                y: 2352,
               },
               3: {
                 x: 2332,
-                y: 2380
+                y: 2380,
               },
               4: {
                 x: 2492,
-                y: 2510
+                y: 2510,
               },
               5: {
                 x: 2492,
-                y: 2510
+                y: 2510,
               },
               6: {
                 x: 2468,
-                y: 2510
-              }
-            }
+                y: 2510,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 536,
@@ -8407,35 +8407,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 32,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 10,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 250
+            consecutiveTime: 250,
           },
           sourceArrival: {
             lock: true,
             time: 50,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 110
+            consecutiveTime: 110,
           },
           targetDeparture: {
             lock: true,
             time: 18,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 78
+            consecutiveTime: 78,
           },
           targetArrival: {
             lock: true,
             time: 42,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 282
+            consecutiveTime: 282,
           },
           numberOfStops: 1,
           trainrunId: 78,
@@ -8445,53 +8445,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2370,
-                y: 2288
+                y: 2288,
               },
               {
                 x: 2434,
-                y: 2288
+                y: 2288,
               },
               {
                 x: 2590,
-                y: 2224
+                y: 2224,
               },
               {
                 x: 2654,
-                y: 2224
-              }
+                y: 2224,
+              },
             ],
             textPositions: {
               0: {
                 x: 2388,
-                y: 2300
+                y: 2300,
               },
               1: {
                 x: 2416,
-                y: 2276
+                y: 2276,
               },
               2: {
                 x: 2636,
-                y: 2212
+                y: 2212,
               },
               3: {
                 x: 2608,
-                y: 2236
+                y: 2236,
               },
               4: {
                 x: 2512,
-                y: 2244
+                y: 2244,
               },
               5: {
                 x: 2512,
-                y: 2244
+                y: 2244,
               },
               6: {
                 x: 2512,
-                y: 2268
-              }
-            }
+                y: 2268,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 537,
@@ -8504,35 +8504,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 23,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 43,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 283
+            consecutiveTime: 283,
           },
           sourceArrival: {
             lock: true,
             time: 17,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 77
+            consecutiveTime: 77,
           },
           targetDeparture: {
             lock: true,
             time: 54,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 54
+            consecutiveTime: 54,
           },
           targetArrival: {
             lock: true,
             time: 6,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 306
+            consecutiveTime: 306,
           },
           numberOfStops: 3,
           trainrunId: 78,
@@ -8542,53 +8542,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2768,
-                y: 2174
+                y: 2174,
               },
               {
                 x: 2768,
-                y: 2110
+                y: 2110,
               },
               {
                 x: 2768,
-                y: 1950
+                y: 1950,
               },
               {
                 x: 2768,
-                y: 1886
-              }
+                y: 1886,
+              },
             ],
             textPositions: {
               0: {
                 x: 2780,
-                y: 2156
+                y: 2156,
               },
               1: {
                 x: 2756,
-                y: 2128
+                y: 2128,
               },
               2: {
                 x: 2756,
-                y: 1904
+                y: 1904,
               },
               3: {
                 x: 2780,
-                y: 1932
+                y: 1932,
               },
               4: {
                 x: 2756,
-                y: 2030
+                y: 2030,
               },
               5: {
                 x: 2756,
-                y: 2030
+                y: 2030,
               },
               6: {
                 x: 2780,
-                y: 2030
-              }
-            }
+                y: 2030,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 538,
@@ -8601,35 +8601,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 15,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 15,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 315
+            consecutiveTime: 315,
           },
           sourceArrival: {
             lock: false,
             time: 45,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 45
+            consecutiveTime: 45,
           },
           targetDeparture: {
             lock: true,
             time: 30,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 30
+            consecutiveTime: 30,
           },
           targetArrival: {
             lock: true,
             time: 30,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 330
+            consecutiveTime: 330,
           },
           numberOfStops: 0,
           trainrunId: 78,
@@ -8639,53 +8639,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2704,
-                y: 1790
+                y: 1790,
               },
               {
                 x: 2704,
-                y: 1726
+                y: 1726,
               },
               {
                 x: 2704,
-                y: 1470
+                y: 1470,
               },
               {
                 x: 2704,
-                y: 1406
-              }
+                y: 1406,
+              },
             ],
             textPositions: {
               0: {
                 x: 2716,
-                y: 1772
+                y: 1772,
               },
               1: {
                 x: 2692,
-                y: 1744
+                y: 1744,
               },
               2: {
                 x: 2692,
-                y: 1424
+                y: 1424,
               },
               3: {
                 x: 2716,
-                y: 1452
+                y: 1452,
               },
               4: {
                 x: 2692,
-                y: 1598
+                y: 1598,
               },
               5: {
                 x: 2692,
-                y: 1598
+                y: 1598,
               },
               6: {
                 x: 2716,
-                y: 1598
-              }
-            }
+                y: 1598,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 539,
@@ -8698,35 +8698,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 16,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 31,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 331
+            consecutiveTime: 331,
           },
           sourceArrival: {
             lock: true,
             time: 29,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 29
+            consecutiveTime: 29,
           },
           targetDeparture: {
             lock: false,
             time: 13,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 13
+            consecutiveTime: 13,
           },
           targetArrival: {
             lock: false,
             time: 47,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 347
+            consecutiveTime: 347,
           },
           numberOfStops: 0,
           trainrunId: 78,
@@ -8736,53 +8736,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2704,
-                y: 1310
+                y: 1310,
               },
               {
                 x: 2704,
-                y: 1246
+                y: 1246,
               },
               {
                 x: 2704,
-                y: 894
+                y: 894,
               },
               {
                 x: 2704,
-                y: 830
-              }
+                y: 830,
+              },
             ],
             textPositions: {
               0: {
                 x: 2716,
-                y: 1292
+                y: 1292,
               },
               1: {
                 x: 2692,
-                y: 1264
+                y: 1264,
               },
               2: {
                 x: 2692,
-                y: 848
+                y: 848,
               },
               3: {
                 x: 2716,
-                y: 876
+                y: 876,
               },
               4: {
                 x: 2692,
-                y: 1070
+                y: 1070,
               },
               5: {
                 x: 2692,
-                y: 1070
+                y: 1070,
               },
               6: {
                 x: 2716,
-                y: 1070
-              }
-            }
+                y: 1070,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 540,
@@ -8795,35 +8795,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 12,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 35,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 35
+            consecutiveTime: 35,
           },
           sourceArrival: {
             lock: true,
             time: 25,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 265
+            consecutiveTime: 265,
           },
           targetDeparture: {
             lock: true,
             time: 13,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 253
+            consecutiveTime: 253,
           },
           targetArrival: {
             lock: true,
             time: 47,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 47
+            consecutiveTime: 47,
           },
           numberOfStops: 0,
           trainrunId: 79,
@@ -8833,53 +8833,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 226,
-                y: 1840
+                y: 1840,
               },
               {
                 x: 290,
-                y: 1840
+                y: 1840,
               },
               {
                 x: 1790,
-                y: 1840
+                y: 1840,
               },
               {
                 x: 1854,
-                y: 1840
-              }
+                y: 1840,
+              },
             ],
             textPositions: {
               0: {
                 x: 244,
-                y: 1852
+                y: 1852,
               },
               1: {
                 x: 272,
-                y: 1828
+                y: 1828,
               },
               2: {
                 x: 1836,
-                y: 1828
+                y: 1828,
               },
               3: {
                 x: 1808,
-                y: 1852
+                y: 1852,
               },
               4: {
                 x: 1040,
-                y: 1828
+                y: 1828,
               },
               5: {
                 x: 1040,
-                y: 1828
+                y: 1828,
               },
               6: {
                 x: 1040,
-                y: 1852
-              }
-            }
+                y: 1852,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 541,
@@ -8892,35 +8892,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 15,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 58,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 58
+            consecutiveTime: 58,
           },
           sourceArrival: {
             lock: true,
             time: 2,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 242
+            consecutiveTime: 242,
           },
           targetDeparture: {
             lock: true,
             time: 47,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 227
+            consecutiveTime: 227,
           },
           targetArrival: {
             lock: true,
             time: 13,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 73
+            consecutiveTime: 73,
           },
           numberOfStops: 1,
           trainrunId: 79,
@@ -8930,53 +8930,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2768,
-                y: 1310
+                y: 1310,
               },
               {
                 x: 2768,
-                y: 1246
+                y: 1246,
               },
               {
                 x: 2768,
-                y: 894
+                y: 894,
               },
               {
                 x: 2768,
-                y: 830
-              }
+                y: 830,
+              },
             ],
             textPositions: {
               0: {
                 x: 2780,
-                y: 1292
+                y: 1292,
               },
               1: {
                 x: 2756,
-                y: 1264
+                y: 1264,
               },
               2: {
                 x: 2756,
-                y: 848
+                y: 848,
               },
               3: {
                 x: 2780,
-                y: 876
+                y: 876,
               },
               4: {
                 x: 2756,
-                y: 1070
+                y: 1070,
               },
               5: {
                 x: 2756,
-                y: 1070
+                y: 1070,
               },
               6: {
                 x: 2780,
-                y: 1070
-              }
-            }
+                y: 1070,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 542,
@@ -8989,35 +8989,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 9,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 9,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 9
+            consecutiveTime: 9,
           },
           sourceArrival: {
             lock: true,
             time: 51,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 51
+            consecutiveTime: 51,
           },
           targetDeparture: {
             lock: false,
             time: 42,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 42
+            consecutiveTime: 42,
           },
           targetArrival: {
             lock: false,
             time: 18,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 18
+            consecutiveTime: 18,
           },
           numberOfStops: 0,
           trainrunId: 80,
@@ -9027,53 +9027,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 226,
-                y: 1808
+                y: 1808,
               },
               {
                 x: 290,
-                y: 1808
+                y: 1808,
               },
               {
                 x: 1790,
-                y: 1808
+                y: 1808,
               },
               {
                 x: 1854,
-                y: 1808
-              }
+                y: 1808,
+              },
             ],
             textPositions: {
               0: {
                 x: 244,
-                y: 1820
+                y: 1820,
               },
               1: {
                 x: 272,
-                y: 1796
+                y: 1796,
               },
               2: {
                 x: 1836,
-                y: 1796
+                y: 1796,
               },
               3: {
                 x: 1808,
-                y: 1820
+                y: 1820,
               },
               4: {
                 x: 1040,
-                y: 1796
+                y: 1796,
               },
               5: {
                 x: 1040,
-                y: 1796
+                y: 1796,
               },
               6: {
                 x: 1040,
-                y: 1820
-              }
-            }
+                y: 1820,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 543,
@@ -9086,35 +9086,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 14,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 29,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 29
+            consecutiveTime: 29,
           },
           sourceArrival: {
             lock: true,
             time: 31,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 31
+            consecutiveTime: 31,
           },
           targetDeparture: {
             lock: false,
             time: 17,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 17
+            consecutiveTime: 17,
           },
           targetArrival: {
             lock: false,
             time: 43,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 43
+            consecutiveTime: 43,
           },
           numberOfStops: 0,
           trainrunId: 80,
@@ -9124,53 +9124,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2736,
-                y: 1310
+                y: 1310,
               },
               {
                 x: 2736,
-                y: 1246
+                y: 1246,
               },
               {
                 x: 2736,
-                y: 894
+                y: 894,
               },
               {
                 x: 2736,
-                y: 830
-              }
+                y: 830,
+              },
             ],
             textPositions: {
               0: {
                 x: 2748,
-                y: 1292
+                y: 1292,
               },
               1: {
                 x: 2724,
-                y: 1264
+                y: 1264,
               },
               2: {
                 x: 2724,
-                y: 848
+                y: 848,
               },
               3: {
                 x: 2748,
-                y: 876
+                y: 876,
               },
               4: {
                 x: 2724,
-                y: 1070
+                y: 1070,
               },
               5: {
                 x: 2724,
-                y: 1070
+                y: 1070,
               },
               6: {
                 x: 2748,
-                y: 1070
-              }
-            }
+                y: 1070,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 544,
@@ -9183,35 +9183,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 19,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 59,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 299
+            consecutiveTime: 299,
           },
           sourceArrival: {
             lock: false,
             time: 1,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 241
+            consecutiveTime: 241,
           },
           targetDeparture: {
             lock: true,
             time: 42,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 222
+            consecutiveTime: 222,
           },
           targetArrival: {
             lock: true,
             time: 18,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 318
+            consecutiveTime: 318,
           },
           numberOfStops: 0,
           trainrunId: 81,
@@ -9221,53 +9221,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 112,
-                y: 1726
+                y: 1726,
               },
               {
                 x: 112,
-                y: 1662
+                y: 1662,
               },
               {
                 x: 112,
-                y: 1314
+                y: 1314,
               },
               {
                 x: 112,
-                y: 1250
-              }
+                y: 1250,
+              },
             ],
             textPositions: {
               0: {
                 x: 124,
-                y: 1708
+                y: 1708,
               },
               1: {
                 x: 100,
-                y: 1680
+                y: 1680,
               },
               2: {
                 x: 100,
-                y: 1268
+                y: 1268,
               },
               3: {
                 x: 124,
-                y: 1296
+                y: 1296,
               },
               4: {
                 x: 100,
-                y: 1488
+                y: 1488,
               },
               5: {
                 x: 100,
-                y: 1488
+                y: 1488,
               },
               6: {
                 x: 124,
-                y: 1488
-              }
-            }
+                y: 1488,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 545,
@@ -9280,35 +9280,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 12,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 19,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 319
+            consecutiveTime: 319,
           },
           sourceArrival: {
             lock: true,
             time: 41,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 221
+            consecutiveTime: 221,
           },
           targetDeparture: {
             lock: true,
             time: 29,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 209
+            consecutiveTime: 209,
           },
           targetArrival: {
             lock: true,
             time: 31,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 331
+            consecutiveTime: 331,
           },
           numberOfStops: 0,
           trainrunId: 81,
@@ -9318,53 +9318,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 112,
-                y: 1182
+                y: 1182,
               },
               {
                 x: 112,
-                y: 1118
+                y: 1118,
               },
               {
                 x: 112,
-                y: 866
+                y: 866,
               },
               {
                 x: 112,
-                y: 802
-              }
+                y: 802,
+              },
             ],
             textPositions: {
               0: {
                 x: 124,
-                y: 1164
+                y: 1164,
               },
               1: {
                 x: 100,
-                y: 1136
+                y: 1136,
               },
               2: {
                 x: 100,
-                y: 820
+                y: 820,
               },
               3: {
                 x: 124,
-                y: 848
+                y: 848,
               },
               4: {
                 x: 100,
-                y: 992
+                y: 992,
               },
               5: {
                 x: 100,
-                y: 992
+                y: 992,
               },
               6: {
                 x: 124,
-                y: 992
-              }
-            }
+                y: 992,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 546,
@@ -9377,35 +9377,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 7,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 32,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 332
+            consecutiveTime: 332,
           },
           sourceArrival: {
             lock: true,
             time: 28,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 208
+            consecutiveTime: 208,
           },
           targetDeparture: {
             lock: false,
             time: 21,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 201
+            consecutiveTime: 201,
           },
           targetArrival: {
             lock: false,
             time: 39,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 339
+            consecutiveTime: 339,
           },
           numberOfStops: 0,
           trainrunId: 81,
@@ -9415,53 +9415,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 62,
-                y: 752
+                y: 752,
               },
               {
                 x: -2,
-                y: 752
+                y: 752,
               },
               {
                 x: -446,
-                y: 336
+                y: 336,
               },
               {
                 x: -510,
-                y: 336
-              }
+                y: 336,
+              },
             ],
             textPositions: {
               0: {
                 x: 44,
-                y: 740
+                y: 740,
               },
               1: {
                 x: 16,
-                y: 764
+                y: 764,
               },
               2: {
                 x: -492,
-                y: 348
+                y: 348,
               },
               3: {
                 x: -464,
-                y: 324
+                y: 324,
               },
               4: {
                 x: -224,
-                y: 532
+                y: 532,
               },
               5: {
                 x: -224,
-                y: 532
+                y: 532,
               },
               6: {
                 x: -224,
-                y: 556
-              }
-            }
+                y: 556,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 547,
@@ -9474,35 +9474,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 22,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 4,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 364
+            consecutiveTime: 364,
           },
           sourceArrival: {
             lock: true,
             time: 56,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 176
+            consecutiveTime: 176,
           },
           targetDeparture: {
             lock: true,
             time: 34,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 154
+            consecutiveTime: 154,
           },
           targetArrival: {
             lock: true,
             time: 26,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 386
+            consecutiveTime: 386,
           },
           numberOfStops: 0,
           trainrunId: 81,
@@ -9512,53 +9512,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: -2146,
-                y: 176
+                y: 176,
               },
               {
                 x: -2210,
-                y: 176
+                y: 176,
               },
               {
                 x: -2398,
-                y: 336
+                y: 336,
               },
               {
                 x: -2462,
-                y: 336
-              }
+                y: 336,
+              },
             ],
             textPositions: {
               0: {
                 x: -2164,
-                y: 164
+                y: 164,
               },
               1: {
                 x: -2192,
-                y: 188
+                y: 188,
               },
               2: {
                 x: -2444,
-                y: 348
+                y: 348,
               },
               3: {
                 x: -2416,
-                y: 324
+                y: 324,
               },
               4: {
                 x: -2304,
-                y: 244
+                y: 244,
               },
               5: {
                 x: -2304,
-                y: 244
+                y: 244,
               },
               6: {
                 x: -2304,
-                y: 268
-              }
-            }
+                y: 268,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 548,
@@ -9571,35 +9571,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 18,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 30,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 90
+            consecutiveTime: 90,
           },
           sourceArrival: {
             lock: true,
             time: 30,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 90
+            consecutiveTime: 90,
           },
           targetDeparture: {
             lock: true,
             time: 12,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 72
+            consecutiveTime: 72,
           },
           targetArrival: {
             lock: true,
             time: 48,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 108
+            consecutiveTime: 108,
           },
           numberOfStops: 0,
           trainrunId: 82,
@@ -9609,53 +9609,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 208,
-                y: 1726
+                y: 1726,
               },
               {
                 x: 208,
-                y: 1662
+                y: 1662,
               },
               {
                 x: 208,
-                y: 1314
+                y: 1314,
               },
               {
                 x: 208,
-                y: 1250
-              }
+                y: 1250,
+              },
             ],
             textPositions: {
               0: {
                 x: 220,
-                y: 1708
+                y: 1708,
               },
               1: {
                 x: 196,
-                y: 1680
+                y: 1680,
               },
               2: {
                 x: 196,
-                y: 1268
+                y: 1268,
               },
               3: {
                 x: 220,
-                y: 1296
+                y: 1296,
               },
               4: {
                 x: 196,
-                y: 1488
+                y: 1488,
               },
               5: {
                 x: 196,
-                y: 1488
+                y: 1488,
               },
               6: {
                 x: 220,
-                y: 1488
-              }
-            }
+                y: 1488,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 549,
@@ -9668,35 +9668,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 13,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 49,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 109
+            consecutiveTime: 109,
           },
           sourceArrival: {
             lock: true,
             time: 11,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 71
+            consecutiveTime: 71,
           },
           targetDeparture: {
             lock: false,
             time: 58,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 58
+            consecutiveTime: 58,
           },
           targetArrival: {
             lock: false,
             time: 2,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 122
+            consecutiveTime: 122,
           },
           numberOfStops: 0,
           trainrunId: 82,
@@ -9706,53 +9706,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 208,
-                y: 1182
+                y: 1182,
               },
               {
                 x: 208,
-                y: 1118
+                y: 1118,
               },
               {
                 x: 208,
-                y: 866
+                y: 866,
               },
               {
                 x: 208,
-                y: 802
-              }
+                y: 802,
+              },
             ],
             textPositions: {
               0: {
                 x: 220,
-                y: 1164
+                y: 1164,
               },
               1: {
                 x: 196,
-                y: 1136
+                y: 1136,
               },
               2: {
                 x: 196,
-                y: 820
+                y: 820,
               },
               3: {
                 x: 220,
-                y: 848
+                y: 848,
               },
               4: {
                 x: 196,
-                y: 992
+                y: 992,
               },
               5: {
                 x: 196,
-                y: 992
+                y: 992,
               },
               6: {
                 x: 220,
-                y: 992
-              }
-            }
+                y: 992,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 550,
@@ -9765,35 +9765,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 7,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 4,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 124
+            consecutiveTime: 124,
           },
           sourceArrival: {
             lock: true,
             time: 56,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 56
+            consecutiveTime: 56,
           },
           targetDeparture: {
             lock: true,
             time: 49,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 49
+            consecutiveTime: 49,
           },
           targetArrival: {
             lock: true,
             time: 11,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 131
+            consecutiveTime: 131,
           },
           numberOfStops: 0,
           trainrunId: 82,
@@ -9803,53 +9803,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 176,
-                y: 734
+                y: 734,
               },
               {
                 x: 176,
-                y: 670
+                y: 670,
               },
               {
                 x: 176,
-                y: 414
+                y: 414,
               },
               {
                 x: 176,
-                y: 350
-              }
+                y: 350,
+              },
             ],
             textPositions: {
               0: {
                 x: 188,
-                y: 716
+                y: 716,
               },
               1: {
                 x: 164,
-                y: 688
+                y: 688,
               },
               2: {
                 x: 164,
-                y: 368
+                y: 368,
               },
               3: {
                 x: 188,
-                y: 396
+                y: 396,
               },
               4: {
                 x: 164,
-                y: 542
+                y: 542,
               },
               5: {
                 x: 164,
-                y: 542
+                y: 542,
               },
               6: {
                 x: 188,
-                y: 542
-              }
-            }
+                y: 542,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 551,
@@ -9862,35 +9862,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 10,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 12,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 132
+            consecutiveTime: 132,
           },
           sourceArrival: {
             lock: true,
             time: 48,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 48
+            consecutiveTime: 48,
           },
           targetDeparture: {
             lock: true,
             time: 38,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 38
+            consecutiveTime: 38,
           },
           targetArrival: {
             lock: true,
             time: 22,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 142
+            consecutiveTime: 142,
           },
           numberOfStops: 0,
           trainrunId: 82,
@@ -9900,53 +9900,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 240,
-                y: 94
+                y: 94,
               },
               {
                 x: 240,
-                y: 30
+                y: 30,
               },
               {
                 x: 240,
-                y: -290
+                y: -290,
               },
               {
                 x: 240,
-                y: -354
-              }
+                y: -354,
+              },
             ],
             textPositions: {
               0: {
                 x: 252,
-                y: 76
+                y: 76,
               },
               1: {
                 x: 228,
-                y: 48
+                y: 48,
               },
               2: {
                 x: 228,
-                y: -336
+                y: -336,
               },
               3: {
                 x: 252,
-                y: -308
+                y: -308,
               },
               4: {
                 x: 228,
-                y: -130
+                y: -130,
               },
               5: {
                 x: 228,
-                y: -130
+                y: -130,
               },
               6: {
                 x: 252,
-                y: -130
-              }
-            }
+                y: -130,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 552,
@@ -9959,35 +9959,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 4,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 23,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 143
+            consecutiveTime: 143,
           },
           sourceArrival: {
             lock: true,
             time: 37,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 37
+            consecutiveTime: 37,
           },
           targetDeparture: {
             lock: true,
             time: 33,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 33
+            consecutiveTime: 33,
           },
           targetArrival: {
             lock: true,
             time: 27,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 147
+            consecutiveTime: 147,
           },
           numberOfStops: 0,
           trainrunId: 82,
@@ -9997,53 +9997,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 304,
-                y: -450
+                y: -450,
               },
               {
                 x: 304,
-                y: -514
+                y: -514,
               },
               {
                 x: 304,
-                y: -798
+                y: -798,
               },
               {
                 x: 304,
-                y: -862
-              }
+                y: -862,
+              },
             ],
             textPositions: {
               0: {
                 x: 316,
-                y: -468
+                y: -468,
               },
               1: {
                 x: 292,
-                y: -496
+                y: -496,
               },
               2: {
                 x: 292,
-                y: -844
+                y: -844,
               },
               3: {
                 x: 316,
-                y: -816
+                y: -816,
               },
               4: {
                 x: 292,
-                y: -656
+                y: -656,
               },
               5: {
                 x: 292,
-                y: -656
+                y: -656,
               },
               6: {
                 x: 316,
-                y: -656
-              }
-            }
+                y: -656,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 553,
@@ -10056,35 +10056,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 5,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 28,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 148
+            consecutiveTime: 148,
           },
           sourceArrival: {
             lock: true,
             time: 32,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 32
+            consecutiveTime: 32,
           },
           targetDeparture: {
             lock: true,
             time: 27,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 27
+            consecutiveTime: 27,
           },
           targetArrival: {
             lock: true,
             time: 33,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 153
+            consecutiveTime: 153,
           },
           numberOfStops: 0,
           trainrunId: 82,
@@ -10094,53 +10094,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 304,
-                y: -930
+                y: -930,
               },
               {
                 x: 304,
-                y: -994
+                y: -994,
               },
               {
                 x: 304,
-                y: -1278
+                y: -1278,
               },
               {
                 x: 304,
-                y: -1342
-              }
+                y: -1342,
+              },
             ],
             textPositions: {
               0: {
                 x: 316,
-                y: -948
+                y: -948,
               },
               1: {
                 x: 292,
-                y: -976
+                y: -976,
               },
               2: {
                 x: 292,
-                y: -1324
+                y: -1324,
               },
               3: {
                 x: 316,
-                y: -1296
+                y: -1296,
               },
               4: {
                 x: 292,
-                y: -1136
+                y: -1136,
               },
               5: {
                 x: 292,
-                y: -1136
+                y: -1136,
               },
               6: {
                 x: 316,
-                y: -1136
-              }
-            }
+                y: -1136,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 554,
@@ -10153,35 +10153,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 10,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 34,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 154
+            consecutiveTime: 154,
           },
           sourceArrival: {
             lock: true,
             time: 26,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 26
+            consecutiveTime: 26,
           },
           targetDeparture: {
             lock: true,
             time: 16,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 16
+            consecutiveTime: 16,
           },
           targetArrival: {
             lock: true,
             time: 44,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 164
+            consecutiveTime: 164,
           },
           numberOfStops: 0,
           trainrunId: 82,
@@ -10191,53 +10191,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 304,
-                y: -1410
+                y: -1410,
               },
               {
                 x: 304,
-                y: -1474
+                y: -1474,
               },
               {
                 x: 304,
-                y: -1758
+                y: -1758,
               },
               {
                 x: 304,
-                y: -1822
-              }
+                y: -1822,
+              },
             ],
             textPositions: {
               0: {
                 x: 316,
-                y: -1428
+                y: -1428,
               },
               1: {
                 x: 292,
-                y: -1456
+                y: -1456,
               },
               2: {
                 x: 292,
-                y: -1804
+                y: -1804,
               },
               3: {
                 x: 316,
-                y: -1776
+                y: -1776,
               },
               4: {
                 x: 292,
-                y: -1616
+                y: -1616,
               },
               5: {
                 x: 292,
-                y: -1616
+                y: -1616,
               },
               6: {
                 x: 316,
-                y: -1616
-              }
-            }
+                y: -1616,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 555,
@@ -10250,35 +10250,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 19,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 55,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 115
+            consecutiveTime: 115,
           },
           sourceArrival: {
             lock: false,
             time: 5,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 65
+            consecutiveTime: 65,
           },
           targetDeparture: {
             lock: false,
             time: 46,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 46
+            consecutiveTime: 46,
           },
           targetArrival: {
             lock: false,
             time: 14,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 134
+            consecutiveTime: 134,
           },
           numberOfStops: 0,
           trainrunId: 83,
@@ -10288,53 +10288,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 176,
-                y: 1726
+                y: 1726,
               },
               {
                 x: 176,
-                y: 1662
+                y: 1662,
               },
               {
                 x: 176,
-                y: 1314
+                y: 1314,
               },
               {
                 x: 176,
-                y: 1250
-              }
+                y: 1250,
+              },
             ],
             textPositions: {
               0: {
                 x: 188,
-                y: 1708
+                y: 1708,
               },
               1: {
                 x: 164,
-                y: 1680
+                y: 1680,
               },
               2: {
                 x: 164,
-                y: 1268
+                y: 1268,
               },
               3: {
                 x: 188,
-                y: 1296
+                y: 1296,
               },
               4: {
                 x: 164,
-                y: 1488
+                y: 1488,
               },
               5: {
                 x: 164,
-                y: 1488
+                y: 1488,
               },
               6: {
                 x: 188,
-                y: 1488
-              }
-            }
+                y: 1488,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 556,
@@ -10347,35 +10347,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 8,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 14,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 134
+            consecutiveTime: 134,
           },
           sourceArrival: {
             lock: false,
             time: 46,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 46
+            consecutiveTime: 46,
           },
           targetDeparture: {
             lock: false,
             time: 38,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 38
+            consecutiveTime: 38,
           },
           targetArrival: {
             lock: false,
             time: 22,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 142
+            consecutiveTime: 142,
           },
           numberOfStops: 0,
           trainrunId: 83,
@@ -10385,53 +10385,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 176,
-                y: 1182
+                y: 1182,
               },
               {
                 x: 176,
-                y: 1118
+                y: 1118,
               },
               {
                 x: 176,
-                y: 866
+                y: 866,
               },
               {
                 x: 176,
-                y: 802
-              }
+                y: 802,
+              },
             ],
             textPositions: {
               0: {
                 x: 188,
-                y: 1164
+                y: 1164,
               },
               1: {
                 x: 164,
-                y: 1136
+                y: 1136,
               },
               2: {
                 x: 164,
-                y: 820
+                y: 820,
               },
               3: {
                 x: 188,
-                y: 848
+                y: 848,
               },
               4: {
                 x: 164,
-                y: 992
+                y: 992,
               },
               5: {
                 x: 164,
-                y: 992
+                y: 992,
               },
               6: {
                 x: 188,
-                y: 992
-              }
-            }
+                y: 992,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 557,
@@ -10444,35 +10444,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 8,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 22,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 142
+            consecutiveTime: 142,
           },
           sourceArrival: {
             lock: false,
             time: 38,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 38
+            consecutiveTime: 38,
           },
           targetDeparture: {
             lock: true,
             time: 30,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 30
+            consecutiveTime: 30,
           },
           targetArrival: {
             lock: true,
             time: 30,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 150
+            consecutiveTime: 150,
           },
           numberOfStops: 0,
           trainrunId: 83,
@@ -10482,53 +10482,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 144,
-                y: 734
+                y: 734,
               },
               {
                 x: 144,
-                y: 670
+                y: 670,
               },
               {
                 x: 144,
-                y: 414
+                y: 414,
               },
               {
                 x: 144,
-                y: 350
-              }
+                y: 350,
+              },
             ],
             textPositions: {
               0: {
                 x: 156,
-                y: 716
+                y: 716,
               },
               1: {
                 x: 132,
-                y: 688
+                y: 688,
               },
               2: {
                 x: 132,
-                y: 368
+                y: 368,
               },
               3: {
                 x: 156,
-                y: 396
+                y: 396,
               },
               4: {
                 x: 132,
-                y: 542
+                y: 542,
               },
               5: {
                 x: 132,
-                y: 542
+                y: 542,
               },
               6: {
                 x: 156,
-                y: 542
-              }
-            }
+                y: 542,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 558,
@@ -10541,35 +10541,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 10,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 32,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 152
+            consecutiveTime: 152,
           },
           sourceArrival: {
             lock: true,
             time: 28,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 28
+            consecutiveTime: 28,
           },
           targetDeparture: {
             lock: false,
             time: 18,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 18
+            consecutiveTime: 18,
           },
           targetArrival: {
             lock: false,
             time: 42,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 162
+            consecutiveTime: 162,
           },
           numberOfStops: 0,
           trainrunId: 83,
@@ -10579,53 +10579,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 208,
-                y: 94
+                y: 94,
               },
               {
                 x: 208,
-                y: 30
+                y: 30,
               },
               {
                 x: 208,
-                y: -290
+                y: -290,
               },
               {
                 x: 208,
-                y: -354
-              }
+                y: -354,
+              },
             ],
             textPositions: {
               0: {
                 x: 220,
-                y: 76
+                y: 76,
               },
               1: {
                 x: 196,
-                y: 48
+                y: 48,
               },
               2: {
                 x: 196,
-                y: -336
+                y: -336,
               },
               3: {
                 x: 220,
-                y: -308
+                y: -308,
               },
               4: {
                 x: 196,
-                y: -130
+                y: -130,
               },
               5: {
                 x: 196,
-                y: -130
+                y: -130,
               },
               6: {
                 x: 220,
-                y: -130
-              }
-            }
+                y: -130,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 559,
@@ -10638,35 +10638,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 5,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 42,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 162
+            consecutiveTime: 162,
           },
           sourceArrival: {
             lock: false,
             time: 18,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 18
+            consecutiveTime: 18,
           },
           targetDeparture: {
             lock: false,
             time: 13,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 13
+            consecutiveTime: 13,
           },
           targetArrival: {
             lock: false,
             time: 47,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 167
+            consecutiveTime: 167,
           },
           numberOfStops: 0,
           trainrunId: 83,
@@ -10676,53 +10676,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 272,
-                y: -450
+                y: -450,
               },
               {
                 x: 272,
-                y: -514
+                y: -514,
               },
               {
                 x: 272,
-                y: -798
+                y: -798,
               },
               {
                 x: 272,
-                y: -862
-              }
+                y: -862,
+              },
             ],
             textPositions: {
               0: {
                 x: 284,
-                y: -468
+                y: -468,
               },
               1: {
                 x: 260,
-                y: -496
+                y: -496,
               },
               2: {
                 x: 260,
-                y: -844
+                y: -844,
               },
               3: {
                 x: 284,
-                y: -816
+                y: -816,
               },
               4: {
                 x: 260,
-                y: -656
+                y: -656,
               },
               5: {
                 x: 260,
-                y: -656
+                y: -656,
               },
               6: {
                 x: 284,
-                y: -656
-              }
-            }
+                y: -656,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 560,
@@ -10735,35 +10735,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 5,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 47,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 167
+            consecutiveTime: 167,
           },
           sourceArrival: {
             lock: false,
             time: 13,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 13
+            consecutiveTime: 13,
           },
           targetDeparture: {
             lock: false,
             time: 8,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 8
+            consecutiveTime: 8,
           },
           targetArrival: {
             lock: false,
             time: 52,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 172
+            consecutiveTime: 172,
           },
           numberOfStops: 0,
           trainrunId: 83,
@@ -10773,53 +10773,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 272,
-                y: -930
+                y: -930,
               },
               {
                 x: 272,
-                y: -994
+                y: -994,
               },
               {
                 x: 272,
-                y: -1278
+                y: -1278,
               },
               {
                 x: 272,
-                y: -1342
-              }
+                y: -1342,
+              },
             ],
             textPositions: {
               0: {
                 x: 284,
-                y: -948
+                y: -948,
               },
               1: {
                 x: 260,
-                y: -976
+                y: -976,
               },
               2: {
                 x: 260,
-                y: -1324
+                y: -1324,
               },
               3: {
                 x: 284,
-                y: -1296
+                y: -1296,
               },
               4: {
                 x: 260,
-                y: -1136
+                y: -1136,
               },
               5: {
                 x: 260,
-                y: -1136
+                y: -1136,
               },
               6: {
                 x: 284,
-                y: -1136
-              }
-            }
+                y: -1136,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 561,
@@ -10832,35 +10832,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 5,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 52,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 172
+            consecutiveTime: 172,
           },
           sourceArrival: {
             lock: false,
             time: 8,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 8
+            consecutiveTime: 8,
           },
           targetDeparture: {
             lock: false,
             time: 3,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 3
+            consecutiveTime: 3,
           },
           targetArrival: {
             lock: false,
             time: 57,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 177
+            consecutiveTime: 177,
           },
           numberOfStops: 0,
           trainrunId: 83,
@@ -10870,53 +10870,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 272,
-                y: -1410
+                y: -1410,
               },
               {
                 x: 272,
-                y: -1474
+                y: -1474,
               },
               {
                 x: 272,
-                y: -1758
+                y: -1758,
               },
               {
                 x: 272,
-                y: -1822
-              }
+                y: -1822,
+              },
             ],
             textPositions: {
               0: {
                 x: 284,
-                y: -1428
+                y: -1428,
               },
               1: {
                 x: 260,
-                y: -1456
+                y: -1456,
               },
               2: {
                 x: 260,
-                y: -1804
+                y: -1804,
               },
               3: {
                 x: 284,
-                y: -1776
+                y: -1776,
               },
               4: {
                 x: 260,
-                y: -1616
+                y: -1616,
               },
               5: {
                 x: 260,
-                y: -1616
+                y: -1616,
               },
               6: {
                 x: 284,
-                y: -1616
-              }
-            }
+                y: -1616,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 562,
@@ -10929,35 +10929,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 12,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 9,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 9
+            consecutiveTime: 9,
           },
           sourceArrival: {
             lock: true,
             time: 51,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 291
+            consecutiveTime: 291,
           },
           targetDeparture: {
             lock: true,
             time: 39,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 279
+            consecutiveTime: 279,
           },
           targetArrival: {
             lock: true,
             time: 21,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 21
+            consecutiveTime: 21,
           },
           numberOfStops: 1,
           trainrunId: 84,
@@ -10967,53 +10967,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2850,
-                y: 176
+                y: 176,
               },
               {
                 x: 2914,
-                y: 176
+                y: 176,
               },
               {
                 x: 3230,
-                y: 176
+                y: 176,
               },
               {
                 x: 3294,
-                y: 176
-              }
+                y: 176,
+              },
             ],
             textPositions: {
               0: {
                 x: 2868,
-                y: 188
+                y: 188,
               },
               1: {
                 x: 2896,
-                y: 164
+                y: 164,
               },
               2: {
                 x: 3276,
-                y: 164
+                y: 164,
               },
               3: {
                 x: 3248,
-                y: 188
+                y: 188,
               },
               4: {
                 x: 3072,
-                y: 164
+                y: 164,
               },
               5: {
                 x: 3072,
-                y: 164
+                y: 164,
               },
               6: {
                 x: 3072,
-                y: 188
-              }
-            }
+                y: 188,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 563,
@@ -11026,35 +11026,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 13,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 23,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 23
+            consecutiveTime: 23,
           },
           sourceArrival: {
             lock: false,
             time: 37,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 277
+            consecutiveTime: 277,
           },
           targetDeparture: {
             lock: true,
             time: 24,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 264
+            consecutiveTime: 264,
           },
           targetArrival: {
             lock: true,
             time: 36,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 36
+            consecutiveTime: 36,
           },
           numberOfStops: 0,
           trainrunId: 84,
@@ -11064,53 +11064,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 3394,
-                y: 176
+                y: 176,
               },
               {
                 x: 3458,
-                y: 176
+                y: 176,
               },
               {
                 x: 3806,
-                y: 176
+                y: 176,
               },
               {
                 x: 3870,
-                y: 176
-              }
+                y: 176,
+              },
             ],
             textPositions: {
               0: {
                 x: 3412,
-                y: 188
+                y: 188,
               },
               1: {
                 x: 3440,
-                y: 164
+                y: 164,
               },
               2: {
                 x: 3852,
-                y: 164
+                y: 164,
               },
               3: {
                 x: 3824,
-                y: 188
+                y: 188,
               },
               4: {
                 x: 3632,
-                y: 164
+                y: 164,
               },
               5: {
                 x: 3632,
-                y: 164
+                y: 164,
               },
               6: {
                 x: 3632,
-                y: 188
-              }
-            }
+                y: 188,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 564,
@@ -11123,35 +11123,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 44,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 38,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 38
+            consecutiveTime: 38,
           },
           sourceArrival: {
             lock: false,
             time: 22,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 262
+            consecutiveTime: 262,
           },
           targetDeparture: {
             lock: false,
             time: 38,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 218
+            consecutiveTime: 218,
           },
           targetArrival: {
             lock: false,
             time: 22,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 82
+            consecutiveTime: 82,
           },
           numberOfStops: 4,
           trainrunId: 84,
@@ -11161,53 +11161,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 3970,
-                y: 176
+                y: 176,
               },
               {
                 x: 4034,
-                y: 176
+                y: 176,
               },
               {
                 x: 4574,
-                y: 176
+                y: 176,
               },
               {
                 x: 4638,
-                y: 176
-              }
+                y: 176,
+              },
             ],
             textPositions: {
               0: {
                 x: 3988,
-                y: 188
+                y: 188,
               },
               1: {
                 x: 4016,
-                y: 164
+                y: 164,
               },
               2: {
                 x: 4620,
-                y: 164
+                y: 164,
               },
               3: {
                 x: 4592,
-                y: 188
+                y: 188,
               },
               4: {
                 x: 4304,
-                y: 164
+                y: 164,
               },
               5: {
                 x: 4304,
-                y: 164
+                y: 164,
               },
               6: {
                 x: 4304,
-                y: 188
-              }
-            }
+                y: 188,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 565,
@@ -11220,35 +11220,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 61,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 24,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 84
+            consecutiveTime: 84,
           },
           sourceArrival: {
             lock: false,
             time: 36,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 216
+            consecutiveTime: 216,
           },
           targetDeparture: {
             lock: false,
             time: 35,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 155
+            consecutiveTime: 155,
           },
           targetArrival: {
             lock: false,
             time: 25,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 145
+            consecutiveTime: 145,
           },
           numberOfStops: 5,
           trainrunId: 84,
@@ -11258,53 +11258,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 4656,
-                y: 222
+                y: 222,
               },
               {
                 x: 4656,
-                y: 286
+                y: 286,
               },
               {
                 x: 4656,
-                y: 1118
+                y: 1118,
               },
               {
                 x: 4656,
-                y: 1182
-              }
+                y: 1182,
+              },
             ],
             textPositions: {
               0: {
                 x: 4644,
-                y: 240
+                y: 240,
               },
               1: {
                 x: 4668,
-                y: 268
+                y: 268,
               },
               2: {
                 x: 4668,
-                y: 1164
+                y: 1164,
               },
               3: {
                 x: 4644,
-                y: 1136
+                y: 1136,
               },
               4: {
                 x: 4644,
-                y: 702
+                y: 702,
               },
               5: {
                 x: 4644,
-                y: 702
+                y: 702,
               },
               6: {
                 x: 4668,
-                y: 702
-              }
-            }
+                y: 702,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 566,
@@ -11317,35 +11317,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 22,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 26,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 146
+            consecutiveTime: 146,
           },
           sourceArrival: {
             lock: true,
             time: 34,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 154
+            consecutiveTime: 154,
           },
           targetDeparture: {
             lock: true,
             time: 12,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 132
+            consecutiveTime: 132,
           },
           targetArrival: {
             lock: true,
             time: 48,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 168
+            consecutiveTime: 168,
           },
           numberOfStops: 2,
           trainrunId: 84,
@@ -11355,53 +11355,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 4688,
-                y: 1278
+                y: 1278,
               },
               {
                 x: 4688,
-                y: 1342
+                y: 1342,
               },
               {
                 x: 4688,
-                y: 1822
+                y: 1822,
               },
               {
                 x: 4688,
-                y: 1886
-              }
+                y: 1886,
+              },
             ],
             textPositions: {
               0: {
                 x: 4676,
-                y: 1296
+                y: 1296,
               },
               1: {
                 x: 4700,
-                y: 1324
+                y: 1324,
               },
               2: {
                 x: 4700,
-                y: 1868
+                y: 1868,
               },
               3: {
                 x: 4676,
-                y: 1840
+                y: 1840,
               },
               4: {
                 x: 4676,
-                y: 1582
+                y: 1582,
               },
               5: {
                 x: 4676,
-                y: 1582
+                y: 1582,
               },
               6: {
                 x: 4700,
-                y: 1582
-              }
-            }
+                y: 1582,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 567,
@@ -11414,35 +11414,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 8,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 7,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 67
+            consecutiveTime: 67,
           },
           sourceArrival: {
             lock: true,
             time: 53,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 293
+            consecutiveTime: 293,
           },
           targetDeparture: {
             lock: false,
             time: 45,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 285
+            consecutiveTime: 285,
           },
           targetArrival: {
             lock: false,
             time: 15,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 75
+            consecutiveTime: 75,
           },
           numberOfStops: 0,
           trainrunId: 85,
@@ -11452,53 +11452,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2704,
-                y: 350
+                y: 350,
               },
               {
                 x: 2704,
-                y: 414
+                y: 414,
               },
               {
                 x: 2704,
-                y: 670
+                y: 670,
               },
               {
                 x: 2704,
-                y: 734
-              }
+                y: 734,
+              },
             ],
             textPositions: {
               0: {
                 x: 2692,
-                y: 368
+                y: 368,
               },
               1: {
                 x: 2716,
-                y: 396
+                y: 396,
               },
               2: {
                 x: 2716,
-                y: 716
+                y: 716,
               },
               3: {
                 x: 2692,
-                y: 688
+                y: 688,
               },
               4: {
                 x: 2692,
-                y: 542
+                y: 542,
               },
               5: {
                 x: 2692,
-                y: 542
+                y: 542,
               },
               6: {
                 x: 2716,
-                y: 542
-              }
-            }
+                y: 542,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 568,
@@ -11511,35 +11511,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 19,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 3,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 123
+            consecutiveTime: 123,
           },
           sourceArrival: {
             lock: true,
             time: 57,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 237
+            consecutiveTime: 237,
           },
           targetDeparture: {
             lock: true,
             time: 38,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 218
+            consecutiveTime: 218,
           },
           targetArrival: {
             lock: true,
             time: 22,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 142
+            consecutiveTime: 142,
           },
           numberOfStops: 1,
           trainrunId: 85,
@@ -11549,53 +11549,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 4656,
-                y: 1278
+                y: 1278,
               },
               {
                 x: 4656,
-                y: 1342
+                y: 1342,
               },
               {
                 x: 4656,
-                y: 1822
+                y: 1822,
               },
               {
                 x: 4656,
-                y: 1886
-              }
+                y: 1886,
+              },
             ],
             textPositions: {
               0: {
                 x: 4644,
-                y: 1296
+                y: 1296,
               },
               1: {
                 x: 4668,
-                y: 1324
+                y: 1324,
               },
               2: {
                 x: 4668,
-                y: 1868
+                y: 1868,
               },
               3: {
                 x: 4644,
-                y: 1840
+                y: 1840,
               },
               4: {
                 x: 4644,
-                y: 1582
+                y: 1582,
               },
               5: {
                 x: 4644,
-                y: 1582
+                y: 1582,
               },
               6: {
                 x: 4668,
-                y: 1582
-              }
-            }
+                y: 1582,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 569,
@@ -11608,35 +11608,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 8,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 12,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 132
+            consecutiveTime: 132,
           },
           sourceArrival: {
             lock: false,
             time: 48,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 288
+            consecutiveTime: 288,
           },
           targetDeparture: {
             lock: true,
             time: 40,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 280
+            consecutiveTime: 280,
           },
           targetArrival: {
             lock: true,
             time: 20,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 140
+            consecutiveTime: 140,
           },
           numberOfStops: 0,
           trainrunId: 86,
@@ -11646,53 +11646,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2736,
-                y: 350
+                y: 350,
               },
               {
                 x: 2736,
-                y: 414
+                y: 414,
               },
               {
                 x: 2736,
-                y: 670
+                y: 670,
               },
               {
                 x: 2736,
-                y: 734
-              }
+                y: 734,
+              },
             ],
             textPositions: {
               0: {
                 x: 2724,
-                y: 368
+                y: 368,
               },
               1: {
                 x: 2748,
-                y: 396
+                y: 396,
               },
               2: {
                 x: 2748,
-                y: 716
+                y: 716,
               },
               3: {
                 x: 2724,
-                y: 688
+                y: 688,
               },
               4: {
                 x: 2724,
-                y: 542
+                y: 542,
               },
               5: {
                 x: 2724,
-                y: 542
+                y: 542,
               },
               6: {
                 x: 2748,
-                y: 542
-              }
-            }
+                y: 542,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 570,
@@ -11705,35 +11705,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 20,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 23,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 203
+            consecutiveTime: 203,
           },
           sourceArrival: {
             lock: true,
             time: 37,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 217
+            consecutiveTime: 217,
           },
           targetDeparture: {
             lock: true,
             time: 17,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 197
+            consecutiveTime: 197,
           },
           targetArrival: {
             lock: true,
             time: 43,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 223
+            consecutiveTime: 223,
           },
           numberOfStops: 1,
           trainrunId: 86,
@@ -11743,53 +11743,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 4720,
-                y: 1278
+                y: 1278,
               },
               {
                 x: 4720,
-                y: 1342
+                y: 1342,
               },
               {
                 x: 4720,
-                y: 1822
+                y: 1822,
               },
               {
                 x: 4720,
-                y: 1886
-              }
+                y: 1886,
+              },
             ],
             textPositions: {
               0: {
                 x: 4708,
-                y: 1296
+                y: 1296,
               },
               1: {
                 x: 4732,
-                y: 1324
+                y: 1324,
               },
               2: {
                 x: 4732,
-                y: 1868
+                y: 1868,
               },
               3: {
                 x: 4708,
-                y: 1840
+                y: 1840,
               },
               4: {
                 x: 4708,
-                y: 1582
+                y: 1582,
               },
               5: {
                 x: 4708,
-                y: 1582
+                y: 1582,
               },
               6: {
                 x: 4732,
-                y: 1582
-              }
-            }
+                y: 1582,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 571,
@@ -11802,35 +11802,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 7,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 54,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 294
+            consecutiveTime: 294,
           },
           sourceArrival: {
             lock: true,
             time: 6,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 126
+            consecutiveTime: 126,
           },
           targetDeparture: {
             lock: false,
             time: 59,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 119
+            consecutiveTime: 119,
           },
           targetArrival: {
             lock: false,
             time: 1,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 301
+            consecutiveTime: 301,
           },
           numberOfStops: 1,
           trainrunId: 86,
@@ -11840,53 +11840,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2654,
-                y: 240
+                y: 240,
               },
               {
                 x: 2590,
-                y: 240
+                y: 240,
               },
               {
                 x: 2402,
-                y: 240
+                y: 240,
               },
               {
                 x: 2338,
-                y: 240
-              }
+                y: 240,
+              },
             ],
             textPositions: {
               0: {
                 x: 2636,
-                y: 228
+                y: 228,
               },
               1: {
                 x: 2608,
-                y: 252
+                y: 252,
               },
               2: {
                 x: 2356,
-                y: 252
+                y: 252,
               },
               3: {
                 x: 2384,
-                y: 228
+                y: 228,
               },
               4: {
                 x: 2496,
-                y: 228
+                y: 228,
               },
               5: {
                 x: 2496,
-                y: 228
+                y: 228,
               },
               6: {
                 x: 2496,
-                y: 252
-              }
-            }
+                y: 252,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 572,
@@ -11899,35 +11899,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 7,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 1,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 301
+            consecutiveTime: 301,
           },
           sourceArrival: {
             lock: false,
             time: 59,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 119
+            consecutiveTime: 119,
           },
           targetDeparture: {
             lock: false,
             time: 52,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 112
+            consecutiveTime: 112,
           },
           targetArrival: {
             lock: false,
             time: 8,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 308
+            consecutiveTime: 308,
           },
           numberOfStops: 0,
           trainrunId: 86,
@@ -11937,53 +11937,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2238,
-                y: 240
+                y: 240,
               },
               {
                 x: 2174,
-                y: 240
+                y: 240,
               },
               {
                 x: 1954,
-                y: 240
+                y: 240,
               },
               {
                 x: 1890,
-                y: 240
-              }
+                y: 240,
+              },
             ],
             textPositions: {
               0: {
                 x: 2220,
-                y: 228
+                y: 228,
               },
               1: {
                 x: 2192,
-                y: 252
+                y: 252,
               },
               2: {
                 x: 1908,
-                y: 252
+                y: 252,
               },
               3: {
                 x: 1936,
-                y: 228
+                y: 228,
               },
               4: {
                 x: 2064,
-                y: 228
+                y: 228,
               },
               5: {
                 x: 2064,
-                y: 228
+                y: 228,
               },
               6: {
                 x: 2064,
-                y: 252
-              }
-            }
+                y: 252,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 573,
@@ -11996,35 +11996,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 7,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 15,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 315
+            consecutiveTime: 315,
           },
           sourceArrival: {
             lock: false,
             time: 45,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 105
+            consecutiveTime: 105,
           },
           targetDeparture: {
             lock: false,
             time: 38,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 98
+            consecutiveTime: 98,
           },
           targetArrival: {
             lock: false,
             time: 22,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 322
+            consecutiveTime: 322,
           },
           numberOfStops: 0,
           trainrunId: 86,
@@ -12034,53 +12034,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 1342,
-                y: 240
+                y: 240,
               },
               {
                 x: 1278,
-                y: 240
+                y: 240,
               },
               {
                 x: 1122,
-                y: 240
+                y: 240,
               },
               {
                 x: 1058,
-                y: 240
-              }
+                y: 240,
+              },
             ],
             textPositions: {
               0: {
                 x: 1324,
-                y: 228
+                y: 228,
               },
               1: {
                 x: 1296,
-                y: 252
+                y: 252,
               },
               2: {
                 x: 1076,
-                y: 252
+                y: 252,
               },
               3: {
                 x: 1104,
-                y: 228
+                y: 228,
               },
               4: {
                 x: 1200,
-                y: 228
+                y: 228,
               },
               5: {
                 x: 1200,
-                y: 228
+                y: 228,
               },
               6: {
                 x: 1200,
-                y: 252
-              }
-            }
+                y: 252,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 574,
@@ -12093,35 +12093,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 8,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 22,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 322
+            consecutiveTime: 322,
           },
           sourceArrival: {
             lock: false,
             time: 38,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 98
+            consecutiveTime: 98,
           },
           targetDeparture: {
             lock: true,
             time: 30,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 90
+            consecutiveTime: 90,
           },
           targetArrival: {
             lock: true,
             time: 30,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 330
+            consecutiveTime: 330,
           },
           numberOfStops: 0,
           trainrunId: 86,
@@ -12131,53 +12131,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 958,
-                y: 240
+                y: 240,
               },
               {
                 x: 894,
-                y: 240
+                y: 240,
               },
               {
                 x: 322,
-                y: 240
+                y: 240,
               },
               {
                 x: 258,
-                y: 240
-              }
+                y: 240,
+              },
             ],
             textPositions: {
               0: {
                 x: 940,
-                y: 228
+                y: 228,
               },
               1: {
                 x: 912,
-                y: 252
+                y: 252,
               },
               2: {
                 x: 276,
-                y: 252
+                y: 252,
               },
               3: {
                 x: 304,
-                y: 228
+                y: 228,
               },
               4: {
                 x: 608,
-                y: 228
+                y: 228,
               },
               5: {
                 x: 608,
-                y: 228
+                y: 228,
               },
               6: {
                 x: 608,
-                y: 252
-              }
-            }
+                y: 252,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 575,
@@ -12190,35 +12190,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 7,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 36,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 336
+            consecutiveTime: 336,
           },
           sourceArrival: {
             lock: true,
             time: 24,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 84
+            consecutiveTime: 84,
           },
           targetDeparture: {
             lock: false,
             time: 17,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 77
+            consecutiveTime: 77,
           },
           targetArrival: {
             lock: false,
             time: 43,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 343
+            consecutiveTime: 343,
           },
           numberOfStops: 0,
           trainrunId: 86,
@@ -12228,53 +12228,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 62,
-                y: 304
+                y: 304,
               },
               {
                 x: -2,
-                y: 304
+                y: 304,
               },
               {
                 x: -446,
-                y: 304
+                y: 304,
               },
               {
                 x: -510,
-                y: 304
-              }
+                y: 304,
+              },
             ],
             textPositions: {
               0: {
                 x: 44,
-                y: 292
+                y: 292,
               },
               1: {
                 x: 16,
-                y: 316
+                y: 316,
               },
               2: {
                 x: -492,
-                y: 316
+                y: 316,
               },
               3: {
                 x: -464,
-                y: 292
+                y: 292,
               },
               4: {
                 x: -224,
-                y: 292
+                y: 292,
               },
               5: {
                 x: -224,
-                y: 292
+                y: 292,
               },
               6: {
                 x: -224,
-                y: 316
-              }
-            }
+                y: 316,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 576,
@@ -12287,35 +12287,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 33,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 58,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 298
+            consecutiveTime: 298,
           },
           sourceArrival: {
             lock: false,
             time: 2,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 242
+            consecutiveTime: 242,
           },
           targetDeparture: {
             lock: false,
             time: 29,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 209
+            consecutiveTime: 209,
           },
           targetArrival: {
             lock: false,
             time: 31,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 331
+            consecutiveTime: 331,
           },
           numberOfStops: 0,
           trainrunId: 87,
@@ -12325,53 +12325,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 4638,
-                y: 144
+                y: 144,
               },
               {
                 x: 4574,
-                y: 144
+                y: 144,
               },
               {
                 x: 4034,
-                y: 144
+                y: 144,
               },
               {
                 x: 3970,
-                y: 144
-              }
+                y: 144,
+              },
             ],
             textPositions: {
               0: {
                 x: 4620,
-                y: 132
+                y: 132,
               },
               1: {
                 x: 4592,
-                y: 156
+                y: 156,
               },
               2: {
                 x: 3988,
-                y: 156
+                y: 156,
               },
               3: {
                 x: 4016,
-                y: 132
+                y: 132,
               },
               4: {
                 x: 4304,
-                y: 132
+                y: 132,
               },
               5: {
                 x: 4304,
-                y: 132
+                y: 132,
               },
               6: {
                 x: 4304,
-                y: 156
-              }
-            }
+                y: 156,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 577,
@@ -12384,35 +12384,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 14,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 33,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 333
+            consecutiveTime: 333,
           },
           sourceArrival: {
             lock: false,
             time: 27,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 207
+            consecutiveTime: 207,
           },
           targetDeparture: {
             lock: true,
             time: 13,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 193
+            consecutiveTime: 193,
           },
           targetArrival: {
             lock: true,
             time: 47,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 347
+            consecutiveTime: 347,
           },
           numberOfStops: 0,
           trainrunId: 87,
@@ -12422,53 +12422,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 3870,
-                y: 80
+                y: 80,
               },
               {
                 x: 3806,
-                y: 80
+                y: 80,
               },
               {
                 x: 3458,
-                y: 80
+                y: 80,
               },
               {
                 x: 3394,
-                y: 80
-              }
+                y: 80,
+              },
             ],
             textPositions: {
               0: {
                 x: 3852,
-                y: 68
+                y: 68,
               },
               1: {
                 x: 3824,
-                y: 92
+                y: 92,
               },
               2: {
                 x: 3412,
-                y: 92
+                y: 92,
               },
               3: {
                 x: 3440,
-                y: 68
+                y: 68,
               },
               4: {
                 x: 3632,
-                y: 68
+                y: 68,
               },
               5: {
                 x: 3632,
-                y: 68
+                y: 68,
               },
               6: {
                 x: 3632,
-                y: 92
-              }
-            }
+                y: 92,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 578,
@@ -12481,35 +12481,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 9,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 48,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 348
+            consecutiveTime: 348,
           },
           sourceArrival: {
             lock: true,
             time: 12,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 192
+            consecutiveTime: 192,
           },
           targetDeparture: {
             lock: true,
             time: 3,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 183
+            consecutiveTime: 183,
           },
           targetArrival: {
             lock: true,
             time: 57,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 357
+            consecutiveTime: 357,
           },
           numberOfStops: 0,
           trainrunId: 87,
@@ -12519,53 +12519,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 3294,
-                y: 80
+                y: 80,
               },
               {
                 x: 3230,
-                y: 80
+                y: 80,
               },
               {
                 x: 2914,
-                y: 80
+                y: 80,
               },
               {
                 x: 2850,
-                y: 80
-              }
+                y: 80,
+              },
             ],
             textPositions: {
               0: {
                 x: 3276,
-                y: 68
+                y: 68,
               },
               1: {
                 x: 3248,
-                y: 92
+                y: 92,
               },
               2: {
                 x: 2868,
-                y: 92
+                y: 92,
               },
               3: {
                 x: 2896,
-                y: 68
+                y: 68,
               },
               4: {
                 x: 3072,
-                y: 68
+                y: 68,
               },
               5: {
                 x: 3072,
-                y: 68
+                y: 68,
               },
               6: {
                 x: 3072,
-                y: 92
-              }
-            }
+                y: 92,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 579,
@@ -12578,41 +12578,41 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 10,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 4,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 364
+            consecutiveTime: 364,
           },
           sourceArrival: {
             lock: true,
             time: 56,
             warning: {
               title: "Quelle Ankunft Warnung",
-              description: "Quellankunftszeit kann nicht erreicht werden"
+              description: "Quellankunftszeit kann nicht erreicht werden",
             },
             timeFormatter: null,
-            consecutiveTime: 176
+            consecutiveTime: 176,
           },
           targetDeparture: {
             lock: false,
             time: 50,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 170
+            consecutiveTime: 170,
           },
           targetArrival: {
             lock: false,
             time: 10,
             warning: {
               title: "Ziel Ankunft Warnung",
-              description: "Zielankunftszeit kann nicht erreicht werden"
+              description: "Zielankunftszeit kann nicht erreicht werden",
             },
             timeFormatter: null,
-            consecutiveTime: 370
+            consecutiveTime: 370,
           },
           numberOfStops: 0,
           trainrunId: 87,
@@ -12622,53 +12622,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2654,
-                y: 144
+                y: 144,
               },
               {
                 x: 2590,
-                y: 144
+                y: 144,
               },
               {
                 x: 2402,
-                y: 144
+                y: 144,
               },
               {
                 x: 2338,
-                y: 144
-              }
+                y: 144,
+              },
             ],
             textPositions: {
               0: {
                 x: 2636,
-                y: 132
+                y: 132,
               },
               1: {
                 x: 2608,
-                y: 156
+                y: 156,
               },
               2: {
                 x: 2356,
-                y: 156
+                y: 156,
               },
               3: {
                 x: 2384,
-                y: 132
+                y: 132,
               },
               4: {
                 x: 2496,
-                y: 132
+                y: 132,
               },
               5: {
                 x: 2496,
-                y: 132
+                y: 132,
               },
               6: {
                 x: 2496,
-                y: 156
-              }
-            }
+                y: 156,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 580,
@@ -12681,35 +12681,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 7,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 10,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 370
+            consecutiveTime: 370,
           },
           sourceArrival: {
             lock: false,
             time: 50,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 170
+            consecutiveTime: 170,
           },
           targetDeparture: {
             lock: false,
             time: 43,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 163
+            consecutiveTime: 163,
           },
           targetArrival: {
             lock: false,
             time: 17,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 377
+            consecutiveTime: 377,
           },
           numberOfStops: 0,
           trainrunId: 87,
@@ -12719,53 +12719,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2238,
-                y: 144
+                y: 144,
               },
               {
                 x: 2174,
-                y: 144
+                y: 144,
               },
               {
                 x: 1954,
-                y: 144
+                y: 144,
               },
               {
                 x: 1890,
-                y: 144
-              }
+                y: 144,
+              },
             ],
             textPositions: {
               0: {
                 x: 2220,
-                y: 132
+                y: 132,
               },
               1: {
                 x: 2192,
-                y: 156
+                y: 156,
               },
               2: {
                 x: 1908,
-                y: 156
+                y: 156,
               },
               3: {
                 x: 1936,
-                y: 132
+                y: 132,
               },
               4: {
                 x: 2064,
-                y: 132
+                y: 132,
               },
               5: {
                 x: 2064,
-                y: 132
+                y: 132,
               },
               6: {
                 x: 2064,
-                y: 156
-              }
-            }
+                y: 156,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 581,
@@ -12778,35 +12778,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 5,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 24,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 384
+            consecutiveTime: 384,
           },
           sourceArrival: {
             lock: false,
             time: 36,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 156
+            consecutiveTime: 156,
           },
           targetDeparture: {
             lock: true,
             time: 31,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 151
+            consecutiveTime: 151,
           },
           targetArrival: {
             lock: true,
             time: 29,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 389
+            consecutiveTime: 389,
           },
           numberOfStops: 0,
           trainrunId: 87,
@@ -12816,53 +12816,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 1342,
-                y: 144
+                y: 144,
               },
               {
                 x: 1278,
-                y: 144
+                y: 144,
               },
               {
                 x: 1122,
-                y: 144
+                y: 144,
               },
               {
                 x: 1058,
-                y: 144
-              }
+                y: 144,
+              },
             ],
             textPositions: {
               0: {
                 x: 1324,
-                y: 132
+                y: 132,
               },
               1: {
                 x: 1296,
-                y: 156
+                y: 156,
               },
               2: {
                 x: 1076,
-                y: 156
+                y: 156,
               },
               3: {
                 x: 1104,
-                y: 132
+                y: 132,
               },
               4: {
                 x: 1200,
-                y: 132
+                y: 132,
               },
               5: {
                 x: 1200,
-                y: 132
+                y: 132,
               },
               6: {
                 x: 1200,
-                y: 156
-              }
-            }
+                y: 156,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 582,
@@ -12875,35 +12875,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 9,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 31,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 391
+            consecutiveTime: 391,
           },
           sourceArrival: {
             lock: true,
             time: 29,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 149
+            consecutiveTime: 149,
           },
           targetDeparture: {
             lock: true,
             time: 20,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 140
+            consecutiveTime: 140,
           },
           targetArrival: {
             lock: true,
             time: 40,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 400
+            consecutiveTime: 400,
           },
           numberOfStops: 0,
           trainrunId: 87,
@@ -12913,53 +12913,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 958,
-                y: 144
+                y: 144,
               },
               {
                 x: 894,
-                y: 144
+                y: 144,
               },
               {
                 x: 322,
-                y: 144
+                y: 144,
               },
               {
                 x: 258,
-                y: 144
-              }
+                y: 144,
+              },
             ],
             textPositions: {
               0: {
                 x: 940,
-                y: 132
+                y: 132,
               },
               1: {
                 x: 912,
-                y: 156
+                y: 156,
               },
               2: {
                 x: 276,
-                y: 156
+                y: 156,
               },
               3: {
                 x: 304,
-                y: 132
+                y: 132,
               },
               4: {
                 x: 608,
-                y: 132
+                y: 132,
               },
               5: {
                 x: 608,
-                y: 132
+                y: 132,
               },
               6: {
                 x: 608,
-                y: 156
-              }
-            }
+                y: 156,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 583,
@@ -12972,35 +12972,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 17,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 42,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 402
+            consecutiveTime: 402,
           },
           sourceArrival: {
             lock: true,
             time: 18,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 138
+            consecutiveTime: 138,
           },
           targetDeparture: {
             lock: false,
             time: 1,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 121
+            consecutiveTime: 121,
           },
           targetArrival: {
             lock: false,
             time: 59,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 419
+            consecutiveTime: 419,
           },
           numberOfStops: 0,
           trainrunId: 87,
@@ -13010,53 +13010,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 62,
-                y: 112
+                y: 112,
               },
               {
                 x: -2,
-                y: 112
+                y: 112,
               },
               {
                 x: -1534,
-                y: -16
+                y: -16,
               },
               {
                 x: -1598,
-                y: -16
-              }
+                y: -16,
+              },
             ],
             textPositions: {
               0: {
                 x: 44,
-                y: 100
+                y: 100,
               },
               1: {
                 x: 16,
-                y: 124
+                y: 124,
               },
               2: {
                 x: -1580,
-                y: -4
+                y: -4,
               },
               3: {
                 x: -1552,
-                y: -28
+                y: -28,
               },
               4: {
                 x: -768,
-                y: 36
+                y: 36,
               },
               5: {
                 x: -768,
-                y: 36
+                y: 36,
               },
               6: {
                 x: -768,
-                y: 60
-              }
-            }
+                y: 60,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 584,
@@ -13069,35 +13069,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 61,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 17,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 437
+            consecutiveTime: 437,
           },
           sourceArrival: {
             lock: true,
             time: 43,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 103
+            consecutiveTime: 103,
           },
           targetDeparture: {
             lock: true,
             time: 42,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 42
+            consecutiveTime: 42,
           },
           targetArrival: {
             lock: true,
             time: 18,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 498
+            consecutiveTime: 498,
           },
           numberOfStops: 2,
           trainrunId: 87,
@@ -13107,53 +13107,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: -2530,
-                y: -16
+                y: -16,
               },
               {
                 x: -2594,
-                y: -16
+                y: -16,
               },
               {
                 x: -3358,
-                y: 560
+                y: 560,
               },
               {
                 x: -3422,
-                y: 560
-              }
+                y: 560,
+              },
             ],
             textPositions: {
               0: {
                 x: -2548,
-                y: -28
+                y: -28,
               },
               1: {
                 x: -2576,
-                y: -4
+                y: -4,
               },
               2: {
                 x: -3404,
-                y: 572
+                y: 572,
               },
               3: {
                 x: -3376,
-                y: 548
+                y: 548,
               },
               4: {
                 x: -2976,
-                y: 260
+                y: 260,
               },
               5: {
                 x: -2976,
-                y: 260
+                y: 260,
               },
               6: {
                 x: -2976,
-                y: 284
-              }
-            }
+                y: 284,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 585,
@@ -13166,35 +13166,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 8,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 48,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 528
+            consecutiveTime: 528,
           },
           sourceArrival: {
             lock: true,
             time: 12,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 12
+            consecutiveTime: 12,
           },
           targetDeparture: {
             lock: false,
             time: 4,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 4
+            consecutiveTime: 4,
           },
           targetArrival: {
             lock: false,
             time: 56,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 536
+            consecutiveTime: 536,
           },
           numberOfStops: 0,
           trainrunId: 87,
@@ -13204,53 +13204,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: -3938,
-                y: 656
+                y: 656,
               },
               {
                 x: -4002,
-                y: 656
+                y: 656,
               },
               {
                 x: -4190,
-                y: 656
+                y: 656,
               },
               {
                 x: -4254,
-                y: 656
-              }
+                y: 656,
+              },
             ],
             textPositions: {
               0: {
                 x: -3956,
-                y: 644
+                y: 644,
               },
               1: {
                 x: -3984,
-                y: 668
+                y: 668,
               },
               2: {
                 x: -4236,
-                y: 668
+                y: 668,
               },
               3: {
                 x: -4208,
-                y: 644
+                y: 644,
               },
               4: {
                 x: -4096,
-                y: 644
+                y: 644,
               },
               5: {
                 x: -4096,
-                y: 644
+                y: 644,
               },
               6: {
                 x: -4096,
-                y: 668
-              }
-            }
+                y: 668,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 586,
@@ -13263,35 +13263,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 11,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 19,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 439
+            consecutiveTime: 439,
           },
           sourceArrival: {
             lock: true,
             time: 41,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 101
+            consecutiveTime: 101,
           },
           targetDeparture: {
             lock: true,
             time: 30,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 90
+            consecutiveTime: 90,
           },
           targetArrival: {
             lock: true,
             time: 30,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 450
+            consecutiveTime: 450,
           },
           numberOfStops: 0,
           trainrunId: 81,
@@ -13301,53 +13301,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: -3074,
-                y: 592
+                y: 592,
               },
               {
                 x: -3138,
-                y: 592
+                y: 592,
               },
               {
                 x: -3358,
-                y: 624
+                y: 624,
               },
               {
                 x: -3422,
-                y: 624
-              }
+                y: 624,
+              },
             ],
             textPositions: {
               0: {
                 x: -3092,
-                y: 580
+                y: 580,
               },
               1: {
                 x: -3120,
-                y: 604
+                y: 604,
               },
               2: {
                 x: -3404,
-                y: 636
+                y: 636,
               },
               3: {
                 x: -3376,
-                y: 612
+                y: 612,
               },
               4: {
                 x: -3248,
-                y: 596
+                y: 596,
               },
               5: {
                 x: -3248,
-                y: 596
+                y: 596,
               },
               6: {
                 x: -3248,
-                y: 620
-              }
-            }
+                y: 620,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 587,
@@ -13360,35 +13360,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 8,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 4,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 484
+            consecutiveTime: 484,
           },
           sourceArrival: {
             lock: true,
             time: 56,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 56
+            consecutiveTime: 56,
           },
           targetDeparture: {
             lock: true,
             time: 48,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 48
+            consecutiveTime: 48,
           },
           targetArrival: {
             lock: true,
             time: 12,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 492
+            consecutiveTime: 492,
           },
           numberOfStops: 0,
           trainrunId: 81,
@@ -13398,53 +13398,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: -3938,
-                y: 688
+                y: 688,
               },
               {
                 x: -4002,
-                y: 688
+                y: 688,
               },
               {
                 x: -4190,
-                y: 688
+                y: 688,
               },
               {
                 x: -4254,
-                y: 688
-              }
+                y: 688,
+              },
             ],
             textPositions: {
               0: {
                 x: -3956,
-                y: 676
+                y: 676,
               },
               1: {
                 x: -3984,
-                y: 700
+                y: 700,
               },
               2: {
                 x: -4236,
-                y: 700
+                y: 700,
               },
               3: {
                 x: -4208,
-                y: 676
+                y: 676,
               },
               4: {
                 x: -4096,
-                y: 676
+                y: 676,
               },
               5: {
                 x: -4096,
-                y: 676
+                y: 676,
               },
               6: {
                 x: -4096,
-                y: 700
-              }
-            }
+                y: 700,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 588,
@@ -13457,35 +13457,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 12,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 39,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 219
+            consecutiveTime: 219,
           },
           sourceArrival: {
             lock: true,
             time: 21,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 321
+            consecutiveTime: 321,
           },
           targetDeparture: {
             lock: true,
             time: 9,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 309
+            consecutiveTime: 309,
           },
           targetArrival: {
             lock: true,
             time: 51,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 231
+            consecutiveTime: 231,
           },
           numberOfStops: 1,
           trainrunId: 88,
@@ -13495,53 +13495,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2850,
-                y: 48
+                y: 48,
               },
               {
                 x: 2914,
-                y: 48
+                y: 48,
               },
               {
                 x: 3230,
-                y: 48
+                y: 48,
               },
               {
                 x: 3294,
-                y: 48
-              }
+                y: 48,
+              },
             ],
             textPositions: {
               0: {
                 x: 2868,
-                y: 60
+                y: 60,
               },
               1: {
                 x: 2896,
-                y: 36
+                y: 36,
               },
               2: {
                 x: 3276,
-                y: 36
+                y: 36,
               },
               3: {
                 x: 3248,
-                y: 60
+                y: 60,
               },
               4: {
                 x: 3072,
-                y: 36
+                y: 36,
               },
               5: {
                 x: 3072,
-                y: 36
+                y: 36,
               },
               6: {
                 x: 3072,
-                y: 60
-              }
-            }
+                y: 60,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 589,
@@ -13554,35 +13554,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 13,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 53,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 233
+            consecutiveTime: 233,
           },
           sourceArrival: {
             lock: false,
             time: 7,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 307
+            consecutiveTime: 307,
           },
           targetDeparture: {
             lock: false,
             time: 54,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 294
+            consecutiveTime: 294,
           },
           targetArrival: {
             lock: false,
             time: 6,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 246
+            consecutiveTime: 246,
           },
           numberOfStops: 0,
           trainrunId: 88,
@@ -13592,53 +13592,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 3394,
-                y: 48
+                y: 48,
               },
               {
                 x: 3458,
-                y: 48
+                y: 48,
               },
               {
                 x: 3806,
-                y: 48
+                y: 48,
               },
               {
                 x: 3870,
-                y: 48
-              }
+                y: 48,
+              },
             ],
             textPositions: {
               0: {
                 x: 3412,
-                y: 60
+                y: 60,
               },
               1: {
                 x: 3440,
-                y: 36
+                y: 36,
               },
               2: {
                 x: 3852,
-                y: 36
+                y: 36,
               },
               3: {
                 x: 3824,
-                y: 60
+                y: 60,
               },
               4: {
                 x: 3632,
-                y: 36
+                y: 36,
               },
               5: {
                 x: 3632,
-                y: 36
+                y: 36,
               },
               6: {
                 x: 3632,
-                y: 60
-              }
-            }
+                y: 60,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 590,
@@ -13651,35 +13651,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 5,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 46,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 346
+            consecutiveTime: 346,
           },
           sourceArrival: {
             lock: false,
             time: 14,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 194
+            consecutiveTime: 194,
           },
           targetDeparture: {
             lock: false,
             time: 9,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 189
+            consecutiveTime: 189,
           },
           targetArrival: {
             lock: false,
             time: 51,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 351
+            consecutiveTime: 351,
           },
           numberOfStops: 0,
           trainrunId: 88,
@@ -13689,53 +13689,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2654,
-                y: 48
+                y: 48,
               },
               {
                 x: 2590,
-                y: 48
+                y: 48,
               },
               {
                 x: 2402,
-                y: 48
+                y: 48,
               },
               {
                 x: 2338,
-                y: 48
-              }
+                y: 48,
+              },
             ],
             textPositions: {
               0: {
                 x: 2636,
-                y: 36
+                y: 36,
               },
               1: {
                 x: 2608,
-                y: 60
+                y: 60,
               },
               2: {
                 x: 2356,
-                y: 60
+                y: 60,
               },
               3: {
                 x: 2384,
-                y: 36
+                y: 36,
               },
               4: {
                 x: 2496,
-                y: 36
+                y: 36,
               },
               5: {
                 x: 2496,
-                y: 36
+                y: 36,
               },
               6: {
                 x: 2496,
-                y: 60
-              }
-            }
+                y: 60,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 591,
@@ -13748,35 +13748,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 5,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 51,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 351
+            consecutiveTime: 351,
           },
           sourceArrival: {
             lock: false,
             time: 9,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 189
+            consecutiveTime: 189,
           },
           targetDeparture: {
             lock: false,
             time: 4,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 184
+            consecutiveTime: 184,
           },
           targetArrival: {
             lock: false,
             time: 56,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 356
+            consecutiveTime: 356,
           },
           numberOfStops: 0,
           trainrunId: 88,
@@ -13786,53 +13786,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2238,
-                y: 48
+                y: 48,
               },
               {
                 x: 2174,
-                y: 48
+                y: 48,
               },
               {
                 x: 1954,
-                y: 48
+                y: 48,
               },
               {
                 x: 1890,
-                y: 48
-              }
+                y: 48,
+              },
             ],
             textPositions: {
               0: {
                 x: 2220,
-                y: 36
+                y: 36,
               },
               1: {
                 x: 2192,
-                y: 60
+                y: 60,
               },
               2: {
                 x: 1908,
-                y: 60
+                y: 60,
               },
               3: {
                 x: 1936,
-                y: 36
+                y: 36,
               },
               4: {
                 x: 2064,
-                y: 36
+                y: 36,
               },
               5: {
                 x: 2064,
-                y: 36
+                y: 36,
               },
               6: {
                 x: 2064,
-                y: 60
-              }
-            }
+                y: 60,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 592,
@@ -13845,35 +13845,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 4,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 1,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 361
+            consecutiveTime: 361,
           },
           sourceArrival: {
             lock: false,
             time: 59,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 179
+            consecutiveTime: 179,
           },
           targetDeparture: {
             lock: false,
             time: 55,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 175
+            consecutiveTime: 175,
           },
           targetArrival: {
             lock: false,
             time: 5,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 365
+            consecutiveTime: 365,
           },
           numberOfStops: 0,
           trainrunId: 88,
@@ -13883,53 +13883,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 1342,
-                y: 48
+                y: 48,
               },
               {
                 x: 1278,
-                y: 48
+                y: 48,
               },
               {
                 x: 1122,
-                y: 48
+                y: 48,
               },
               {
                 x: 1058,
-                y: 48
-              }
+                y: 48,
+              },
             ],
             textPositions: {
               0: {
                 x: 1324,
-                y: 36
+                y: 36,
               },
               1: {
                 x: 1296,
-                y: 60
+                y: 60,
               },
               2: {
                 x: 1076,
-                y: 60
+                y: 60,
               },
               3: {
                 x: 1104,
-                y: 36
+                y: 36,
               },
               4: {
                 x: 1200,
-                y: 36
+                y: 36,
               },
               5: {
                 x: 1200,
-                y: 36
+                y: 36,
               },
               6: {
                 x: 1200,
-                y: 60
-              }
-            }
+                y: 60,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 593,
@@ -13942,35 +13942,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 5,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 5,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 365
+            consecutiveTime: 365,
           },
           sourceArrival: {
             lock: false,
             time: 55,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 175
+            consecutiveTime: 175,
           },
           targetDeparture: {
             lock: false,
             time: 50,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 170
+            consecutiveTime: 170,
           },
           targetArrival: {
             lock: false,
             time: 10,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 370
+            consecutiveTime: 370,
           },
           numberOfStops: 0,
           trainrunId: 88,
@@ -13980,53 +13980,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 958,
-                y: 112
+                y: 112,
               },
               {
                 x: 894,
-                y: 112
+                y: 112,
               },
               {
                 x: 322,
-                y: 112
+                y: 112,
               },
               {
                 x: 258,
-                y: 112
-              }
+                y: 112,
+              },
             ],
             textPositions: {
               0: {
                 x: 940,
-                y: 100
+                y: 100,
               },
               1: {
                 x: 912,
-                y: 124
+                y: 124,
               },
               2: {
                 x: 276,
-                y: 124
+                y: 124,
               },
               3: {
                 x: 304,
-                y: 100
+                y: 100,
               },
               4: {
                 x: 608,
-                y: 100
+                y: 100,
               },
               5: {
                 x: 608,
-                y: 100
+                y: 100,
               },
               6: {
                 x: 608,
-                y: 124
-              }
-            }
+                y: 124,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 594,
@@ -14039,35 +14039,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 7,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 10,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 370
+            consecutiveTime: 370,
           },
           sourceArrival: {
             lock: false,
             time: 50,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 170
+            consecutiveTime: 170,
           },
           targetDeparture: {
             lock: false,
             time: 43,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 163
+            consecutiveTime: 163,
           },
           targetArrival: {
             lock: false,
             time: 17,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 377
+            consecutiveTime: 377,
           },
           numberOfStops: 0,
           trainrunId: 88,
@@ -14077,53 +14077,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 62,
-                y: 144
+                y: 144,
               },
               {
                 x: -2,
-                y: 144
+                y: 144,
               },
               {
                 x: -446,
-                y: 144
+                y: 144,
               },
               {
                 x: -510,
-                y: 144
-              }
+                y: 144,
+              },
             ],
             textPositions: {
               0: {
                 x: 44,
-                y: 132
+                y: 132,
               },
               1: {
                 x: 16,
-                y: 156
+                y: 156,
               },
               2: {
                 x: -492,
-                y: 156
+                y: 156,
               },
               3: {
                 x: -464,
-                y: 132
+                y: 132,
               },
               4: {
                 x: -224,
-                y: 132
+                y: 132,
               },
               5: {
                 x: -224,
-                y: 132
+                y: 132,
               },
               6: {
                 x: -224,
-                y: 156
-              }
-            }
+                y: 156,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 595,
@@ -14136,35 +14136,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 22,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 30,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 390
+            consecutiveTime: 390,
           },
           sourceArrival: {
             lock: false,
             time: 30,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 150
+            consecutiveTime: 150,
           },
           targetDeparture: {
             lock: false,
             time: 8,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 128
+            consecutiveTime: 128,
           },
           targetArrival: {
             lock: false,
             time: 52,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 412
+            consecutiveTime: 412,
           },
           numberOfStops: 0,
           trainrunId: 88,
@@ -14174,53 +14174,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: -2146,
-                y: 144
+                y: 144,
               },
               {
                 x: -2210,
-                y: 144
+                y: 144,
               },
               {
                 x: -2398,
-                y: 304
+                y: 304,
               },
               {
                 x: -2462,
-                y: 304
-              }
+                y: 304,
+              },
             ],
             textPositions: {
               0: {
                 x: -2164,
-                y: 132
+                y: 132,
               },
               1: {
                 x: -2192,
-                y: 156
+                y: 156,
               },
               2: {
                 x: -2444,
-                y: 316
+                y: 316,
               },
               3: {
                 x: -2416,
-                y: 292
+                y: 292,
               },
               4: {
                 x: -2304,
-                y: 212
+                y: 212,
               },
               5: {
                 x: -2304,
-                y: 212
+                y: 212,
               },
               6: {
                 x: -2304,
-                y: 236
-              }
-            }
+                y: 236,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 596,
@@ -14233,35 +14233,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 9,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 43,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 463
+            consecutiveTime: 463,
           },
           sourceArrival: {
             lock: true,
             time: 17,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 77
+            consecutiveTime: 77,
           },
           targetDeparture: {
             lock: false,
             time: 8,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 68
+            consecutiveTime: 68,
           },
           targetArrival: {
             lock: false,
             time: 52,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 472
+            consecutiveTime: 472,
           },
           numberOfStops: 0,
           trainrunId: 88,
@@ -14271,53 +14271,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: -3074,
-                y: 560
+                y: 560,
               },
               {
                 x: -3138,
-                y: 560
+                y: 560,
               },
               {
                 x: -3358,
-                y: 592
+                y: 592,
               },
               {
                 x: -3422,
-                y: 592
-              }
+                y: 592,
+              },
             ],
             textPositions: {
               0: {
                 x: -3092,
-                y: 548
+                y: 548,
               },
               1: {
                 x: -3120,
-                y: 572
+                y: 572,
               },
               2: {
                 x: -3404,
-                y: 604
+                y: 604,
               },
               3: {
                 x: -3376,
-                y: 580
+                y: 580,
               },
               4: {
                 x: -3248,
-                y: 564
+                y: 564,
               },
               5: {
                 x: -3248,
-                y: 564
+                y: 564,
               },
               6: {
                 x: -3248,
-                y: 588
-              }
-            }
+                y: 588,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 597,
@@ -14330,35 +14330,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 7,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 21,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 501
+            consecutiveTime: 501,
           },
           sourceArrival: {
             lock: true,
             time: 39,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 39
+            consecutiveTime: 39,
           },
           targetDeparture: {
             lock: true,
             time: 32,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 32
+            consecutiveTime: 32,
           },
           targetArrival: {
             lock: true,
             time: 28,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 508
+            consecutiveTime: 508,
           },
           numberOfStops: 0,
           trainrunId: 88,
@@ -14368,53 +14368,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: -3938,
-                y: 624
+                y: 624,
               },
               {
                 x: -4002,
-                y: 624
+                y: 624,
               },
               {
                 x: -4190,
-                y: 624
+                y: 624,
               },
               {
                 x: -4254,
-                y: 624
-              }
+                y: 624,
+              },
             ],
             textPositions: {
               0: {
                 x: -3956,
-                y: 612
+                y: 612,
               },
               1: {
                 x: -3984,
-                y: 636
+                y: 636,
               },
               2: {
                 x: -4236,
-                y: 636
+                y: 636,
               },
               3: {
                 x: -4208,
-                y: 612
+                y: 612,
               },
               4: {
                 x: -4096,
-                y: 612
+                y: 612,
               },
               5: {
                 x: -4096,
-                y: 612
+                y: 612,
               },
               6: {
                 x: -4096,
-                y: 636
-              }
-            }
+                y: 636,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 598,
@@ -14427,35 +14427,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 44,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 8,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 248
+            consecutiveTime: 248,
           },
           sourceArrival: {
             lock: true,
             time: 52,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 292
+            consecutiveTime: 292,
           },
           targetDeparture: {
             lock: false,
             time: 8,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 248
+            consecutiveTime: 248,
           },
           targetArrival: {
             lock: false,
             time: 52,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 292
+            consecutiveTime: 292,
           },
           numberOfStops: 4,
           trainrunId: 88,
@@ -14465,53 +14465,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 3970,
-                y: 112
+                y: 112,
               },
               {
                 x: 4034,
-                y: 112
+                y: 112,
               },
               {
                 x: 4574,
-                y: 112
+                y: 112,
               },
               {
                 x: 4638,
-                y: 112
-              }
+                y: 112,
+              },
             ],
             textPositions: {
               0: {
                 x: 3988,
-                y: 124
+                y: 124,
               },
               1: {
                 x: 4016,
-                y: 100
+                y: 100,
               },
               2: {
                 x: 4620,
-                y: 100
+                y: 100,
               },
               3: {
                 x: 4592,
-                y: 124
+                y: 124,
               },
               4: {
                 x: 4304,
-                y: 100
+                y: 100,
               },
               5: {
                 x: 4304,
-                y: 100
+                y: 100,
               },
               6: {
                 x: 4304,
-                y: 124
-              }
-            }
+                y: 124,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 599,
@@ -14524,35 +14524,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 9,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 5,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 125
+            consecutiveTime: 125,
           },
           sourceArrival: {
             lock: false,
             time: 55,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 295
+            consecutiveTime: 295,
           },
           targetDeparture: {
             lock: false,
             time: 46,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 286
+            consecutiveTime: 286,
           },
           targetArrival: {
             lock: false,
             time: 14,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 134
+            consecutiveTime: 134,
           },
           numberOfStops: 0,
           trainrunId: 89,
@@ -14562,53 +14562,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2850,
-                y: 112
+                y: 112,
               },
               {
                 x: 2914,
-                y: 112
+                y: 112,
               },
               {
                 x: 3230,
-                y: 112
+                y: 112,
               },
               {
                 x: 3294,
-                y: 112
-              }
+                y: 112,
+              },
             ],
             textPositions: {
               0: {
                 x: 2868,
-                y: 124
+                y: 124,
               },
               1: {
                 x: 2896,
-                y: 100
+                y: 100,
               },
               2: {
                 x: 3276,
-                y: 100
+                y: 100,
               },
               3: {
                 x: 3248,
-                y: 124
+                y: 124,
               },
               4: {
                 x: 3072,
-                y: 100
+                y: 100,
               },
               5: {
                 x: 3072,
-                y: 100
+                y: 100,
               },
               6: {
                 x: 3072,
-                y: 124
-              }
-            }
+                y: 124,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 600,
@@ -14621,35 +14621,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 13,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 16,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 136
+            consecutiveTime: 136,
           },
           sourceArrival: {
             lock: false,
             time: 44,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 284
+            consecutiveTime: 284,
           },
           targetDeparture: {
             lock: false,
             time: 31,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 271
+            consecutiveTime: 271,
           },
           targetArrival: {
             lock: false,
             time: 29,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 149
+            consecutiveTime: 149,
           },
           numberOfStops: 0,
           trainrunId: 89,
@@ -14659,53 +14659,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 3394,
-                y: 112
+                y: 112,
               },
               {
                 x: 3458,
-                y: 112
+                y: 112,
               },
               {
                 x: 3806,
-                y: 112
+                y: 112,
               },
               {
                 x: 3870,
-                y: 112
-              }
+                y: 112,
+              },
             ],
             textPositions: {
               0: {
                 x: 3412,
-                y: 124
+                y: 124,
               },
               1: {
                 x: 3440,
-                y: 100
+                y: 100,
               },
               2: {
                 x: 3852,
-                y: 100
+                y: 100,
               },
               3: {
                 x: 3824,
-                y: 124
+                y: 124,
               },
               4: {
                 x: 3632,
-                y: 100
+                y: 100,
               },
               5: {
                 x: 3632,
-                y: 100
+                y: 100,
               },
               6: {
                 x: 3632,
-                y: 124
-              }
-            }
+                y: 124,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 601,
@@ -14718,35 +14718,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 6,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 2,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 302
+            consecutiveTime: 302,
           },
           sourceArrival: {
             lock: true,
             time: 58,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 118
+            consecutiveTime: 118,
           },
           targetDeparture: {
             lock: false,
             time: 52,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 112
+            consecutiveTime: 112,
           },
           targetArrival: {
             lock: false,
             time: 8,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 308
+            consecutiveTime: 308,
           },
           numberOfStops: 0,
           trainrunId: 89,
@@ -14756,53 +14756,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2654,
-                y: 176
+                y: 176,
               },
               {
                 x: 2590,
-                y: 176
+                y: 176,
               },
               {
                 x: 2402,
-                y: 176
+                y: 176,
               },
               {
                 x: 2338,
-                y: 176
-              }
+                y: 176,
+              },
             ],
             textPositions: {
               0: {
                 x: 2636,
-                y: 164
+                y: 164,
               },
               1: {
                 x: 2608,
-                y: 188
+                y: 188,
               },
               2: {
                 x: 2356,
-                y: 188
+                y: 188,
               },
               3: {
                 x: 2384,
-                y: 164
+                y: 164,
               },
               4: {
                 x: 2496,
-                y: 164
+                y: 164,
               },
               5: {
                 x: 2496,
-                y: 164
+                y: 164,
               },
               6: {
                 x: 2496,
-                y: 188
-              }
-            }
+                y: 188,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 602,
@@ -14815,35 +14815,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 6,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 8,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 308
+            consecutiveTime: 308,
           },
           sourceArrival: {
             lock: false,
             time: 52,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 112
+            consecutiveTime: 112,
           },
           targetDeparture: {
             lock: false,
             time: 46,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 106
+            consecutiveTime: 106,
           },
           targetArrival: {
             lock: false,
             time: 14,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 314
+            consecutiveTime: 314,
           },
           numberOfStops: 0,
           trainrunId: 89,
@@ -14853,53 +14853,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2238,
-                y: 176
+                y: 176,
               },
               {
                 x: 2174,
-                y: 176
+                y: 176,
               },
               {
                 x: 1954,
-                y: 176
+                y: 176,
               },
               {
                 x: 1890,
-                y: 176
-              }
+                y: 176,
+              },
             ],
             textPositions: {
               0: {
                 x: 2220,
-                y: 164
+                y: 164,
               },
               1: {
                 x: 2192,
-                y: 188
+                y: 188,
               },
               2: {
                 x: 1908,
-                y: 188
+                y: 188,
               },
               3: {
                 x: 1936,
-                y: 164
+                y: 164,
               },
               4: {
                 x: 2064,
-                y: 164
+                y: 164,
               },
               5: {
                 x: 2064,
-                y: 164
+                y: 164,
               },
               6: {
                 x: 2064,
-                y: 188
-              }
-            }
+                y: 188,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 603,
@@ -14912,35 +14912,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 5,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 20,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 320
+            consecutiveTime: 320,
           },
           sourceArrival: {
             lock: false,
             time: 40,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 100
+            consecutiveTime: 100,
           },
           targetDeparture: {
             lock: false,
             time: 35,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 95
+            consecutiveTime: 95,
           },
           targetArrival: {
             lock: false,
             time: 25,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 325
+            consecutiveTime: 325,
           },
           numberOfStops: 0,
           trainrunId: 89,
@@ -14950,53 +14950,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 1342,
-                y: 176
+                y: 176,
               },
               {
                 x: 1278,
-                y: 176
+                y: 176,
               },
               {
                 x: 1122,
-                y: 176
+                y: 176,
               },
               {
                 x: 1058,
-                y: 176
-              }
+                y: 176,
+              },
             ],
             textPositions: {
               0: {
                 x: 1324,
-                y: 164
+                y: 164,
               },
               1: {
                 x: 1296,
-                y: 188
+                y: 188,
               },
               2: {
                 x: 1076,
-                y: 188
+                y: 188,
               },
               3: {
                 x: 1104,
-                y: 164
+                y: 164,
               },
               4: {
                 x: 1200,
-                y: 164
+                y: 164,
               },
               5: {
                 x: 1200,
-                y: 164
+                y: 164,
               },
               6: {
                 x: 1200,
-                y: 188
-              }
-            }
+                y: 188,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 604,
@@ -15009,35 +15009,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 5,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 25,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 325
+            consecutiveTime: 325,
           },
           sourceArrival: {
             lock: false,
             time: 35,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 95
+            consecutiveTime: 95,
           },
           targetDeparture: {
             lock: false,
             time: 30,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 90
+            consecutiveTime: 90,
           },
           targetArrival: {
             lock: false,
             time: 30,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 330
+            consecutiveTime: 330,
           },
           numberOfStops: 0,
           trainrunId: 89,
@@ -15047,53 +15047,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 958,
-                y: 176
+                y: 176,
               },
               {
                 x: 894,
-                y: 176
+                y: 176,
               },
               {
                 x: 322,
-                y: 176
+                y: 176,
               },
               {
                 x: 258,
-                y: 176
-              }
+                y: 176,
+              },
             ],
             textPositions: {
               0: {
                 x: 940,
-                y: 164
+                y: 164,
               },
               1: {
                 x: 912,
-                y: 188
+                y: 188,
               },
               2: {
                 x: 276,
-                y: 188
+                y: 188,
               },
               3: {
                 x: 304,
-                y: 164
+                y: 164,
               },
               4: {
                 x: 608,
-                y: 164
+                y: 164,
               },
               5: {
                 x: 608,
-                y: 164
+                y: 164,
               },
               6: {
                 x: 608,
-                y: 188
-              }
-            }
+                y: 188,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 605,
@@ -15106,35 +15106,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 7,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 30,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 330
+            consecutiveTime: 330,
           },
           sourceArrival: {
             lock: true,
             time: 30,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 90
+            consecutiveTime: 90,
           },
           targetDeparture: {
             lock: false,
             time: 23,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 83
+            consecutiveTime: 83,
           },
           targetArrival: {
             lock: false,
             time: 37,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 337
+            consecutiveTime: 337,
           },
           numberOfStops: 0,
           trainrunId: 89,
@@ -15144,53 +15144,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 62,
-                y: 240
+                y: 240,
               },
               {
                 x: -2,
-                y: 240
+                y: 240,
               },
               {
                 x: -446,
-                y: 240
+                y: 240,
               },
               {
                 x: -510,
-                y: 240
-              }
+                y: 240,
+              },
             ],
             textPositions: {
               0: {
                 x: 44,
-                y: 228
+                y: 228,
               },
               1: {
                 x: 16,
-                y: 252
+                y: 252,
               },
               2: {
                 x: -492,
-                y: 252
+                y: 252,
               },
               3: {
                 x: -464,
-                y: 228
+                y: 228,
               },
               4: {
                 x: -224,
-                y: 228
+                y: 228,
               },
               5: {
                 x: -224,
-                y: 228
+                y: 228,
               },
               6: {
                 x: -224,
-                y: 252
-              }
-            }
+                y: 252,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 606,
@@ -15203,35 +15203,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 51,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 31,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 151
+            consecutiveTime: 151,
           },
           sourceArrival: {
             lock: false,
             time: 29,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 269
+            consecutiveTime: 269,
           },
           targetDeparture: {
             lock: false,
             time: 38,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 218
+            consecutiveTime: 218,
           },
           targetArrival: {
             lock: false,
             time: 22,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 202
+            consecutiveTime: 202,
           },
           numberOfStops: 0,
           trainrunId: 89,
@@ -15241,53 +15241,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 3970,
-                y: 48
+                y: 48,
               },
               {
                 x: 4034,
-                y: 48
+                y: 48,
               },
               {
                 x: 4574,
-                y: -176
+                y: -176,
               },
               {
                 x: 4638,
-                y: -176
-              }
+                y: -176,
+              },
             ],
             textPositions: {
               0: {
                 x: 3988,
-                y: 60
+                y: 60,
               },
               1: {
                 x: 4016,
-                y: 36
+                y: 36,
               },
               2: {
                 x: 4620,
-                y: -188
+                y: -188,
               },
               3: {
                 x: 4592,
-                y: -164
+                y: -164,
               },
               4: {
                 x: 4304,
-                y: -76
+                y: -76,
               },
               5: {
                 x: 4304,
-                y: -76
+                y: -76,
               },
               6: {
                 x: 4304,
-                y: -52
-              }
-            }
+                y: -52,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 607,
@@ -15300,35 +15300,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 9,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 5,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 125
+            consecutiveTime: 125,
           },
           sourceArrival: {
             lock: false,
             time: 55,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 295
+            consecutiveTime: 295,
           },
           targetDeparture: {
             lock: true,
             time: 46,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 286
+            consecutiveTime: 286,
           },
           targetArrival: {
             lock: true,
             time: 14,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 134
+            consecutiveTime: 134,
           },
           numberOfStops: 0,
           trainrunId: 90,
@@ -15338,53 +15338,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2850,
-                y: 144
+                y: 144,
               },
               {
                 x: 2914,
-                y: 144
+                y: 144,
               },
               {
                 x: 3230,
-                y: 144
+                y: 144,
               },
               {
                 x: 3294,
-                y: 144
-              }
+                y: 144,
+              },
             ],
             textPositions: {
               0: {
                 x: 2868,
-                y: 156
+                y: 156,
               },
               1: {
                 x: 2896,
-                y: 132
+                y: 132,
               },
               2: {
                 x: 3276,
-                y: 132
+                y: 132,
               },
               3: {
                 x: 3248,
-                y: 156
+                y: 156,
               },
               4: {
                 x: 3072,
-                y: 132
+                y: 132,
               },
               5: {
                 x: 3072,
-                y: 132
+                y: 132,
               },
               6: {
                 x: 3072,
-                y: 156
-              }
-            }
+                y: 156,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 608,
@@ -15397,35 +15397,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 13,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 16,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 136
+            consecutiveTime: 136,
           },
           sourceArrival: {
             lock: false,
             time: 44,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 284
+            consecutiveTime: 284,
           },
           targetDeparture: {
             lock: false,
             time: 31,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 271
+            consecutiveTime: 271,
           },
           targetArrival: {
             lock: false,
             time: 29,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 149
+            consecutiveTime: 149,
           },
           numberOfStops: 0,
           trainrunId: 90,
@@ -15435,53 +15435,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 3394,
-                y: 144
+                y: 144,
               },
               {
                 x: 3458,
-                y: 144
+                y: 144,
               },
               {
                 x: 3806,
-                y: 144
+                y: 144,
               },
               {
                 x: 3870,
-                y: 144
-              }
+                y: 144,
+              },
             ],
             textPositions: {
               0: {
                 x: 3412,
-                y: 156
+                y: 156,
               },
               1: {
                 x: 3440,
-                y: 132
+                y: 132,
               },
               2: {
                 x: 3852,
-                y: 132
+                y: 132,
               },
               3: {
                 x: 3824,
-                y: 156
+                y: 156,
               },
               4: {
                 x: 3632,
-                y: 132
+                y: 132,
               },
               5: {
                 x: 3632,
-                y: 132
+                y: 132,
               },
               6: {
                 x: 3632,
-                y: 156
-              }
-            }
+                y: 156,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 609,
@@ -15494,35 +15494,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 15,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 2,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 302
+            consecutiveTime: 302,
           },
           sourceArrival: {
             lock: true,
             time: 58,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 118
+            consecutiveTime: 118,
           },
           targetDeparture: {
             lock: true,
             time: 43,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 103
+            consecutiveTime: 103,
           },
           targetArrival: {
             lock: true,
             time: 17,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 317
+            consecutiveTime: 317,
           },
           numberOfStops: 0,
           trainrunId: 90,
@@ -15532,53 +15532,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2654,
-                y: 208
+                y: 208,
               },
               {
                 x: 2590,
-                y: 208
+                y: 208,
               },
               {
                 x: 2402,
-                y: 208
+                y: 208,
               },
               {
                 x: 2338,
-                y: 208
-              }
+                y: 208,
+              },
             ],
             textPositions: {
               0: {
                 x: 2636,
-                y: 196
+                y: 196,
               },
               1: {
                 x: 2608,
-                y: 220
+                y: 220,
               },
               2: {
                 x: 2356,
-                y: 220
+                y: 220,
               },
               3: {
                 x: 2384,
-                y: 196
+                y: 196,
               },
               4: {
                 x: 2496,
-                y: 196
+                y: 196,
               },
               5: {
                 x: 2496,
-                y: 196
+                y: 196,
               },
               6: {
                 x: 2496,
-                y: 220
-              }
-            }
+                y: 220,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 610,
@@ -15591,35 +15591,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 6,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 17,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 317
+            consecutiveTime: 317,
           },
           sourceArrival: {
             lock: false,
             time: 43,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 103
+            consecutiveTime: 103,
           },
           targetDeparture: {
             lock: false,
             time: 37,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 97
+            consecutiveTime: 97,
           },
           targetArrival: {
             lock: false,
             time: 23,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 323
+            consecutiveTime: 323,
           },
           numberOfStops: 0,
           trainrunId: 90,
@@ -15629,53 +15629,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2238,
-                y: 208
+                y: 208,
               },
               {
                 x: 2174,
-                y: 208
+                y: 208,
               },
               {
                 x: 1954,
-                y: 208
+                y: 208,
               },
               {
                 x: 1890,
-                y: 208
-              }
+                y: 208,
+              },
             ],
             textPositions: {
               0: {
                 x: 2220,
-                y: 196
+                y: 196,
               },
               1: {
                 x: 2192,
-                y: 220
+                y: 220,
               },
               2: {
                 x: 1908,
-                y: 220
+                y: 220,
               },
               3: {
                 x: 1936,
-                y: 196
+                y: 196,
               },
               4: {
                 x: 2064,
-                y: 196
+                y: 196,
               },
               5: {
                 x: 2064,
-                y: 196
+                y: 196,
               },
               6: {
                 x: 2064,
-                y: 220
-              }
-            }
+                y: 220,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 611,
@@ -15688,35 +15688,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 5,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 30,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 330
+            consecutiveTime: 330,
           },
           sourceArrival: {
             lock: false,
             time: 30,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 90
+            consecutiveTime: 90,
           },
           targetDeparture: {
             lock: false,
             time: 25,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 85
+            consecutiveTime: 85,
           },
           targetArrival: {
             lock: false,
             time: 35,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 335
+            consecutiveTime: 335,
           },
           numberOfStops: 0,
           trainrunId: 90,
@@ -15726,53 +15726,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 1342,
-                y: 208
+                y: 208,
               },
               {
                 x: 1278,
-                y: 208
+                y: 208,
               },
               {
                 x: 1122,
-                y: 208
+                y: 208,
               },
               {
                 x: 1058,
-                y: 208
-              }
+                y: 208,
+              },
             ],
             textPositions: {
               0: {
                 x: 1324,
-                y: 196
+                y: 196,
               },
               1: {
                 x: 1296,
-                y: 220
+                y: 220,
               },
               2: {
                 x: 1076,
-                y: 220
+                y: 220,
               },
               3: {
                 x: 1104,
-                y: 196
+                y: 196,
               },
               4: {
                 x: 1200,
-                y: 196
+                y: 196,
               },
               5: {
                 x: 1200,
-                y: 196
+                y: 196,
               },
               6: {
                 x: 1200,
-                y: 220
-              }
-            }
+                y: 220,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 612,
@@ -15785,35 +15785,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 5,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 35,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 335
+            consecutiveTime: 335,
           },
           sourceArrival: {
             lock: false,
             time: 25,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 85
+            consecutiveTime: 85,
           },
           targetDeparture: {
             lock: false,
             time: 20,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 80
+            consecutiveTime: 80,
           },
           targetArrival: {
             lock: false,
             time: 40,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 340
+            consecutiveTime: 340,
           },
           numberOfStops: 0,
           trainrunId: 90,
@@ -15823,53 +15823,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 958,
-                y: 208
+                y: 208,
               },
               {
                 x: 894,
-                y: 208
+                y: 208,
               },
               {
                 x: 322,
-                y: 208
+                y: 208,
               },
               {
                 x: 258,
-                y: 208
-              }
+                y: 208,
+              },
             ],
             textPositions: {
               0: {
                 x: 940,
-                y: 196
+                y: 196,
               },
               1: {
                 x: 912,
-                y: 220
+                y: 220,
               },
               2: {
                 x: 276,
-                y: 220
+                y: 220,
               },
               3: {
                 x: 304,
-                y: 196
+                y: 196,
               },
               4: {
                 x: 608,
-                y: 196
+                y: 196,
               },
               5: {
                 x: 608,
-                y: 196
+                y: 196,
               },
               6: {
                 x: 608,
-                y: 220
-              }
-            }
+                y: 220,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 613,
@@ -15882,35 +15882,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 7,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 40,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 340
+            consecutiveTime: 340,
           },
           sourceArrival: {
             lock: false,
             time: 20,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 80
+            consecutiveTime: 80,
           },
           targetDeparture: {
             lock: false,
             time: 13,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 73
+            consecutiveTime: 73,
           },
           targetArrival: {
             lock: false,
             time: 47,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 347
+            consecutiveTime: 347,
           },
           numberOfStops: 0,
           trainrunId: 90,
@@ -15920,53 +15920,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 62,
-                y: 272
+                y: 272,
               },
               {
                 x: -2,
-                y: 272
+                y: 272,
               },
               {
                 x: -446,
-                y: 272
+                y: 272,
               },
               {
                 x: -510,
-                y: 272
-              }
+                y: 272,
+              },
             ],
             textPositions: {
               0: {
                 x: 44,
-                y: 260
+                y: 260,
               },
               1: {
                 x: 16,
-                y: 284
+                y: 284,
               },
               2: {
                 x: -492,
-                y: 284
+                y: 284,
               },
               3: {
                 x: -464,
-                y: 260
+                y: 260,
               },
               4: {
                 x: -224,
-                y: 260
+                y: 260,
               },
               5: {
                 x: -224,
-                y: 260
+                y: 260,
               },
               6: {
                 x: -224,
-                y: 284
-              }
-            }
+                y: 284,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 614,
@@ -15979,35 +15979,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 41,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 31,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 151
+            consecutiveTime: 151,
           },
           sourceArrival: {
             lock: false,
             time: 29,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 269
+            consecutiveTime: 269,
           },
           targetDeparture: {
             lock: false,
             time: 48,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 228
+            consecutiveTime: 228,
           },
           targetArrival: {
             lock: false,
             time: 12,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 192
+            consecutiveTime: 192,
           },
           numberOfStops: 0,
           trainrunId: 90,
@@ -16017,53 +16017,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 3970,
-                y: 80
+                y: 80,
               },
               {
                 x: 4034,
-                y: 80
+                y: 80,
               },
               {
                 x: 4574,
-                y: -144
+                y: -144,
               },
               {
                 x: 4638,
-                y: -144
-              }
+                y: -144,
+              },
             ],
             textPositions: {
               0: {
                 x: 3988,
-                y: 92
+                y: 92,
               },
               1: {
                 x: 4016,
-                y: 68
+                y: 68,
               },
               2: {
                 x: 4620,
-                y: -156
+                y: -156,
               },
               3: {
                 x: 4592,
-                y: -132
+                y: -132,
               },
               4: {
                 x: 4304,
-                y: -44
+                y: -44,
               },
               5: {
                 x: 4304,
-                y: -44
+                y: -44,
               },
               6: {
                 x: 4304,
-                y: -20
-              }
-            }
+                y: -20,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 615,
@@ -16076,35 +16076,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 9,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 35,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 95
+            consecutiveTime: 95,
           },
           sourceArrival: {
             lock: true,
             time: 25,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 205
+            consecutiveTime: 205,
           },
           targetDeparture: {
             lock: true,
             time: 16,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 196
+            consecutiveTime: 196,
           },
           targetArrival: {
             lock: true,
             time: 44,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 104
+            consecutiveTime: 104,
           },
           numberOfStops: 0,
           trainrunId: 79,
@@ -16114,53 +16114,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2850,
-                y: 208
+                y: 208,
               },
               {
                 x: 2914,
-                y: 208
+                y: 208,
               },
               {
                 x: 3230,
-                y: 208
+                y: 208,
               },
               {
                 x: 3294,
-                y: 208
-              }
+                y: 208,
+              },
             ],
             textPositions: {
               0: {
                 x: 2868,
-                y: 220
+                y: 220,
               },
               1: {
                 x: 2896,
-                y: 196
+                y: 196,
               },
               2: {
                 x: 3276,
-                y: 196
+                y: 196,
               },
               3: {
                 x: 3248,
-                y: 220
+                y: 220,
               },
               4: {
                 x: 3072,
-                y: 196
+                y: 196,
               },
               5: {
                 x: 3072,
-                y: 196
+                y: 196,
               },
               6: {
                 x: 3072,
-                y: 220
-              }
-            }
+                y: 220,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 616,
@@ -16173,35 +16173,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 13,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 46,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 106
+            consecutiveTime: 106,
           },
           sourceArrival: {
             lock: true,
             time: 14,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 194
+            consecutiveTime: 194,
           },
           targetDeparture: {
             lock: true,
             time: 1,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 181
+            consecutiveTime: 181,
           },
           targetArrival: {
             lock: true,
             time: 59,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 119
+            consecutiveTime: 119,
           },
           numberOfStops: 0,
           trainrunId: 79,
@@ -16211,53 +16211,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 3394,
-                y: 208
+                y: 208,
               },
               {
                 x: 3458,
-                y: 208
+                y: 208,
               },
               {
                 x: 3806,
-                y: 208
+                y: 208,
               },
               {
                 x: 3870,
-                y: 208
-              }
+                y: 208,
+              },
             ],
             textPositions: {
               0: {
                 x: 3412,
-                y: 220
+                y: 220,
               },
               1: {
                 x: 3440,
-                y: 196
+                y: 196,
               },
               2: {
                 x: 3852,
-                y: 196
+                y: 196,
               },
               3: {
                 x: 3824,
-                y: 220
+                y: 220,
               },
               4: {
                 x: 3632,
-                y: 196
+                y: 196,
               },
               5: {
                 x: 3632,
-                y: 196
+                y: 196,
               },
               6: {
                 x: 3632,
-                y: 220
-              }
-            }
+                y: 220,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 617,
@@ -16270,35 +16270,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 49,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 1,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 121
+            consecutiveTime: 121,
           },
           sourceArrival: {
             lock: true,
             time: 59,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 179
+            consecutiveTime: 179,
           },
           targetDeparture: {
             lock: true,
             time: 10,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 130
+            consecutiveTime: 130,
           },
           targetArrival: {
             lock: true,
             time: 50,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 170
+            consecutiveTime: 170,
           },
           numberOfStops: 2,
           trainrunId: 79,
@@ -16308,53 +16308,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 3888,
-                y: 30
+                y: 30,
               },
               {
                 x: 3888,
-                y: -34
+                y: -34,
               },
               {
                 x: 4272,
-                y: -286
+                y: -286,
               },
               {
                 x: 4272,
-                y: -350
-              }
+                y: -350,
+              },
             ],
             textPositions: {
               0: {
                 x: 3900,
-                y: 12
+                y: 12,
               },
               1: {
                 x: 3876,
-                y: -16
+                y: -16,
               },
               2: {
                 x: 4260,
-                y: -332
+                y: -332,
               },
               3: {
                 x: 4284,
-                y: -304
+                y: -304,
               },
               4: {
                 x: 4068,
-                y: -160
+                y: -160,
               },
               5: {
                 x: 4068,
-                y: -160
+                y: -160,
               },
               6: {
                 x: 4092,
-                y: -160
-              }
-            }
+                y: -160,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 618,
@@ -16367,35 +16367,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 1,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 0,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 0
+            consecutiveTime: 0,
           },
           sourceArrival: {
             lock: false,
             time: 0,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 60
+            consecutiveTime: 60,
           },
           targetDeparture: {
             lock: false,
             time: 59,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 59
+            consecutiveTime: 59,
           },
           targetArrival: {
             lock: false,
             time: 1,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           numberOfStops: 0,
           trainrunId: 91,
@@ -16405,53 +16405,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2672,
-                y: -1054
+                y: -1054,
               },
               {
                 x: 2672,
-                y: -990
+                y: -990,
               },
               {
                 x: 2800,
-                y: -610
+                y: -610,
               },
               {
                 x: 2800,
-                y: -546
-              }
+                y: -546,
+              },
             ],
             textPositions: {
               0: {
                 x: 2660,
-                y: -1036
+                y: -1036,
               },
               1: {
                 x: 2684,
-                y: -1008
+                y: -1008,
               },
               2: {
                 x: 2812,
-                y: -564
+                y: -564,
               },
               3: {
                 x: 2788,
-                y: -592
+                y: -592,
               },
               4: {
                 x: 2748,
-                y: -800
+                y: -800,
               },
               5: {
                 x: 2748,
-                y: -800
+                y: -800,
               },
               6: {
                 x: 2724,
-                y: -800
-              }
-            }
+                y: -800,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 619,
@@ -16464,35 +16464,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 1,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 3,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 3
+            consecutiveTime: 3,
           },
           sourceArrival: {
             lock: false,
             time: 57,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 57
+            consecutiveTime: 57,
           },
           targetDeparture: {
             lock: false,
             time: 56,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 56
+            consecutiveTime: 56,
           },
           targetArrival: {
             lock: false,
             time: 4,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 4
+            consecutiveTime: 4,
           },
           numberOfStops: 0,
           trainrunId: 91,
@@ -16502,53 +16502,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2800,
-                y: -478
+                y: -478,
               },
               {
                 x: 2800,
-                y: -414
+                y: -414,
               },
               {
                 x: 2704,
-                y: -34
+                y: -34,
               },
               {
                 x: 2704,
-                y: 30
-              }
+                y: 30,
+              },
             ],
             textPositions: {
               0: {
                 x: 2788,
-                y: -460
+                y: -460,
               },
               1: {
                 x: 2812,
-                y: -432
+                y: -432,
               },
               2: {
                 x: 2716,
-                y: 12
+                y: 12,
               },
               3: {
                 x: 2692,
-                y: -16
+                y: -16,
               },
               4: {
                 x: 2740,
-                y: -224
+                y: -224,
               },
               5: {
                 x: 2740,
-                y: -224
+                y: -224,
               },
               6: {
                 x: 2764,
-                y: -224
-              }
-            }
+                y: -224,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 620,
@@ -16561,35 +16561,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 1,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 0,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 120
+            consecutiveTime: 120,
           },
           sourceArrival: {
             lock: false,
             time: 0,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 60
+            consecutiveTime: 60,
           },
           targetDeparture: {
             lock: false,
             time: 59,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 59
+            consecutiveTime: 59,
           },
           targetArrival: {
             lock: false,
             time: 1,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 121
+            consecutiveTime: 121,
           },
           numberOfStops: 0,
           trainrunId: 92,
@@ -16599,53 +16599,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2672,
-                y: 30
+                y: 30,
               },
               {
                 x: 2672,
-                y: -34
+                y: -34,
               },
               {
                 x: 2640,
-                y: -990
+                y: -990,
               },
               {
                 x: 2640,
-                y: -1054
-              }
+                y: -1054,
+              },
             ],
             textPositions: {
               0: {
                 x: 2684,
-                y: 12
+                y: 12,
               },
               1: {
                 x: 2660,
-                y: -16
+                y: -16,
               },
               2: {
                 x: 2628,
-                y: -1036
+                y: -1036,
               },
               3: {
                 x: 2652,
-                y: -1008
+                y: -1008,
               },
               4: {
                 x: 2668,
-                y: -512
+                y: -512,
               },
               5: {
                 x: 2668,
-                y: -512
+                y: -512,
               },
               6: {
                 x: 2644,
-                y: -512
-              }
-            }
+                y: -512,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 621,
@@ -16658,35 +16658,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 5,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 56,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 356
+            consecutiveTime: 356,
           },
           sourceArrival: {
             lock: false,
             time: 4,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 184
+            consecutiveTime: 184,
           },
           targetDeparture: {
             lock: false,
             time: 59,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 179
+            consecutiveTime: 179,
           },
           targetArrival: {
             lock: false,
             time: 1,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 361
+            consecutiveTime: 361,
           },
           numberOfStops: 0,
           trainrunId: 88,
@@ -16696,53 +16696,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 1790,
-                y: 48
+                y: 48,
               },
               {
                 x: 1726,
-                y: 48
+                y: 48,
               },
               {
                 x: 1506,
-                y: 48
+                y: 48,
               },
               {
                 x: 1442,
-                y: 48
-              }
+                y: 48,
+              },
             ],
             textPositions: {
               0: {
                 x: 1772,
-                y: 36
+                y: 36,
               },
               1: {
                 x: 1744,
-                y: 60
+                y: 60,
               },
               2: {
                 x: 1460,
-                y: 60
+                y: 60,
               },
               3: {
                 x: 1488,
-                y: 36
+                y: 36,
               },
               4: {
                 x: 1616,
-                y: 36
+                y: 36,
               },
               5: {
                 x: 1616,
-                y: 36
+                y: 36,
               },
               6: {
                 x: 1616,
-                y: 60
-              }
-            }
+                y: 60,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 622,
@@ -16755,35 +16755,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 7,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 17,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 377
+            consecutiveTime: 377,
           },
           sourceArrival: {
             lock: false,
             time: 43,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 163
+            consecutiveTime: 163,
           },
           targetDeparture: {
             lock: false,
             time: 36,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 156
+            consecutiveTime: 156,
           },
           targetArrival: {
             lock: false,
             time: 24,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 384
+            consecutiveTime: 384,
           },
           numberOfStops: 0,
           trainrunId: 87,
@@ -16793,53 +16793,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 1790,
-                y: 144
+                y: 144,
               },
               {
                 x: 1726,
-                y: 144
+                y: 144,
               },
               {
                 x: 1506,
-                y: 144
+                y: 144,
               },
               {
                 x: 1442,
-                y: 144
-              }
+                y: 144,
+              },
             ],
             textPositions: {
               0: {
                 x: 1772,
-                y: 132
+                y: 132,
               },
               1: {
                 x: 1744,
-                y: 156
+                y: 156,
               },
               2: {
                 x: 1460,
-                y: 156
+                y: 156,
               },
               3: {
                 x: 1488,
-                y: 132
+                y: 132,
               },
               4: {
                 x: 1616,
-                y: 132
+                y: 132,
               },
               5: {
                 x: 1616,
-                y: 132
+                y: 132,
               },
               6: {
                 x: 1616,
-                y: 156
-              }
-            }
+                y: 156,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 623,
@@ -16852,35 +16852,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 6,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 14,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 314
+            consecutiveTime: 314,
           },
           sourceArrival: {
             lock: false,
             time: 46,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 106
+            consecutiveTime: 106,
           },
           targetDeparture: {
             lock: false,
             time: 40,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 100
+            consecutiveTime: 100,
           },
           targetArrival: {
             lock: false,
             time: 20,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 320
+            consecutiveTime: 320,
           },
           numberOfStops: 0,
           trainrunId: 89,
@@ -16890,53 +16890,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 1790,
-                y: 176
+                y: 176,
               },
               {
                 x: 1726,
-                y: 176
+                y: 176,
               },
               {
                 x: 1506,
-                y: 176
+                y: 176,
               },
               {
                 x: 1442,
-                y: 176
-              }
+                y: 176,
+              },
             ],
             textPositions: {
               0: {
                 x: 1772,
-                y: 164
+                y: 164,
               },
               1: {
                 x: 1744,
-                y: 188
+                y: 188,
               },
               2: {
                 x: 1460,
-                y: 188
+                y: 188,
               },
               3: {
                 x: 1488,
-                y: 164
+                y: 164,
               },
               4: {
                 x: 1616,
-                y: 164
+                y: 164,
               },
               5: {
                 x: 1616,
-                y: 164
+                y: 164,
               },
               6: {
                 x: 1616,
-                y: 188
-              }
-            }
+                y: 188,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 624,
@@ -16949,35 +16949,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 5,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 25,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 325
+            consecutiveTime: 325,
           },
           sourceArrival: {
             lock: false,
             time: 35,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 95
+            consecutiveTime: 95,
           },
           targetDeparture: {
             lock: false,
             time: 30,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 90
+            consecutiveTime: 90,
           },
           targetArrival: {
             lock: false,
             time: 30,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 330
+            consecutiveTime: 330,
           },
           numberOfStops: 0,
           trainrunId: 90,
@@ -16987,53 +16987,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 1790,
-                y: 208
+                y: 208,
               },
               {
                 x: 1726,
-                y: 208
+                y: 208,
               },
               {
                 x: 1506,
-                y: 208
+                y: 208,
               },
               {
                 x: 1442,
-                y: 208
-              }
+                y: 208,
+              },
             ],
             textPositions: {
               0: {
                 x: 1772,
-                y: 196
+                y: 196,
               },
               1: {
                 x: 1744,
-                y: 220
+                y: 220,
               },
               2: {
                 x: 1460,
-                y: 220
+                y: 220,
               },
               3: {
                 x: 1488,
-                y: 196
+                y: 196,
               },
               4: {
                 x: 1616,
-                y: 196
+                y: 196,
               },
               5: {
                 x: 1616,
-                y: 196
+                y: 196,
               },
               6: {
                 x: 1616,
-                y: 220
-              }
-            }
+                y: 220,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 625,
@@ -17046,35 +17046,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 7,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 8,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 308
+            consecutiveTime: 308,
           },
           sourceArrival: {
             lock: false,
             time: 52,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 112
+            consecutiveTime: 112,
           },
           targetDeparture: {
             lock: false,
             time: 45,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 105
+            consecutiveTime: 105,
           },
           targetArrival: {
             lock: false,
             time: 15,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 315
+            consecutiveTime: 315,
           },
           numberOfStops: 0,
           trainrunId: 86,
@@ -17084,53 +17084,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 1790,
-                y: 240
+                y: 240,
               },
               {
                 x: 1726,
-                y: 240
+                y: 240,
               },
               {
                 x: 1506,
-                y: 240
+                y: 240,
               },
               {
                 x: 1442,
-                y: 240
-              }
+                y: 240,
+              },
             ],
             textPositions: {
               0: {
                 x: 1772,
-                y: 228
+                y: 228,
               },
               1: {
                 x: 1744,
-                y: 252
+                y: 252,
               },
               2: {
                 x: 1460,
-                y: 252
+                y: 252,
               },
               3: {
                 x: 1488,
-                y: 228
+                y: 228,
               },
               4: {
                 x: 1616,
-                y: 228
+                y: 228,
               },
               5: {
                 x: 1616,
-                y: 228
+                y: 228,
               },
               6: {
                 x: 1616,
-                y: 252
-              }
-            }
+                y: 252,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 626,
@@ -17143,35 +17143,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 13,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 11,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 11
+            consecutiveTime: 11,
           },
           sourceArrival: {
             lock: false,
             time: 49,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 169
+            consecutiveTime: 169,
           },
           targetDeparture: {
             lock: false,
             time: 36,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 156
+            consecutiveTime: 156,
           },
           targetArrival: {
             lock: false,
             time: 24,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 24
+            consecutiveTime: 24,
           },
           numberOfStops: 0,
           trainrunId: 93,
@@ -17181,53 +17181,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 322,
-                y: -1872
+                y: -1872,
               },
               {
                 x: 386,
-                y: -1872
+                y: -1872,
               },
               {
                 x: 990,
-                y: -944
+                y: -944,
               },
               {
                 x: 1054,
-                y: -944
-              }
+                y: -944,
+              },
             ],
             textPositions: {
               0: {
                 x: 340,
-                y: -1860
+                y: -1860,
               },
               1: {
                 x: 368,
-                y: -1884
+                y: -1884,
               },
               2: {
                 x: 1036,
-                y: -956
+                y: -956,
               },
               3: {
                 x: 1008,
-                y: -932
+                y: -932,
               },
               4: {
                 x: 688,
-                y: -1420
+                y: -1420,
               },
               5: {
                 x: 688,
-                y: -1420
+                y: -1420,
               },
               6: {
                 x: 688,
-                y: -1396
-              }
-            }
+                y: -1396,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 627,
@@ -17240,35 +17240,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 9,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 25,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 25
+            consecutiveTime: 25,
           },
           sourceArrival: {
             lock: false,
             time: 35,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 155
+            consecutiveTime: 155,
           },
           targetDeparture: {
             lock: false,
             time: 26,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 146
+            consecutiveTime: 146,
           },
           targetArrival: {
             lock: false,
             time: 34,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 34
+            consecutiveTime: 34,
           },
           numberOfStops: 0,
           trainrunId: 93,
@@ -17278,53 +17278,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 1154,
-                y: -944
+                y: -944,
               },
               {
                 x: 1218,
-                y: -944
+                y: -944,
               },
               {
                 x: 1726,
-                y: -656
+                y: -656,
               },
               {
                 x: 1790,
-                y: -656
-              }
+                y: -656,
+              },
             ],
             textPositions: {
               0: {
                 x: 1172,
-                y: -932
+                y: -932,
               },
               1: {
                 x: 1200,
-                y: -956
+                y: -956,
               },
               2: {
                 x: 1772,
-                y: -668
+                y: -668,
               },
               3: {
                 x: 1744,
-                y: -644
+                y: -644,
               },
               4: {
                 x: 1472,
-                y: -812
+                y: -812,
               },
               5: {
                 x: 1472,
-                y: -812
+                y: -812,
               },
               6: {
                 x: 1472,
-                y: -788
-              }
-            }
+                y: -788,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 628,
@@ -17337,35 +17337,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 22,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 35,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 35
+            consecutiveTime: 35,
           },
           sourceArrival: {
             lock: false,
             time: 25,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 145
+            consecutiveTime: 145,
           },
           targetDeparture: {
             lock: false,
             time: 3,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 123
+            consecutiveTime: 123,
           },
           targetArrival: {
             lock: false,
             time: 57,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 57
+            consecutiveTime: 57,
           },
           numberOfStops: 0,
           trainrunId: 93,
@@ -17375,53 +17375,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 1808,
-                y: -606
+                y: -606,
               },
               {
                 x: 1808,
-                y: -542
+                y: -542,
               },
               {
                 x: 1808,
-                y: -34
+                y: -34,
               },
               {
                 x: 1808,
-                y: 30
-              }
+                y: 30,
+              },
             ],
             textPositions: {
               0: {
                 x: 1796,
-                y: -588
+                y: -588,
               },
               1: {
                 x: 1820,
-                y: -560
+                y: -560,
               },
               2: {
                 x: 1820,
-                y: 12
+                y: 12,
               },
               3: {
                 x: 1796,
-                y: -16
+                y: -16,
               },
               4: {
                 x: 1796,
-                y: -288
+                y: -288,
               },
               5: {
                 x: 1796,
-                y: -288
+                y: -288,
               },
               6: {
                 x: 1820,
-                y: -288
-              }
-            }
+                y: -288,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 629,
@@ -17434,35 +17434,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 7,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 0,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 60
+            consecutiveTime: 60,
           },
           sourceArrival: {
             lock: false,
             time: 0,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 120
+            consecutiveTime: 120,
           },
           targetDeparture: {
             lock: false,
             time: 53,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 113
+            consecutiveTime: 113,
           },
           targetArrival: {
             lock: false,
             time: 7,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 67
+            consecutiveTime: 67,
           },
           numberOfStops: 0,
           trainrunId: 93,
@@ -17472,53 +17472,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 1890,
-                y: 272
+                y: 272,
               },
               {
                 x: 1954,
-                y: 272
+                y: 272,
               },
               {
                 x: 2174,
-                y: 272
+                y: 272,
               },
               {
                 x: 2238,
-                y: 272
-              }
+                y: 272,
+              },
             ],
             textPositions: {
               0: {
                 x: 1908,
-                y: 284
+                y: 284,
               },
               1: {
                 x: 1936,
-                y: 260
+                y: 260,
               },
               2: {
                 x: 2220,
-                y: 260
+                y: 260,
               },
               3: {
                 x: 2192,
-                y: 284
+                y: 284,
               },
               4: {
                 x: 2064,
-                y: 260
+                y: 260,
               },
               5: {
                 x: 2064,
-                y: 260
+                y: 260,
               },
               6: {
                 x: 2064,
-                y: 284
-              }
-            }
+                y: 284,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 630,
@@ -17531,35 +17531,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 16,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 8,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 68
+            consecutiveTime: 68,
           },
           sourceArrival: {
             lock: false,
             time: 52,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 112
+            consecutiveTime: 112,
           },
           targetDeparture: {
             lock: false,
             time: 36,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 96
+            consecutiveTime: 96,
           },
           targetArrival: {
             lock: false,
             time: 24,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 84
+            consecutiveTime: 84,
           },
           numberOfStops: 0,
           trainrunId: 93,
@@ -17569,53 +17569,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2338,
-                y: 272
+                y: 272,
               },
               {
                 x: 2402,
-                y: 272
+                y: 272,
               },
               {
                 x: 2590,
-                y: 272
+                y: 272,
               },
               {
                 x: 2654,
-                y: 272
-              }
+                y: 272,
+              },
             ],
             textPositions: {
               0: {
                 x: 2356,
-                y: 284
+                y: 284,
               },
               1: {
                 x: 2384,
-                y: 260
+                y: 260,
               },
               2: {
                 x: 2636,
-                y: 260
+                y: 260,
               },
               3: {
                 x: 2608,
-                y: 284
+                y: 284,
               },
               4: {
                 x: 2496,
-                y: 260
+                y: 260,
               },
               5: {
                 x: 2496,
-                y: 260
+                y: 260,
               },
               6: {
                 x: 2496,
-                y: 284
-              }
-            }
+                y: 284,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 631,
@@ -17628,35 +17628,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 5,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 6,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 6
+            consecutiveTime: 6,
           },
           sourceArrival: {
             lock: false,
             time: 54,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 174
+            consecutiveTime: 174,
           },
           targetDeparture: {
             lock: false,
             time: 49,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 169
+            consecutiveTime: 169,
           },
           targetArrival: {
             lock: false,
             time: 11,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 11
+            consecutiveTime: 11,
           },
           numberOfStops: 0,
           trainrunId: 94,
@@ -17666,53 +17666,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 144,
-                y: -1822
+                y: -1822,
               },
               {
                 x: 144,
-                y: -1758
+                y: -1758,
               },
               {
                 x: 144,
-                y: -1474
+                y: -1474,
               },
               {
                 x: 144,
-                y: -1410
-              }
+                y: -1410,
+              },
             ],
             textPositions: {
               0: {
                 x: 132,
-                y: -1804
+                y: -1804,
               },
               1: {
                 x: 156,
-                y: -1776
+                y: -1776,
               },
               2: {
                 x: 156,
-                y: -1428
+                y: -1428,
               },
               3: {
                 x: 132,
-                y: -1456
+                y: -1456,
               },
               4: {
                 x: 132,
-                y: -1616
+                y: -1616,
               },
               5: {
                 x: 132,
-                y: -1616
+                y: -1616,
               },
               6: {
                 x: 156,
-                y: -1616
-              }
-            }
+                y: -1616,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 632,
@@ -17725,35 +17725,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 6,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 11,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 11
+            consecutiveTime: 11,
           },
           sourceArrival: {
             lock: false,
             time: 49,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 169
+            consecutiveTime: 169,
           },
           targetDeparture: {
             lock: false,
             time: 43,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 163
+            consecutiveTime: 163,
           },
           targetArrival: {
             lock: false,
             time: 17,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 17
+            consecutiveTime: 17,
           },
           numberOfStops: 0,
           trainrunId: 94,
@@ -17763,53 +17763,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 144,
-                y: -1342
+                y: -1342,
               },
               {
                 x: 144,
-                y: -1278
+                y: -1278,
               },
               {
                 x: 144,
-                y: -994
+                y: -994,
               },
               {
                 x: 144,
-                y: -930
-              }
+                y: -930,
+              },
             ],
             textPositions: {
               0: {
                 x: 132,
-                y: -1324
+                y: -1324,
               },
               1: {
                 x: 156,
-                y: -1296
+                y: -1296,
               },
               2: {
                 x: 156,
-                y: -948
+                y: -948,
               },
               3: {
                 x: 132,
-                y: -976
+                y: -976,
               },
               4: {
                 x: 132,
-                y: -1136
+                y: -1136,
               },
               5: {
                 x: 132,
-                y: -1136
+                y: -1136,
               },
               6: {
                 x: 156,
-                y: -1136
-              }
-            }
+                y: -1136,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 633,
@@ -17822,35 +17822,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 6,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 17,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 17
+            consecutiveTime: 17,
           },
           sourceArrival: {
             lock: false,
             time: 43,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 163
+            consecutiveTime: 163,
           },
           targetDeparture: {
             lock: false,
             time: 37,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 157
+            consecutiveTime: 157,
           },
           targetArrival: {
             lock: false,
             time: 23,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 23
+            consecutiveTime: 23,
           },
           numberOfStops: 0,
           trainrunId: 94,
@@ -17860,53 +17860,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 144,
-                y: -862
+                y: -862,
               },
               {
                 x: 144,
-                y: -798
+                y: -798,
               },
               {
                 x: 144,
-                y: -514
+                y: -514,
               },
               {
                 x: 144,
-                y: -450
-              }
+                y: -450,
+              },
             ],
             textPositions: {
               0: {
                 x: 132,
-                y: -844
+                y: -844,
               },
               1: {
                 x: 156,
-                y: -816
+                y: -816,
               },
               2: {
                 x: 156,
-                y: -468
+                y: -468,
               },
               3: {
                 x: 132,
-                y: -496
+                y: -496,
               },
               4: {
                 x: 132,
-                y: -656
+                y: -656,
               },
               5: {
                 x: 132,
-                y: -656
+                y: -656,
               },
               6: {
                 x: 156,
-                y: -656
-              }
-            }
+                y: -656,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 634,
@@ -17919,35 +17919,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 10,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 23,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 23
+            consecutiveTime: 23,
           },
           sourceArrival: {
             lock: false,
             time: 37,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 157
+            consecutiveTime: 157,
           },
           targetDeparture: {
             lock: false,
             time: 27,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 147
+            consecutiveTime: 147,
           },
           targetArrival: {
             lock: false,
             time: 33,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 33
+            consecutiveTime: 33,
           },
           numberOfStops: 0,
           trainrunId: 94,
@@ -17957,53 +17957,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 322,
-                y: -400
+                y: -400,
               },
               {
                 x: 386,
-                y: -400
+                y: -400,
               },
               {
                 x: 894,
-                y: 80
+                y: 80,
               },
               {
                 x: 958,
-                y: 80
-              }
+                y: 80,
+              },
             ],
             textPositions: {
               0: {
                 x: 340,
-                y: -388
+                y: -388,
               },
               1: {
                 x: 368,
-                y: -412
+                y: -412,
               },
               2: {
                 x: 940,
-                y: 68
+                y: 68,
               },
               3: {
                 x: 912,
-                y: 92
+                y: 92,
               },
               4: {
                 x: 640,
-                y: -172
+                y: -172,
               },
               5: {
                 x: 640,
-                y: -172
+                y: -172,
               },
               6: {
                 x: 640,
-                y: -148
-              }
-            }
+                y: -148,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 635,
@@ -18016,35 +18016,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 7,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 33,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 33
+            consecutiveTime: 33,
           },
           sourceArrival: {
             lock: false,
             time: 27,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 147
+            consecutiveTime: 147,
           },
           targetDeparture: {
             lock: false,
             time: 20,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 140
+            consecutiveTime: 140,
           },
           targetArrival: {
             lock: false,
             time: 40,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 40
+            consecutiveTime: 40,
           },
           numberOfStops: 0,
           trainrunId: 94,
@@ -18054,53 +18054,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 1058,
-                y: 112
+                y: 112,
               },
               {
                 x: 1122,
-                y: 112
+                y: 112,
               },
               {
                 x: 1278,
-                y: 112
+                y: 112,
               },
               {
                 x: 1342,
-                y: 112
-              }
+                y: 112,
+              },
             ],
             textPositions: {
               0: {
                 x: 1076,
-                y: 124
+                y: 124,
               },
               1: {
                 x: 1104,
-                y: 100
+                y: 100,
               },
               2: {
                 x: 1324,
-                y: 100
+                y: 100,
               },
               3: {
                 x: 1296,
-                y: 124
+                y: 124,
               },
               4: {
                 x: 1200,
-                y: 100
+                y: 100,
               },
               5: {
                 x: 1200,
-                y: 100
+                y: 100,
               },
               6: {
                 x: 1200,
-                y: 124
-              }
-            }
+                y: 124,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 636,
@@ -18113,35 +18113,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 6,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 40,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 40
+            consecutiveTime: 40,
           },
           sourceArrival: {
             lock: false,
             time: 20,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 140
+            consecutiveTime: 140,
           },
           targetDeparture: {
             lock: false,
             time: 14,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 134
+            consecutiveTime: 134,
           },
           targetArrival: {
             lock: false,
             time: 46,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 46
+            consecutiveTime: 46,
           },
           numberOfStops: 0,
           trainrunId: 94,
@@ -18151,53 +18151,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 1442,
-                y: 112
+                y: 112,
               },
               {
                 x: 1506,
-                y: 112
+                y: 112,
               },
               {
                 x: 1726,
-                y: 112
+                y: 112,
               },
               {
                 x: 1790,
-                y: 112
-              }
+                y: 112,
+              },
             ],
             textPositions: {
               0: {
                 x: 1460,
-                y: 124
+                y: 124,
               },
               1: {
                 x: 1488,
-                y: 100
+                y: 100,
               },
               2: {
                 x: 1772,
-                y: 100
+                y: 100,
               },
               3: {
                 x: 1744,
-                y: 124
+                y: 124,
               },
               4: {
                 x: 1616,
-                y: 100
+                y: 100,
               },
               5: {
                 x: 1616,
-                y: 100
+                y: 100,
               },
               6: {
                 x: 1616,
-                y: 124
-              }
-            }
+                y: 124,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 637,
@@ -18210,35 +18210,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 6,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 46,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 46
+            consecutiveTime: 46,
           },
           sourceArrival: {
             lock: false,
             time: 14,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 134
+            consecutiveTime: 134,
           },
           targetDeparture: {
             lock: false,
             time: 8,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 128
+            consecutiveTime: 128,
           },
           targetArrival: {
             lock: false,
             time: 52,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 52
+            consecutiveTime: 52,
           },
           numberOfStops: 0,
           trainrunId: 94,
@@ -18248,53 +18248,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 1890,
-                y: 112
+                y: 112,
               },
               {
                 x: 1954,
-                y: 112
+                y: 112,
               },
               {
                 x: 2174,
-                y: 112
+                y: 112,
               },
               {
                 x: 2238,
-                y: 112
-              }
+                y: 112,
+              },
             ],
             textPositions: {
               0: {
                 x: 1908,
-                y: 124
+                y: 124,
               },
               1: {
                 x: 1936,
-                y: 100
+                y: 100,
               },
               2: {
                 x: 2220,
-                y: 100
+                y: 100,
               },
               3: {
                 x: 2192,
-                y: 124
+                y: 124,
               },
               4: {
                 x: 2064,
-                y: 100
+                y: 100,
               },
               5: {
                 x: 2064,
-                y: 100
+                y: 100,
               },
               6: {
                 x: 2064,
-                y: 124
-              }
-            }
+                y: 124,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 638,
@@ -18307,35 +18307,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 8,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 52,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 52
+            consecutiveTime: 52,
           },
           sourceArrival: {
             lock: false,
             time: 8,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 128
+            consecutiveTime: 128,
           },
           targetDeparture: {
             lock: false,
             time: 0,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 120
+            consecutiveTime: 120,
           },
           targetArrival: {
             lock: false,
             time: 0,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 60
+            consecutiveTime: 60,
           },
           numberOfStops: 0,
           trainrunId: 94,
@@ -18345,53 +18345,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2338,
-                y: 112
+                y: 112,
               },
               {
                 x: 2402,
-                y: 112
+                y: 112,
               },
               {
                 x: 2590,
-                y: 112
+                y: 112,
               },
               {
                 x: 2654,
-                y: 112
-              }
+                y: 112,
+              },
             ],
             textPositions: {
               0: {
                 x: 2356,
-                y: 124
+                y: 124,
               },
               1: {
                 x: 2384,
-                y: 100
+                y: 100,
               },
               2: {
                 x: 2636,
-                y: 100
+                y: 100,
               },
               3: {
                 x: 2608,
-                y: 124
+                y: 124,
               },
               4: {
                 x: 2496,
-                y: 100
+                y: 100,
               },
               5: {
                 x: 2496,
-                y: 100
+                y: 100,
               },
               6: {
                 x: 2496,
-                y: 124
-              }
-            }
+                y: 124,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 639,
@@ -18404,35 +18404,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 6,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 54,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 54
+            consecutiveTime: 54,
           },
           sourceArrival: {
             lock: false,
             time: 6,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 126
+            consecutiveTime: 126,
           },
           targetDeparture: {
             lock: false,
             time: 0,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 120
+            consecutiveTime: 120,
           },
           targetArrival: {
             lock: false,
             time: 0,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 60
+            consecutiveTime: 60,
           },
           numberOfStops: 0,
           trainrunId: 97,
@@ -18442,53 +18442,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 1058,
-                y: 272
+                y: 272,
               },
               {
                 x: 1122,
-                y: 272
+                y: 272,
               },
               {
                 x: 1278,
-                y: 272
+                y: 272,
               },
               {
                 x: 1342,
-                y: 272
-              }
+                y: 272,
+              },
             ],
             textPositions: {
               0: {
                 x: 1076,
-                y: 284
+                y: 284,
               },
               1: {
                 x: 1104,
-                y: 260
+                y: 260,
               },
               2: {
                 x: 1324,
-                y: 260
+                y: 260,
               },
               3: {
                 x: 1296,
-                y: 284
+                y: 284,
               },
               4: {
                 x: 1200,
-                y: 260
+                y: 260,
               },
               5: {
                 x: 1200,
-                y: 260
+                y: 260,
               },
               6: {
                 x: 1200,
-                y: 284
-              }
-            }
+                y: 284,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 640,
@@ -18501,35 +18501,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 6,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 2,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 62
+            consecutiveTime: 62,
           },
           sourceArrival: {
             lock: false,
             time: 58,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 118
+            consecutiveTime: 118,
           },
           targetDeparture: {
             lock: false,
             time: 52,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 112
+            consecutiveTime: 112,
           },
           targetArrival: {
             lock: false,
             time: 8,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 68
+            consecutiveTime: 68,
           },
           numberOfStops: 0,
           trainrunId: 97,
@@ -18539,53 +18539,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 1442,
-                y: 272
+                y: 272,
               },
               {
                 x: 1506,
-                y: 272
+                y: 272,
               },
               {
                 x: 1726,
-                y: 272
+                y: 272,
               },
               {
                 x: 1790,
-                y: 272
-              }
+                y: 272,
+              },
             ],
             textPositions: {
               0: {
                 x: 1460,
-                y: 284
+                y: 284,
               },
               1: {
                 x: 1488,
-                y: 260
+                y: 260,
               },
               2: {
                 x: 1772,
-                y: 260
+                y: 260,
               },
               3: {
                 x: 1744,
-                y: 284
+                y: 284,
               },
               4: {
                 x: 1616,
-                y: 260
+                y: 260,
               },
               5: {
                 x: 1616,
-                y: 260
+                y: 260,
               },
               6: {
                 x: 1616,
-                y: 284
-              }
-            }
+                y: 284,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 641,
@@ -18598,35 +18598,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 7,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 8,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 68
+            consecutiveTime: 68,
           },
           sourceArrival: {
             lock: false,
             time: 52,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 112
+            consecutiveTime: 112,
           },
           targetDeparture: {
             lock: false,
             time: 45,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 105
+            consecutiveTime: 105,
           },
           targetArrival: {
             lock: false,
             time: 15,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 75
+            consecutiveTime: 75,
           },
           numberOfStops: 0,
           trainrunId: 97,
@@ -18636,53 +18636,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 1890,
-                y: 304
+                y: 304,
               },
               {
                 x: 1954,
-                y: 304
+                y: 304,
               },
               {
                 x: 2174,
-                y: 304
+                y: 304,
               },
               {
                 x: 2238,
-                y: 304
-              }
+                y: 304,
+              },
             ],
             textPositions: {
               0: {
                 x: 1908,
-                y: 316
+                y: 316,
               },
               1: {
                 x: 1936,
-                y: 292
+                y: 292,
               },
               2: {
                 x: 2220,
-                y: 292
+                y: 292,
               },
               3: {
                 x: 2192,
-                y: 316
+                y: 316,
               },
               4: {
                 x: 2064,
-                y: 292
+                y: 292,
               },
               5: {
                 x: 2064,
-                y: 292
+                y: 292,
               },
               6: {
                 x: 2064,
-                y: 316
-              }
-            }
+                y: 316,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 642,
@@ -18695,35 +18695,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 7,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 15,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 75
+            consecutiveTime: 75,
           },
           sourceArrival: {
             lock: false,
             time: 45,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 105
+            consecutiveTime: 105,
           },
           targetDeparture: {
             lock: false,
             time: 38,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 98
+            consecutiveTime: 98,
           },
           targetArrival: {
             lock: false,
             time: 22,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 82
+            consecutiveTime: 82,
           },
           numberOfStops: 0,
           trainrunId: 97,
@@ -18733,53 +18733,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2338,
-                y: 304
+                y: 304,
               },
               {
                 x: 2402,
-                y: 304
+                y: 304,
               },
               {
                 x: 2590,
-                y: 304
+                y: 304,
               },
               {
                 x: 2654,
-                y: 304
-              }
+                y: 304,
+              },
             ],
             textPositions: {
               0: {
                 x: 2356,
-                y: 316
+                y: 316,
               },
               1: {
                 x: 2384,
-                y: 292
+                y: 292,
               },
               2: {
                 x: 2636,
-                y: 292
+                y: 292,
               },
               3: {
                 x: 2608,
-                y: 316
+                y: 316,
               },
               4: {
                 x: 2496,
-                y: 292
+                y: 292,
               },
               5: {
                 x: 2496,
-                y: 292
+                y: 292,
               },
               6: {
                 x: 2496,
-                y: 316
-              }
-            }
+                y: 316,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 643,
@@ -18792,35 +18792,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 7,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 28,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 28
+            consecutiveTime: 28,
           },
           sourceArrival: {
             lock: false,
             time: 32,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 272
+            consecutiveTime: 272,
           },
           targetDeparture: {
             lock: false,
             time: 25,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 265
+            consecutiveTime: 265,
           },
           targetArrival: {
             lock: false,
             time: 35,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 35
+            consecutiveTime: 35,
           },
           numberOfStops: 0,
           trainrunId: 95,
@@ -18830,53 +18830,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 208,
-                y: -1822
+                y: -1822,
               },
               {
                 x: 208,
-                y: -1758
+                y: -1758,
               },
               {
                 x: 208,
-                y: -1474
+                y: -1474,
               },
               {
                 x: 208,
-                y: -1410
-              }
+                y: -1410,
+              },
             ],
             textPositions: {
               0: {
                 x: 196,
-                y: -1804
+                y: -1804,
               },
               1: {
                 x: 220,
-                y: -1776
+                y: -1776,
               },
               2: {
                 x: 220,
-                y: -1428
+                y: -1428,
               },
               3: {
                 x: 196,
-                y: -1456
+                y: -1456,
               },
               4: {
                 x: 196,
-                y: -1616
+                y: -1616,
               },
               5: {
                 x: 196,
-                y: -1616
+                y: -1616,
               },
               6: {
                 x: 220,
-                y: -1616
-              }
-            }
+                y: -1616,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 644,
@@ -18889,35 +18889,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 6,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 35,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 35
+            consecutiveTime: 35,
           },
           sourceArrival: {
             lock: false,
             time: 25,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 265
+            consecutiveTime: 265,
           },
           targetDeparture: {
             lock: false,
             time: 19,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 259
+            consecutiveTime: 259,
           },
           targetArrival: {
             lock: false,
             time: 41,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 41
+            consecutiveTime: 41,
           },
           numberOfStops: 0,
           trainrunId: 95,
@@ -18927,53 +18927,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 208,
-                y: -1342
+                y: -1342,
               },
               {
                 x: 208,
-                y: -1278
+                y: -1278,
               },
               {
                 x: 208,
-                y: -994
+                y: -994,
               },
               {
                 x: 208,
-                y: -930
-              }
+                y: -930,
+              },
             ],
             textPositions: {
               0: {
                 x: 196,
-                y: -1324
+                y: -1324,
               },
               1: {
                 x: 220,
-                y: -1296
+                y: -1296,
               },
               2: {
                 x: 220,
-                y: -948
+                y: -948,
               },
               3: {
                 x: 196,
-                y: -976
+                y: -976,
               },
               4: {
                 x: 196,
-                y: -1136
+                y: -1136,
               },
               5: {
                 x: 196,
-                y: -1136
+                y: -1136,
               },
               6: {
                 x: 220,
-                y: -1136
-              }
-            }
+                y: -1136,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 645,
@@ -18986,35 +18986,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 6,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 41,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 41
+            consecutiveTime: 41,
           },
           sourceArrival: {
             lock: false,
             time: 19,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 259
+            consecutiveTime: 259,
           },
           targetDeparture: {
             lock: false,
             time: 13,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 253
+            consecutiveTime: 253,
           },
           targetArrival: {
             lock: false,
             time: 47,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 47
+            consecutiveTime: 47,
           },
           numberOfStops: 0,
           trainrunId: 95,
@@ -19024,53 +19024,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 208,
-                y: -862
+                y: -862,
               },
               {
                 x: 208,
-                y: -798
+                y: -798,
               },
               {
                 x: 208,
-                y: -514
+                y: -514,
               },
               {
                 x: 208,
-                y: -450
-              }
+                y: -450,
+              },
             ],
             textPositions: {
               0: {
                 x: 196,
-                y: -844
+                y: -844,
               },
               1: {
                 x: 220,
-                y: -816
+                y: -816,
               },
               2: {
                 x: 220,
-                y: -468
+                y: -468,
               },
               3: {
                 x: 196,
-                y: -496
+                y: -496,
               },
               4: {
                 x: 196,
-                y: -656
+                y: -656,
               },
               5: {
                 x: 196,
-                y: -656
+                y: -656,
               },
               6: {
                 x: 220,
-                y: -656
-              }
-            }
+                y: -656,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 646,
@@ -19083,35 +19083,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 8,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 47,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 47
+            consecutiveTime: 47,
           },
           sourceArrival: {
             lock: false,
             time: 13,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 253
+            consecutiveTime: 253,
           },
           targetDeparture: {
             lock: true,
             time: 5,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 245
+            consecutiveTime: 245,
           },
           targetArrival: {
             lock: true,
             time: 55,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 55
+            consecutiveTime: 55,
           },
           numberOfStops: 0,
           trainrunId: 95,
@@ -19121,53 +19121,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 144,
-                y: -354
+                y: -354,
               },
               {
                 x: 144,
-                y: -290
+                y: -290,
               },
               {
                 x: 144,
-                y: 30
+                y: 30,
               },
               {
                 x: 144,
-                y: 94
-              }
+                y: 94,
+              },
             ],
             textPositions: {
               0: {
                 x: 132,
-                y: -336
+                y: -336,
               },
               1: {
                 x: 156,
-                y: -308
+                y: -308,
               },
               2: {
                 x: 156,
-                y: 76
+                y: 76,
               },
               3: {
                 x: 132,
-                y: 48
+                y: 48,
               },
               4: {
                 x: 132,
-                y: -130
+                y: -130,
               },
               5: {
                 x: 132,
-                y: -130
+                y: -130,
               },
               6: {
                 x: 156,
-                y: -130
-              }
-            }
+                y: -130,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 647,
@@ -19180,35 +19180,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 7,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 58,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 58
+            consecutiveTime: 58,
           },
           sourceArrival: {
             lock: true,
             time: 2,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 242
+            consecutiveTime: 242,
           },
           targetDeparture: {
             lock: false,
             time: 55,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 235
+            consecutiveTime: 235,
           },
           targetArrival: {
             lock: false,
             time: 5,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 65
+            consecutiveTime: 65,
           },
           numberOfStops: 0,
           trainrunId: 95,
@@ -19218,53 +19218,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 62,
-                y: 208
+                y: 208,
               },
               {
                 x: -2,
-                y: 208
+                y: 208,
               },
               {
                 x: -446,
-                y: 208
+                y: 208,
               },
               {
                 x: -510,
-                y: 208
-              }
+                y: 208,
+              },
             ],
             textPositions: {
               0: {
                 x: 44,
-                y: 196
+                y: 196,
               },
               1: {
                 x: 16,
-                y: 220
+                y: 220,
               },
               2: {
                 x: -492,
-                y: 220
+                y: 220,
               },
               3: {
                 x: -464,
-                y: 196
+                y: 196,
               },
               4: {
                 x: -224,
-                y: 196
+                y: 196,
               },
               5: {
                 x: -224,
-                y: 196
+                y: 196,
               },
               6: {
                 x: -224,
-                y: 220
-              }
-            }
+                y: 220,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 648,
@@ -19277,35 +19277,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 18,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 34,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 94
+            consecutiveTime: 94,
           },
           sourceArrival: {
             lock: true,
             time: 26,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 206
+            consecutiveTime: 206,
           },
           targetDeparture: {
             lock: true,
             time: 8,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 188
+            consecutiveTime: 188,
           },
           targetArrival: {
             lock: true,
             time: 52,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 112
+            consecutiveTime: 112,
           },
           numberOfStops: 0,
           trainrunId: 95,
@@ -19315,53 +19315,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: -2096,
-                y: 382
+                y: 382,
               },
               {
                 x: -2096,
-                y: 446
+                y: 446,
               },
               {
                 x: -2096,
-                y: 574
+                y: 574,
               },
               {
                 x: -2096,
-                y: 638
-              }
+                y: 638,
+              },
             ],
             textPositions: {
               0: {
                 x: -2108,
-                y: 400
+                y: 400,
               },
               1: {
                 x: -2084,
-                y: 428
+                y: 428,
               },
               2: {
                 x: -2084,
-                y: 620
+                y: 620,
               },
               3: {
                 x: -2108,
-                y: 592
+                y: 592,
               },
               4: {
                 x: -2108,
-                y: 510
+                y: 510,
               },
               5: {
                 x: -2108,
-                y: 510
+                y: 510,
               },
               6: {
                 x: -2084,
-                y: 510
-              }
-            }
+                y: 510,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 649,
@@ -19374,35 +19374,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 18,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 59,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 359
+            consecutiveTime: 359,
           },
           sourceArrival: {
             lock: false,
             time: 1,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 61
+            consecutiveTime: 61,
           },
           targetDeparture: {
             lock: false,
             time: 43,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 43
+            consecutiveTime: 43,
           },
           targetArrival: {
             lock: false,
             time: 17,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 377
+            consecutiveTime: 377,
           },
           numberOfStops: 0,
           trainrunId: 89,
@@ -19412,53 +19412,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: -2064,
-                y: 382
+                y: 382,
               },
               {
                 x: -2064,
-                y: 446
+                y: 446,
               },
               {
                 x: -2064,
-                y: 574
+                y: 574,
               },
               {
                 x: -2064,
-                y: 638
-              }
+                y: 638,
+              },
             ],
             textPositions: {
               0: {
                 x: -2076,
-                y: 400
+                y: 400,
               },
               1: {
                 x: -2052,
-                y: 428
+                y: 428,
               },
               2: {
                 x: -2052,
-                y: 620
+                y: 620,
               },
               3: {
                 x: -2076,
-                y: 592
+                y: 592,
               },
               4: {
                 x: -2076,
-                y: 510
+                y: 510,
               },
               5: {
                 x: -2076,
-                y: 510
+                y: 510,
               },
               6: {
                 x: -2052,
-                y: 510
-              }
-            }
+                y: 510,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 650,
@@ -19471,35 +19471,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 8,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 54,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 114
+            consecutiveTime: 114,
           },
           sourceArrival: {
             lock: false,
             time: 6,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 186
+            consecutiveTime: 186,
           },
           targetDeparture: {
             lock: false,
             time: 58,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 178
+            consecutiveTime: 178,
           },
           targetArrival: {
             lock: false,
             time: 2,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 122
+            consecutiveTime: 122,
           },
           numberOfStops: 0,
           trainrunId: 95,
@@ -19509,53 +19509,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: -2096,
-                y: 706
+                y: 706,
               },
               {
                 x: -2096,
-                y: 770
+                y: 770,
               },
               {
                 x: -2096,
-                y: 862
+                y: 862,
               },
               {
                 x: -2096,
-                y: 926
-              }
+                y: 926,
+              },
             ],
             textPositions: {
               0: {
                 x: -2108,
-                y: 724
+                y: 724,
               },
               1: {
                 x: -2084,
-                y: 752
+                y: 752,
               },
               2: {
                 x: -2084,
-                y: 908
+                y: 908,
               },
               3: {
                 x: -2108,
-                y: 880
+                y: 880,
               },
               4: {
                 x: -2108,
-                y: 816
+                y: 816,
               },
               5: {
                 x: -2108,
-                y: 816
+                y: 816,
               },
               6: {
                 x: -2084,
-                y: 816
-              }
-            }
+                y: 816,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 651,
@@ -19568,35 +19568,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 24,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 4,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 124
+            consecutiveTime: 124,
           },
           sourceArrival: {
             lock: false,
             time: 56,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 176
+            consecutiveTime: 176,
           },
           targetDeparture: {
             lock: false,
             time: 32,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 152
+            consecutiveTime: 152,
           },
           targetArrival: {
             lock: false,
             time: 28,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 148
+            consecutiveTime: 148,
           },
           numberOfStops: 0,
           trainrunId: 95,
@@ -19606,53 +19606,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: -2014,
-                y: 944
+                y: 944,
               },
               {
                 x: -1950,
-                y: 944
+                y: 944,
               },
               {
                 x: -1154,
-                y: 944
+                y: 944,
               },
               {
                 x: -1090,
-                y: 944
-              }
+                y: 944,
+              },
             ],
             textPositions: {
               0: {
                 x: -1996,
-                y: 956
+                y: 956,
               },
               1: {
                 x: -1968,
-                y: 932
+                y: 932,
               },
               2: {
                 x: -1108,
-                y: 932
+                y: 932,
               },
               3: {
                 x: -1136,
-                y: 956
+                y: 956,
               },
               4: {
                 x: -1552,
-                y: 932
+                y: 932,
               },
               5: {
                 x: -1552,
-                y: 932
+                y: 932,
               },
               6: {
                 x: -1552,
-                y: 956
-              }
-            }
+                y: 956,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 652,
@@ -19665,35 +19665,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 10,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 19,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 379
+            consecutiveTime: 379,
           },
           sourceArrival: {
             lock: false,
             time: 41,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 41
+            consecutiveTime: 41,
           },
           targetDeparture: {
             lock: false,
             time: 31,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 31
+            consecutiveTime: 31,
           },
           targetArrival: {
             lock: false,
             time: 29,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 389
+            consecutiveTime: 389,
           },
           numberOfStops: 0,
           trainrunId: 89,
@@ -19703,53 +19703,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: -2064,
-                y: 706
+                y: 706,
               },
               {
                 x: -2064,
-                y: 770
+                y: 770,
               },
               {
                 x: -2064,
-                y: 862
+                y: 862,
               },
               {
                 x: -2064,
-                y: 926
-              }
+                y: 926,
+              },
             ],
             textPositions: {
               0: {
                 x: -2076,
-                y: 724
+                y: 724,
               },
               1: {
                 x: -2052,
-                y: 752
+                y: 752,
               },
               2: {
                 x: -2052,
-                y: 908
+                y: 908,
               },
               3: {
                 x: -2076,
-                y: 880
+                y: 880,
               },
               4: {
                 x: -2076,
-                y: 816
+                y: 816,
               },
               5: {
                 x: -2076,
-                y: 816
+                y: 816,
               },
               6: {
                 x: -2052,
-                y: 816
-              }
-            }
+                y: 816,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 653,
@@ -19762,35 +19762,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 25,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 31,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 391
+            consecutiveTime: 391,
           },
           sourceArrival: {
             lock: false,
             time: 29,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 29
+            consecutiveTime: 29,
           },
           targetDeparture: {
             lock: false,
             time: 4,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 4
+            consecutiveTime: 4,
           },
           targetArrival: {
             lock: false,
             time: 56,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 416
+            consecutiveTime: 416,
           },
           numberOfStops: 0,
           trainrunId: 89,
@@ -19800,53 +19800,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: -2096,
-                y: 1022
+                y: 1022,
               },
               {
                 x: -2096,
-                y: 1086
+                y: 1086,
               },
               {
                 x: -2096,
-                y: 1374
+                y: 1374,
               },
               {
                 x: -2096,
-                y: 1438
-              }
+                y: 1438,
+              },
             ],
             textPositions: {
               0: {
                 x: -2108,
-                y: 1040
+                y: 1040,
               },
               1: {
                 x: -2084,
-                y: 1068
+                y: 1068,
               },
               2: {
                 x: -2084,
-                y: 1420
+                y: 1420,
               },
               3: {
                 x: -2108,
-                y: 1392
+                y: 1392,
               },
               4: {
                 x: -2108,
-                y: 1230
+                y: 1230,
               },
               5: {
                 x: -2108,
-                y: 1230
+                y: 1230,
               },
               6: {
                 x: -2084,
-                y: 1230
-              }
-            }
+                y: 1230,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 654,
@@ -19859,35 +19859,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 26,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 29,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 149
+            consecutiveTime: 149,
           },
           sourceArrival: {
             lock: false,
             time: 31,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 151
+            consecutiveTime: 151,
           },
           targetDeparture: {
             lock: false,
             time: 5,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 125
+            consecutiveTime: 125,
           },
           targetArrival: {
             lock: false,
             time: 55,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 175
+            consecutiveTime: 175,
           },
           numberOfStops: 0,
           trainrunId: 96,
@@ -19897,53 +19897,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: -2128,
-                y: 1438
+                y: 1438,
               },
               {
                 x: -2128,
-                y: 1374
+                y: 1374,
               },
               {
                 x: -2128,
-                y: 1086
+                y: 1086,
               },
               {
                 x: -2128,
-                y: 1022
-              }
+                y: 1022,
+              },
             ],
             textPositions: {
               0: {
                 x: -2116,
-                y: 1420
+                y: 1420,
               },
               1: {
                 x: -2140,
-                y: 1392
+                y: 1392,
               },
               2: {
                 x: -2140,
-                y: 1040
+                y: 1040,
               },
               3: {
                 x: -2116,
-                y: 1068
+                y: 1068,
               },
               4: {
                 x: -2140,
-                y: 1230
+                y: 1230,
               },
               5: {
                 x: -2140,
-                y: 1230
+                y: 1230,
               },
               6: {
                 x: -2116,
-                y: 1230
-              }
-            }
+                y: 1230,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 655,
@@ -19956,35 +19956,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 8,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 58,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 178
+            consecutiveTime: 178,
           },
           sourceArrival: {
             lock: false,
             time: 2,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 122
+            consecutiveTime: 122,
           },
           targetDeparture: {
             lock: false,
             time: 54,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 114
+            consecutiveTime: 114,
           },
           targetArrival: {
             lock: false,
             time: 6,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 186
+            consecutiveTime: 186,
           },
           numberOfStops: 0,
           trainrunId: 96,
@@ -19994,53 +19994,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: -2128,
-                y: 926
+                y: 926,
               },
               {
                 x: -2128,
-                y: 862
+                y: 862,
               },
               {
                 x: -2128,
-                y: 770
+                y: 770,
               },
               {
                 x: -2128,
-                y: 706
-              }
+                y: 706,
+              },
             ],
             textPositions: {
               0: {
                 x: -2116,
-                y: 908
+                y: 908,
               },
               1: {
                 x: -2140,
-                y: 880
+                y: 880,
               },
               2: {
                 x: -2140,
-                y: 724
+                y: 724,
               },
               3: {
                 x: -2116,
-                y: 752
+                y: 752,
               },
               4: {
                 x: -2140,
-                y: 816
+                y: 816,
               },
               5: {
                 x: -2140,
-                y: 816
+                y: 816,
               },
               6: {
                 x: -2116,
-                y: 816
-              }
-            }
+                y: 816,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 656,
@@ -20053,35 +20053,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 18,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 8,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 188
+            consecutiveTime: 188,
           },
           sourceArrival: {
             lock: false,
             time: 52,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 112
+            consecutiveTime: 112,
           },
           targetDeparture: {
             lock: true,
             time: 34,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 94
+            consecutiveTime: 94,
           },
           targetArrival: {
             lock: true,
             time: 26,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 206
+            consecutiveTime: 206,
           },
           numberOfStops: 0,
           trainrunId: 96,
@@ -20091,53 +20091,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: -2128,
-                y: 638
+                y: 638,
               },
               {
                 x: -2128,
-                y: 574
+                y: 574,
               },
               {
                 x: -2128,
-                y: 446
+                y: 446,
               },
               {
                 x: -2128,
-                y: 382
-              }
+                y: 382,
+              },
             ],
             textPositions: {
               0: {
                 x: -2116,
-                y: 620
+                y: 620,
               },
               1: {
                 x: -2140,
-                y: 592
+                y: 592,
               },
               2: {
                 x: -2140,
-                y: 400
+                y: 400,
               },
               3: {
                 x: -2116,
-                y: 428
+                y: 428,
               },
               4: {
                 x: -2140,
-                y: 510
+                y: 510,
               },
               5: {
                 x: -2140,
-                y: 510
+                y: 510,
               },
               6: {
                 x: -2116,
-                y: 510
-              }
-            }
+                y: 510,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 657,
@@ -20150,35 +20150,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 3,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 34,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 214
+            consecutiveTime: 214,
           },
           sourceArrival: {
             lock: true,
             time: 26,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 86
+            consecutiveTime: 86,
           },
           targetDeparture: {
             lock: false,
             time: 23,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 83
+            consecutiveTime: 83,
           },
           targetArrival: {
             lock: false,
             time: 37,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 217
+            consecutiveTime: 217,
           },
           numberOfStops: 0,
           trainrunId: 96,
@@ -20188,53 +20188,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: -2014,
-                y: 176
+                y: 176,
               },
               {
                 x: -1950,
-                y: 176
+                y: 176,
               },
               {
                 x: -1762,
-                y: 176
+                y: 176,
               },
               {
                 x: -1698,
-                y: 176
-              }
+                y: 176,
+              },
             ],
             textPositions: {
               0: {
                 x: -1996,
-                y: 188
+                y: 188,
               },
               1: {
                 x: -1968,
-                y: 164
+                y: 164,
               },
               2: {
                 x: -1716,
-                y: 164
+                y: 164,
               },
               3: {
                 x: -1744,
-                y: 188
+                y: 188,
               },
               4: {
                 x: -1856,
-                y: 164
+                y: 164,
               },
               5: {
                 x: -1856,
-                y: 164
+                y: 164,
               },
               6: {
                 x: -1856,
-                y: 188
-              }
-            }
+                y: 188,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 658,
@@ -20247,35 +20247,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 8,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 5,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 245
+            consecutiveTime: 245,
           },
           sourceArrival: {
             lock: true,
             time: 55,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 55
+            consecutiveTime: 55,
           },
           targetDeparture: {
             lock: false,
             time: 47,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 47
+            consecutiveTime: 47,
           },
           targetArrival: {
             lock: false,
             time: 13,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 253
+            consecutiveTime: 253,
           },
           numberOfStops: 0,
           trainrunId: 96,
@@ -20285,53 +20285,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 112,
-                y: 94
+                y: 94,
               },
               {
                 x: 112,
-                y: 30
+                y: 30,
               },
               {
                 x: 112,
-                y: -290
+                y: -290,
               },
               {
                 x: 112,
-                y: -354
-              }
+                y: -354,
+              },
             ],
             textPositions: {
               0: {
                 x: 124,
-                y: 76
+                y: 76,
               },
               1: {
                 x: 100,
-                y: 48
+                y: 48,
               },
               2: {
                 x: 100,
-                y: -336
+                y: -336,
               },
               3: {
                 x: 124,
-                y: -308
+                y: -308,
               },
               4: {
                 x: 100,
-                y: -130
+                y: -130,
               },
               5: {
                 x: 100,
-                y: -130
+                y: -130,
               },
               6: {
                 x: 124,
-                y: -130
-              }
-            }
+                y: -130,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 659,
@@ -20344,35 +20344,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 6,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 13,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 253
+            consecutiveTime: 253,
           },
           sourceArrival: {
             lock: false,
             time: 47,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 47
+            consecutiveTime: 47,
           },
           targetDeparture: {
             lock: false,
             time: 41,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 41
+            consecutiveTime: 41,
           },
           targetArrival: {
             lock: false,
             time: 19,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 259
+            consecutiveTime: 259,
           },
           numberOfStops: 0,
           trainrunId: 96,
@@ -20382,53 +20382,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 176,
-                y: -450
+                y: -450,
               },
               {
                 x: 176,
-                y: -514
+                y: -514,
               },
               {
                 x: 176,
-                y: -798
+                y: -798,
               },
               {
                 x: 176,
-                y: -862
-              }
+                y: -862,
+              },
             ],
             textPositions: {
               0: {
                 x: 188,
-                y: -468
+                y: -468,
               },
               1: {
                 x: 164,
-                y: -496
+                y: -496,
               },
               2: {
                 x: 164,
-                y: -844
+                y: -844,
               },
               3: {
                 x: 188,
-                y: -816
+                y: -816,
               },
               4: {
                 x: 164,
-                y: -656
+                y: -656,
               },
               5: {
                 x: 164,
-                y: -656
+                y: -656,
               },
               6: {
                 x: 188,
-                y: -656
-              }
-            }
+                y: -656,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 660,
@@ -20441,35 +20441,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 6,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 19,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 259
+            consecutiveTime: 259,
           },
           sourceArrival: {
             lock: false,
             time: 41,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 41
+            consecutiveTime: 41,
           },
           targetDeparture: {
             lock: false,
             time: 35,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 35
+            consecutiveTime: 35,
           },
           targetArrival: {
             lock: false,
             time: 25,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 265
+            consecutiveTime: 265,
           },
           numberOfStops: 0,
           trainrunId: 96,
@@ -20479,53 +20479,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 176,
-                y: -930
+                y: -930,
               },
               {
                 x: 176,
-                y: -994
+                y: -994,
               },
               {
                 x: 176,
-                y: -1278
+                y: -1278,
               },
               {
                 x: 176,
-                y: -1342
-              }
+                y: -1342,
+              },
             ],
             textPositions: {
               0: {
                 x: 188,
-                y: -948
+                y: -948,
               },
               1: {
                 x: 164,
-                y: -976
+                y: -976,
               },
               2: {
                 x: 164,
-                y: -1324
+                y: -1324,
               },
               3: {
                 x: 188,
-                y: -1296
+                y: -1296,
               },
               4: {
                 x: 164,
-                y: -1136
+                y: -1136,
               },
               5: {
                 x: 164,
-                y: -1136
+                y: -1136,
               },
               6: {
                 x: 188,
-                y: -1136
-              }
-            }
+                y: -1136,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 661,
@@ -20538,35 +20538,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 7,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 25,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 265
+            consecutiveTime: 265,
           },
           sourceArrival: {
             lock: false,
             time: 35,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 35
+            consecutiveTime: 35,
           },
           targetDeparture: {
             lock: true,
             time: 28,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 28
+            consecutiveTime: 28,
           },
           targetArrival: {
             lock: true,
             time: 32,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 272
+            consecutiveTime: 272,
           },
           numberOfStops: 0,
           trainrunId: 96,
@@ -20576,53 +20576,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 176,
-                y: -1410
+                y: -1410,
               },
               {
                 x: 176,
-                y: -1474
+                y: -1474,
               },
               {
                 x: 176,
-                y: -1758
+                y: -1758,
               },
               {
                 x: 176,
-                y: -1822
-              }
+                y: -1822,
+              },
             ],
             textPositions: {
               0: {
                 x: 188,
-                y: -1428
+                y: -1428,
               },
               1: {
                 x: 164,
-                y: -1456
+                y: -1456,
               },
               2: {
                 x: 164,
-                y: -1804
+                y: -1804,
               },
               3: {
                 x: 188,
-                y: -1776
+                y: -1776,
               },
               4: {
                 x: 164,
-                y: -1616
+                y: -1616,
               },
               5: {
                 x: 164,
-                y: -1616
+                y: -1616,
               },
               6: {
                 x: 188,
-                y: -1616
-              }
-            }
+                y: -1616,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 662,
@@ -20635,35 +20635,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 19,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 8,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 368
+            consecutiveTime: 368,
           },
           sourceArrival: {
             lock: true,
             time: 52,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 52
+            consecutiveTime: 52,
           },
           targetDeparture: {
             lock: true,
             time: 33,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 33
+            consecutiveTime: 33,
           },
           targetArrival: {
             lock: true,
             time: 27,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 387
+            consecutiveTime: 387,
           },
           numberOfStops: 0,
           trainrunId: 90,
@@ -20673,53 +20673,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: -2032,
-                y: 382
+                y: 382,
               },
               {
                 x: -2032,
-                y: 446
+                y: 446,
               },
               {
                 x: -2032,
-                y: 574
+                y: 574,
               },
               {
                 x: -2032,
-                y: 638
-              }
+                y: 638,
+              },
             ],
             textPositions: {
               0: {
                 x: -2044,
-                y: 400
+                y: 400,
               },
               1: {
                 x: -2020,
-                y: 428
+                y: 428,
               },
               2: {
                 x: -2020,
-                y: 620
+                y: 620,
               },
               3: {
                 x: -2044,
-                y: 592
+                y: 592,
               },
               4: {
                 x: -2044,
-                y: 510
+                y: 510,
               },
               5: {
                 x: -2044,
-                y: 510
+                y: 510,
               },
               6: {
                 x: -2020,
-                y: 510
-              }
-            }
+                y: 510,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 663,
@@ -20732,35 +20732,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 10,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 28,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 388
+            consecutiveTime: 388,
           },
           sourceArrival: {
             lock: false,
             time: 32,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 32
+            consecutiveTime: 32,
           },
           targetDeparture: {
             lock: true,
             time: 22,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 22
+            consecutiveTime: 22,
           },
           targetArrival: {
             lock: true,
             time: 38,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 398
+            consecutiveTime: 398,
           },
           numberOfStops: 0,
           trainrunId: 90,
@@ -20770,53 +20770,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: -2032,
-                y: 706
+                y: 706,
               },
               {
                 x: -2032,
-                y: 770
+                y: 770,
               },
               {
                 x: -2032,
-                y: 862
+                y: 862,
               },
               {
                 x: -2032,
-                y: 926
-              }
+                y: 926,
+              },
             ],
             textPositions: {
               0: {
                 x: -2044,
-                y: 724
+                y: 724,
               },
               1: {
                 x: -2020,
-                y: 752
+                y: 752,
               },
               2: {
                 x: -2020,
-                y: 908
+                y: 908,
               },
               3: {
                 x: -2044,
-                y: 880
+                y: 880,
               },
               4: {
                 x: -2044,
-                y: 816
+                y: 816,
               },
               5: {
                 x: -2044,
-                y: 816
+                y: 816,
               },
               6: {
                 x: -2020,
-                y: 816
-              }
-            }
+                y: 816,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 664,
@@ -20829,35 +20829,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 21,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 39,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 399
+            consecutiveTime: 399,
           },
           sourceArrival: {
             lock: true,
             time: 21,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 21
+            consecutiveTime: 21,
           },
           targetDeparture: {
             lock: false,
             time: 0,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 0
+            consecutiveTime: 0,
           },
           targetArrival: {
             lock: false,
             time: 0,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 420
+            consecutiveTime: 420,
           },
           numberOfStops: 0,
           trainrunId: 90,
@@ -20867,53 +20867,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: -2014,
-                y: 976
+                y: 976,
               },
               {
                 x: -1950,
-                y: 976
+                y: 976,
               },
               {
                 x: -1154,
-                y: 976
+                y: 976,
               },
               {
                 x: -1090,
-                y: 976
-              }
+                y: 976,
+              },
             ],
             textPositions: {
               0: {
                 x: -1996,
-                y: 988
+                y: 988,
               },
               1: {
                 x: -1968,
-                y: 964
+                y: 964,
               },
               2: {
                 x: -1108,
-                y: 964
+                y: 964,
               },
               3: {
                 x: -1136,
-                y: 988
+                y: 988,
               },
               4: {
                 x: -1552,
-                y: 964
+                y: 964,
               },
               5: {
                 x: -1552,
-                y: 964
+                y: 964,
               },
               6: {
                 x: -1552,
-                y: 988
-              }
-            }
+                y: 988,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 665,
@@ -20926,35 +20926,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 9,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 48,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 48
+            consecutiveTime: 48,
           },
           sourceArrival: {
             lock: true,
             time: 12,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 252
+            consecutiveTime: 252,
           },
           targetDeparture: {
             lock: true,
             time: 3,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 243
+            consecutiveTime: 243,
           },
           targetArrival: {
             lock: true,
             time: 57,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 57
+            consecutiveTime: 57,
           },
           numberOfStops: 0,
           trainrunId: 79,
@@ -20964,53 +20964,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 1954,
-                y: 1776
+                y: 1776,
               },
               {
                 x: 2018,
-                y: 1776
+                y: 1776,
               },
               {
                 x: 2590,
-                y: 1360
+                y: 1360,
               },
               {
                 x: 2654,
-                y: 1360
-              }
+                y: 1360,
+              },
             ],
             textPositions: {
               0: {
                 x: 1972,
-                y: 1788
+                y: 1788,
               },
               1: {
                 x: 2000,
-                y: 1764
+                y: 1764,
               },
               2: {
                 x: 2636,
-                y: 1348
+                y: 1348,
               },
               3: {
                 x: 2608,
-                y: 1372
+                y: 1372,
               },
               4: {
                 x: 2304,
-                y: 1556
+                y: 1556,
               },
               5: {
                 x: 2304,
-                y: 1556
+                y: 1556,
               },
               6: {
                 x: 2304,
-                y: 1580
-              }
-            }
+                y: 1580,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 666,
@@ -21023,35 +21023,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 10,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 18,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 18
+            consecutiveTime: 18,
           },
           sourceArrival: {
             lock: false,
             time: 42,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 42
+            consecutiveTime: 42,
           },
           targetDeparture: {
             lock: false,
             time: 32,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 32
+            consecutiveTime: 32,
           },
           targetArrival: {
             lock: false,
             time: 28,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 28
+            consecutiveTime: 28,
           },
           numberOfStops: 0,
           trainrunId: 80,
@@ -21061,53 +21061,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 1954,
-                y: 1744
+                y: 1744,
               },
               {
                 x: 2018,
-                y: 1744
+                y: 1744,
               },
               {
                 x: 2590,
-                y: 1328
+                y: 1328,
               },
               {
                 x: 2654,
-                y: 1328
-              }
+                y: 1328,
+              },
             ],
             textPositions: {
               0: {
                 x: 1972,
-                y: 1756
+                y: 1756,
               },
               1: {
                 x: 2000,
-                y: 1732
+                y: 1732,
               },
               2: {
                 x: 2636,
-                y: 1316
+                y: 1316,
               },
               3: {
                 x: 2608,
-                y: 1340
+                y: 1340,
               },
               4: {
                 x: 2304,
-                y: 1524
+                y: 1524,
               },
               5: {
                 x: 2304,
-                y: 1524
+                y: 1524,
               },
               6: {
                 x: 2304,
-                y: 1548
-              }
-            }
+                y: 1548,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 667,
@@ -21120,35 +21120,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 9,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 33,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 453
+            consecutiveTime: 453,
           },
           sourceArrival: {
             lock: false,
             time: 27,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 147
+            consecutiveTime: 147,
           },
           targetDeparture: {
             lock: false,
             time: 18,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 138
+            consecutiveTime: 138,
           },
           targetArrival: {
             lock: false,
             time: 42,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 462
+            consecutiveTime: 462,
           },
           numberOfStops: 0,
           trainrunId: 77,
@@ -21158,53 +21158,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 1854,
-                y: 1776
+                y: 1776,
               },
               {
                 x: 1790,
-                y: 1776
+                y: 1776,
               },
               {
                 x: 290,
-                y: 1776
+                y: 1776,
               },
               {
                 x: 226,
-                y: 1776
-              }
+                y: 1776,
+              },
             ],
             textPositions: {
               0: {
                 x: 1836,
-                y: 1764
+                y: 1764,
               },
               1: {
                 x: 1808,
-                y: 1788
+                y: 1788,
               },
               2: {
                 x: 244,
-                y: 1788
+                y: 1788,
               },
               3: {
                 x: 272,
-                y: 1764
+                y: 1764,
               },
               4: {
                 x: 1040,
-                y: 1764
+                y: 1764,
               },
               5: {
                 x: 1040,
-                y: 1764
+                y: 1764,
               },
               6: {
                 x: 1040,
-                y: 1788
-              }
-            }
+                y: 1788,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 668,
@@ -21217,35 +21217,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 9,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 33,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 273
+            consecutiveTime: 273,
           },
           sourceArrival: {
             lock: false,
             time: 27,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 87
+            consecutiveTime: 87,
           },
           targetDeparture: {
             lock: true,
             time: 18,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 78
+            consecutiveTime: 78,
           },
           targetArrival: {
             lock: true,
             time: 42,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 282
+            consecutiveTime: 282,
           },
           numberOfStops: 0,
           trainrunId: 75,
@@ -21255,53 +21255,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 1854,
-                y: 1744
+                y: 1744,
               },
               {
                 x: 1790,
-                y: 1744
+                y: 1744,
               },
               {
                 x: 290,
-                y: 1744
+                y: 1744,
               },
               {
                 x: 226,
-                y: 1744
-              }
+                y: 1744,
+              },
             ],
             textPositions: {
               0: {
                 x: 1836,
-                y: 1732
+                y: 1732,
               },
               1: {
                 x: 1808,
-                y: 1756
+                y: 1756,
               },
               2: {
                 x: 244,
-                y: 1756
+                y: 1756,
               },
               3: {
                 x: 272,
-                y: 1732
+                y: 1732,
               },
               4: {
                 x: 1040,
-                y: 1732
+                y: 1732,
               },
               5: {
                 x: 1040,
-                y: 1732
+                y: 1732,
               },
               6: {
                 x: 1040,
-                y: 1756
-              }
-            }
+                y: 1756,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 669,
@@ -21314,35 +21314,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 11,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 14,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 74
+            consecutiveTime: 74,
           },
           sourceArrival: {
             lock: true,
             time: 46,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 226
+            consecutiveTime: 226,
           },
           targetDeparture: {
             lock: true,
             time: 35,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 215
+            consecutiveTime: 215,
           },
           targetArrival: {
             lock: true,
             time: 25,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 85
+            consecutiveTime: 85,
           },
           numberOfStops: 0,
           trainrunId: 79,
@@ -21352,53 +21352,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2832,
-                y: 734
+                y: 734,
               },
               {
                 x: 2832,
-                y: 670
+                y: 670,
               },
               {
                 x: 2832,
-                y: 414
+                y: 414,
               },
               {
                 x: 2832,
-                y: 350
-              }
+                y: 350,
+              },
             ],
             textPositions: {
               0: {
                 x: 2844,
-                y: 716
+                y: 716,
               },
               1: {
                 x: 2820,
-                y: 688
+                y: 688,
               },
               2: {
                 x: 2820,
-                y: 368
+                y: 368,
               },
               3: {
                 x: 2844,
-                y: 396
+                y: 396,
               },
               4: {
                 x: 2820,
-                y: 542
+                y: 542,
               },
               5: {
                 x: 2820,
-                y: 542
+                y: 542,
               },
               6: {
                 x: 2844,
-                y: 542
-              }
-            }
+                y: 542,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 670,
@@ -21411,35 +21411,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 7,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 43,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 43
+            consecutiveTime: 43,
           },
           sourceArrival: {
             lock: false,
             time: 17,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 17
+            consecutiveTime: 17,
           },
           targetDeparture: {
             lock: true,
             time: 10,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 10
+            consecutiveTime: 10,
           },
           targetArrival: {
             lock: true,
             time: 50,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 50
+            consecutiveTime: 50,
           },
           numberOfStops: 0,
           trainrunId: 80,
@@ -21449,53 +21449,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2800,
-                y: 734
+                y: 734,
               },
               {
                 x: 2800,
-                y: 670
+                y: 670,
               },
               {
                 x: 2800,
-                y: 414
+                y: 414,
               },
               {
                 x: 2800,
-                y: 350
-              }
+                y: 350,
+              },
             ],
             textPositions: {
               0: {
                 x: 2812,
-                y: 716
+                y: 716,
               },
               1: {
                 x: 2788,
-                y: 688
+                y: 688,
               },
               2: {
                 x: 2788,
-                y: 368
+                y: 368,
               },
               3: {
                 x: 2812,
-                y: 396
+                y: 396,
               },
               4: {
                 x: 2788,
-                y: 542
+                y: 542,
               },
               5: {
                 x: 2788,
-                y: 542
+                y: 542,
               },
               6: {
                 x: 2812,
-                y: 542
-              }
-            }
+                y: 542,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 671,
@@ -21508,35 +21508,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 8,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 47,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 347
+            consecutiveTime: 347,
           },
           sourceArrival: {
             lock: false,
             time: 13,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 13
+            consecutiveTime: 13,
           },
           targetDeparture: {
             lock: true,
             time: 5,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 5
+            consecutiveTime: 5,
           },
           targetArrival: {
             lock: true,
             time: 55,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 355
+            consecutiveTime: 355,
           },
           numberOfStops: 0,
           trainrunId: 78,
@@ -21546,53 +21546,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2768,
-                y: 734
+                y: 734,
               },
               {
                 x: 2768,
-                y: 670
+                y: 670,
               },
               {
                 x: 2768,
-                y: 414
+                y: 414,
               },
               {
                 x: 2768,
-                y: 350
-              }
+                y: 350,
+              },
             ],
             textPositions: {
               0: {
                 x: 2780,
-                y: 716
+                y: 716,
               },
               1: {
                 x: 2756,
-                y: 688
+                y: 688,
               },
               2: {
                 x: 2756,
-                y: 368
+                y: 368,
               },
               3: {
                 x: 2780,
-                y: 396
+                y: 396,
               },
               4: {
                 x: 2756,
-                y: 542
+                y: 542,
               },
               5: {
                 x: 2756,
-                y: 542
+                y: 542,
               },
               6: {
                 x: 2780,
-                y: 542
-              }
-            }
+                y: 542,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 672,
@@ -21605,35 +21605,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 8,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 47,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 107
+            consecutiveTime: 107,
           },
           sourceArrival: {
             lock: false,
             time: 13,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 13
+            consecutiveTime: 13,
           },
           targetDeparture: {
             lock: true,
             time: 5,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 5
+            consecutiveTime: 5,
           },
           targetArrival: {
             lock: true,
             time: 55,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 115
+            consecutiveTime: 115,
           },
           numberOfStops: 0,
           trainrunId: 76,
@@ -21643,53 +21643,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2672,
-                y: 734
+                y: 734,
               },
               {
                 x: 2672,
-                y: 670
+                y: 670,
               },
               {
                 x: 2672,
-                y: 414
+                y: 414,
               },
               {
                 x: 2672,
-                y: 350
-              }
+                y: 350,
+              },
             ],
             textPositions: {
               0: {
                 x: 2684,
-                y: 716
+                y: 716,
               },
               1: {
                 x: 2660,
-                y: 688
+                y: 688,
               },
               2: {
                 x: 2660,
-                y: 368
+                y: 368,
               },
               3: {
                 x: 2684,
-                y: 396
+                y: 396,
               },
               4: {
                 x: 2660,
-                y: 542
+                y: 542,
               },
               5: {
                 x: 2660,
-                y: 542
+                y: 542,
               },
               6: {
                 x: 2684,
-                y: 542
-              }
-            }
+                y: 542,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 673,
@@ -21702,35 +21702,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 47,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 15,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 75
+            consecutiveTime: 75,
           },
           sourceArrival: {
             lock: false,
             time: 45,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 285
+            consecutiveTime: 285,
           },
           targetDeparture: {
             lock: true,
             time: 58,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 238
+            consecutiveTime: 238,
           },
           targetArrival: {
             lock: true,
             time: 2,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 122
+            consecutiveTime: 122,
           },
           numberOfStops: 0,
           trainrunId: 85,
@@ -21740,53 +21740,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2850,
-                y: 752
+                y: 752,
               },
               {
                 x: 2914,
-                y: 752
+                y: 752,
               },
               {
                 x: 4574,
-                y: 1200
+                y: 1200,
               },
               {
                 x: 4638,
-                y: 1200
-              }
+                y: 1200,
+              },
             ],
             textPositions: {
               0: {
                 x: 2868,
-                y: 764
+                y: 764,
               },
               1: {
                 x: 2896,
-                y: 740
+                y: 740,
               },
               2: {
                 x: 4620,
-                y: 1188
+                y: 1188,
               },
               3: {
                 x: 4592,
-                y: 1212
+                y: 1212,
               },
               4: {
                 x: 3744,
-                y: 964
+                y: 964,
               },
               5: {
                 x: 3744,
-                y: 964
+                y: 964,
               },
               6: {
                 x: 3744,
-                y: 988
-              }
-            }
+                y: 988,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 674,
@@ -21799,35 +21799,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 61,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 21,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 141
+            consecutiveTime: 141,
           },
           sourceArrival: {
             lock: true,
             time: 39,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 279
+            consecutiveTime: 279,
           },
           targetDeparture: {
             lock: true,
             time: 38,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 218
+            consecutiveTime: 218,
           },
           targetArrival: {
             lock: true,
             time: 22,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 202
+            consecutiveTime: 202,
           },
           numberOfStops: 5,
           trainrunId: 86,
@@ -21837,53 +21837,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2850,
-                y: 784
+                y: 784,
               },
               {
                 x: 2914,
-                y: 784
+                y: 784,
               },
               {
                 x: 4574,
-                y: 1232
+                y: 1232,
               },
               {
                 x: 4638,
-                y: 1232
-              }
+                y: 1232,
+              },
             ],
             textPositions: {
               0: {
                 x: 2868,
-                y: 796
+                y: 796,
               },
               1: {
                 x: 2896,
-                y: 772
+                y: 772,
               },
               2: {
                 x: 4620,
-                y: 1220
+                y: 1220,
               },
               3: {
                 x: 4592,
-                y: 1244
+                y: 1244,
               },
               4: {
                 x: 3744,
-                y: 996
+                y: 996,
               },
               5: {
                 x: 3744,
-                y: 996
+                y: 996,
               },
               6: {
                 x: 3744,
-                y: 1020
-              }
-            }
+                y: 1020,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 675,
@@ -21896,35 +21896,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 19,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 55,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 475
+            consecutiveTime: 475,
           },
           sourceArrival: {
             lock: true,
             time: 5,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 125
+            consecutiveTime: 125,
           },
           targetDeparture: {
             lock: false,
             time: 46,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 106
+            consecutiveTime: 106,
           },
           targetArrival: {
             lock: false,
             time: 14,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 494
+            consecutiveTime: 494,
           },
           numberOfStops: 0,
           trainrunId: 77,
@@ -21934,53 +21934,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 144,
-                y: 1726
+                y: 1726,
               },
               {
                 x: 144,
-                y: 1662
+                y: 1662,
               },
               {
                 x: 144,
-                y: 1314
+                y: 1314,
               },
               {
                 x: 144,
-                y: 1250
-              }
+                y: 1250,
+              },
             ],
             textPositions: {
               0: {
                 x: 156,
-                y: 1708
+                y: 1708,
               },
               1: {
                 x: 132,
-                y: 1680
+                y: 1680,
               },
               2: {
                 x: 132,
-                y: 1268
+                y: 1268,
               },
               3: {
                 x: 156,
-                y: 1296
+                y: 1296,
               },
               4: {
                 x: 132,
-                y: 1488
+                y: 1488,
               },
               5: {
                 x: 132,
-                y: 1488
+                y: 1488,
               },
               6: {
                 x: 156,
-                y: 1488
-              }
-            }
+                y: 1488,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 676,
@@ -21993,35 +21993,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 7,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 14,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 494
+            consecutiveTime: 494,
           },
           sourceArrival: {
             lock: false,
             time: 46,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 106
+            consecutiveTime: 106,
           },
           targetDeparture: {
             lock: false,
             time: 39,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 99
+            consecutiveTime: 99,
           },
           targetArrival: {
             lock: false,
             time: 21,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 501
+            consecutiveTime: 501,
           },
           numberOfStops: 0,
           trainrunId: 77,
@@ -22031,53 +22031,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 144,
-                y: 1182
+                y: 1182,
               },
               {
                 x: 144,
-                y: 1118
+                y: 1118,
               },
               {
                 x: 144,
-                y: 866
+                y: 866,
               },
               {
                 x: 144,
-                y: 802
-              }
+                y: 802,
+              },
             ],
             textPositions: {
               0: {
                 x: 156,
-                y: 1164
+                y: 1164,
               },
               1: {
                 x: 132,
-                y: 1136
+                y: 1136,
               },
               2: {
                 x: 132,
-                y: 820
+                y: 820,
               },
               3: {
                 x: 156,
-                y: 848
+                y: 848,
               },
               4: {
                 x: 132,
-                y: 992
+                y: 992,
               },
               5: {
                 x: 132,
-                y: 992
+                y: 992,
               },
               6: {
                 x: 156,
-                y: 992
-              }
-            }
+                y: 992,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 677,
@@ -22090,35 +22090,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 7,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 23,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 503
+            consecutiveTime: 503,
           },
           sourceArrival: {
             lock: false,
             time: 37,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 97
+            consecutiveTime: 97,
           },
           targetDeparture: {
             lock: false,
             time: 30,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 90
+            consecutiveTime: 90,
           },
           targetArrival: {
             lock: false,
             time: 30,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 510
+            consecutiveTime: 510,
           },
           numberOfStops: 0,
           trainrunId: 77,
@@ -22128,53 +22128,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 112,
-                y: 734
+                y: 734,
               },
               {
                 x: 112,
-                y: 670
+                y: 670,
               },
               {
                 x: 112,
-                y: 414
+                y: 414,
               },
               {
                 x: 112,
-                y: 350
-              }
+                y: 350,
+              },
             ],
             textPositions: {
               0: {
                 x: 124,
-                y: 716
+                y: 716,
               },
               1: {
                 x: 100,
-                y: 688
+                y: 688,
               },
               2: {
                 x: 100,
-                y: 368
+                y: 368,
               },
               3: {
                 x: 124,
-                y: 396
+                y: 396,
               },
               4: {
                 x: 100,
-                y: 542
+                y: 542,
               },
               5: {
                 x: 100,
-                y: 542
+                y: 542,
               },
               6: {
                 x: 124,
-                y: 542
-              }
-            }
+                y: 542,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 678,
@@ -22187,35 +22187,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 10,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 32,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 512
+            consecutiveTime: 512,
           },
           sourceArrival: {
             lock: true,
             time: 28,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 88
+            consecutiveTime: 88,
           },
           targetDeparture: {
             lock: false,
             time: 18,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 78
+            consecutiveTime: 78,
           },
           targetArrival: {
             lock: false,
             time: 42,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 522
+            consecutiveTime: 522,
           },
           numberOfStops: 0,
           trainrunId: 77,
@@ -22225,53 +22225,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 176,
-                y: 94
+                y: 94,
               },
               {
                 x: 176,
-                y: 30
+                y: 30,
               },
               {
                 x: 176,
-                y: -290
+                y: -290,
               },
               {
                 x: 176,
-                y: -354
-              }
+                y: -354,
+              },
             ],
             textPositions: {
               0: {
                 x: 188,
-                y: 76
+                y: 76,
               },
               1: {
                 x: 164,
-                y: 48
+                y: 48,
               },
               2: {
                 x: 164,
-                y: -336
+                y: -336,
               },
               3: {
                 x: 188,
-                y: -308
+                y: -308,
               },
               4: {
                 x: 164,
-                y: -130
+                y: -130,
               },
               5: {
                 x: 164,
-                y: -130
+                y: -130,
               },
               6: {
                 x: 188,
-                y: -130
-              }
-            }
+                y: -130,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 679,
@@ -22284,35 +22284,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 5,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 42,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 522
+            consecutiveTime: 522,
           },
           sourceArrival: {
             lock: false,
             time: 18,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 78
+            consecutiveTime: 78,
           },
           targetDeparture: {
             lock: false,
             time: 13,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 73
+            consecutiveTime: 73,
           },
           targetArrival: {
             lock: false,
             time: 47,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 527
+            consecutiveTime: 527,
           },
           numberOfStops: 0,
           trainrunId: 77,
@@ -22322,53 +22322,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 240,
-                y: -450
+                y: -450,
               },
               {
                 x: 240,
-                y: -514
+                y: -514,
               },
               {
                 x: 240,
-                y: -798
+                y: -798,
               },
               {
                 x: 240,
-                y: -862
-              }
+                y: -862,
+              },
             ],
             textPositions: {
               0: {
                 x: 252,
-                y: -468
+                y: -468,
               },
               1: {
                 x: 228,
-                y: -496
+                y: -496,
               },
               2: {
                 x: 228,
-                y: -844
+                y: -844,
               },
               3: {
                 x: 252,
-                y: -816
+                y: -816,
               },
               4: {
                 x: 228,
-                y: -656
+                y: -656,
               },
               5: {
                 x: 228,
-                y: -656
+                y: -656,
               },
               6: {
                 x: 252,
-                y: -656
-              }
-            }
+                y: -656,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 680,
@@ -22381,35 +22381,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 5,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 47,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 527
+            consecutiveTime: 527,
           },
           sourceArrival: {
             lock: false,
             time: 13,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 73
+            consecutiveTime: 73,
           },
           targetDeparture: {
             lock: false,
             time: 8,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 68
+            consecutiveTime: 68,
           },
           targetArrival: {
             lock: false,
             time: 52,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 532
+            consecutiveTime: 532,
           },
           numberOfStops: 0,
           trainrunId: 77,
@@ -22419,53 +22419,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 240,
-                y: -930
+                y: -930,
               },
               {
                 x: 240,
-                y: -994
+                y: -994,
               },
               {
                 x: 240,
-                y: -1278
+                y: -1278,
               },
               {
                 x: 240,
-                y: -1342
-              }
+                y: -1342,
+              },
             ],
             textPositions: {
               0: {
                 x: 252,
-                y: -948
+                y: -948,
               },
               1: {
                 x: 228,
-                y: -976
+                y: -976,
               },
               2: {
                 x: 228,
-                y: -1324
+                y: -1324,
               },
               3: {
                 x: 252,
-                y: -1296
+                y: -1296,
               },
               4: {
                 x: 228,
-                y: -1136
+                y: -1136,
               },
               5: {
                 x: 228,
-                y: -1136
+                y: -1136,
               },
               6: {
                 x: 252,
-                y: -1136
-              }
-            }
+                y: -1136,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 681,
@@ -22478,35 +22478,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 5,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 52,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 532
+            consecutiveTime: 532,
           },
           sourceArrival: {
             lock: false,
             time: 8,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 68
+            consecutiveTime: 68,
           },
           targetDeparture: {
             lock: true,
             time: 3,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 63
+            consecutiveTime: 63,
           },
           targetArrival: {
             lock: true,
             time: 57,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 537
+            consecutiveTime: 537,
           },
           numberOfStops: 0,
           trainrunId: 77,
@@ -22516,53 +22516,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 240,
-                y: -1410
+                y: -1410,
               },
               {
                 x: 240,
-                y: -1474
+                y: -1474,
               },
               {
                 x: 240,
-                y: -1758
+                y: -1758,
               },
               {
                 x: 240,
-                y: -1822
-              }
+                y: -1822,
+              },
             ],
             textPositions: {
               0: {
                 x: 252,
-                y: -1428
+                y: -1428,
               },
               1: {
                 x: 228,
-                y: -1456
+                y: -1456,
               },
               2: {
                 x: 228,
-                y: -1804
+                y: -1804,
               },
               3: {
                 x: 252,
-                y: -1776
+                y: -1776,
               },
               4: {
                 x: 228,
-                y: -1616
+                y: -1616,
               },
               5: {
                 x: 228,
-                y: -1616
+                y: -1616,
               },
               6: {
                 x: 252,
-                y: -1616
-              }
-            }
+                y: -1616,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 682,
@@ -22575,35 +22575,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 49,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 27,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 387
+            consecutiveTime: 387,
           },
           sourceArrival: {
             lock: true,
             time: 33,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 153
+            consecutiveTime: 153,
           },
           targetDeparture: {
             lock: true,
             time: 44,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 104
+            consecutiveTime: 104,
           },
           targetArrival: {
             lock: true,
             time: 16,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 436
+            consecutiveTime: 436,
           },
           numberOfStops: 2,
           trainrunId: 81,
@@ -22613,53 +22613,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: -2562,
-                y: 336
+                y: 336,
               },
               {
                 x: -2626,
-                y: 336
+                y: 336,
               },
               {
                 x: -2910,
-                y: 592
+                y: 592,
               },
               {
                 x: -2974,
-                y: 592
-              }
+                y: 592,
+              },
             ],
             textPositions: {
               0: {
                 x: -2580,
-                y: 324
+                y: 324,
               },
               1: {
                 x: -2608,
-                y: 348
+                y: 348,
               },
               2: {
                 x: -2956,
-                y: 604
+                y: 604,
               },
               3: {
                 x: -2928,
-                y: 580
+                y: 580,
               },
               4: {
                 x: -2768,
-                y: 452
+                y: 452,
               },
               5: {
                 x: -2768,
-                y: 452
+                y: 452,
               },
               6: {
                 x: -2768,
-                y: 476
-              }
-            }
+                y: 476,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 683,
@@ -22672,35 +22672,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 44,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 54,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 414
+            consecutiveTime: 414,
           },
           sourceArrival: {
             lock: false,
             time: 6,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 126
+            consecutiveTime: 126,
           },
           targetDeparture: {
             lock: false,
             time: 22,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 82
+            consecutiveTime: 82,
           },
           targetArrival: {
             lock: false,
             time: 38,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 458
+            consecutiveTime: 458,
           },
           numberOfStops: 0,
           trainrunId: 88,
@@ -22710,53 +22710,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: -2562,
-                y: 304
+                y: 304,
               },
               {
                 x: -2626,
-                y: 304
+                y: 304,
               },
               {
                 x: -2910,
-                y: 560
+                y: 560,
               },
               {
                 x: -2974,
-                y: 560
-              }
+                y: 560,
+              },
             ],
             textPositions: {
               0: {
                 x: -2580,
-                y: 292
+                y: 292,
               },
               1: {
                 x: -2608,
-                y: 316
+                y: 316,
               },
               2: {
                 x: -2956,
-                y: 572
+                y: 572,
               },
               3: {
                 x: -2928,
-                y: 548
+                y: 548,
               },
               4: {
                 x: -2768,
-                y: 420
+                y: 420,
               },
               5: {
                 x: -2768,
-                y: 420
+                y: 420,
               },
               6: {
                 x: -2768,
-                y: 444
-              }
-            }
+                y: 444,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 684,
@@ -22769,35 +22769,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 16,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 39,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 339
+            consecutiveTime: 339,
           },
           sourceArrival: {
             lock: false,
             time: 21,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 201
+            consecutiveTime: 201,
           },
           targetDeparture: {
             lock: false,
             time: 5,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 185
+            consecutiveTime: 185,
           },
           targetArrival: {
             lock: false,
             time: 55,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 355
+            consecutiveTime: 355,
           },
           numberOfStops: 0,
           trainrunId: 81,
@@ -22807,53 +22807,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: -610,
-                y: 304
+                y: 304,
               },
               {
                 x: -674,
-                y: 304
+                y: 304,
               },
               {
                 x: -1534,
-                y: 304
+                y: 304,
               },
               {
                 x: -1598,
-                y: 304
-              }
+                y: 304,
+              },
             ],
             textPositions: {
               0: {
                 x: -628,
-                y: 292
+                y: 292,
               },
               1: {
                 x: -656,
-                y: 316
+                y: 316,
               },
               2: {
                 x: -1580,
-                y: 316
+                y: 316,
               },
               3: {
                 x: -1552,
-                y: 292
+                y: 292,
               },
               4: {
                 x: -1104,
-                y: 292
+                y: 292,
               },
               5: {
                 x: -1104,
-                y: 292
+                y: 292,
               },
               6: {
                 x: -1104,
-                y: 316
-              }
-            }
+                y: 316,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 685,
@@ -22866,35 +22866,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 8,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 43,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 343
+            consecutiveTime: 343,
           },
           sourceArrival: {
             lock: false,
             time: 17,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 77
+            consecutiveTime: 77,
           },
           targetDeparture: {
             lock: true,
             time: 9,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 69
+            consecutiveTime: 69,
           },
           targetArrival: {
             lock: true,
             time: 51,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 351
+            consecutiveTime: 351,
           },
           numberOfStops: 0,
           trainrunId: 86,
@@ -22904,53 +22904,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: -610,
-                y: 336
+                y: 336,
               },
               {
                 x: -674,
-                y: 336
+                y: 336,
               },
               {
                 x: -830,
-                y: 368
+                y: 368,
               },
               {
                 x: -894,
-                y: 368
-              }
+                y: 368,
+              },
             ],
             textPositions: {
               0: {
                 x: -628,
-                y: 324
+                y: 324,
               },
               1: {
                 x: -656,
-                y: 348
+                y: 348,
               },
               2: {
                 x: -876,
-                y: 380
+                y: 380,
               },
               3: {
                 x: -848,
-                y: 356
+                y: 356,
               },
               4: {
                 x: -752,
-                y: 340
+                y: 340,
               },
               5: {
                 x: -752,
-                y: 340
+                y: 340,
               },
               6: {
                 x: -752,
-                y: 364
-              }
-            }
+                y: 364,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 686,
@@ -22963,35 +22963,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 8,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 47,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 347
+            consecutiveTime: 347,
           },
           sourceArrival: {
             lock: false,
             time: 13,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 73
+            consecutiveTime: 73,
           },
           targetDeparture: {
             lock: false,
             time: 5,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 65
+            consecutiveTime: 65,
           },
           targetArrival: {
             lock: false,
             time: 55,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 355
+            consecutiveTime: 355,
           },
           numberOfStops: 0,
           trainrunId: 90,
@@ -23001,53 +23001,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: -610,
-                y: 272
+                y: 272,
               },
               {
                 x: -674,
-                y: 272
+                y: 272,
               },
               {
                 x: -1534,
-                y: 272
+                y: 272,
               },
               {
                 x: -1598,
-                y: 272
-              }
+                y: 272,
+              },
             ],
             textPositions: {
               0: {
                 x: -628,
-                y: 260
+                y: 260,
               },
               1: {
                 x: -656,
-                y: 284
+                y: 284,
               },
               2: {
                 x: -1580,
-                y: 284
+                y: 284,
               },
               3: {
                 x: -1552,
-                y: 260
+                y: 260,
               },
               4: {
                 x: -1104,
-                y: 260
+                y: 260,
               },
               5: {
                 x: -1104,
-                y: 260
+                y: 260,
               },
               6: {
                 x: -1104,
-                y: 284
-              }
-            }
+                y: 284,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 687,
@@ -23060,35 +23060,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 17,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 37,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 337
+            consecutiveTime: 337,
           },
           sourceArrival: {
             lock: false,
             time: 23,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 83
+            consecutiveTime: 83,
           },
           targetDeparture: {
             lock: true,
             time: 6,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 66
+            consecutiveTime: 66,
           },
           targetArrival: {
             lock: true,
             time: 54,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 354
+            consecutiveTime: 354,
           },
           numberOfStops: 0,
           trainrunId: 89,
@@ -23098,53 +23098,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: -610,
-                y: 240
+                y: 240,
               },
               {
                 x: -674,
-                y: 240
+                y: 240,
               },
               {
                 x: -1534,
-                y: 240
+                y: 240,
               },
               {
                 x: -1598,
-                y: 240
-              }
+                y: 240,
+              },
             ],
             textPositions: {
               0: {
                 x: -628,
-                y: 228
+                y: 228,
               },
               1: {
                 x: -656,
-                y: 252
+                y: 252,
               },
               2: {
                 x: -1580,
-                y: 252
+                y: 252,
               },
               3: {
                 x: -1552,
-                y: 228
+                y: 228,
               },
               4: {
                 x: -1104,
-                y: 228
+                y: 228,
               },
               5: {
                 x: -1104,
-                y: 228
+                y: 228,
               },
               6: {
                 x: -1104,
-                y: 252
-              }
-            }
+                y: 252,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 688,
@@ -23157,35 +23157,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 18,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 5,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 65
+            consecutiveTime: 65,
           },
           sourceArrival: {
             lock: false,
             time: 55,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 235
+            consecutiveTime: 235,
           },
           targetDeparture: {
             lock: false,
             time: 37,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 217
+            consecutiveTime: 217,
           },
           targetArrival: {
             lock: false,
             time: 23,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 83
+            consecutiveTime: 83,
           },
           numberOfStops: 0,
           trainrunId: 95,
@@ -23195,53 +23195,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: -610,
-                y: 208
+                y: 208,
               },
               {
                 x: -674,
-                y: 208
+                y: 208,
               },
               {
                 x: -1534,
-                y: 208
+                y: 208,
               },
               {
                 x: -1598,
-                y: 208
-              }
+                y: 208,
+              },
             ],
             textPositions: {
               0: {
                 x: -628,
-                y: 196
+                y: 196,
               },
               1: {
                 x: -656,
-                y: 220
+                y: 220,
               },
               2: {
                 x: -1580,
-                y: 220
+                y: 220,
               },
               3: {
                 x: -1552,
-                y: 196
+                y: 196,
               },
               4: {
                 x: -1104,
-                y: 196
+                y: 196,
               },
               5: {
                 x: -1104,
-                y: 196
+                y: 196,
               },
               6: {
                 x: -1104,
-                y: 220
-              }
-            }
+                y: 220,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 689,
@@ -23254,35 +23254,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 8,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 54,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 234
+            consecutiveTime: 234,
           },
           sourceArrival: {
             lock: false,
             time: 6,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 66
+            consecutiveTime: 66,
           },
           targetDeparture: {
             lock: true,
             time: 58,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 58
+            consecutiveTime: 58,
           },
           targetArrival: {
             lock: true,
             time: 2,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 242
+            consecutiveTime: 242,
           },
           numberOfStops: 0,
           trainrunId: 96,
@@ -23292,53 +23292,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: -510,
-                y: 176
+                y: 176,
               },
               {
                 x: -446,
-                y: 176
+                y: 176,
               },
               {
                 x: -2,
-                y: 176
+                y: 176,
               },
               {
                 x: 62,
-                y: 176
-              }
+                y: 176,
+              },
             ],
             textPositions: {
               0: {
                 x: -492,
-                y: 188
+                y: 188,
               },
               1: {
                 x: -464,
-                y: 164
+                y: 164,
               },
               2: {
                 x: 44,
-                y: 164
+                y: 164,
               },
               3: {
                 x: 16,
-                y: 188
+                y: 188,
               },
               4: {
                 x: -224,
-                y: 164
+                y: 164,
               },
               5: {
                 x: -224,
-                y: 164
+                y: 164,
               },
               6: {
                 x: -224,
-                y: 188
-              }
-            }
+                y: 188,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 690,
@@ -23351,35 +23351,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 9,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 17,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 377
+            consecutiveTime: 377,
           },
           sourceArrival: {
             lock: false,
             time: 43,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 163
+            consecutiveTime: 163,
           },
           targetDeparture: {
             lock: false,
             time: 34,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 154
+            consecutiveTime: 154,
           },
           targetArrival: {
             lock: false,
             time: 26,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 386
+            consecutiveTime: 386,
           },
           numberOfStops: 0,
           trainrunId: 88,
@@ -23389,53 +23389,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: -610,
-                y: 144
+                y: 144,
               },
               {
                 x: -674,
-                y: 144
+                y: 144,
               },
               {
                 x: -1534,
-                y: 144
+                y: 144,
               },
               {
                 x: -1598,
-                y: 144
-              }
+                y: 144,
+              },
             ],
             textPositions: {
               0: {
                 x: -628,
-                y: 132
+                y: 132,
               },
               1: {
                 x: -656,
-                y: 156
+                y: 156,
               },
               2: {
                 x: -1580,
-                y: 156
+                y: 156,
               },
               3: {
                 x: -1552,
-                y: 132
+                y: 132,
               },
               4: {
                 x: -1104,
-                y: 132
+                y: 132,
               },
               5: {
                 x: -1104,
-                y: 132
+                y: 132,
               },
               6: {
                 x: -1104,
-                y: 156
-              }
-            }
+                y: 156,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 691,
@@ -23448,35 +23448,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 10,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 11,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 371
+            consecutiveTime: 371,
           },
           sourceArrival: {
             lock: true,
             time: 49,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 49
+            consecutiveTime: 49,
           },
           targetDeparture: {
             lock: false,
             time: 39,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 39
+            consecutiveTime: 39,
           },
           targetArrival: {
             lock: false,
             time: 21,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 381
+            consecutiveTime: 381,
           },
           numberOfStops: 0,
           trainrunId: 86,
@@ -23486,53 +23486,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: -1346,
-                y: 368
+                y: 368,
               },
               {
                 x: -1410,
-                y: 368
+                y: 368,
               },
               {
                 x: -1534,
-                y: 336
+                y: 336,
               },
               {
                 x: -1598,
-                y: 336
-              }
+                y: 336,
+              },
             ],
             textPositions: {
               0: {
                 x: -1364,
-                y: 356
+                y: 356,
               },
               1: {
                 x: -1392,
-                y: 380
+                y: 380,
               },
               2: {
                 x: -1580,
-                y: 348
+                y: 348,
               },
               3: {
                 x: -1552,
-                y: 324
+                y: 324,
               },
               4: {
                 x: -1472,
-                y: 340
+                y: 340,
               },
               5: {
                 x: -1472,
-                y: 340
+                y: 340,
               },
               6: {
                 x: -1472,
-                y: 364
-              }
-            }
+                y: 364,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 692,
@@ -23545,35 +23545,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 17,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 52,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 352
+            consecutiveTime: 352,
           },
           sourceArrival: {
             lock: true,
             time: 8,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 68
+            consecutiveTime: 68,
           },
           targetDeparture: {
             lock: false,
             time: 51,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 51
+            consecutiveTime: 51,
           },
           targetArrival: {
             lock: false,
             time: 9,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 369
+            consecutiveTime: 369,
           },
           numberOfStops: 1,
           trainrunId: 86,
@@ -23583,53 +23583,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: -994,
-                y: 368
+                y: 368,
               },
               {
                 x: -1058,
-                y: 368
+                y: 368,
               },
               {
                 x: -1182,
-                y: 368
+                y: 368,
               },
               {
                 x: -1246,
-                y: 368
-              }
+                y: 368,
+              },
             ],
             textPositions: {
               0: {
                 x: -1012,
-                y: 356
+                y: 356,
               },
               1: {
                 x: -1040,
-                y: 380
+                y: 380,
               },
               2: {
                 x: -1228,
-                y: 380
+                y: 380,
               },
               3: {
                 x: -1200,
-                y: 356
+                y: 356,
               },
               4: {
                 x: -1120,
-                y: 356
+                y: 356,
               },
               5: {
                 x: -1120,
-                y: 356
+                y: 356,
               },
               6: {
                 x: -1120,
-                y: 380
-              }
-            }
+                y: 380,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 693,
@@ -23642,35 +23642,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 8,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 0,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 300
+            consecutiveTime: 300,
           },
           sourceArrival: {
             lock: true,
             time: 0,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 60
+            consecutiveTime: 60,
           },
           targetDeparture: {
             lock: false,
             time: 52,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 52
+            consecutiveTime: 52,
           },
           targetArrival: {
             lock: false,
             time: 8,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 308
+            consecutiveTime: 308,
           },
           numberOfStops: 0,
           trainrunId: 85,
@@ -23680,53 +23680,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2654,
-                y: 80
+                y: 80,
               },
               {
                 x: 2590,
-                y: 80
+                y: 80,
               },
               {
                 x: 2402,
-                y: 80
+                y: 80,
               },
               {
                 x: 2338,
-                y: 80
-              }
+                y: 80,
+              },
             ],
             textPositions: {
               0: {
                 x: 2636,
-                y: 68
+                y: 68,
               },
               1: {
                 x: 2608,
-                y: 92
+                y: 92,
               },
               2: {
                 x: 2356,
-                y: 92
+                y: 92,
               },
               3: {
                 x: 2384,
-                y: 68
+                y: 68,
               },
               4: {
                 x: 2496,
-                y: 68
+                y: 68,
               },
               5: {
                 x: 2496,
-                y: 68
+                y: 68,
               },
               6: {
                 x: 2496,
-                y: 92
-              }
-            }
+                y: 92,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 694,
@@ -23739,35 +23739,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 6,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 8,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 308
+            consecutiveTime: 308,
           },
           sourceArrival: {
             lock: false,
             time: 52,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 52
+            consecutiveTime: 52,
           },
           targetDeparture: {
             lock: false,
             time: 46,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 46
+            consecutiveTime: 46,
           },
           targetArrival: {
             lock: false,
             time: 14,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 314
+            consecutiveTime: 314,
           },
           numberOfStops: 0,
           trainrunId: 85,
@@ -23777,53 +23777,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 2238,
-                y: 80
+                y: 80,
               },
               {
                 x: 2174,
-                y: 80
+                y: 80,
               },
               {
                 x: 1954,
-                y: 80
+                y: 80,
               },
               {
                 x: 1890,
-                y: 80
-              }
+                y: 80,
+              },
             ],
             textPositions: {
               0: {
                 x: 2220,
-                y: 68
+                y: 68,
               },
               1: {
                 x: 2192,
-                y: 92
+                y: 92,
               },
               2: {
                 x: 1908,
-                y: 92
+                y: 92,
               },
               3: {
                 x: 1936,
-                y: 68
+                y: 68,
               },
               4: {
                 x: 2064,
-                y: 68
+                y: 68,
               },
               5: {
                 x: 2064,
-                y: 68
+                y: 68,
               },
               6: {
                 x: 2064,
-                y: 92
-              }
-            }
+                y: 92,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 695,
@@ -23836,35 +23836,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 6,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 14,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 314
+            consecutiveTime: 314,
           },
           sourceArrival: {
             lock: false,
             time: 46,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 46
+            consecutiveTime: 46,
           },
           targetDeparture: {
             lock: false,
             time: 40,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 40
+            consecutiveTime: 40,
           },
           targetArrival: {
             lock: false,
             time: 20,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 320
+            consecutiveTime: 320,
           },
           numberOfStops: 0,
           trainrunId: 85,
@@ -23874,53 +23874,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 1790,
-                y: 80
+                y: 80,
               },
               {
                 x: 1726,
-                y: 80
+                y: 80,
               },
               {
                 x: 1506,
-                y: 80
+                y: 80,
               },
               {
                 x: 1442,
-                y: 80
-              }
+                y: 80,
+              },
             ],
             textPositions: {
               0: {
                 x: 1772,
-                y: 68
+                y: 68,
               },
               1: {
                 x: 1744,
-                y: 92
+                y: 92,
               },
               2: {
                 x: 1460,
-                y: 92
+                y: 92,
               },
               3: {
                 x: 1488,
-                y: 68
+                y: 68,
               },
               4: {
                 x: 1616,
-                y: 68
+                y: 68,
               },
               5: {
                 x: 1616,
-                y: 68
+                y: 68,
               },
               6: {
                 x: 1616,
-                y: 92
-              }
-            }
+                y: 92,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 696,
@@ -23933,35 +23933,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 6,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 20,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 320
+            consecutiveTime: 320,
           },
           sourceArrival: {
             lock: false,
             time: 40,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 40
+            consecutiveTime: 40,
           },
           targetDeparture: {
             lock: false,
             time: 34,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 34
+            consecutiveTime: 34,
           },
           targetArrival: {
             lock: false,
             time: 26,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 326
+            consecutiveTime: 326,
           },
           numberOfStops: 0,
           trainrunId: 85,
@@ -23971,53 +23971,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 1342,
-                y: 80
+                y: 80,
               },
               {
                 x: 1278,
-                y: 80
+                y: 80,
               },
               {
                 x: 1122,
-                y: 80
+                y: 80,
               },
               {
                 x: 1058,
-                y: 80
-              }
+                y: 80,
+              },
             ],
             textPositions: {
               0: {
                 x: 1324,
-                y: 68
+                y: 68,
               },
               1: {
                 x: 1296,
-                y: 92
+                y: 92,
               },
               2: {
                 x: 1076,
-                y: 92
+                y: 92,
               },
               3: {
                 x: 1104,
-                y: 68
+                y: 68,
               },
               4: {
                 x: 1200,
-                y: 68
+                y: 68,
               },
               5: {
                 x: 1200,
-                y: 68
+                y: 68,
               },
               6: {
                 x: 1200,
-                y: 92
-              }
-            }
+                y: 92,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 697,
@@ -24030,35 +24030,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 7,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 26,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 326
+            consecutiveTime: 326,
           },
           sourceArrival: {
             lock: false,
             time: 34,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 34
+            consecutiveTime: 34,
           },
           targetDeparture: {
             lock: false,
             time: 27,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 27
+            consecutiveTime: 27,
           },
           targetArrival: {
             lock: false,
             time: 33,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 333
+            consecutiveTime: 333,
           },
           numberOfStops: 0,
           trainrunId: 85,
@@ -24068,53 +24068,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 958,
-                y: 48
+                y: 48,
               },
               {
                 x: 894,
-                y: 48
+                y: 48,
               },
               {
                 x: 386,
-                y: -432
+                y: -432,
               },
               {
                 x: 322,
-                y: -432
-              }
+                y: -432,
+              },
             ],
             textPositions: {
               0: {
                 x: 940,
-                y: 36
+                y: 36,
               },
               1: {
                 x: 912,
-                y: 60
+                y: 60,
               },
               2: {
                 x: 340,
-                y: -420
+                y: -420,
               },
               3: {
                 x: 368,
-                y: -444
+                y: -444,
               },
               4: {
                 x: 640,
-                y: -204
+                y: -204,
               },
               5: {
                 x: 640,
-                y: -204
+                y: -204,
               },
               6: {
                 x: 640,
-                y: -180
-              }
-            }
+                y: -180,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 698,
@@ -24127,35 +24127,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 6,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 33,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 333
+            consecutiveTime: 333,
           },
           sourceArrival: {
             lock: false,
             time: 27,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 27
+            consecutiveTime: 27,
           },
           targetDeparture: {
             lock: false,
             time: 21,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 21
+            consecutiveTime: 21,
           },
           targetArrival: {
             lock: false,
             time: 39,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 339
+            consecutiveTime: 339,
           },
           numberOfStops: 0,
           trainrunId: 85,
@@ -24165,53 +24165,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 112,
-                y: -450
+                y: -450,
               },
               {
                 x: 112,
-                y: -514
+                y: -514,
               },
               {
                 x: 112,
-                y: -798
+                y: -798,
               },
               {
                 x: 112,
-                y: -862
-              }
+                y: -862,
+              },
             ],
             textPositions: {
               0: {
                 x: 124,
-                y: -468
+                y: -468,
               },
               1: {
                 x: 100,
-                y: -496
+                y: -496,
               },
               2: {
                 x: 100,
-                y: -844
+                y: -844,
               },
               3: {
                 x: 124,
-                y: -816
+                y: -816,
               },
               4: {
                 x: 100,
-                y: -656
+                y: -656,
               },
               5: {
                 x: 100,
-                y: -656
+                y: -656,
               },
               6: {
                 x: 124,
-                y: -656
-              }
-            }
+                y: -656,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 699,
@@ -24224,35 +24224,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 7,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 39,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 339
+            consecutiveTime: 339,
           },
           sourceArrival: {
             lock: false,
             time: 21,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 21
+            consecutiveTime: 21,
           },
           targetDeparture: {
             lock: false,
             time: 14,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 14
+            consecutiveTime: 14,
           },
           targetArrival: {
             lock: false,
             time: 46,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 346
+            consecutiveTime: 346,
           },
           numberOfStops: 0,
           trainrunId: 85,
@@ -24262,53 +24262,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 112,
-                y: -930
+                y: -930,
               },
               {
                 x: 112,
-                y: -994
+                y: -994,
               },
               {
                 x: 112,
-                y: -1278
+                y: -1278,
               },
               {
                 x: 112,
-                y: -1342
-              }
+                y: -1342,
+              },
             ],
             textPositions: {
               0: {
                 x: 124,
-                y: -948
+                y: -948,
               },
               1: {
                 x: 100,
-                y: -976
+                y: -976,
               },
               2: {
                 x: 100,
-                y: -1324
+                y: -1324,
               },
               3: {
                 x: 124,
-                y: -1296
+                y: -1296,
               },
               4: {
                 x: 100,
-                y: -1136
+                y: -1136,
               },
               5: {
                 x: 100,
-                y: -1136
+                y: -1136,
               },
               6: {
                 x: 124,
-                y: -1136
-              }
-            }
+                y: -1136,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 700,
@@ -24321,35 +24321,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 8,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 46,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 346
+            consecutiveTime: 346,
           },
           sourceArrival: {
             lock: false,
             time: 14,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 14
+            consecutiveTime: 14,
           },
           targetDeparture: {
             lock: true,
             time: 6,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 6
+            consecutiveTime: 6,
           },
           targetArrival: {
             lock: true,
             time: 54,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 354
+            consecutiveTime: 354,
           },
           numberOfStops: 0,
           trainrunId: 85,
@@ -24359,53 +24359,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 112,
-                y: -1410
+                y: -1410,
               },
               {
                 x: 112,
-                y: -1474
+                y: -1474,
               },
               {
                 x: 112,
-                y: -1758
+                y: -1758,
               },
               {
                 x: 112,
-                y: -1822
-              }
+                y: -1822,
+              },
             ],
             textPositions: {
               0: {
                 x: 124,
-                y: -1428
+                y: -1428,
               },
               1: {
                 x: 100,
-                y: -1456
+                y: -1456,
               },
               2: {
                 x: 100,
-                y: -1804
+                y: -1804,
               },
               3: {
                 x: 124,
-                y: -1776
+                y: -1776,
               },
               4: {
                 x: 100,
-                y: -1616
+                y: -1616,
               },
               5: {
                 x: 100,
-                y: -1616
+                y: -1616,
               },
               6: {
                 x: 124,
-                y: -1616
-              }
-            }
+                y: -1616,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 701,
@@ -24418,35 +24418,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 13,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 1,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 421
+            consecutiveTime: 421,
           },
           sourceArrival: {
             lock: true,
             time: 59,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 119
+            consecutiveTime: 119,
           },
           targetDeparture: {
             lock: true,
             time: 46,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 106
+            consecutiveTime: 106,
           },
           targetArrival: {
             lock: true,
             time: 14,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 434
+            consecutiveTime: 434,
           },
           numberOfStops: 0,
           trainrunId: 87,
@@ -24456,53 +24456,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: -1698,
-                y: -16
+                y: -16,
               },
               {
                 x: -1762,
-                y: -16
+                y: -16,
               },
               {
                 x: -2366,
-                y: -16
+                y: -16,
               },
               {
                 x: -2430,
-                y: -16
-              }
+                y: -16,
+              },
             ],
             textPositions: {
               0: {
                 x: -1716,
-                y: -28
+                y: -28,
               },
               1: {
                 x: -1744,
-                y: -4
+                y: -4,
               },
               2: {
                 x: -2412,
-                y: -4
+                y: -4,
               },
               3: {
                 x: -2384,
-                y: -28
+                y: -28,
               },
               4: {
                 x: -2064,
-                y: -28
+                y: -28,
               },
               5: {
                 x: -2064,
-                y: -28
+                y: -28,
               },
               6: {
                 x: -2064,
-                y: -4
-              }
-            }
+                y: -4,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 702,
@@ -24515,35 +24515,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 16,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 5,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 245
+            consecutiveTime: 245,
           },
           sourceArrival: {
             lock: true,
             time: 55,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 295
+            consecutiveTime: 295,
           },
           targetDeparture: {
             lock: false,
             time: 39,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 279
+            consecutiveTime: 279,
           },
           targetArrival: {
             lock: false,
             time: 21,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 261
+            consecutiveTime: 261,
           },
           numberOfStops: 0,
           trainrunId: 87,
@@ -24553,53 +24553,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: 4738,
-                y: 112
+                y: 112,
               },
               {
                 x: 4802,
-                y: 112
+                y: 112,
               },
               {
                 x: 5310,
-                y: 112
+                y: 112,
               },
               {
                 x: 5374,
-                y: 112
-              }
+                y: 112,
+              },
             ],
             textPositions: {
               0: {
                 x: 4756,
-                y: 124
+                y: 124,
               },
               1: {
                 x: 4784,
-                y: 100
+                y: 100,
               },
               2: {
                 x: 5356,
-                y: 100
+                y: 100,
               },
               3: {
                 x: 5328,
-                y: 124
+                y: 124,
               },
               4: {
                 x: 5056,
-                y: 100
+                y: 100,
               },
               5: {
                 x: 5056,
-                y: 100
+                y: 100,
               },
               6: {
                 x: 5056,
-                y: 124
-              }
-            }
+                y: 124,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 703,
@@ -24612,35 +24612,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 30,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: true,
             time: 31,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 451
+            consecutiveTime: 451,
           },
           sourceArrival: {
             lock: true,
             time: 29,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 89
+            consecutiveTime: 89,
           },
           targetDeparture: {
             lock: true,
             time: 59,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 59
+            consecutiveTime: 59,
           },
           targetArrival: {
             lock: true,
             time: 1,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 481
+            consecutiveTime: 481,
           },
           numberOfStops: 1,
           trainrunId: 81,
@@ -24650,53 +24650,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: -3522,
-                y: 624
+                y: 624,
               },
               {
                 x: -3586,
-                y: 624
+                y: 624,
               },
               {
                 x: -3774,
-                y: 688
+                y: 688,
               },
               {
                 x: -3838,
-                y: 688
-              }
+                y: 688,
+              },
             ],
             textPositions: {
               0: {
                 x: -3540,
-                y: 612
+                y: 612,
               },
               1: {
                 x: -3568,
-                y: 636
+                y: 636,
               },
               2: {
                 x: -3820,
-                y: 700
+                y: 700,
               },
               3: {
                 x: -3792,
-                y: 676
+                y: 676,
               },
               4: {
                 x: -3680,
-                y: 644
+                y: 644,
               },
               5: {
                 x: -3680,
-                y: 644
+                y: 644,
               },
               6: {
                 x: -3680,
-                y: 668
-              }
-            }
+                y: 668,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 704,
@@ -24709,35 +24709,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 26,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 52,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 472
+            consecutiveTime: 472,
           },
           sourceArrival: {
             lock: false,
             time: 8,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 68
+            consecutiveTime: 68,
           },
           targetDeparture: {
             lock: true,
             time: 42,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 42
+            consecutiveTime: 42,
           },
           targetArrival: {
             lock: true,
             time: 18,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 498
+            consecutiveTime: 498,
           },
           numberOfStops: 0,
           trainrunId: 88,
@@ -24747,53 +24747,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: -3522,
-                y: 560
+                y: 560,
               },
               {
                 x: -3586,
-                y: 560
+                y: 560,
               },
               {
                 x: -3774,
-                y: 624
+                y: 624,
               },
               {
                 x: -3838,
-                y: 624
-              }
+                y: 624,
+              },
             ],
             textPositions: {
               0: {
                 x: -3540,
-                y: 548
+                y: 548,
               },
               1: {
                 x: -3568,
-                y: 572
+                y: 572,
               },
               2: {
                 x: -3820,
-                y: 636
+                y: 636,
               },
               3: {
                 x: -3792,
-                y: 612
+                y: 612,
               },
               4: {
                 x: -3680,
-                y: 580
+                y: 580,
               },
               5: {
                 x: -3680,
-                y: 580
+                y: 580,
               },
               6: {
                 x: -3680,
-                y: 604
-              }
-            }
+                y: 604,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 705,
@@ -24806,35 +24806,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 26,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 19,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 499
+            consecutiveTime: 499,
           },
           sourceArrival: {
             lock: false,
             time: 41,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 41
+            consecutiveTime: 41,
           },
           targetDeparture: {
             lock: true,
             time: 15,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 15
+            consecutiveTime: 15,
           },
           targetArrival: {
             lock: true,
             time: 45,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 525
+            consecutiveTime: 525,
           },
           numberOfStops: 0,
           trainrunId: 87,
@@ -24844,53 +24844,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: -3522,
-                y: 592
+                y: 592,
               },
               {
                 x: -3586,
-                y: 592
+                y: 592,
               },
               {
                 x: -3774,
-                y: 656
+                y: 656,
               },
               {
                 x: -3838,
-                y: 656
-              }
+                y: 656,
+              },
             ],
             textPositions: {
               0: {
                 x: -3540,
-                y: 580
+                y: 580,
               },
               1: {
                 x: -3568,
-                y: 604
+                y: 604,
               },
               2: {
                 x: -3820,
-                y: 668
+                y: 668,
               },
               3: {
                 x: -3792,
-                y: 644
+                y: 644,
               },
               4: {
                 x: -3680,
-                y: 612
+                y: 612,
               },
               5: {
                 x: -3680,
-                y: 612
+                y: 612,
               },
               6: {
                 x: -3680,
-                y: 636
-              }
-            }
+                y: 636,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 706,
@@ -24903,35 +24903,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 3,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 21,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 381
+            consecutiveTime: 381,
           },
           sourceArrival: {
             lock: false,
             time: 39,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 39
+            consecutiveTime: 39,
           },
           targetDeparture: {
             lock: true,
             time: 36,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 36
+            consecutiveTime: 36,
           },
           targetArrival: {
             lock: true,
             time: 24,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 384
+            consecutiveTime: 384,
           },
           numberOfStops: 0,
           trainrunId: 86,
@@ -24941,53 +24941,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: -1698,
-                y: 336
+                y: 336,
               },
               {
                 x: -1762,
-                y: 336
+                y: 336,
               },
               {
                 x: -1950,
-                y: 336
+                y: 336,
               },
               {
                 x: -2014,
-                y: 336
-              }
+                y: 336,
+              },
             ],
             textPositions: {
               0: {
                 x: -1716,
-                y: 324
+                y: 324,
               },
               1: {
                 x: -1744,
-                y: 348
+                y: 348,
               },
               2: {
                 x: -1996,
-                y: 348
+                y: 348,
               },
               3: {
                 x: -1968,
-                y: 324
+                y: 324,
               },
               4: {
                 x: -1856,
-                y: 324
+                y: 324,
               },
               5: {
                 x: -1856,
-                y: 324
+                y: 324,
               },
               6: {
                 x: -1856,
-                y: 348
-              }
-            }
+                y: 348,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 707,
@@ -25000,41 +25000,41 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 4,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 55,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 355
+            consecutiveTime: 355,
           },
           sourceArrival: {
             lock: false,
             time: 5,
             warning: {
               title: "Quelle Ankunft Warnung",
-              description: "Quellankunftszeit kann nicht erreicht werden"
+              description: "Quellankunftszeit kann nicht erreicht werden",
             },
             timeFormatter: null,
-            consecutiveTime: 185
+            consecutiveTime: 185,
           },
           targetDeparture: {
             lock: true,
             time: 0,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 180
+            consecutiveTime: 180,
           },
           targetArrival: {
             lock: true,
             time: 0,
             warning: {
               title: "Ziel Ankunft Warnung",
-              description: "Zielankunftszeit kann nicht erreicht werden"
+              description: "Zielankunftszeit kann nicht erreicht werden",
             },
             timeFormatter: null,
-            consecutiveTime: 360
+            consecutiveTime: 360,
           },
           numberOfStops: 0,
           trainrunId: 81,
@@ -25044,53 +25044,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: -1698,
-                y: 304
+                y: 304,
               },
               {
                 x: -1762,
-                y: 304
+                y: 304,
               },
               {
                 x: -1950,
-                y: 304
+                y: 304,
               },
               {
                 x: -2014,
-                y: 304
-              }
+                y: 304,
+              },
             ],
             textPositions: {
               0: {
                 x: -1716,
-                y: 292
+                y: 292,
               },
               1: {
                 x: -1744,
-                y: 316
+                y: 316,
               },
               2: {
                 x: -1996,
-                y: 316
+                y: 316,
               },
               3: {
                 x: -1968,
-                y: 292
+                y: 292,
               },
               4: {
                 x: -1856,
-                y: 292
+                y: 292,
               },
               5: {
                 x: -1856,
-                y: 292
+                y: 292,
               },
               6: {
                 x: -1856,
-                y: 316
-              }
-            }
+                y: 316,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 708,
@@ -25103,35 +25103,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 3,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 55,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 355
+            consecutiveTime: 355,
           },
           sourceArrival: {
             lock: false,
             time: 5,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 65
+            consecutiveTime: 65,
           },
           targetDeparture: {
             lock: false,
             time: 2,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 62
+            consecutiveTime: 62,
           },
           targetArrival: {
             lock: false,
             time: 58,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 358
+            consecutiveTime: 358,
           },
           numberOfStops: 0,
           trainrunId: 90,
@@ -25141,53 +25141,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: -1698,
-                y: 272
+                y: 272,
               },
               {
                 x: -1762,
-                y: 272
+                y: 272,
               },
               {
                 x: -1950,
-                y: 272
+                y: 272,
               },
               {
                 x: -2014,
-                y: 272
-              }
+                y: 272,
+              },
             ],
             textPositions: {
               0: {
                 x: -1716,
-                y: 260
+                y: 260,
               },
               1: {
                 x: -1744,
-                y: 284
+                y: 284,
               },
               2: {
                 x: -1996,
-                y: 284
+                y: 284,
               },
               3: {
                 x: -1968,
-                y: 260
+                y: 260,
               },
               4: {
                 x: -1856,
-                y: 260
+                y: 260,
               },
               5: {
                 x: -1856,
-                y: 260
+                y: 260,
               },
               6: {
                 x: -1856,
-                y: 284
-              }
-            }
+                y: 284,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 709,
@@ -25200,35 +25200,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 3,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 54,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 354
+            consecutiveTime: 354,
           },
           sourceArrival: {
             lock: false,
             time: 6,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 66
+            consecutiveTime: 66,
           },
           targetDeparture: {
             lock: true,
             time: 3,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 63
+            consecutiveTime: 63,
           },
           targetArrival: {
             lock: true,
             time: 57,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 357
+            consecutiveTime: 357,
           },
           numberOfStops: 0,
           trainrunId: 89,
@@ -25238,53 +25238,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: -1698,
-                y: 240
+                y: 240,
               },
               {
                 x: -1762,
-                y: 240
+                y: 240,
               },
               {
                 x: -1950,
-                y: 240
+                y: 240,
               },
               {
                 x: -2014,
-                y: 240
-              }
+                y: 240,
+              },
             ],
             textPositions: {
               0: {
                 x: -1716,
-                y: 228
+                y: 228,
               },
               1: {
                 x: -1744,
-                y: 252
+                y: 252,
               },
               2: {
                 x: -1996,
-                y: 252
+                y: 252,
               },
               3: {
                 x: -1968,
-                y: 228
+                y: 228,
               },
               4: {
                 x: -1856,
-                y: 228
+                y: 228,
               },
               5: {
                 x: -1856,
-                y: 228
+                y: 228,
               },
               6: {
                 x: -1856,
-                y: 252
-              }
-            }
+                y: 252,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 710,
@@ -25297,35 +25297,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 3,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 23,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 83
+            consecutiveTime: 83,
           },
           sourceArrival: {
             lock: false,
             time: 37,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 217
+            consecutiveTime: 217,
           },
           targetDeparture: {
             lock: true,
             time: 34,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 214
+            consecutiveTime: 214,
           },
           targetArrival: {
             lock: true,
             time: 26,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 86
+            consecutiveTime: 86,
           },
           numberOfStops: 0,
           trainrunId: 95,
@@ -25335,53 +25335,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: -1698,
-                y: 208
+                y: 208,
               },
               {
                 x: -1762,
-                y: 208
+                y: 208,
               },
               {
                 x: -1950,
-                y: 208
+                y: 208,
               },
               {
                 x: -2014,
-                y: 208
-              }
+                y: 208,
+              },
             ],
             textPositions: {
               0: {
                 x: -1716,
-                y: 196
+                y: 196,
               },
               1: {
                 x: -1744,
-                y: 220
+                y: 220,
               },
               2: {
                 x: -1996,
-                y: 220
+                y: 220,
               },
               3: {
                 x: -1968,
-                y: 196
+                y: 196,
               },
               4: {
                 x: -1856,
-                y: 196
+                y: 196,
               },
               5: {
                 x: -1856,
-                y: 196
+                y: 196,
               },
               6: {
                 x: -1856,
-                y: 220
-              }
-            }
+                y: 220,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 711,
@@ -25394,35 +25394,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 17,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 37,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 217
+            consecutiveTime: 217,
           },
           sourceArrival: {
             lock: false,
             time: 23,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 83
+            consecutiveTime: 83,
           },
           targetDeparture: {
             lock: false,
             time: 6,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 66
+            consecutiveTime: 66,
           },
           targetArrival: {
             lock: false,
             time: 54,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 234
+            consecutiveTime: 234,
           },
           numberOfStops: 0,
           trainrunId: 96,
@@ -25432,53 +25432,53 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: -1598,
-                y: 176
+                y: 176,
               },
               {
                 x: -1534,
-                y: 176
+                y: 176,
               },
               {
                 x: -674,
-                y: 176
+                y: 176,
               },
               {
                 x: -610,
-                y: 176
-              }
+                y: 176,
+              },
             ],
             textPositions: {
               0: {
                 x: -1580,
-                y: 188
+                y: 188,
               },
               1: {
                 x: -1552,
-                y: 164
+                y: 164,
               },
               2: {
                 x: -628,
-                y: 164
+                y: 164,
               },
               3: {
                 x: -656,
-                y: 188
+                y: 188,
               },
               4: {
                 x: -1104,
-                y: 164
+                y: 164,
               },
               5: {
                 x: -1104,
-                y: 164
+                y: 164,
               },
               6: {
                 x: -1104,
-                y: 188
-              }
-            }
+                y: 188,
+              },
+            },
           },
-          warnings: null
+          warnings: null,
         },
         {
           id: 712,
@@ -25491,35 +25491,35 @@ export class NetzgrafikDemoStandaloneGithub {
             time: 3,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 1
+            consecutiveTime: 1,
           },
           sourceDeparture: {
             lock: false,
             time: 26,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 386
+            consecutiveTime: 386,
           },
           sourceArrival: {
             lock: false,
             time: 34,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 154
+            consecutiveTime: 154,
           },
           targetDeparture: {
             lock: false,
             time: 31,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 151
+            consecutiveTime: 151,
           },
           targetArrival: {
             lock: false,
             time: 29,
             warning: null,
             timeFormatter: null,
-            consecutiveTime: 389
+            consecutiveTime: 389,
           },
           numberOfStops: 0,
           trainrunId: 88,
@@ -25529,54 +25529,54 @@ export class NetzgrafikDemoStandaloneGithub {
             path: [
               {
                 x: -1698,
-                y: 144
+                y: 144,
               },
               {
                 x: -1762,
-                y: 144
+                y: 144,
               },
               {
                 x: -1950,
-                y: 144
+                y: 144,
               },
               {
                 x: -2014,
-                y: 144
-              }
+                y: 144,
+              },
             ],
             textPositions: {
               0: {
                 x: -1716,
-                y: 132
+                y: 132,
               },
               1: {
                 x: -1744,
-                y: 156
+                y: 156,
               },
               2: {
                 x: -1996,
-                y: 156
+                y: 156,
               },
               3: {
                 x: -1968,
-                y: 132
+                y: 132,
               },
               4: {
                 x: -1856,
-                y: 132
+                y: 132,
               },
               5: {
                 x: -1856,
-                y: 132
+                y: 132,
               },
               6: {
                 x: -1856,
-                y: 156
-              }
-            }
+                y: 156,
+              },
+            },
           },
-          warnings: null
-        }
+          warnings: null,
+        },
       ],
       trainruns: [
         {
@@ -25585,11 +25585,7 @@ export class NetzgrafikDemoStandaloneGithub {
           categoryId: 1,
           frequencyId: 4,
           trainrunTimeCategoryId: 0,
-          labelIds: [
-            3,
-            8,
-            4
-          ]
+          labelIds: [3, 8, 4],
         },
         {
           id: 76,
@@ -25597,11 +25593,7 @@ export class NetzgrafikDemoStandaloneGithub {
           categoryId: 1,
           frequencyId: 4,
           trainrunTimeCategoryId: 0,
-          labelIds: [
-            3,
-            8,
-            4
-          ]
+          labelIds: [3, 8, 4],
         },
         {
           id: 77,
@@ -25609,11 +25601,7 @@ export class NetzgrafikDemoStandaloneGithub {
           categoryId: 2,
           frequencyId: 5,
           trainrunTimeCategoryId: 0,
-          labelIds: [
-            3,
-            8,
-            4
-          ]
+          labelIds: [3, 8, 4],
         },
         {
           id: 78,
@@ -25621,11 +25609,7 @@ export class NetzgrafikDemoStandaloneGithub {
           categoryId: 2,
           frequencyId: 4,
           trainrunTimeCategoryId: 0,
-          labelIds: [
-            3,
-            8,
-            4
-          ]
+          labelIds: [3, 8, 4],
         },
         {
           id: 79,
@@ -25633,11 +25617,7 @@ export class NetzgrafikDemoStandaloneGithub {
           categoryId: 2,
           frequencyId: 3,
           trainrunTimeCategoryId: 0,
-          labelIds: [
-            3,
-            8,
-            4
-          ]
+          labelIds: [3, 8, 4],
         },
         {
           id: 80,
@@ -25645,11 +25625,7 @@ export class NetzgrafikDemoStandaloneGithub {
           categoryId: 2,
           frequencyId: 3,
           trainrunTimeCategoryId: 0,
-          labelIds: [
-            3,
-            8,
-            4
-          ]
+          labelIds: [3, 8, 4],
         },
         {
           id: 81,
@@ -25657,11 +25633,7 @@ export class NetzgrafikDemoStandaloneGithub {
           categoryId: 2,
           frequencyId: 3,
           trainrunTimeCategoryId: 0,
-          labelIds: [
-            3,
-            8,
-            4
-          ]
+          labelIds: [3, 8, 4],
         },
         {
           id: 82,
@@ -25669,11 +25641,7 @@ export class NetzgrafikDemoStandaloneGithub {
           categoryId: 2,
           frequencyId: 3,
           trainrunTimeCategoryId: 0,
-          labelIds: [
-            3,
-            8,
-            4
-          ]
+          labelIds: [3, 8, 4],
         },
         {
           id: 83,
@@ -25681,11 +25649,7 @@ export class NetzgrafikDemoStandaloneGithub {
           categoryId: 2,
           frequencyId: 3,
           trainrunTimeCategoryId: 0,
-          labelIds: [
-            3,
-            8,
-            4
-          ]
+          labelIds: [3, 8, 4],
         },
         {
           id: 84,
@@ -25693,11 +25657,7 @@ export class NetzgrafikDemoStandaloneGithub {
           categoryId: 2,
           frequencyId: 3,
           trainrunTimeCategoryId: 0,
-          labelIds: [
-            3,
-            8,
-            4
-          ]
+          labelIds: [3, 8, 4],
         },
         {
           id: 85,
@@ -25705,11 +25665,7 @@ export class NetzgrafikDemoStandaloneGithub {
           categoryId: 1,
           frequencyId: 4,
           trainrunTimeCategoryId: 0,
-          labelIds: [
-            3,
-            8,
-            4
-          ]
+          labelIds: [3, 8, 4],
         },
         {
           id: 86,
@@ -25717,11 +25673,7 @@ export class NetzgrafikDemoStandaloneGithub {
           categoryId: 2,
           frequencyId: 3,
           trainrunTimeCategoryId: 0,
-          labelIds: [
-            3,
-            8,
-            4
-          ]
+          labelIds: [3, 8, 4],
         },
         {
           id: 87,
@@ -25729,11 +25681,7 @@ export class NetzgrafikDemoStandaloneGithub {
           categoryId: 1,
           frequencyId: 3,
           trainrunTimeCategoryId: 0,
-          labelIds: [
-            3,
-            8,
-            4
-          ]
+          labelIds: [3, 8, 4],
         },
         {
           id: 88,
@@ -25741,11 +25689,7 @@ export class NetzgrafikDemoStandaloneGithub {
           categoryId: 1,
           frequencyId: 3,
           trainrunTimeCategoryId: 0,
-          labelIds: [
-            3,
-            8,
-            4
-          ]
+          labelIds: [3, 8, 4],
         },
         {
           id: 89,
@@ -25753,11 +25697,7 @@ export class NetzgrafikDemoStandaloneGithub {
           categoryId: 1,
           frequencyId: 3,
           trainrunTimeCategoryId: 0,
-          labelIds: [
-            3,
-            8,
-            4
-          ]
+          labelIds: [3, 8, 4],
         },
         {
           id: 90,
@@ -25765,11 +25705,7 @@ export class NetzgrafikDemoStandaloneGithub {
           categoryId: 1,
           frequencyId: 3,
           trainrunTimeCategoryId: 0,
-          labelIds: [
-            3,
-            8,
-            4
-          ]
+          labelIds: [3, 8, 4],
         },
         {
           id: 91,
@@ -25777,11 +25713,7 @@ export class NetzgrafikDemoStandaloneGithub {
           categoryId: 2,
           frequencyId: 3,
           trainrunTimeCategoryId: 0,
-          labelIds: [
-            1,
-            9,
-            5
-          ]
+          labelIds: [1, 9, 5],
         },
         {
           id: 92,
@@ -25789,11 +25721,7 @@ export class NetzgrafikDemoStandaloneGithub {
           categoryId: 1,
           frequencyId: 3,
           trainrunTimeCategoryId: 0,
-          labelIds: [
-            1,
-            9,
-            5
-          ]
+          labelIds: [1, 9, 5],
         },
         {
           id: 93,
@@ -25801,11 +25729,7 @@ export class NetzgrafikDemoStandaloneGithub {
           categoryId: 2,
           frequencyId: 3,
           trainrunTimeCategoryId: 0,
-          labelIds: [
-            3,
-            8,
-            4
-          ]
+          labelIds: [3, 8, 4],
         },
         {
           id: 94,
@@ -25813,11 +25737,7 @@ export class NetzgrafikDemoStandaloneGithub {
           categoryId: 1,
           frequencyId: 3,
           trainrunTimeCategoryId: 0,
-          labelIds: [
-            3,
-            8,
-            4
-          ]
+          labelIds: [3, 8, 4],
         },
         {
           id: 95,
@@ -25825,11 +25745,7 @@ export class NetzgrafikDemoStandaloneGithub {
           categoryId: 1,
           frequencyId: 3,
           trainrunTimeCategoryId: 0,
-          labelIds: [
-            3,
-            8,
-            4
-          ]
+          labelIds: [3, 8, 4],
         },
         {
           id: 96,
@@ -25837,11 +25753,7 @@ export class NetzgrafikDemoStandaloneGithub {
           categoryId: 1,
           frequencyId: 3,
           trainrunTimeCategoryId: 0,
-          labelIds: [
-            3,
-            8,
-            4
-          ]
+          labelIds: [3, 8, 4],
         },
         {
           id: 97,
@@ -25849,480 +25761,476 @@ export class NetzgrafikDemoStandaloneGithub {
           categoryId: 2,
           frequencyId: 3,
           trainrunTimeCategoryId: 0,
-          labelIds: [
-            3,
-            8,
-            4
-          ]
-        }
+          labelIds: [3, 8, 4],
+        },
       ],
       resources: [
         {
           id: 88,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 89,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 90,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 91,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 92,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 93,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 94,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 95,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 96,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 97,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 98,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 99,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 100,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 101,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 102,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 103,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 104,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 105,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 106,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 107,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 108,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 109,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 110,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 111,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 112,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 113,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 114,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 115,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 116,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 117,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 118,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 119,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 120,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 121,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 122,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 123,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 124,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 125,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 126,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 127,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 128,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 129,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 130,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 131,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 132,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 133,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 134,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 135,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 136,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 137,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 138,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 139,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 140,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 141,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 142,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 143,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 144,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 145,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 146,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 147,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 148,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 149,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 150,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 151,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 152,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 153,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 154,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 155,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 156,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 157,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 158,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 159,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 160,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 161,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 162,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 163,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 164,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 165,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 166,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 167,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 168,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 169,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 170,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 171,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 172,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 173,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 174,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 175,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 176,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 177,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 178,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 179,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 180,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 181,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 182,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 183,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 184,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 185,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 186,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 187,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 188,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 189,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 190,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 191,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 192,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 193,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 194,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 195,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 196,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 197,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 198,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 199,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 200,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 201,
-          capacity: 2
+          capacity: 2,
         },
         {
           id: 202,
-          capacity: 2
-        }
+          capacity: 2,
+        },
       ],
       metadata: {
         analyticsSettings: {
           originDestinationSettings: {
             connectionPenalty: 5,
-          }
+          },
         },
         trainrunCategories: [
           {

--- a/src/app/sample-netzgrafik/netzgrafik_abzweiger.json
+++ b/src/app/sample-netzgrafik/netzgrafik_abzweiger.json
@@ -3137,15 +3137,7 @@
         "shortName": "7/24",
         "name": "verkehrt uneingeschränkt",
         "dayTimeInterval": [],
-        "weekday": [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7
-        ],
+        "weekday": [1, 2, 3, 4, 5, 6, 7],
         "linePatternRef": "7/24"
       },
       {
@@ -3163,15 +3155,7 @@
             "to": 1140
           }
         ],
-        "weekday": [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7
-        ],
+        "weekday": [1, 2, 3, 4, 5, 6, 7],
         "linePatternRef": "HVZ"
       },
       {
@@ -3186,6 +3170,6 @@
     ]
   },
   "freeFloatingTexts": [],
-  "labels" : [],
-  "labelGroups" : []
+  "labels": [],
+  "labelGroups": []
 }

--- a/src/app/sample-netzgrafik/netzgrafik_demo_takte.json
+++ b/src/app/sample-netzgrafik/netzgrafik_demo_takte.json
@@ -4014,15 +4014,7 @@
         "shortName": "7/24",
         "name": "verkehrt uneingeschränkt",
         "dayTimeInterval": [],
-        "weekday": [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7
-        ],
+        "weekday": [1, 2, 3, 4, 5, 6, 7],
         "linePatternRef": "7/24"
       },
       {
@@ -4040,15 +4032,7 @@
             "to": 1140
           }
         ],
-        "weekday": [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7
-        ],
+        "weekday": [1, 2, 3, 4, 5, 6, 7],
         "linePatternRef": "HVZ"
       },
       {
@@ -4063,6 +4047,6 @@
     ]
   },
   "freeFloatingTexts": [],
-  "labels" : [],
-  "labelGroups" : []
+  "labels": [],
+  "labelGroups": []
 }

--- a/src/app/sample-netzgrafik/netzgrafik_raum_luzern.json
+++ b/src/app/sample-netzgrafik/netzgrafik_raum_luzern.json
@@ -8722,15 +8722,7 @@
         "shortName": "7/24",
         "name": "verkehrt uneingeschränkt",
         "dayTimeInterval": [],
-        "weekday": [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7
-        ],
+        "weekday": [1, 2, 3, 4, 5, 6, 7],
         "linePatternRef": "7/24"
       },
       {
@@ -8748,15 +8740,7 @@
             "to": 1140
           }
         ],
-        "weekday": [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7
-        ],
+        "weekday": [1, 2, 3, 4, 5, 6, 7],
         "linePatternRef": "HVZ"
       },
       {
@@ -8771,6 +8755,6 @@
     ]
   },
   "freeFloatingTexts": [],
-  "labels" : [],
-  "labelGroups" : []
+  "labels": [],
+  "labelGroups": []
 }

--- a/src/app/services/analytics/origin-destination/components/origin-destination.component.html
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.component.html
@@ -1,7 +1,5 @@
 <div class="matrix-wrapper">
-  <div
-    id="main-origin-destination-container-root"
-  ></div>
+  <div id="main-origin-destination-container-root"></div>
 
   <div class="palette-buttons">
     <div
@@ -38,7 +36,7 @@
           [checked]="colorBy === 'totalCost'"
           (change)="onChangeColorBy('totalCost')"
         />
-        {{ 'app.origin-destination.color-by-selector.total-cost' | translate }}
+        {{ "app.origin-destination.color-by-selector.total-cost" | translate }}
       </label>
       <label>
         <input
@@ -48,7 +46,7 @@
           [checked]="colorBy === 'travelTime'"
           (change)="onChangeColorBy('travelTime')"
         />
-        {{ 'app.origin-destination.color-by-selector.travel-time' | translate }}
+        {{ "app.origin-destination.color-by-selector.travel-time" | translate }}
       </label>
       <label>
         <input
@@ -58,20 +56,32 @@
           [checked]="colorBy === 'transfers'"
           (change)="onChangeColorBy('transfers')"
         />
-        {{ 'app.origin-destination.color-by-selector.transfers' | translate }}
+        {{ "app.origin-destination.color-by-selector.transfers" | translate }}
       </label>
     </div>
   </div>
 
-  <sbb-radio-group class="sbb-checkbox-group-horizontal" [(ngModel)]="displayBy">
-    <sbb-radio-button value="totalCost" (change)="onChangeDisplayBy('totalCost')">
-      {{ 'app.origin-destination.display-by-selector.total-cost' | translate }}
+  <sbb-radio-group
+    class="sbb-checkbox-group-horizontal"
+    [(ngModel)]="displayBy"
+  >
+    <sbb-radio-button
+      value="totalCost"
+      (change)="onChangeDisplayBy('totalCost')"
+    >
+      {{ "app.origin-destination.display-by-selector.total-cost" | translate }}
     </sbb-radio-button>
-    <sbb-radio-button value="travelTime" (change)="onChangeDisplayBy('travelTime')">
-      {{ 'app.origin-destination.display-by-selector.travel-time' | translate }}
+    <sbb-radio-button
+      value="travelTime"
+      (change)="onChangeDisplayBy('travelTime')"
+    >
+      {{ "app.origin-destination.display-by-selector.travel-time" | translate }}
     </sbb-radio-button>
-    <sbb-radio-button value="transfers" (change)="onChangeDisplayBy('transfers')">
-      {{ 'app.origin-destination.display-by-selector.transfers' | translate }}
+    <sbb-radio-button
+      value="transfers"
+      (change)="onChangeDisplayBy('transfers')"
+    >
+      {{ "app.origin-destination.display-by-selector.transfers" | translate }}
     </sbb-radio-button>
   </sbb-radio-group>
 </div>

--- a/src/app/services/analytics/origin-destination/components/origin-destination.component.scss
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.component.scss
@@ -10,7 +10,7 @@
     width: calc(100% - 188px);
     height: calc(100% - 74px);
     box-sizing: border-box;
-}
+  }
 
   ::ng-deep svg.main-origin-destination-container {
     transform: translateX(16px);

--- a/src/app/services/auth/auth.service.ts
+++ b/src/app/services/auth/auth.service.ts
@@ -31,27 +31,27 @@ export class AuthService {
     location: Location,
   ) {
     if (environment.disableBackend) return;
-      this.oauthService.configure(environment.authConfig);
-      this.oauthService.setupAutomaticSilentRefresh();
-      // If the user should not be forcefully logged in (e.g. if you have pages, which can be
-      // accessed anonymously), change loadDiscoveryDocumentAndLogin to
-      // loadDiscoveryDocumentAndTryLogin and have a login functionality in the
-      // template of the component injecting the AuthService which calls the login() method.
-      this.initialized = this.oauthService
-        .loadDiscoveryDocumentAndLogin({state: location.path()})
-        // If the user is not logged in, he will be forwarded to the identity provider
-        // and this promise will not resolve. After being redirected from the identity
-        // provider, the login promise will return true.
-        .then((v) => (v ? true : new Promise(() => {})));
-      // Redirect the user to the url configured with state above or in a separate login call.
-      this.oauthService.events
-        .pipe(first((e) => e.type === "token_received"))
-        .subscribe(() => {
-          const state = decodeURIComponent(this.oauthService.state || "");
-          if (state && state !== "/") {
-            this.router.navigate([state]);
-          }
-        });
+    this.oauthService.configure(environment.authConfig);
+    this.oauthService.setupAutomaticSilentRefresh();
+    // If the user should not be forcefully logged in (e.g. if you have pages, which can be
+    // accessed anonymously), change loadDiscoveryDocumentAndLogin to
+    // loadDiscoveryDocumentAndTryLogin and have a login functionality in the
+    // template of the component injecting the AuthService which calls the login() method.
+    this.initialized = this.oauthService
+      .loadDiscoveryDocumentAndLogin({state: location.path()})
+      // If the user is not logged in, he will be forwarded to the identity provider
+      // and this promise will not resolve. After being redirected from the identity
+      // provider, the login promise will return true.
+      .then((v) => (v ? true : new Promise(() => {})));
+    // Redirect the user to the url configured with state above or in a separate login call.
+    this.oauthService.events
+      .pipe(first((e) => e.type === "token_received"))
+      .subscribe(() => {
+        const state = decodeURIComponent(this.oauthService.state || "");
+        if (state && state !== "/") {
+          this.router.navigate([state]);
+        }
+      });
   }
 
   logOut() {

--- a/src/app/services/data/copy.service.spec.ts
+++ b/src/app/services/data/copy.service.spec.ts
@@ -90,7 +90,7 @@ describe("CopyService", () => {
       trainrunService,
       trainrunSectionService,
       nodeService,
-      filterService
+      filterService,
     );
 
     uiInteractionService = new UiInteractionService(

--- a/src/app/services/data/data.service.ts
+++ b/src/app/services/data/data.service.ts
@@ -112,10 +112,7 @@ export class DataService implements OnDestroy {
     );
   }
 
-  insertCopyNetzgrafikDto(
-    netzgrafikDto: NetzgrafikDto,
-    enforceUpdate = true
-  ) {
+  insertCopyNetzgrafikDto(netzgrafikDto: NetzgrafikDto, enforceUpdate = true) {
     this.nodeService.unselectAllNodes();
     const nodeMap = this.nodeService.mergeNodes(netzgrafikDto.nodes);
     const trainrunMap = this.trainrunService.createNewTrainrunsFromDtoList(
@@ -127,7 +124,7 @@ export class DataService implements OnDestroy {
         nodeMap,
         trainrunMap,
         netzgrafikDto.nodes,
-        enforceUpdate
+        enforceUpdate,
       );
     this.nodeService.mergeLabelNode(netzgrafikDto, nodeMap);
     this.nodeService.mergeConnections(
@@ -211,31 +208,40 @@ export class DataService implements OnDestroy {
   }
 
   getTrainrunCategory(categoryId: number): TrainrunCategory {
-    const found = this.netzgrafikDtoStore.netzgrafikDto.metadata.trainrunCategories.find(
-      (trainrunCategory) => trainrunCategory.id === categoryId,
-    );
+    const found =
+      this.netzgrafikDtoStore.netzgrafikDto.metadata.trainrunCategories.find(
+        (trainrunCategory) => trainrunCategory.id === categoryId,
+      );
     if (found === undefined) {
-      return this.netzgrafikDtoStore.netzgrafikDto.metadata.trainrunCategories.find((freq) => true);
+      return this.netzgrafikDtoStore.netzgrafikDto.metadata.trainrunCategories.find(
+        (freq) => true,
+      );
     }
     return found;
   }
 
   getTrainrunFrequency(frequencyId: number): TrainrunFrequency {
-    const found = this.netzgrafikDtoStore.netzgrafikDto.metadata.trainrunFrequencies.find(
-      (trainrunFrequency) => trainrunFrequency.id === frequencyId,
-    );
+    const found =
+      this.netzgrafikDtoStore.netzgrafikDto.metadata.trainrunFrequencies.find(
+        (trainrunFrequency) => trainrunFrequency.id === frequencyId,
+      );
     if (found === undefined) {
-      return this.netzgrafikDtoStore.netzgrafikDto.metadata.trainrunFrequencies.find((freq) => true);
+      return this.netzgrafikDtoStore.netzgrafikDto.metadata.trainrunFrequencies.find(
+        (freq) => true,
+      );
     }
     return found;
   }
 
   getTrainrunTimeCategory(timeCategoryId: number): TrainrunTimeCategory {
-    const found = this.netzgrafikDtoStore.netzgrafikDto.metadata.trainrunTimeCategories.find(
-      (trainrunTimeCategory) => trainrunTimeCategory.id === timeCategoryId,
-    );
+    const found =
+      this.netzgrafikDtoStore.netzgrafikDto.metadata.trainrunTimeCategories.find(
+        (trainrunTimeCategory) => trainrunTimeCategory.id === timeCategoryId,
+      );
     if (found === undefined) {
-      return this.netzgrafikDtoStore.netzgrafikDto.metadata.trainrunTimeCategories.find((freq) => true);
+      return this.netzgrafikDtoStore.netzgrafikDto.metadata.trainrunTimeCategories.find(
+        (freq) => true,
+      );
     }
     return found;
   }

--- a/src/app/services/data/netzgrafikColoring.service.spec.ts
+++ b/src/app/services/data/netzgrafikColoring.service.spec.ts
@@ -89,7 +89,7 @@ describe("NetzgraphikColoringService", () => {
       trainrunService,
       trainrunSectionService,
       nodeService,
-      filterService
+      filterService,
     );
 
     uiInteractionService = new UiInteractionService(

--- a/src/app/services/data/netzgrafikColoring.service.ts
+++ b/src/app/services/data/netzgrafikColoring.service.ts
@@ -35,20 +35,20 @@ export class NetzgrafikColoringService {
   ) {
     [
       "path.edge_line.layer_3.Freq_30." +
-      StaticDomTags.TAG_UI_DIALOG +
-      " {  stroke: var(--sbb-header-lean-background-color); }",
+        StaticDomTags.TAG_UI_DIALOG +
+        " {  stroke: var(--sbb-header-lean-background-color); }",
       "path.edge_line.layer_2.Freq_20." +
-      StaticDomTags.TAG_UI_DIALOG +
-      " {  stroke: var(--sbb-header-lean-background-color); }",
+        StaticDomTags.TAG_UI_DIALOG +
+        " {  stroke: var(--sbb-header-lean-background-color); }",
       "path.edge_line.layer_1.Freq_15." +
-      StaticDomTags.TAG_UI_DIALOG +
-      " {  stroke: var(--sbb-header-lean-background-color); }",
+        StaticDomTags.TAG_UI_DIALOG +
+        " {  stroke: var(--sbb-header-lean-background-color); }",
       "path.edge_line.layer_3.Freq_15." +
-      StaticDomTags.TAG_UI_DIALOG +
-      " {  stroke: var(--sbb-header-lean-background-color); }",
+        StaticDomTags.TAG_UI_DIALOG +
+        " {  stroke: var(--sbb-header-lean-background-color); }",
       "path.edge_line.layer_3.Freq_15." +
-      StaticDomTags.TAG_UI_DIALOG +
-      " {  stroke: var(--sbb-header-lean-background-color); }",
+        StaticDomTags.TAG_UI_DIALOG +
+        " {  stroke: var(--sbb-header-lean-background-color); }",
     ].forEach((rule) => {
       sheet.insertRule(rule, sheet.cssRules.length);
       if (verbose) {
@@ -86,8 +86,7 @@ export class NetzgrafikColoringService {
     [
       {
         tag: "",
-        color:
-          "NODE_TEXT_FOCUS",
+        color: "NODE_TEXT_FOCUS",
         backgroundColor:
           StaticDomTags.PREFIX_COLOR_VARIABLE +
           "_" +
@@ -97,8 +96,7 @@ export class NetzgrafikColoringService {
       },
       {
         tag: StaticDomTags.TAG_SELECTED,
-        color:
-          "sbb-color-white",
+        color: "sbb-color-white",
         backgroundColor:
           StaticDomTags.PREFIX_COLOR_VARIABLE +
           "_" +
@@ -301,80 +299,80 @@ export class NetzgrafikColoringService {
 
       document.documentElement.style.setProperty(
         "--" +
-        StaticDomTags.PREFIX_COLOR_VARIABLE +
-        "_" +
-        netzgrafikColor.getColorRef(),
+          StaticDomTags.PREFIX_COLOR_VARIABLE +
+          "_" +
+          netzgrafikColor.getColorRef(),
         colors.color,
       );
       document.documentElement.style.setProperty(
         "--" +
-        StaticDomTags.PREFIX_COLOR_VARIABLE +
-        "_" +
-        netzgrafikColor.getColorRef() +
-        "_" +
-        StaticDomTags.TAG_FOCUS.toUpperCase(),
+          StaticDomTags.PREFIX_COLOR_VARIABLE +
+          "_" +
+          netzgrafikColor.getColorRef() +
+          "_" +
+          StaticDomTags.TAG_FOCUS.toUpperCase(),
         colors.colorFocus,
       );
       document.documentElement.style.setProperty(
         "--" +
-        StaticDomTags.PREFIX_COLOR_VARIABLE +
-        "_" +
-        netzgrafikColor.getColorRef() +
-        "_" +
-        StaticDomTags.TAG_MUTED.toUpperCase(),
+          StaticDomTags.PREFIX_COLOR_VARIABLE +
+          "_" +
+          netzgrafikColor.getColorRef() +
+          "_" +
+          StaticDomTags.TAG_MUTED.toUpperCase(),
         colors.colorMuted,
       );
       document.documentElement.style.setProperty(
         "--" +
-        StaticDomTags.PREFIX_COLOR_VARIABLE +
-        "_" +
-        netzgrafikColor.getColorRef() +
-        "_" +
-        StaticDomTags.TAG_RELATED.toUpperCase(),
+          StaticDomTags.PREFIX_COLOR_VARIABLE +
+          "_" +
+          netzgrafikColor.getColorRef() +
+          "_" +
+          StaticDomTags.TAG_RELATED.toUpperCase(),
         colors.colorRelated,
       );
 
       const uiColors = netzgrafikColor.getColors(false);
       document.documentElement.style.setProperty(
         "--" +
-        StaticDomTags.TAG_UI_DIALOG +
-        "_" +
-        StaticDomTags.PREFIX_COLOR_VARIABLE +
-        "_" +
-        netzgrafikColor.getColorRef(),
+          StaticDomTags.TAG_UI_DIALOG +
+          "_" +
+          StaticDomTags.PREFIX_COLOR_VARIABLE +
+          "_" +
+          netzgrafikColor.getColorRef(),
         uiColors.color,
       );
       document.documentElement.style.setProperty(
         "--" +
-        StaticDomTags.TAG_UI_DIALOG +
-        "_" +
-        StaticDomTags.PREFIX_COLOR_VARIABLE +
-        "_" +
-        netzgrafikColor.getColorRef() +
-        "_" +
-        StaticDomTags.TAG_FOCUS.toUpperCase(),
+          StaticDomTags.TAG_UI_DIALOG +
+          "_" +
+          StaticDomTags.PREFIX_COLOR_VARIABLE +
+          "_" +
+          netzgrafikColor.getColorRef() +
+          "_" +
+          StaticDomTags.TAG_FOCUS.toUpperCase(),
         uiColors.colorFocus,
       );
       document.documentElement.style.setProperty(
         "--" +
-        StaticDomTags.TAG_UI_DIALOG +
-        "_" +
-        StaticDomTags.PREFIX_COLOR_VARIABLE +
-        "_" +
-        netzgrafikColor.getColorRef() +
-        "_" +
-        StaticDomTags.TAG_MUTED.toUpperCase(),
+          StaticDomTags.TAG_UI_DIALOG +
+          "_" +
+          StaticDomTags.PREFIX_COLOR_VARIABLE +
+          "_" +
+          netzgrafikColor.getColorRef() +
+          "_" +
+          StaticDomTags.TAG_MUTED.toUpperCase(),
         uiColors.colorMuted,
       );
       document.documentElement.style.setProperty(
         "--" +
-        StaticDomTags.TAG_UI_DIALOG +
-        "_" +
-        StaticDomTags.PREFIX_COLOR_VARIABLE +
-        "_" +
-        netzgrafikColor.getColorRef() +
-        "_" +
-        StaticDomTags.TAG_RELATED.toUpperCase(),
+          StaticDomTags.TAG_UI_DIALOG +
+          "_" +
+          StaticDomTags.PREFIX_COLOR_VARIABLE +
+          "_" +
+          netzgrafikColor.getColorRef() +
+          "_" +
+          StaticDomTags.TAG_RELATED.toUpperCase(),
         uiColors.colorRelated,
       );
     });
@@ -536,8 +534,8 @@ export class NetzgrafikColoringService {
       colorRef,
       "fill",
       StaticDomTags.EDGE_LINE_STOPS_DOM_REF +
-      "." +
-      StaticDomTags.EDGE_LINE_STOPS_FILL,
+        "." +
+        StaticDomTags.EDGE_LINE_STOPS_FILL,
       verbose,
     );
     NetzgrafikColoringService.generateColors(
@@ -566,8 +564,8 @@ export class NetzgrafikColoringService {
       colorRef,
       "fill",
       StaticDomTags.EDGE_LINE_STOP_ICON_CLASS_DOM_REF +
-      "." +
-      StaticDomTags.TAG_FILL,
+        "." +
+        StaticDomTags.TAG_FILL,
       verbose,
     );
     NetzgrafikColoringService.generateColors(

--- a/src/app/services/data/node.service.ts
+++ b/src/app/services/data/node.service.ts
@@ -31,7 +31,12 @@ import {LabelService} from "./label.service";
 import {FilterService} from "../ui/filter.service";
 import {ConnectionDto} from "../../data-structures/technical.data.structures";
 import {TrainrunSectionValidator} from "../util/trainrunsection.validator";
-import {NodeOperation, Operation, OperationType, TrainrunOperation} from "../../models/operation.model";
+import {
+  NodeOperation,
+  Operation,
+  OperationType,
+  TrainrunOperation,
+} from "../../models/operation.model";
 
 @Injectable({
   providedIn: "root",
@@ -393,10 +398,14 @@ export class NodeService implements OnDestroy {
     const port2 = node.getPort(transition.getPortId2());
     const trainrunSection1 = port1.getTrainrunSection();
     const trainrunSection2 = port2.getTrainrunSection();
-    const timeLock1 = trainrunSection1.getSourceNodeId() !== node.getId() ?
-      trainrunSection1.getSourceDepartureLock() : trainrunSection1.getTargetDepartureLock();
-    const timeLock2 = trainrunSection2.getSourceNodeId() !== node.getId() ?
-      trainrunSection2.getSourceDepartureLock() : trainrunSection2.getTargetDepartureLock();
+    const timeLock1 =
+      trainrunSection1.getSourceNodeId() !== node.getId()
+        ? trainrunSection1.getSourceDepartureLock()
+        : trainrunSection1.getTargetDepartureLock();
+    const timeLock2 =
+      trainrunSection2.getSourceNodeId() !== node.getId()
+        ? trainrunSection2.getSourceDepartureLock()
+        : trainrunSection2.getTargetDepartureLock();
 
     const oppNodeTrainrunSection1 = node.getOppositeNode(trainrunSection1);
     const oppNodeTrainrunSection2 = node.getOppositeNode(trainrunSection2);
@@ -425,7 +434,8 @@ export class NodeService implements OnDestroy {
     );
 
     // temporary store the source/target node information for updating the locks
-    const isTargetNodeEqToNodeId = trainrunSection1.getTargetNodeId() === node.getId();
+    const isTargetNodeEqToNodeId =
+      trainrunSection1.getTargetNodeId() === node.getId();
 
     // compute the new reconnected trainrun sections (create / fusion)
     this.trainrunSectionService.reconnectTrainrunSection(
@@ -469,7 +479,7 @@ export class NodeService implements OnDestroy {
         timeLock1,
         timeLock2,
         trainrunSection1.getTravelTimeLock(),
-        enforceUpdate
+        enforceUpdate,
       );
     } else {
       this.trainrunSectionService.updateTrainrunSectionTimeLock(
@@ -477,7 +487,7 @@ export class NodeService implements OnDestroy {
         timeLock2,
         timeLock1,
         trainrunSection1.getTravelTimeLock(),
-        enforceUpdate
+        enforceUpdate,
       );
     }
 
@@ -601,7 +611,12 @@ export class NodeService implements OnDestroy {
     TransitionValidator.validateTransition(node, transitionId);
     this.transitionsUpdated();
     this.nodesUpdated();
-    this.operation.emit(new TrainrunOperation(OperationType.update, trainrunSections.trainrunSection1.getTrainrun()));
+    this.operation.emit(
+      new TrainrunOperation(
+        OperationType.update,
+        trainrunSections.trainrunSection1.getTrainrun(),
+      ),
+    );
   }
 
   checkExistsNoCycleTrainrunAfterFreePortsConnecting(
@@ -973,13 +988,17 @@ export class NodeService implements OnDestroy {
   changeNodeFullName(nodeId: number, name: string) {
     this.getNodeFromId(nodeId).setFullName(name);
     this.nodesUpdated();
-    this.operation.emit(new NodeOperation(OperationType.update, this.getNodeFromId(nodeId)));
+    this.operation.emit(
+      new NodeOperation(OperationType.update, this.getNodeFromId(nodeId)),
+    );
   }
 
   changeConnectionTime(nodeId: number, connectionTime: number) {
     this.getNodeFromId(nodeId).setConnectionTime(connectionTime);
     this.nodesUpdated();
-    this.operation.emit(new NodeOperation(OperationType.update, this.getNodeFromId(nodeId)));
+    this.operation.emit(
+      new NodeOperation(OperationType.update, this.getNodeFromId(nodeId)),
+    );
   }
 
   changeLabels(nodeId: number, labels: string[]) {
@@ -987,8 +1006,8 @@ export class NodeService implements OnDestroy {
 
     // ensure uniqueness of input labels
     const uniqueLabels = Array.from(new Set(labels));
-    const labelIds = uniqueLabels.map(label =>
-      this.labelService.getOrCreateLabel(label, LabelRef.Node).getId()
+    const labelIds = uniqueLabels.map((label) =>
+      this.labelService.getOrCreateLabel(label, LabelRef.Node).getId(),
     );
     const deletedLabelIds = this.labelService.clearLabel(
       this.findClearedLabel(node, labelIds),
@@ -1283,7 +1302,7 @@ export class NodeService implements OnDestroy {
     if (connectedTrainrunSections.length !== 0) {
       this.trainrunSectionService.deleteListOfTrainrunSections(
         node.getConnectedTrainrunSections(),
-        enforceUpdate
+        enforceUpdate,
       );
     }
     this.nodesStore.nodes = this.nodesStore.nodes.filter(

--- a/src/app/services/data/note.service.ts
+++ b/src/app/services/data/note.service.ts
@@ -56,7 +56,11 @@ export class NoteService {
     });
   }
 
-  addNote(position: Vec2D, title = $localize`:@@app.models.note.default-title:Note title`, text = $localize`:@@app.models.note.default-text:Note text`): Note {
+  addNote(
+    position: Vec2D,
+    title = $localize`:@@app.models.note.default-title:Note title`,
+    text = $localize`:@@app.models.note.default-text:Note text`,
+  ): Note {
     const newNote = new Note();
     newNote.setPosition(position.getX(), position.getY());
     newNote.setTitle(title);
@@ -191,8 +195,8 @@ export class NoteService {
 
     // ensure uniqueness of input labels
     const uniqueLabels = Array.from(new Set(labels));
-    const labelIds = uniqueLabels.map(label =>
-      this.labelService.getOrCreateLabel(label, LabelRef.Note).getId()
+    const labelIds = uniqueLabels.map((label) =>
+      this.labelService.getOrCreateLabel(label, LabelRef.Note).getId(),
     );
     const deletedLabelIds = this.labelService.clearLabel(
       this.findClearedLabel(note, labelIds),

--- a/src/app/services/data/origin-destination.service.ts
+++ b/src/app/services/data/origin-destination.service.ts
@@ -72,11 +72,14 @@ export class OriginDestinationService {
     // In theory we could parallelize the pathfindings, but the overhead might be too big.
     const res = new Map<string, [number, number]>();
     odNodes.forEach((origin) => {
-      computeShortestPaths(origin.getId(), neighbors, vertices, tsSuccessor).forEach(
-        (value, key) => {
-          res.set([origin.getId(), key].join(","), value);
-        },
-      );
+      computeShortestPaths(
+        origin.getId(),
+        neighbors,
+        vertices,
+        tsSuccessor,
+      ).forEach((value, key) => {
+        res.set([origin.getId(), key].join(","), value);
+      });
     });
 
     const rows = [];

--- a/src/app/services/data/trainrun-section-times.service.ts
+++ b/src/app/services/data/trainrun-section-times.service.ts
@@ -1,6 +1,9 @@
 import {Injectable} from "@angular/core";
 import {MathUtils} from "../../utils/math";
-import {LeftAndRightElement, TrainrunsectionHelper,} from "../util/trainrunsection.helper";
+import {
+  LeftAndRightElement,
+  TrainrunsectionHelper,
+} from "../util/trainrunsection.helper";
 import {
   LeftAndRightLockStructure,
   LeftAndRightTimeStructure,
@@ -421,8 +424,9 @@ export class TrainrunSectionTimesService {
   }
 
   updateTrainrunSectionTimeLock() {
-    const leftRight =
-      this.trainrunSectionHelper.getLeftRightSections(this.selectedTrainrunSection);
+    const leftRight = this.trainrunSectionHelper.getLeftRightSections(
+      this.selectedTrainrunSection,
+    );
 
     this.trainrunSectionService.updateTrainrunSectionTimeLock(
       leftRight.leftSection.getId(),
@@ -435,7 +439,7 @@ export class TrainrunSectionTimesService {
         leftRight.leftSection,
       ),
       this.lockStructure.travelTimeLock,
-      true
+      true,
     );
 
     this.trainrunSectionService.updateTrainrunSectionTimeLock(
@@ -449,7 +453,7 @@ export class TrainrunSectionTimesService {
         leftRight.rightSection,
       ),
       undefined,
-      true
+      true,
     );
   }
 
@@ -489,7 +493,7 @@ export class TrainrunSectionTimesService {
       this.initialLeftAndRightElement === LeftAndRightElement.LeftDeparture ||
       this.initialLeftAndRightElement === LeftAndRightElement.RightArrival ||
       this.initialLeftAndRightElement ===
-      LeftAndRightElement.LeftRightTrainrunName
+        LeftAndRightElement.LeftRightTrainrunName
     ) {
       this.timeStructure.leftDepartureTime =
         (this.timeStructure.leftDepartureTime + this.offset) % 60;
@@ -519,7 +523,7 @@ export class TrainrunSectionTimesService {
       this.initialLeftAndRightElement === LeftAndRightElement.LeftDeparture ||
       this.initialLeftAndRightElement === LeftAndRightElement.RightArrival ||
       this.initialLeftAndRightElement ===
-      LeftAndRightElement.LeftRightTrainrunName
+        LeftAndRightElement.LeftRightTrainrunName
     ) {
       this.timeStructure.leftDepartureTime =
         (maxMinutes + this.timeStructure.leftDepartureTime - this.offset) % 60;
@@ -598,7 +602,7 @@ export class TrainrunSectionTimesService {
         this.timeStructure,
       ),
       this.selectedTrainrunSection,
-      this.filterService.getTimeDisplayPrecision()
+      this.filterService.getTimeDisplayPrecision(),
     );
   }
 }

--- a/src/app/services/data/trainrun.service.spec.ts
+++ b/src/app/services/data/trainrun.service.spec.ts
@@ -402,8 +402,8 @@ describe("TrainrunService", () => {
       );
 
     expect(trainrunSections75.length).toBe(
-      trainrunSections5.length +
-      trainrunSections7.length);
+      trainrunSections5.length + trainrunSections7.length,
+    );
     expect(trainrunSections75.length).toBe(3);
   });
 

--- a/src/app/services/data/trainrun.service.ts
+++ b/src/app/services/data/trainrun.service.ts
@@ -16,14 +16,21 @@ import {DataService} from "./data.service";
 import {Node} from "../../models/node.model";
 import {TrainrunSection} from "../../models/trainrunsection.model";
 import {GeneralViewFunctions} from "../../view/util/generalViewFunctions";
-import {NonStopTrainrunIterator, TrainrunIterator,} from "../util/trainrun.iterator";
+import {
+  NonStopTrainrunIterator,
+  TrainrunIterator,
+} from "../util/trainrun.iterator";
 import {LogService} from "../../logger/log.service";
 import {LabelService} from "./label.service";
 import {FilterService} from "../ui/filter.service";
 import {Transition} from "../../models/transition.model";
 import {Port} from "../../models/port.model";
 import {Connection} from "../../models/connection.model";
-import {Operation, OperationType, TrainrunOperation} from "../../models/operation.model";
+import {
+  Operation,
+  OperationType,
+  TrainrunOperation,
+} from "../../models/operation.model";
 
 @Injectable({
   providedIn: "root",
@@ -33,7 +40,7 @@ export class TrainrunService {
   trainrunsSubject = new BehaviorSubject<Trainrun[]>([]);
   readonly trainruns = this.trainrunsSubject.asObservable();
 
-  trainrunsStore: { trainruns: Trainrun[] } = {trainruns: []}; // store the data in memory
+  trainrunsStore: {trainruns: Trainrun[]} = {trainruns: []}; // store the data in memory
 
   readonly operation = new EventEmitter<Operation>();
 
@@ -45,8 +52,7 @@ export class TrainrunService {
     private logService: LogService,
     private labelService: LabelService,
     private filterService: FilterService,
-  ) {
-  }
+  ) {}
 
   setDataService(dataService: DataService) {
     this.dataService = dataService;
@@ -264,7 +270,7 @@ export class TrainrunService {
   }
 
   updateTrainrunCategory(trainrun: Trainrun, category: TrainrunCategory) {
-    if (trainrun.getTrainrunCategory().id === category.id){
+    if (trainrun.getTrainrunCategory().id === category.id) {
       // no update needed
       return;
     }
@@ -278,7 +284,7 @@ export class TrainrunService {
     trainrun: Trainrun,
     timeCategory: TrainrunTimeCategory,
   ) {
-    if (trainrun.getTrainrunTimeCategory().id === timeCategory.id){
+    if (trainrun.getTrainrunTimeCategory().id === timeCategory.id) {
       // no update needed
       return;
     }
@@ -303,7 +309,9 @@ export class TrainrunService {
   }
 
   getVisibleTrainruns(): Trainrun[] {
-    return this.getTrainruns().filter((t) => this.filterService.filterTrainrun(t));
+    return this.getTrainruns().filter((t) =>
+      this.filterService.filterTrainrun(t),
+    );
   }
 
   getAllTrainrunLabels(): string[] {
@@ -399,17 +407,19 @@ export class TrainrunService {
     const port1 = node.getPort(portId1);
     const port2 = node.getPort(portId2);
     const trainrunSection2 = port2.getTrainrunSection();
-    const newTrainrun =
-      this.duplicateTrainrun(
-        trainrunSection2.getTrainrunId(),
-        false,
-        "-2");
+    const newTrainrun = this.duplicateTrainrun(
+      trainrunSection2.getTrainrunId(),
+      false,
+      "-2",
+    );
 
     trainrunSection2.setTrainrun(newTrainrun);
     const iterator = this.getIterator(node, trainrunSection2);
     while (iterator.hasNext()) {
       iterator.next();
-      const trans = iterator.current().node.getTransition(iterator.current().trainrunSection.getId());
+      const trans = iterator
+        .current()
+        .node.getTransition(iterator.current().trainrunSection.getId());
       if (trans) {
         trans.setTrainrun(newTrainrun);
       }
@@ -442,14 +452,14 @@ export class TrainrunService {
     // should be shifted by 30 minutes (1 frequency ) so that both are in the same cycle position,
     // i.e. 02.
     const arrivalTimeAtNode =
-      node.getId() !== port1.getTrainrunSection().getSourceNodeId() ?
-        port1.getTrainrunSection().getTargetArrival() :
-        port1.getTrainrunSection().getSourceArrival();
+      node.getId() !== port1.getTrainrunSection().getSourceNodeId()
+        ? port1.getTrainrunSection().getTargetArrival()
+        : port1.getTrainrunSection().getSourceArrival();
 
     const departTimeAtNode =
-      node.getId() !== port2.getTrainrunSection().getSourceNodeId() ?
-        port2.getTrainrunSection().getTargetDeparture() :
-        port2.getTrainrunSection().getSourceDeparture();
+      node.getId() !== port2.getTrainrunSection().getSourceNodeId()
+        ? port2.getTrainrunSection().getTargetDeparture()
+        : port2.getTrainrunSection().getSourceDeparture();
 
     let frequencyOffset = 0;
     while (60 + arrivalTimeAtNode > departTimeAtNode + frequencyOffset) {
@@ -462,21 +472,30 @@ export class TrainrunService {
     const iterator = this.getIterator(node, trainrunSection);
     while (iterator.hasNext()) {
       iterator.next();
-      const trans = iterator.current().node.getTransition(iterator.current().trainrunSection.getId());
+      const trans = iterator
+        .current()
+        .node.getTransition(iterator.current().trainrunSection.getId());
       if (trans) {
         trans.setTrainrun(trainrun1);
       }
       iterator.current().trainrunSection.setTrainrun(trainrun1);
-      iterator.current().trainrunSection.shiftAllTimes(
-        frequencyOffset,
-        node.getId() === port2.getTrainrunSection().getSourceNodeId());
+      iterator
+        .current()
+        .trainrunSection.shiftAllTimes(
+          frequencyOffset,
+          node.getId() === port2.getTrainrunSection().getSourceNodeId(),
+        );
     }
 
     // update trainrun references (1st transition)
     const trans1 = node.getTransitionFromPortId(port1.getId());
     const trans2 = node.getTransitionFromPortId(port2.getId());
     if (trans1 === undefined && trans2 === undefined) {
-      const trans = node.addTransitionAndComputeRouting(port1, port2, trainrun1);
+      const trans = node.addTransitionAndComputeRouting(
+        port1,
+        port2,
+        trainrun1,
+      );
       if (60 + arrivalTimeAtNode === departTimeAtNode + frequencyOffset) {
         trans.setIsNonStopTransit(true);
       } else {
@@ -486,8 +505,11 @@ export class TrainrunService {
 
     // update trainrun references (connection)
     const connections2delete = node.getConnections().filter((c: Connection) => {
-      return (c.getPortId1() === port1.getId() && c.getPortId2() === port2.getId()) ||
-        (c.getPortId1() === port2.getId() && c.getPortId2() === port1.getId());
+      return (
+        (c.getPortId1() === port1.getId() &&
+          c.getPortId2() === port2.getId()) ||
+        (c.getPortId1() === port2.getId() && c.getPortId2() === port1.getId())
+      );
     });
     connections2delete.forEach((c: Connection) => {
       node.removeConnection(c.getId());
@@ -500,9 +522,9 @@ export class TrainrunService {
     // Change all trainrun sections' trainrunId reference from trainrun2 to trainrun1
     // There can be some other "unconnected" trainrun segments left; those have to be moved to
     // trainrun1, which will "survive".
-    this.trainrunSectionService.getAllTrainrunSectionsForTrainrun(trainrun2.getId()).forEach(
-      (ts: TrainrunSection) => ts.setTrainrun(trainrun1)
-    );
+    this.trainrunSectionService
+      .getAllTrainrunSectionsForTrainrun(trainrun2.getId())
+      .forEach((ts: TrainrunSection) => ts.setTrainrun(trainrun1));
 
     // remove empty trainrun
     this.deleteTrainrun(trainrun2, false);
@@ -512,7 +534,9 @@ export class TrainrunService {
     this.nodeService.reorderPortsOnNodesForTrainrun(trainrun1, false);
 
     // Update the cumulative times for the combined trainrun
-    this.propagateConsecutiveTimesForTrainrun(port1.getTrainrunSection().getId());
+    this.propagateConsecutiveTimesForTrainrun(
+      port1.getTrainrunSection().getId(),
+    );
 
     // update
     this.trainrunsUpdated();
@@ -534,7 +558,9 @@ export class TrainrunService {
     copiedtrainrun.setTitle(trainrun.getTitle() + postfix);
     copiedtrainrun.setLabelIds(trainrun.getLabelIds());
     this.trainrunsStore.trainruns.push(copiedtrainrun);
-    this.operation.emit(new TrainrunOperation(OperationType.create, copiedtrainrun));
+    this.operation.emit(
+      new TrainrunOperation(OperationType.create, copiedtrainrun),
+    );
     return copiedtrainrun;
   }
 
@@ -543,7 +569,11 @@ export class TrainrunService {
     enforceUpdate = true,
     postfix = " COPY",
   ): Trainrun {
-    const copiedtrainrun = this.duplicateTrainrun(trainrunId, enforceUpdate, postfix);
+    const copiedtrainrun = this.duplicateTrainrun(
+      trainrunId,
+      enforceUpdate,
+      postfix,
+    );
     this.trainrunSectionService.copyAllTrainrunSectionsForTrainrun(
       trainrunId,
       copiedtrainrun.getId(),
@@ -562,8 +592,8 @@ export class TrainrunService {
 
     // ensure uniqueness of input labels
     const uniqueLabels = Array.from(new Set(labels));
-    const labelIds = uniqueLabels.map(label =>
-      this.labelService.getOrCreateLabel(label, LabelRef.Trainrun).getId()
+    const labelIds = uniqueLabels.map((label) =>
+      this.labelService.getOrCreateLabel(label, LabelRef.Trainrun).getId(),
     );
     const deletedLabelIds = this.labelService.clearLabel(
       this.findClearedLabel(trainrun, labelIds),
@@ -573,7 +603,9 @@ export class TrainrunService {
     trainrun.setLabelIds(labelIds);
     this.trainrunsUpdated();
     if (uniqueLabels.length === labels.length) {
-      this.operation.emit(new TrainrunOperation(OperationType.update, trainrun));
+      this.operation.emit(
+        new TrainrunOperation(OperationType.update, trainrun),
+      );
     }
   }
 
@@ -595,11 +627,10 @@ export class TrainrunService {
     this.propagateConsecutiveTimesForTrainrun(ts.getId());
   }
 
-  getBothEndNodesFromTrainrunPart(trainrunSection: TrainrunSection):
-    {
-      endNode1: Node;
-      endNode2: Node;
-    } {
+  getBothEndNodesFromTrainrunPart(trainrunSection: TrainrunSection): {
+    endNode1: Node;
+    endNode2: Node;
+  } {
     const sourceNode = trainrunSection.getSourceNode();
     const targetNode = trainrunSection.getTargetNode();
     const endNode1 = this.getEndNode(sourceNode, trainrunSection);
@@ -615,8 +646,9 @@ export class TrainrunService {
     }
 
     let alltrainrunsections =
-      this.trainrunSectionService
-        .getAllTrainrunSectionsForTrainrun(inTrainrunSection.getTrainrunId());
+      this.trainrunSectionService.getAllTrainrunSectionsForTrainrun(
+        inTrainrunSection.getTrainrunId(),
+      );
 
     while (alltrainrunsections.length > 0) {
       // propagate Consecutive Times Forward
@@ -634,14 +666,16 @@ export class TrainrunService {
         startForwardBackwardNode.startForwardNode,
         startForwardBackwardNode.startForwardNode.getStartTrainrunSection(
           trainrunSection.getTrainrunId(),
-          true
+          true,
         ),
         trainrunSection.getFrequencyOffset(),
       );
       const arrivalTime = propDataForward.cumTime;
 
       // propagate Consecutive Times Backward
-      const freq = trainrunSection.getTrainrun().getTrainrunFrequency().frequency;
+      const freq = trainrunSection
+        .getTrainrun()
+        .getTrainrunFrequency().frequency;
       const restFreqArrivalTime = Math.floor(arrivalTime / freq) * freq;
       const freqDependantArrivalTime = arrivalTime - restFreqArrivalTime;
       let offset = freq - freqDependantArrivalTime;
@@ -652,15 +686,16 @@ export class TrainrunService {
         startForwardBackwardNode.startBackwardNode,
         startForwardBackwardNode.startBackwardNode.getStartTrainrunSection(
           trainrunSection.getTrainrunId(),
-          false
+          false,
         ),
         offset,
       );
 
       // filter all still visited trainrun sections
-      alltrainrunsections = alltrainrunsections.filter(ts =>
-        propDataForward.visitedTrainrunSections.indexOf(ts) === -1 &&
-        propDataBackward.visitedTrainrunSections.indexOf(ts) === -1
+      alltrainrunsections = alltrainrunsections.filter(
+        (ts) =>
+          propDataForward.visitedTrainrunSections.indexOf(ts) === -1 &&
+          propDataBackward.visitedTrainrunSections.indexOf(ts) === -1,
       );
     }
   }
@@ -830,7 +865,10 @@ export class TrainrunService {
       if (node.isEndNode(ts)) {
         const it = iterators.get(trainrunId);
         const consecutiveTime = ts.getSourceDepartureDto().consecutiveTime;
-        if (it === undefined || consecutiveTimes.get(trainrunId) > consecutiveTime) {
+        if (
+          it === undefined ||
+          consecutiveTimes.get(trainrunId) > consecutiveTime
+        ) {
           iterators.set(trainrunId, this.getIterator(node, ts));
           consecutiveTimes.set(trainrunId, consecutiveTime);
         }
@@ -839,7 +877,10 @@ export class TrainrunService {
       if (node.isEndNode(ts)) {
         const it = iterators.get(trainrunId);
         const consecutiveTime = ts.getTargetDepartureDto().consecutiveTime;
-        if (it === undefined || consecutiveTimes.get(trainrunId) > consecutiveTime) {
+        if (
+          it === undefined ||
+          consecutiveTimes.get(trainrunId) > consecutiveTime
+        ) {
           iterators.set(trainrunId, this.getIterator(node, ts));
           consecutiveTimes.set(trainrunId, consecutiveTime);
         }
@@ -886,7 +927,7 @@ export class TrainrunService {
     if (trainrunSection === undefined) {
       return {
         cumTime: 0,
-        visitedTrainrunSections: visitedTrainrunSections
+        visitedTrainrunSections: visitedTrainrunSections,
       };
     }
     let accumulatedTime = node.getDepartureTime(trainrunSection) + offset;
@@ -938,7 +979,7 @@ export class TrainrunService {
     }
     return {
       cumTime: accumulatedTime,
-      visitedTrainrunSections: visitedTrainrunSections
+      visitedTrainrunSections: visitedTrainrunSections,
     };
   }
 

--- a/src/app/services/data/trainrunsection.service.spec.ts
+++ b/src/app/services/data/trainrunsection.service.spec.ts
@@ -138,7 +138,6 @@ describe("TrainrunSectionService", () => {
     expect(ts.getSourceArrivalConsecutiveTime()).toBe(48);
   });
 
-
   it("TrainrunSectionService.checkMissingTransitionsAfterDeletion", () => {
     // tests: https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/369
     dataService.loadNetzgrafikDto(
@@ -153,11 +152,26 @@ describe("TrainrunSectionService", () => {
     const nodeC = nodeService.addNodeWithPosition(0, 2, "C");
     const nodeD = nodeService.addNodeWithPosition(0, 3, "D");
     const nodeE = nodeService.addNodeWithPosition(0, 4, "E");
-    const tsAB = trainrunSectionService.createTrainrunSection(nodeA.getId(), nodeB.getId());
-    const tsBC = trainrunSectionService.createTrainrunSection(nodeB.getId(), nodeC.getId());
-    const tsCD = trainrunSectionService.createTrainrunSection(nodeC.getId(), nodeD.getId());
-    const tsDE = trainrunSectionService.createTrainrunSection(nodeD.getId(), nodeE.getId());
-    const tsEA = trainrunSectionService.createTrainrunSection(nodeE.getId(), nodeA.getId());
+    const tsAB = trainrunSectionService.createTrainrunSection(
+      nodeA.getId(),
+      nodeB.getId(),
+    );
+    const tsBC = trainrunSectionService.createTrainrunSection(
+      nodeB.getId(),
+      nodeC.getId(),
+    );
+    const tsCD = trainrunSectionService.createTrainrunSection(
+      nodeC.getId(),
+      nodeD.getId(),
+    );
+    const tsDE = trainrunSectionService.createTrainrunSection(
+      nodeD.getId(),
+      nodeE.getId(),
+    );
+    const tsEA = trainrunSectionService.createTrainrunSection(
+      nodeE.getId(),
+      nodeA.getId(),
+    );
 
     expect(nodeA.getTransitions().length).toBe(0);
     expect(nodeB.getTransitions().length).toBe(1);
@@ -167,10 +181,12 @@ describe("TrainrunSectionService", () => {
 
     const transA_AB1 = nodeA.getTransition(tsAB.getId());
     const transA_EA1 = nodeA.getTransition(tsEA.getId());
-    expect(transA_AB1 ).toBe(undefined);
-    expect(transA_EA1 ).toBe(undefined);
+    expect(transA_AB1).toBe(undefined);
+    expect(transA_EA1).toBe(undefined);
 
-    trainrunSectionService.deleteTrainrunSection(trainrunSectionService.getTrainrunSections()[1].getId());
+    trainrunSectionService.deleteTrainrunSection(
+      trainrunSectionService.getTrainrunSections()[1].getId(),
+    );
 
     expect(nodeA.getTransitions().length).toBe(1);
     expect(nodeB.getTransitions().length).toBe(0);
@@ -181,7 +197,5 @@ describe("TrainrunSectionService", () => {
     const transA_AB2 = nodeA.getTransition(tsAB.getId());
     const transA_EA2 = nodeA.getTransition(tsEA.getId());
     expect(transA_AB2.getId()).toBe(transA_EA2.getId());
-
   });
-
 });

--- a/src/app/services/data/trainrunsection.service.ts
+++ b/src/app/services/data/trainrunsection.service.ts
@@ -13,16 +13,18 @@ import {TrainrunSectionValidator} from "../util/trainrunsection.validator";
 import {Trainrun} from "../../models/trainrun.model";
 import {MathUtils} from "../../utils/math";
 import {GeneralViewFunctions} from "../../view/util/generalViewFunctions";
-import {
-  LeftAndRightTimeStructure
-} from "../../view/dialogs/trainrun-and-section-dialog/trainrunsection-tab/trainrun-section-tab.component";
+import {LeftAndRightTimeStructure} from "../../view/dialogs/trainrun-and-section-dialog/trainrunsection-tab/trainrun-section-tab.component";
 import {TrainrunsectionHelper} from "../util/trainrunsection.helper";
 import {LogService} from "../../logger/log.service";
 import {Transition} from "../../models/transition.model";
 import {takeUntil} from "rxjs/operators";
 import {FilterService} from "../ui/filter.service";
 import {TrainrunSectionNodePair} from "../util/trainrun.iterator";
-import {Operation, OperationType, TrainrunOperation} from "../../models/operation.model";
+import {
+  Operation,
+  OperationType,
+  TrainrunOperation,
+} from "../../models/operation.model";
 
 interface DepartureAndArrivalTimes {
   nodeFromDepartureTime: number;
@@ -43,7 +45,7 @@ export class TrainrunSectionService implements OnDestroy {
   // Description of observable data service: https://coryrylan.com/blog/angular-observable-data-services
   trainrunSectionsSubject = new BehaviorSubject<TrainrunSection[]>([]);
   readonly trainrunSections = this.trainrunSectionsSubject.asObservable();
-  trainrunSectionsStore: { trainrunSections: TrainrunSection[] } = {
+  trainrunSectionsStore: {trainrunSections: TrainrunSection[]} = {
     trainrunSections: [],
   }; // store the data in memory
 
@@ -80,12 +82,12 @@ export class TrainrunSectionService implements OnDestroy {
     trainrunSection: TrainrunSection,
     nonStop: boolean,
     halteZeiten: TrainrunCategoryHaltezeit,
-    precision: number = 10
+    precision: number = 10,
   ): DepartureAndArrivalTimes {
     let haltezeit =
       halteZeiten[
         trainrunSection.getTrainrun().getTrainrunCategory().fachCategory
-        ].haltezeit;
+      ].haltezeit;
     haltezeit = nonStop ? 0 : haltezeit;
     const fromDepartureTime = MathUtils.round(
       (nodeArrival + haltezeit) % 60,
@@ -164,7 +166,7 @@ export class TrainrunSectionService implements OnDestroy {
           trainrunSection,
           false,
           halteZeit,
-          TrainrunSectionService.TIME_PRECISION
+          TrainrunSectionService.TIME_PRECISION,
         );
 
       if (trainrunSection.getSourceNodeId() === nodeFrom.getId()) {
@@ -197,12 +199,14 @@ export class TrainrunSectionService implements OnDestroy {
     } else {
       // first or unconnected section - special case
       const targetArrivalTime = MathUtils.round(
-        (trainrunSection.getSourceDeparture() + (trainrunSection.getTravelTime() % 60)) % 60,
-        TrainrunSectionService.TIME_PRECISION
+        (trainrunSection.getSourceDeparture() +
+          (trainrunSection.getTravelTime() % 60)) %
+          60,
+        TrainrunSectionService.TIME_PRECISION,
       );
       const targetDepartureTime = MathUtils.round(
         TrainrunsectionHelper.getSymmetricTime(targetArrivalTime),
-        TrainrunSectionService.TIME_PRECISION
+        TrainrunSectionService.TIME_PRECISION,
       );
       trainrunSection.setTargetDeparture(targetDepartureTime);
       trainrunSection.setTargetArrival(targetArrivalTime);
@@ -254,7 +258,7 @@ export class TrainrunSectionService implements OnDestroy {
     nodeMap: Map<number, number>,
     trainrunMap: Map<number, number>,
     nodes: NodeDto[],
-    enforceUpdate = true
+    enforceUpdate = true,
   ): Map<number, number> {
     const trainrunSectionMap: Map<number, number> = new Map<number, number>();
     trainrunSections.forEach((trainrunSection) => {
@@ -263,7 +267,7 @@ export class TrainrunSectionService implements OnDestroy {
         nodeMap,
         trainrunMap,
         nodes,
-        enforceUpdate
+        enforceUpdate,
       );
       trainrunSectionMap.set(trainrunSection.id, newTrainrunSection.getId());
     });
@@ -332,7 +336,12 @@ export class TrainrunSectionService implements OnDestroy {
     const trainrunSection = this.getTrainrunSectionFromId(trs.getId());
     trainrunSection.setNumberOfStops(numberOfStops);
     this.trainrunSectionsUpdated();
-    this.operation.emit(new TrainrunOperation(OperationType.update, trainrunSection.getTrainrun()));
+    this.operation.emit(
+      new TrainrunOperation(
+        OperationType.update,
+        trainrunSection.getTrainrun(),
+      ),
+    );
   }
 
   updateTrainrunSectionTime(
@@ -342,7 +351,7 @@ export class TrainrunSectionService implements OnDestroy {
     targetArrival: number,
     targetDeparture: number,
     travelTime: number,
-    emit: boolean = true
+    emit: boolean = true,
   ) {
     const trainrunSection = this.getTrainrunSectionFromId(trsId);
     trainrunSection.setSourceArrival(sourceArrivalTime);
@@ -357,7 +366,12 @@ export class TrainrunSectionService implements OnDestroy {
     this.nodeService.validateConnections(trainrunSection.getSourceNode());
     this.nodeService.validateConnections(trainrunSection.getTargetNode());
     if (emit) {
-      this.operation.emit(new TrainrunOperation(OperationType.update, trainrunSection.getTrainrun()));
+      this.operation.emit(
+        new TrainrunOperation(
+          OperationType.update,
+          trainrunSection.getTrainrun(),
+        ),
+      );
     }
   }
 
@@ -416,24 +430,26 @@ export class TrainrunSectionService implements OnDestroy {
     this.trainrunSectionsUpdated();
   }
 
-  propagteTimeSourceToTarget(previousPair: TrainrunSectionNodePair,
-                             pair: TrainrunSectionNodePair,
-                             arrivalDepartureTimes: DepartureAndArrivalTimes,
-                             isNonStop: boolean) {
-
+  propagteTimeSourceToTarget(
+    previousPair: TrainrunSectionNodePair,
+    pair: TrainrunSectionNodePair,
+    arrivalDepartureTimes: DepartureAndArrivalTimes,
+    isNonStop: boolean,
+  ) {
     // -------------------------------------------------------------------------------------------
     // Source to Target (pair)
     // -------------------------------------------------------------------------------------------
     // retrieve haltezeit at node
     const arrivalTimeAtSource =
-      previousPair.node.getId() === previousPair.trainrunSection.getTargetNodeId() ?
-        previousPair.trainrunSection.getTargetArrival() :
-        previousPair.trainrunSection.getSourceArrival();
+      previousPair.node.getId() ===
+      previousPair.trainrunSection.getTargetNodeId()
+        ? previousPair.trainrunSection.getTargetArrival()
+        : previousPair.trainrunSection.getSourceArrival();
 
     let halteZeit =
       previousPair.node.getTrainrunCategoryHaltezeit()[
         pair.trainrunSection.getTrainrun().getTrainrunCategory().fachCategory
-        ].haltezeit;
+      ].haltezeit;
     halteZeit = isNonStop ? 0 : halteZeit;
 
     // try to update the pair (based on previousPair)
@@ -447,11 +463,11 @@ export class TrainrunSectionService implements OnDestroy {
     // ----------------------------------------------------------------------------------
     const depTimeAtSource = MathUtils.round(
       (arrivalTimeAtSource + halteZeit) % 60,
-      TrainrunSectionService.TIME_PRECISION
+      TrainrunSectionService.TIME_PRECISION,
     );
     const arrTimeAtSource = MathUtils.round(
       TrainrunsectionHelper.getSymmetricTime(depTimeAtSource),
-      TrainrunSectionService.TIME_PRECISION
+      TrainrunSectionService.TIME_PRECISION,
     );
     pair.trainrunSection.setSourceDeparture(depTimeAtSource);
     pair.trainrunSection.setSourceArrival(arrTimeAtSource);
@@ -463,11 +479,11 @@ export class TrainrunSectionService implements OnDestroy {
       // Target is not locked -> update the Target Arrival Time
       const arrTimeAtTarget = MathUtils.round(
         (depTimeAtSource + pair.trainrunSection.getTravelTime()) % 60,
-        TrainrunSectionService.TIME_PRECISION
+        TrainrunSectionService.TIME_PRECISION,
       );
       const depTimeAtTarget = MathUtils.round(
         TrainrunsectionHelper.getSymmetricTime(arrTimeAtTarget),
-        TrainrunSectionService.TIME_PRECISION
+        TrainrunSectionService.TIME_PRECISION,
       );
       pair.trainrunSection.setTargetArrival(arrTimeAtTarget);
       pair.trainrunSection.setTargetDeparture(depTimeAtTarget);
@@ -482,7 +498,8 @@ export class TrainrunSectionService implements OnDestroy {
       return;
     }
 
-    let newTravelTime = pair.trainrunSection.getTargetArrival() - depTimeAtSource;
+    let newTravelTime =
+      pair.trainrunSection.getTargetArrival() - depTimeAtSource;
     newTravelTime += Math.floor(pair.trainrunSection.getTravelTime() / 60) * 60;
     while (newTravelTime < 0.0) {
       newTravelTime += 60;
@@ -490,24 +507,26 @@ export class TrainrunSectionService implements OnDestroy {
     pair.trainrunSection.setTravelTime(newTravelTime);
   }
 
-  propagteTimeTargetToSource(previousPair: TrainrunSectionNodePair,
-                             pair: TrainrunSectionNodePair,
-                             arrivalDepartureTimes: DepartureAndArrivalTimes,
-                             isNonStop: boolean) {
-
+  propagteTimeTargetToSource(
+    previousPair: TrainrunSectionNodePair,
+    pair: TrainrunSectionNodePair,
+    arrivalDepartureTimes: DepartureAndArrivalTimes,
+    isNonStop: boolean,
+  ) {
     // -------------------------------------------------------------------------------------------
     // Target to Source (pair)
     // -------------------------------------------------------------------------------------------
     // retrieve haltezeit at node
     const arrivalTimeAtTarget =
-      previousPair.node.getId() === previousPair.trainrunSection.getTargetNodeId() ?
-        previousPair.trainrunSection.getTargetArrival() :
-        previousPair.trainrunSection.getSourceArrival();
+      previousPair.node.getId() ===
+      previousPair.trainrunSection.getTargetNodeId()
+        ? previousPair.trainrunSection.getTargetArrival()
+        : previousPair.trainrunSection.getSourceArrival();
 
     let halteZeit =
       previousPair.node.getTrainrunCategoryHaltezeit()[
         pair.trainrunSection.getTrainrun().getTrainrunCategory().fachCategory
-        ].haltezeit;
+      ].haltezeit;
     halteZeit = isNonStop ? 0 : halteZeit;
 
     // try to update the pair (based on previousPair)
@@ -521,11 +540,11 @@ export class TrainrunSectionService implements OnDestroy {
     // ----------------------------------------------------------------------------------
     const depTimeAtTarget = MathUtils.round(
       (arrivalTimeAtTarget + halteZeit) % 60,
-      TrainrunSectionService.TIME_PRECISION
+      TrainrunSectionService.TIME_PRECISION,
     );
     const arrTimeAtTarget = MathUtils.round(
       TrainrunsectionHelper.getSymmetricTime(depTimeAtTarget),
-      TrainrunSectionService.TIME_PRECISION
+      TrainrunSectionService.TIME_PRECISION,
     );
     pair.trainrunSection.setTargetDeparture(depTimeAtTarget);
     pair.trainrunSection.setTargetArrival(arrTimeAtTarget);
@@ -537,11 +556,11 @@ export class TrainrunSectionService implements OnDestroy {
       // Target is not locked -> update the Target Arrival Time
       const arrTimeAtSource = MathUtils.round(
         (depTimeAtTarget + pair.trainrunSection.getTravelTime()) % 60,
-        TrainrunSectionService.TIME_PRECISION
+        TrainrunSectionService.TIME_PRECISION,
       );
       const depTimeAtSource = MathUtils.round(
         TrainrunsectionHelper.getSymmetricTime(arrTimeAtSource),
-        TrainrunSectionService.TIME_PRECISION
+        TrainrunSectionService.TIME_PRECISION,
       );
       pair.trainrunSection.setSourceArrival(arrTimeAtSource);
       pair.trainrunSection.setSourceDeparture(depTimeAtSource);
@@ -556,7 +575,8 @@ export class TrainrunSectionService implements OnDestroy {
       return;
     }
 
-    let newTravelTime = pair.trainrunSection.getSourceArrival() - depTimeAtTarget;
+    let newTravelTime =
+      pair.trainrunSection.getSourceArrival() - depTimeAtTarget;
     newTravelTime += Math.floor(pair.trainrunSection.getTravelTime() / 60) * 60;
     while (newTravelTime < 0.0) {
       newTravelTime += 60;
@@ -592,15 +612,25 @@ export class TrainrunSectionService implements OnDestroy {
           pair.trainrunSection,
           isNonStop,
           halteZeit,
-          TrainrunSectionService.TIME_PRECISION
+          TrainrunSectionService.TIME_PRECISION,
         );
 
       if (
         pair.trainrunSection.getSourceNodeId() === previousPair.node.getId()
       ) {
-        this.propagteTimeSourceToTarget(previousPair, pair, arrivalDepartureTimes, isNonStop);
+        this.propagteTimeSourceToTarget(
+          previousPair,
+          pair,
+          arrivalDepartureTimes,
+          isNonStop,
+        );
       } else {
-        this.propagteTimeTargetToSource(previousPair, pair, arrivalDepartureTimes, isNonStop);
+        this.propagteTimeTargetToSource(
+          previousPair,
+          pair,
+          arrivalDepartureTimes,
+          isNonStop,
+        );
       }
       TrainrunSectionValidator.validateOneSection(pair.trainrunSection);
 
@@ -625,7 +655,7 @@ export class TrainrunSectionService implements OnDestroy {
     sourceLock: boolean,
     targetLock: boolean,
     travelTimeLock: boolean,
-    enforceUpdate = true
+    enforceUpdate = true,
   ) {
     const trainrunSection = this.getTrainrunSectionFromId(trsId);
     if (sourceLock !== undefined) {
@@ -659,33 +689,46 @@ export class TrainrunSectionService implements OnDestroy {
     }
   }
 
-  retrieveTravelTime(sourceNodeId: number, targetNodeId: number, trainrun: Trainrun): number {
+  retrieveTravelTime(
+    sourceNodeId: number,
+    targetNodeId: number,
+    trainrun: Trainrun,
+  ): number {
     const foundTrainruns = this.getTrainrunSections().filter(
       (ts) =>
-        (
-          (ts.getSourceNodeId() === sourceNodeId && ts.getTargetNodeId() === targetNodeId) ||
-          (ts.getSourceNodeId() === targetNodeId && ts.getTargetNodeId() === sourceNodeId)
-        )
+        (ts.getSourceNodeId() === sourceNodeId &&
+          ts.getTargetNodeId() === targetNodeId) ||
+        (ts.getSourceNodeId() === targetNodeId &&
+          ts.getTargetNodeId() === sourceNodeId),
     );
     if (foundTrainruns.length === 0) {
       return 1;
     }
 
-    const sameTrainCat = foundTrainruns.filter((ts) =>
-      ts.getTrainrun().getTrainrunCategory().id === trainrun.getTrainrunCategory().id
+    const sameTrainCat = foundTrainruns.filter(
+      (ts) =>
+        ts.getTrainrun().getTrainrunCategory().id ===
+        trainrun.getTrainrunCategory().id,
     );
     if (sameTrainCat.length === 0) {
-      return foundTrainruns.reduce((a, b) =>
-        a.getTravelTime() > b.getTravelTime() ? a : b).getTravelTime();
+      return foundTrainruns
+        .reduce((a, b) => (a.getTravelTime() > b.getTravelTime() ? a : b))
+        .getTravelTime();
     }
 
-    return sameTrainCat.reduce((a, b) =>
-      a.getTravelTime() > b.getTravelTime() ? a : b).getTravelTime();
+    return sameTrainCat
+      .reduce((a, b) => (a.getTravelTime() > b.getTravelTime() ? a : b))
+      .getTravelTime();
   }
 
-  createTrainrunSection(sourceNodeId: number, targetNodeId: number, retrieveTravelTimeFromEdge: boolean = false): TrainrunSection {
+  createTrainrunSection(
+    sourceNodeId: number,
+    targetNodeId: number,
+    retrieveTravelTimeFromEdge: boolean = false,
+  ): TrainrunSection {
     const trainrunSection: TrainrunSection = new TrainrunSection();
-    const initialTrainrunsLength = this.trainrunService.trainrunsStore.trainruns.length;
+    const initialTrainrunsLength =
+      this.trainrunService.trainrunsStore.trainruns.length;
 
     trainrunSection.setTrainrun(
       this.trainrunService.getSelectedOrNewTrainrun(),
@@ -693,7 +736,11 @@ export class TrainrunSectionService implements OnDestroy {
 
     if (retrieveTravelTimeFromEdge) {
       trainrunSection.setTravelTime(
-        this.retrieveTravelTime(sourceNodeId, targetNodeId, trainrunSection.getTrainrun())
+        this.retrieveTravelTime(
+          sourceNodeId,
+          targetNodeId,
+          trainrunSection.getTrainrun(),
+        ),
       );
     }
 
@@ -718,10 +765,23 @@ export class TrainrunSectionService implements OnDestroy {
     //this.trainrunSectionsUpdated();
     this.trainrunService.trainrunsUpdated();
 
-    if (initialTrainrunsLength !== this.trainrunService.trainrunsStore.trainruns.length) {
-      this.operation.emit(new TrainrunOperation(OperationType.create, trainrunSection.getTrainrun()));
+    if (
+      initialTrainrunsLength !==
+      this.trainrunService.trainrunsStore.trainruns.length
+    ) {
+      this.operation.emit(
+        new TrainrunOperation(
+          OperationType.create,
+          trainrunSection.getTrainrun(),
+        ),
+      );
     } else {
-      this.operation.emit(new TrainrunOperation(OperationType.update, trainrunSection.getTrainrun()));
+      this.operation.emit(
+        new TrainrunOperation(
+          OperationType.update,
+          trainrunSection.getTrainrun(),
+        ),
+      );
     }
 
     return trainrunSection;
@@ -813,10 +873,18 @@ export class TrainrunSectionService implements OnDestroy {
       this.nodeService.transitionsUpdated();
       this.trainrunSectionsUpdated();
     }
-    this.operation.emit(new TrainrunOperation(OperationType.update, trainrunSection.getTrainrun()));
+    this.operation.emit(
+      new TrainrunOperation(
+        OperationType.update,
+        trainrunSection.getTrainrun(),
+      ),
+    );
   }
 
-  deleteListOfTrainrunSections(trainrunSections: TrainrunSection[], enforceUpdate = true) {
+  deleteListOfTrainrunSections(
+    trainrunSections: TrainrunSection[],
+    enforceUpdate = true,
+  ) {
     trainrunSections.forEach((trainrunSection) => {
       this.deleteTrainrunSectionAndCleanupNodes(trainrunSection, false);
     });
@@ -885,7 +953,12 @@ export class TrainrunSectionService implements OnDestroy {
       this.trainrunSectionsUpdated();
     }
     if (this.getTrainrunSections().length) {
-      this.operation.emit(new TrainrunOperation(OperationType.update, trainrunSection.getTrainrun()));
+      this.operation.emit(
+        new TrainrunOperation(
+          OperationType.update,
+          trainrunSection.getTrainrun(),
+        ),
+      );
     }
   }
 
@@ -926,7 +999,7 @@ export class TrainrunSectionService implements OnDestroy {
   setTimeStructureToTrainrunSections(
     timeStructure: LeftAndRightTimeStructure,
     trainrunSection: TrainrunSection,
-    precision = 0
+    precision = 0,
   ) {
     const newTotalTravelTime = timeStructure.travelTime;
 
@@ -965,12 +1038,15 @@ export class TrainrunSectionService implements OnDestroy {
         travelTimeFactor,
         nextPair.trainrunSection.getTravelTime(),
         isRightNodeNonStop,
-        precision
+        precision,
       );
       trsTimeStructure.rightArrivalTime =
         TrainrunsectionHelper.getRightArrivalTime(trsTimeStructure, precision);
       trsTimeStructure.rightDepartureTime =
-        TrainrunsectionHelper.getRightDepartureTime(trsTimeStructure, precision);
+        TrainrunsectionHelper.getRightDepartureTime(
+          trsTimeStructure,
+          precision,
+        );
       const rightIsTarget =
         nextPair.node.getId() ===
         nextPair.trainrunSection.getTargetNode().getId();
@@ -1013,7 +1089,10 @@ export class TrainrunSectionService implements OnDestroy {
     const trainrunSections =
       this.getAllTrainrunSectionsForTrainrun(trainrunIdToCopyFrom);
     trainrunSections.forEach((trainrunSection) => {
-      const newSection = this.copyTrainrunSectionAndAddToNodes(trainrunSection, newTrainrunId);
+      const newSection = this.copyTrainrunSectionAndAddToNodes(
+        trainrunSection,
+        newTrainrunId,
+      );
       if (trainrunSection.selected()) {
         trainrunSection.unselect();
         newSection.select();
@@ -1121,13 +1200,13 @@ export class TrainrunSectionService implements OnDestroy {
     trainrunSection1.setTargetArrival(
       TrainrunSectionService.boundMinutesToOneHour(
         trainrunSection1.getSourceDeparture() +
-        trainrunSection1.getTravelTime(),
+          trainrunSection1.getTravelTime(),
       ),
     );
     trainrunSection2.setSourceArrival(
       TrainrunSectionService.boundMinutesToOneHour(
         trainrunSection1.getTargetDeparture() +
-        trainrunSection2.getTravelTime(),
+          trainrunSection2.getTravelTime(),
       ),
     );
     trainrunSection1.setTargetDeparture(
@@ -1144,9 +1223,9 @@ export class TrainrunSectionService implements OnDestroy {
     if (
       minHalteZeitFromNode < halteZeit ||
       trainrunSection1.getTravelTime() +
-      trainrunSection2.getTravelTime() +
-      halteZeit !==
-      origTravelTime ||
+        trainrunSection2.getTravelTime() +
+        halteZeit !==
+        origTravelTime ||
       travelTimeIssue
     ) {
       const title = $localize`:@@app.services.data.trainrunsection.intermediate-stop-replacement.title:Intermediate stop replacement`;
@@ -1327,19 +1406,27 @@ export class TrainrunSectionService implements OnDestroy {
   }
 
   private checkMissingTransitionsAfterDeletion(trainrun: Trainrun) {
-    const trainrunSections = this.getAllTrainrunSectionsForTrainrun(trainrun.getId());
-    trainrunSections.forEach(ts => {
+    const trainrunSections = this.getAllTrainrunSectionsForTrainrun(
+      trainrun.getId(),
+    );
+    trainrunSections.forEach((ts) => {
       const sourceNode = ts.getSourceNode();
       const targetNode = ts.getTargetNode();
 
-      const srcPortsWithoutTransitions = sourceNode.getPorts().filter(
-        (port) => port.getTrainrunSection().getTrainrunId() === trainrun.getId() &&
-          sourceNode.getTransitionFromPortId(port.getId()) === undefined
-      );
-      const trgPortsWithoutTransitions = targetNode.getPorts().filter(
-        (port) => port.getTrainrunSection().getTrainrunId() === trainrun.getId() &&
-          targetNode.getTransitionFromPortId(port.getId()) === undefined
-      );
+      const srcPortsWithoutTransitions = sourceNode
+        .getPorts()
+        .filter(
+          (port) =>
+            port.getTrainrunSection().getTrainrunId() === trainrun.getId() &&
+            sourceNode.getTransitionFromPortId(port.getId()) === undefined,
+        );
+      const trgPortsWithoutTransitions = targetNode
+        .getPorts()
+        .filter(
+          (port) =>
+            port.getTrainrunSection().getTrainrunId() === trainrun.getId() &&
+            targetNode.getTransitionFromPortId(port.getId()) === undefined,
+        );
 
       if (srcPortsWithoutTransitions.length > 1) {
         this.nodeService.addTransitionToNodes(
@@ -1431,7 +1518,7 @@ export class TrainrunSectionService implements OnDestroy {
     trainrunSection: TrainrunSection,
     sourceIsNonStop = false,
     targetIsNonStop = false,
-    enforceUpdate = true
+    enforceUpdate = true,
   ) {
     this.nodeService.addPortsToNodes(
       sourceNode.getId(),
@@ -1461,7 +1548,7 @@ export class TrainrunSectionService implements OnDestroy {
     nodeMap: Map<number, number>,
     trainrunMap: Map<number, number>,
     nodes: NodeDto[],
-    enforceUpdate = true
+    enforceUpdate = true,
   ) {
     const trainrunId = trainrunMap.get(trainrunSection.trainrunId);
     const trainrun = this.trainrunService.getTrainrunFromId(trainrunId);
@@ -1498,7 +1585,7 @@ export class TrainrunSectionService implements OnDestroy {
       newTrainrunSection,
       sourceIsNonStop,
       targetIsNonStop,
-      enforceUpdate
+      enforceUpdate,
     );
     return newTrainrunSection;
   }

--- a/src/app/services/data/version-control.service.ts
+++ b/src/app/services/data/version-control.service.ts
@@ -205,7 +205,8 @@ export class VersionControlService implements OnDestroy {
       this.variantChanged = true;
       return;
     }
-    this.variantChanged = this.previousVariantDto.projectId !== variant.projectId &&
+    this.variantChanged =
+      this.previousVariantDto.projectId !== variant.projectId &&
       this.previousVariantDto.id !== variant.id;
     this.previousVariantDto = variant;
   }

--- a/src/app/services/ui/filter.service.ts
+++ b/src/app/services/ui/filter.service.ts
@@ -28,7 +28,7 @@ export class FilterService implements OnDestroy {
 
   filterSettingSubject = new BehaviorSubject<FilterSetting[]>(null);
   readonly filterSetting = this.filterSettingSubject.asObservable();
-  filterSettingStore: { filterSettings: FilterSetting[] } = {filterSettings: []}; // store the data in memory
+  filterSettingStore: {filterSettings: FilterSetting[]} = {filterSettings: []}; // store the data in memory
 
   private activeFilterSetting: FilterSetting = null;
   private destroyed = new Subject<void>();
@@ -129,7 +129,10 @@ export class FilterService implements OnDestroy {
     const fs = this.activeFilterSetting.copy();
     this.filterSettingStore.filterSettings.push(fs);
     this.activateFilterSetting(fs.getId());
-    this.setActiveFilterSettingName($localize`:@@app.services.ui.newFilter:New filter`, fs.getId());
+    this.setActiveFilterSettingName(
+      $localize`:@@app.services.ui.newFilter:New filter`,
+      fs.getId(),
+    );
     this.filterSettingUpdated();
     return fs;
   }
@@ -399,7 +402,9 @@ export class FilterService implements OnDestroy {
       filterTrainrunSection &&
       this.isFilterTrainrunFrequencyEnabled(trainrun.getTrainrunFrequency()) &&
       this.isFilterTrainrunCategoryEnabled(trainrun.getTrainrunCategory()) &&
-      this.isFilterTrainrunTimeCategoryEnabled(trainrun.getTrainrunTimeCategory())
+      this.isFilterTrainrunTimeCategoryEnabled(
+        trainrun.getTrainrunTimeCategory(),
+      )
     );
   }
 

--- a/src/app/services/ui/level.of.detail.service.ts
+++ b/src/app/services/ui/level.of.detail.service.ts
@@ -36,7 +36,10 @@ export class LevelOfDetailService implements OnDestroy {
     this.uiInteractionService.zoomFactorObservable
       .pipe(takeUntil(this.destroyed))
       .subscribe((changedZoomFactor) => {
-        if ( this.uiInteractionService.getEditorMode() !== EditorMode.NetzgrafikEditing) {
+        if (
+          this.uiInteractionService.getEditorMode() !==
+          EditorMode.NetzgrafikEditing
+        ) {
           // don't change level of detail
           return;
         }
@@ -70,5 +73,4 @@ export class LevelOfDetailService implements OnDestroy {
   enableLevelOfDetailRendering() {
     this.switchLevelOfDetailOff = false;
   }
-
 }

--- a/src/app/services/ui/ui.interaction.service.spec.ts
+++ b/src/app/services/ui/ui.interaction.service.spec.ts
@@ -91,7 +91,7 @@ describe("UiInteractionService", () => {
       trainrunService,
       trainrunSectionService,
       nodeService,
-      filterService
+      filterService,
     );
     nodeService.nodes.subscribe((updatesNodes) => (nodes = updatesNodes));
 

--- a/src/app/services/ui/ui.interaction.service.ts
+++ b/src/app/services/ui/ui.interaction.service.ts
@@ -2,13 +2,9 @@ import {BehaviorSubject, Observable, Subject} from "rxjs";
 import {EditorMode} from "../../view/editor-menu/editor-mode";
 import {Injectable, OnDestroy} from "@angular/core";
 import {Stammdaten} from "../../models/stammdaten.model";
-import {
-  TrainrunDialogParameter
-} from "../../view/dialogs/trainrun-and-section-dialog/trainrun-and-section-dialog.component";
+import {TrainrunDialogParameter} from "../../view/dialogs/trainrun-and-section-dialog/trainrun-and-section-dialog.component";
 import {ThemeBase} from "../../view/themes/theme-base";
-import {
-  ConfirmationDialogParameter
-} from "../../view/dialogs/confirmation-dialog/confirmation-dialog.component";
+import {ConfirmationDialogParameter} from "../../view/dialogs/confirmation-dialog/confirmation-dialog.component";
 import {FilterService} from "./filter.service";
 import {NodeService} from "../data/node.service";
 import {StammdatenService} from "../data/stammdaten.service";
@@ -35,9 +31,7 @@ import {MainViewMode} from "../../view/filter-main-side-view/main-view-mode";
 import {TrainrunService} from "../data/trainrun.service";
 import {Trainrun} from "../../models/trainrun.model";
 import {LoadPerlenketteService} from "../../perlenkette/service/load-perlenkette.service";
-import {
-  TravelTimeCreationEstimatorType
-} from "../../view/themes/editor-trainrun-traveltime-creator-type";
+import {TravelTimeCreationEstimatorType} from "../../view/themes/editor-trainrun-traveltime-creator-type";
 
 export interface ViewboxProperties {
   currentViewBox: string;

--- a/src/app/services/ui/viewport.cull.service.ts
+++ b/src/app/services/ui/viewport.cull.service.ts
@@ -21,11 +21,12 @@ export class ViewportCullService implements OnDestroy {
   private destroyed = new Subject<void>();
   private doCheckIsInViewport = true;
 
-  constructor(private readonly uiInteractionService: UiInteractionService,
-              private nodeService: NodeService,
-              private noteService: NoteService,
-              private trainrunSectionService: TrainrunSectionService) {
-  }
+  constructor(
+    private readonly uiInteractionService: UiInteractionService,
+    private nodeService: NodeService,
+    private noteService: NoteService,
+    private trainrunSectionService: TrainrunSectionService,
+  ) {}
 
   ngOnDestroy(): void {
     this.destroyed.next();
@@ -44,7 +45,11 @@ export class ViewportCullService implements OnDestroy {
     this.trainrunSectionService.trainrunSectionsUpdated();
   }
 
-  private checkIsElementPositionInViewport(pos: Vec2D, strSvgName: string, extraPixels = 64): ViewportOut[] {
+  private checkIsElementPositionInViewport(
+    pos: Vec2D,
+    strSvgName: string,
+    extraPixels = 64,
+  ): ViewportOut[] {
     const vp = this.uiInteractionService.getViewboxProperties(strSvgName);
     const x0 = Number(vp.panZoomLeft) - extraPixels;
     const y0 = Number(vp.panZoomTop) - extraPixels;
@@ -70,38 +75,55 @@ export class ViewportCullService implements OnDestroy {
     return retOut;
   }
 
-  cullCheckPositionsInViewport(positions: Vec2D[], strSvgName: string, extraPixelsIn = 32): boolean {
+  cullCheckPositionsInViewport(
+    positions: Vec2D[],
+    strSvgName: string,
+    extraPixelsIn = 32,
+  ): boolean {
     if (!this.doCheckIsInViewport) {
       return true;
     }
     // check whether an element is inside the "Viewport", or the spanned object overlays the
     // viewport box
     const mappedPositions = positions.map((el: Vec2D) =>
-      this.checkIsElementPositionInViewport(el, strSvgName, extraPixelsIn));
+      this.checkIsElementPositionInViewport(el, strSvgName, extraPixelsIn),
+    );
 
-    if (mappedPositions.find(el => el.find(el2 => el2 === ViewportOut.ElementIsInside) !== undefined) !== undefined) {
+    if (
+      mappedPositions.find(
+        (el) =>
+          el.find((el2) => el2 === ViewportOut.ElementIsInside) !== undefined,
+      ) !== undefined
+    ) {
       // check whether an element is inside the "Viewport"
       return true;
     }
 
-    const topOutside = mappedPositions.filter(el => el.find(el2 => el2 === ViewportOut.TopOutside) !== undefined);
+    const topOutside = mappedPositions.filter(
+      (el) => el.find((el2) => el2 === ViewportOut.TopOutside) !== undefined,
+    );
     if (topOutside.length === mappedPositions.length) {
       return false;
     }
-    const bottomOutside = mappedPositions.filter(el => el.find(el2 => el2 === ViewportOut.BottomOutside) !== undefined);
+    const bottomOutside = mappedPositions.filter(
+      (el) => el.find((el2) => el2 === ViewportOut.BottomOutside) !== undefined,
+    );
     if (bottomOutside.length === mappedPositions.length) {
       return false;
     }
-    const leftOutside = mappedPositions.filter(el => el.find(el2 => el2 === ViewportOut.LeftOutside) !== undefined);
+    const leftOutside = mappedPositions.filter(
+      (el) => el.find((el2) => el2 === ViewportOut.LeftOutside) !== undefined,
+    );
     if (leftOutside.length === mappedPositions.length) {
       return false;
     }
-    const rightOutside = mappedPositions.filter(el => el.find(el2 => el2 === ViewportOut.RightOutside) !== undefined);
+    const rightOutside = mappedPositions.filter(
+      (el) => el.find((el2) => el2 === ViewportOut.RightOutside) !== undefined,
+    );
     if (rightOutside.length === mappedPositions.length) {
       return false;
     }
 
     return true;
   }
-
 }

--- a/src/app/services/util/connection.validator.ts
+++ b/src/app/services/util/connection.validator.ts
@@ -30,7 +30,7 @@ export class ConnectionValidator {
     if (nonStopConnectionError) {
       connection.setWarning(
         $localize`:@@app.services.util.connection-validator.connection-marked-for-transit.title:Connection marked for transition!`,
-        $localize`:@@app.services.util.connection-validator.connection-marked-for-transit.description:Connection marked for transition!`
+        $localize`:@@app.services.util.connection-validator.connection-marked-for-transit.description:Connection marked for transition!`,
       );
     } else {
       connection.resetWarning();

--- a/src/app/services/util/position.transformation.service.spec.ts
+++ b/src/app/services/util/position.transformation.service.spec.ts
@@ -89,7 +89,7 @@ describe("PositionTransformationService", () => {
       trainrunService,
       trainrunSectionService,
       nodeService,
-      filterService
+      filterService,
     );
 
     uiInteractionService = new UiInteractionService(
@@ -107,7 +107,7 @@ describe("PositionTransformationService", () => {
       uiInteractionService,
       nodeService,
       noteService,
-      trainrunSectionService
+      trainrunSectionService,
     );
 
     positionTransformationService = new PositionTransformationService(
@@ -115,7 +115,7 @@ describe("PositionTransformationService", () => {
       nodeService,
       noteService,
       uiInteractionService,
-      viewportCullService
+      viewportCullService,
     );
   });
 
@@ -185,13 +185,14 @@ describe("PositionTransformationService", () => {
       pos.push(new Vec2D(n.getPositionX(), n.getPositionY()));
     });
     // all node are selected (default) - nothing changes
-    positionTransformationService.scaleNetzgrafikArea(2.0,
+    positionTransformationService.scaleNetzgrafikArea(
+      2.0,
       new Vec2D(0.0, 0.0),
-      "graphContainer");
+      "graphContainer",
+    );
     nodeService.getNodes().forEach((n: Node, index: number) => {
       expect(n.getPositionX()).toBe(pos[index].getX() * 2.0);
       expect(n.getPositionY()).toBe(pos[index].getY() * 2.0);
     });
   });
-
 });

--- a/src/app/services/util/position.transformation.service.ts
+++ b/src/app/services/util/position.transformation.service.ts
@@ -6,7 +6,11 @@ import {NoteService} from "../data/note.service";
 import {Vec2D} from "../../utils/vec2D";
 import {Node} from "../../models/node.model";
 import {ViewportCullService} from "../ui/viewport.cull.service";
-import {NodeOperation, Operation, OperationType} from "src/app/models/operation.model";
+import {
+  NodeOperation,
+  Operation,
+  OperationType,
+} from "src/app/models/operation.model";
 
 @Injectable({
   providedIn: "root",
@@ -18,32 +22,46 @@ export class PositionTransformationService {
     private readonly noteService: NoteService,
     private readonly uiInteractionService: UiInteractionService,
     private readonly viewportCullService: ViewportCullService,
-  ) {
-  }
+  ) {}
   readonly operation = new EventEmitter<Operation>();
 
-  private scaleFullNetzgrafikArea(factor: number, zoomCenter: Vec2D, windowViewboxPropertiesMapKey: string) {
-    const scaleCenterCoordinates: Vec2D = this.computeScaleCenterCoordinates(zoomCenter, windowViewboxPropertiesMapKey);
+  private scaleFullNetzgrafikArea(
+    factor: number,
+    zoomCenter: Vec2D,
+    windowViewboxPropertiesMapKey: string,
+  ) {
+    const scaleCenterCoordinates: Vec2D = this.computeScaleCenterCoordinates(
+      zoomCenter,
+      windowViewboxPropertiesMapKey,
+    );
     const focalNode: Node = this.getFocalNode(scaleCenterCoordinates);
 
     this.nodeService.getNodes().forEach((n, index) => {
       let newPos = new Vec2D(
-        (n.getPositionX() - scaleCenterCoordinates.getX()) * factor + scaleCenterCoordinates.getX(),
-        (n.getPositionY() - scaleCenterCoordinates.getY()) * factor + scaleCenterCoordinates.getY()
+        (n.getPositionX() - scaleCenterCoordinates.getX()) * factor +
+          scaleCenterCoordinates.getX(),
+        (n.getPositionY() - scaleCenterCoordinates.getY()) * factor +
+          scaleCenterCoordinates.getY(),
       );
 
       if (focalNode?.getId() === n.getId()) {
-        const delta = Vec2D.sub(newPos, new Vec2D(focalNode.getPositionX(), focalNode.getPositionY(),));
+        const delta = Vec2D.sub(
+          newPos,
+          new Vec2D(focalNode.getPositionX(), focalNode.getPositionY()),
+        );
         newPos = Vec2D.sub(newPos, delta);
       }
       n.setPosition(newPos.getX(), newPos.getY());
     });
   }
 
-  private computeScaleCenterCoordinates(zoomCenter: Vec2D,
-                                        windowViewboxPropertiesMapKey: string): Vec2D {
-    const vp =
-      this.uiInteractionService.getViewboxProperties(windowViewboxPropertiesMapKey);
+  private computeScaleCenterCoordinates(
+    zoomCenter: Vec2D,
+    windowViewboxPropertiesMapKey: string,
+  ): Vec2D {
+    const vp = this.uiInteractionService.getViewboxProperties(
+      windowViewboxPropertiesMapKey,
+    );
     const scaleCenterCoordinates = new Vec2D(
       vp.panZoomLeft + zoomCenter.getX() * vp.panZoomWidth,
       vp.panZoomTop + zoomCenter.getY() * vp.panZoomHeight,
@@ -54,27 +72,43 @@ export class PositionTransformationService {
 
   private getFocalNode(scaleCenterCoordinates: Vec2D): Node {
     // get the node under the mouse cursor and update the scaleCenter
-    const focalNode = this.nodeService.getNodes().find((n) =>
-      scaleCenterCoordinates.getX() > n.getPositionX() && scaleCenterCoordinates.getX() < (n.getPositionX() + n.getNodeWidth()) &&
-      scaleCenterCoordinates.getY() > n.getPositionY() && scaleCenterCoordinates.getY() < (n.getPositionY() + n.getNodeHeight())
-    );
+    const focalNode = this.nodeService
+      .getNodes()
+      .find(
+        (n) =>
+          scaleCenterCoordinates.getX() > n.getPositionX() &&
+          scaleCenterCoordinates.getX() < n.getPositionX() + n.getNodeWidth() &&
+          scaleCenterCoordinates.getY() > n.getPositionY() &&
+          scaleCenterCoordinates.getY() < n.getPositionY() + n.getNodeHeight(),
+      );
     return focalNode;
   }
 
-  private scaleNetzgrafikSelectedNodesArea(factor: number, zoomCenter: Vec2D, nodes: Node[], windowViewboxPropertiesMapKey: string) {
-    const scaleCenterCoordinates: Vec2D = this.computeScaleCenterCoordinates(zoomCenter, windowViewboxPropertiesMapKey);
+  private scaleNetzgrafikSelectedNodesArea(
+    factor: number,
+    zoomCenter: Vec2D,
+    nodes: Node[],
+    windowViewboxPropertiesMapKey: string,
+  ) {
+    const scaleCenterCoordinates: Vec2D = this.computeScaleCenterCoordinates(
+      zoomCenter,
+      windowViewboxPropertiesMapKey,
+    );
     const focalNode: Node = this.getFocalNode(scaleCenterCoordinates);
 
     if (!focalNode) {
       /*
-      * if more than one node is selected (multi-selected nodes) transform the nodes with center of
-      * mass
+       * if more than one node is selected (multi-selected nodes) transform the nodes with center of
+       * mass
        */
       let centerOfMass = new Vec2D(0, 0);
-      nodes.forEach(n => {
+      nodes.forEach((n) => {
         centerOfMass = Vec2D.add(
           centerOfMass,
-          new Vec2D(n.getPositionX() + n.getNodeWidth() / 2.0, n.getPositionY() + n.getNodeHeight() / 2.0)
+          new Vec2D(
+            n.getPositionX() + n.getNodeWidth() / 2.0,
+            n.getPositionY() + n.getNodeHeight() / 2.0,
+          ),
         );
       });
       centerOfMass = Vec2D.scale(centerOfMass, 1.0 / Math.max(1, nodes.length));
@@ -84,24 +118,36 @@ export class PositionTransformationService {
 
     nodes.forEach((n, index) => {
       let newPos = new Vec2D(
-        (n.getPositionX() + n.getNodeWidth() / 2.0 - scaleCenterCoordinates.getX()) * factor + scaleCenterCoordinates.getX() - n.getNodeWidth() / 2.0,
-        (n.getPositionY() + n.getNodeHeight() / 2.0 - scaleCenterCoordinates.getY()) * factor + scaleCenterCoordinates.getY() - n.getNodeHeight() / 2.0
+        (n.getPositionX() +
+          n.getNodeWidth() / 2.0 -
+          scaleCenterCoordinates.getX()) *
+          factor +
+          scaleCenterCoordinates.getX() -
+          n.getNodeWidth() / 2.0,
+        (n.getPositionY() +
+          n.getNodeHeight() / 2.0 -
+          scaleCenterCoordinates.getY()) *
+          factor +
+          scaleCenterCoordinates.getY() -
+          n.getNodeHeight() / 2.0,
       );
 
       if (focalNode?.getId() === n.getId()) {
-        const delta = Vec2D.sub(newPos, new Vec2D(focalNode.getPositionX(), focalNode.getPositionY(),));
+        const delta = Vec2D.sub(
+          newPos,
+          new Vec2D(focalNode.getPositionX(), focalNode.getPositionY()),
+        );
         newPos = Vec2D.sub(newPos, delta);
       }
 
       n.setPosition(newPos.getX(), newPos.getY());
-
     });
   }
 
   private updateRendering() {
     this.nodeService.initPortOrdering();
 
-    this.trainrunSectionService.getTrainrunSections().forEach(ts => {
+    this.trainrunSectionService.getTrainrunSections().forEach((ts) => {
       ts.routeEdgeAndPlaceText();
       ts.getSourceNode().updateTransitionsAndConnections();
     });
@@ -109,13 +155,26 @@ export class PositionTransformationService {
     this.viewportCullService.onViewportChangeUpdateRendering(true);
   }
 
-  scaleNetzgrafikArea(factor: number, zoomCenter: Vec2D, windowViewboxPropertiesMapKey: string) {
+  scaleNetzgrafikArea(
+    factor: number,
+    zoomCenter: Vec2D,
+    windowViewboxPropertiesMapKey: string,
+  ) {
     const nodes: Node[] = this.nodeService.getSelectedNodes();
 
     if (nodes.length < 2) {
-      this.scaleFullNetzgrafikArea(factor, zoomCenter, windowViewboxPropertiesMapKey);
+      this.scaleFullNetzgrafikArea(
+        factor,
+        zoomCenter,
+        windowViewboxPropertiesMapKey,
+      );
     } else {
-      this.scaleNetzgrafikSelectedNodesArea(factor, zoomCenter, nodes, windowViewboxPropertiesMapKey);
+      this.scaleNetzgrafikSelectedNodesArea(
+        factor,
+        zoomCenter,
+        nodes,
+        windowViewboxPropertiesMapKey,
+      );
     }
 
     this.updateRendering();
@@ -212,5 +271,4 @@ export class PositionTransformationService {
 
     this.updateRendering();
   }
-
 }

--- a/src/app/services/util/trainrunsection.helper.ts
+++ b/src/app/services/util/trainrunsection.helper.ts
@@ -21,8 +21,7 @@ export enum LeftAndRightElement {
 }
 
 export class TrainrunsectionHelper {
-  constructor(private trainrunService: TrainrunService) {
-  }
+  constructor(private trainrunService: TrainrunService) {}
 
   static getSymmetricTime(time: number) {
     return time === 0 ? 0 : 60 - time;
@@ -46,11 +45,13 @@ export class TrainrunsectionHelper {
     travelTimeFactor: number,
     trsTravelTime: number,
     isRightNodeNonStopTransit: boolean,
-    precision = TrainrunSectionService.TIME_PRECISION
+    precision = TrainrunSectionService.TIME_PRECISION,
   ): number {
     if (isRightNodeNonStopTransit) {
-      return Math.max(MathUtils.round(trsTravelTime * travelTimeFactor, precision),
-        1.0 / Math.pow(10, precision));
+      return Math.max(
+        MathUtils.round(trsTravelTime * travelTimeFactor, precision),
+        1.0 / Math.pow(10, precision),
+      );
     } else {
       return Math.max(
         MathUtils.round(totalTravelTime - summedTravelTime, precision),
@@ -61,21 +62,21 @@ export class TrainrunsectionHelper {
 
   static getRightArrivalTime(
     timeStructure: LeftAndRightTimeStructure,
-    precision = TrainrunSectionService.TIME_PRECISION
+    precision = TrainrunSectionService.TIME_PRECISION,
   ): number {
     return MathUtils.round(
       (timeStructure.leftDepartureTime + (timeStructure.travelTime % 60)) % 60,
-      precision
+      precision,
     );
   }
 
   static getRightDepartureTime(
     timeStructure: LeftAndRightTimeStructure,
-    precision = TrainrunSectionService.TIME_PRECISION
+    precision = TrainrunSectionService.TIME_PRECISION,
   ): number {
     return MathUtils.round(
       this.getSymmetricTime(timeStructure.rightArrivalTime),
-      precision
+      precision,
     );
   }
 
@@ -113,19 +114,21 @@ export class TrainrunsectionHelper {
     const lastLeftNode = startForwardBackwardNode.startForwardNode;
     const lastRightNode = startForwardBackwardNode.startBackwardNode;
 
-    const towardsSource =
-      this.trainrunService.getLastNonStopTrainrunSection(
-        trainrunSection.getSourceNode(),
-        trainrunSection);
-    const towradsTarget =
-      this.trainrunService.getLastNonStopTrainrunSection(
-        trainrunSection.getTargetNode(),
-        trainrunSection);
+    const towardsSource = this.trainrunService.getLastNonStopTrainrunSection(
+      trainrunSection.getSourceNode(),
+      trainrunSection,
+    );
+    const towradsTarget = this.trainrunService.getLastNonStopTrainrunSection(
+      trainrunSection.getTargetNode(),
+      trainrunSection,
+    );
 
     let leftSection = towradsTarget;
     let rightSection = towardsSource;
-    if (towardsSource.getSourceNodeId() === lastLeftNode.getId() ||
-      towardsSource.getTargetNodeId() === lastLeftNode.getId()) {
+    if (
+      towardsSource.getSourceNodeId() === lastLeftNode.getId() ||
+      towardsSource.getTargetNodeId() === lastLeftNode.getId()
+    ) {
       leftSection = towardsSource;
       rightSection = towradsTarget;
     }
@@ -133,7 +136,7 @@ export class TrainrunsectionHelper {
       leftSection: leftSection,
       rightSection: rightSection,
       lastLeftNode: lastLeftNode,
-      lastRightNode: lastRightNode
+      lastRightNode: lastRightNode,
     };
   }
 
@@ -172,12 +175,20 @@ export class TrainrunsectionHelper {
     const lastLeftNode = this.getLeftNode(trainrunSection, orderedNodes);
     const lastRightNode = this.getRightNode(trainrunSection, orderedNodes);
 
-    const towardsSource = this.trainrunService.getLastNonStopTrainrunSection(trainrunSection.getSourceNode(), trainrunSection);
-    const towradsTarget = this.trainrunService.getLastNonStopTrainrunSection(trainrunSection.getTargetNode(), trainrunSection);
+    const towardsSource = this.trainrunService.getLastNonStopTrainrunSection(
+      trainrunSection.getSourceNode(),
+      trainrunSection,
+    );
+    const towradsTarget = this.trainrunService.getLastNonStopTrainrunSection(
+      trainrunSection.getTargetNode(),
+      trainrunSection,
+    );
     let leftSection = towradsTarget;
     let rightSection = towardsSource;
-    if (towardsSource.getSourceNodeId() === lastLeftNode.getId() ||
-      towardsSource.getTargetNodeId() === lastLeftNode.getId()) {
+    if (
+      towardsSource.getSourceNodeId() === lastLeftNode.getId() ||
+      towardsSource.getTargetNodeId() === lastLeftNode.getId()
+    ) {
       leftSection = towardsSource;
       rightSection = towradsTarget;
     }
@@ -186,15 +197,15 @@ export class TrainrunsectionHelper {
       leftLock:
         leftSection.getSourceNodeId() === lastLeftNode.getId()
           ? leftSection.getSourceArrivalLock() ||
-          leftSection.getSourceDepartureLock()
+            leftSection.getSourceDepartureLock()
           : leftSection.getTargetArrivalLock() ||
-          leftSection.getTargetDepartureLock(),
+            leftSection.getTargetDepartureLock(),
       rightLock:
         rightSection.getSourceNodeId() === lastRightNode.getId()
           ? rightSection.getSourceArrivalLock() ||
-          rightSection.getSourceDepartureLock()
+            rightSection.getSourceDepartureLock()
           : rightSection.getTargetArrivalLock() ||
-          rightSection.getTargetDepartureLock(),
+            rightSection.getTargetDepartureLock(),
       travelTimeLock: trainrunSection.getTravelTimeLock(),
     };
   }

--- a/src/app/services/util/trainrunsection.validator.ts
+++ b/src/app/services/util/trainrunsection.validator.ts
@@ -7,13 +7,21 @@ export class TrainrunSectionValidator {
     trainrunSection.resetTargetDepartureWarning();
 
     TrainrunSectionValidator.validateTravelTimeOneSection(trainrunSection);
-    TrainrunSectionValidator.validateUnsymmetricTimesOneSection(trainrunSection);
+    TrainrunSectionValidator.validateUnsymmetricTimesOneSection(
+      trainrunSection,
+    );
   }
 
   static validateTravelTimeOneSection(trainrunSection: TrainrunSection) {
     const calculatedTargetArrivalTime =
-      (trainrunSection.getSourceDeparture() + trainrunSection.getTravelTime()) % 60;
-    if (Math.abs(calculatedTargetArrivalTime - trainrunSection.getTargetArrival()) > 1 / 60) {
+      (trainrunSection.getSourceDeparture() + trainrunSection.getTravelTime()) %
+      60;
+    if (
+      Math.abs(
+        calculatedTargetArrivalTime - trainrunSection.getTargetArrival(),
+      ) >
+      1 / 60
+    ) {
       trainrunSection.setTargetArrivalWarning(
         $localize`:@@app.services.util.trainrunsection-validator.target-arrival-not-reacheable.title:Target Arrival Warning`,
         $localize`:@@app.services.util.trainrunsection-validator.target-arrival-not-reacheable.description:Target arrival time cannot be reached`,
@@ -23,8 +31,14 @@ export class TrainrunSectionValidator {
     }
 
     const calculatedSourceArrivalTime =
-      (trainrunSection.getTargetDeparture() + trainrunSection.getTravelTime()) % 60;
-    if (Math.abs(calculatedSourceArrivalTime - trainrunSection.getSourceArrival()) > 1 / 60) {
+      (trainrunSection.getTargetDeparture() + trainrunSection.getTravelTime()) %
+      60;
+    if (
+      Math.abs(
+        calculatedSourceArrivalTime - trainrunSection.getSourceArrival(),
+      ) >
+      1 / 60
+    ) {
       trainrunSection.setSourceArrivalWarning(
         $localize`:@@app.services.util.trainrunsection-validator.source-arrival-not-reacheable.title:Source Arrival Warning`,
         $localize`:@@app.services.util.trainrunsection-validator.source-arrival-not-reacheable.description:Source arrival time cannot be reached`,
@@ -38,21 +52,55 @@ export class TrainrunSectionValidator {
     // check for broken symmetry (times)
     trainrunSection.resetSourceDepartureWarning();
     trainrunSection.resetTargetDepartureWarning();
-    const sourceSum = MathUtils.round(trainrunSection.getSourceArrival() + trainrunSection.getSourceDeparture(), 4);
+    const sourceSum = MathUtils.round(
+      trainrunSection.getSourceArrival() + trainrunSection.getSourceDeparture(),
+      4,
+    );
     const sourceSymmetricCheck = Math.abs(sourceSum % 60) < 1 / 60;
     if (!sourceSymmetricCheck) {
-      trainrunSection.setSourceArrivalWarning($localize`:@@app.services.util.trainrunsection-validator.broken-symmetry:Broken symmetry`,
-        "" + (trainrunSection.getSourceArrival() + " + " + trainrunSection.getSourceDeparture()) + " = " + sourceSum);
-      trainrunSection.setSourceDepartureWarning($localize`:@@app.services.util.trainrunsection-validator.broken-symmetry:Broken symmetry`,
-        "" + (trainrunSection.getSourceArrival() + " + " + trainrunSection.getSourceDeparture()) + " = " + sourceSum);
+      trainrunSection.setSourceArrivalWarning(
+        $localize`:@@app.services.util.trainrunsection-validator.broken-symmetry:Broken symmetry`,
+        "" +
+          (trainrunSection.getSourceArrival() +
+            " + " +
+            trainrunSection.getSourceDeparture()) +
+          " = " +
+          sourceSum,
+      );
+      trainrunSection.setSourceDepartureWarning(
+        $localize`:@@app.services.util.trainrunsection-validator.broken-symmetry:Broken symmetry`,
+        "" +
+          (trainrunSection.getSourceArrival() +
+            " + " +
+            trainrunSection.getSourceDeparture()) +
+          " = " +
+          sourceSum,
+      );
     }
-    const targetSum = MathUtils.round(trainrunSection.getTargetArrival() + trainrunSection.getTargetDeparture(), 4);
+    const targetSum = MathUtils.round(
+      trainrunSection.getTargetArrival() + trainrunSection.getTargetDeparture(),
+      4,
+    );
     const targetSymmetricCheck = Math.abs(targetSum % 60) < 1 / 60;
     if (!targetSymmetricCheck) {
-      trainrunSection.setTargetArrivalWarning($localize`:@@app.services.util.trainrunsection-validator.broken-symmetry:Broken symmetry`,
-        "" + (trainrunSection.getTargetArrival() + " + " + trainrunSection.getTargetDeparture()) + " = " + targetSum);
-      trainrunSection.setTargetDepartureWarning($localize`:@@app.services.util.trainrunsection-validator.broken-symmetry:Broken symmetry`,
-        "" + (trainrunSection.getTargetArrival() + " + " + trainrunSection.getTargetDeparture()) + " =  " + targetSum);
+      trainrunSection.setTargetArrivalWarning(
+        $localize`:@@app.services.util.trainrunsection-validator.broken-symmetry:Broken symmetry`,
+        "" +
+          (trainrunSection.getTargetArrival() +
+            " + " +
+            trainrunSection.getTargetDeparture()) +
+          " = " +
+          targetSum,
+      );
+      trainrunSection.setTargetDepartureWarning(
+        $localize`:@@app.services.util.trainrunsection-validator.broken-symmetry:Broken symmetry`,
+        "" +
+          (trainrunSection.getTargetArrival() +
+            " + " +
+            trainrunSection.getTargetDeparture()) +
+          " =  " +
+          targetSum,
+      );
     }
   }
 

--- a/src/app/services/util/transition.validator.spec.ts
+++ b/src/app/services/util/transition.validator.spec.ts
@@ -184,16 +184,16 @@ describe("TransitionValidator", () => {
       nodeHaltezeiten[
         trainrunSections.trainrunSection1.getTrainrun().getTrainrunCategory()
           .fachCategory
-        ].haltezeit;
+      ].haltezeit;
     trainrunSections.trainrunSection2.setSourceDeparture(
       trainrunSections.trainrunSection1.getSourceArrival() -
-      trainrunHaltezeit -
-      1,
+        trainrunHaltezeit -
+        1,
     );
     trainrunSections.trainrunSection2.setTargetDeparture(
       trainrunSections.trainrunSection1.getTargetArrival() -
-      trainrunHaltezeit -
-      1,
+        trainrunHaltezeit -
+        1,
     );
 
     trainrunSections.trainrunSection1.resetTargetArrivalWarning();
@@ -276,16 +276,16 @@ describe("TransitionValidator", () => {
       nodeHaltezeiten[
         trainrunSections.trainrunSection2.getTrainrun().getTrainrunCategory()
           .fachCategory
-        ].haltezeit;
+      ].haltezeit;
     trainrunSections.trainrunSection1.setSourceDeparture(
       trainrunSections.trainrunSection2.getSourceArrival() -
-      trainrunHaltezeit -
-      1,
+        trainrunHaltezeit -
+        1,
     );
     trainrunSections.trainrunSection1.setTargetDeparture(
       trainrunSections.trainrunSection2.getTargetArrival() -
-      trainrunHaltezeit -
-      1,
+        trainrunHaltezeit -
+        1,
     );
 
     trainrunSections.trainrunSection1.resetTargetArrivalWarning();
@@ -386,16 +386,16 @@ describe("TransitionValidator", () => {
       nodeHaltezeiten[
         trainrunSections.trainrunSection2.getTrainrun().getTrainrunCategory()
           .fachCategory
-        ].haltezeit;
+      ].haltezeit;
     trainrunSections.trainrunSection1.setSourceDeparture(
       trainrunSections.trainrunSection2.getSourceArrival() -
-      trainrunHaltezeit -
-      1,
+        trainrunHaltezeit -
+        1,
     );
     trainrunSections.trainrunSection1.setTargetDeparture(
       trainrunSections.trainrunSection2.getTargetArrival() -
-      trainrunHaltezeit -
-      1,
+        trainrunHaltezeit -
+        1,
     );
 
     trainrunSections.trainrunSection1.resetTargetArrivalWarning();
@@ -496,16 +496,16 @@ describe("TransitionValidator", () => {
       nodeHaltezeiten[
         trainrunSections.trainrunSection2.getTrainrun().getTrainrunCategory()
           .fachCategory
-        ].haltezeit;
+      ].haltezeit;
     trainrunSections.trainrunSection1.setSourceDeparture(
       trainrunSections.trainrunSection2.getSourceArrival() -
-      trainrunHaltezeit -
-      1,
+        trainrunHaltezeit -
+        1,
     );
     trainrunSections.trainrunSection1.setTargetDeparture(
       trainrunSections.trainrunSection2.getTargetArrival() -
-      trainrunHaltezeit -
-      1,
+        trainrunHaltezeit -
+        1,
     );
 
     trainrunSections.trainrunSection1.resetTargetArrivalWarning();
@@ -606,16 +606,16 @@ describe("TransitionValidator", () => {
       nodeHaltezeiten[
         trainrunSections.trainrunSection2.getTrainrun().getTrainrunCategory()
           .fachCategory
-        ].haltezeit;
+      ].haltezeit;
     trainrunSections.trainrunSection1.setSourceDeparture(
       trainrunSections.trainrunSection2.getSourceArrival() -
-      trainrunHaltezeit -
-      1,
+        trainrunHaltezeit -
+        1,
     );
     trainrunSections.trainrunSection2.setTargetDeparture(
       trainrunSections.trainrunSection1.getTargetArrival() -
-      trainrunHaltezeit -
-      1,
+        trainrunHaltezeit -
+        1,
     );
 
     trainrunSections.trainrunSection1.resetTargetArrivalWarning();
@@ -691,6 +691,8 @@ describe("TransitionValidator", () => {
     ts1.setSourceDeparture((ts1.getSourceDeparture() + 1) % 60);
     const a = ts1.getSourceArrival();
     const b = ts1.getSourceDeparture();
-    expect(ts1.getSourceArrivalWarning().description).toBe("" + a + " + " + b + " = " + (a + b));
+    expect(ts1.getSourceArrivalWarning().description).toBe(
+      "" + a + " + " + b + " = " + (a + b),
+    );
   });
 });

--- a/src/app/streckengrafik/components/streckengrafik.component.html
+++ b/src/app/streckengrafik/components/streckengrafik.component.html
@@ -1,15 +1,22 @@
-<div id="main-streckengrafik-container-root" style="width: 98%; height: 100%;">
-  <svg id='main-streckengrafik-container' [attr.height]="mainStreckengrafikContainer.offsetHeight"
-       [attr.width]="mainStreckengrafikContainer.offsetWidth">
-    <foreignObject [attr.height]="mainStreckengrafikContainer.offsetHeight"
-                   [attr.width]="mainStreckengrafikContainer.offsetWidth">
+<div id="main-streckengrafik-container-root" style="width: 98%; height: 100%">
+  <svg
+    id="main-streckengrafik-container"
+    [attr.height]="mainStreckengrafikContainer.offsetHeight"
+    [attr.width]="mainStreckengrafikContainer.offsetWidth"
+  >
+    <foreignObject
+      [attr.height]="mainStreckengrafikContainer.offsetHeight"
+      [attr.width]="mainStreckengrafikContainer.offsetWidth"
+    >
       <div #mainStreckengrafikContainer class="main-streckengrafik-container">
         <div class="head_1 background">
           <div class="noprint">
-            <button type="button"
-                    class="SimpleButton"
-                    [title]="'app.streckengrafik.components.reset' | translate"
-                    (click)="onResetButton()">
+            <button
+              type="button"
+              class="SimpleButton"
+              [title]="'app.streckengrafik.components.reset' | translate"
+              (click)="onResetButton()"
+            >
               <sbb-icon svgIcon="kom:arrow-circle-reset-small"></sbb-icon>
             </button>
           </div>
@@ -17,78 +24,93 @@
         <div class="head_2 pathSlider">
           <sbb-path-slider
             [showRailTrackSlider]="showRailTrackSlider()"
-          />
+          ></sbb-path-slider>
         </div>
         <div class="head_3 background">
           <div class="noprint">
             <ng-container *ngIf="!allPathNodeClosed()">
-              <button type="button"
-                      height="16px" width="16px"
-                      class="SimpleButton TogglePathNode"
-                      [title]="'app.streckengrafik.components.close-all-path-nodes' | translate"
-                      (click)="collapseAllPathNodes()">
-                <sbb-icon svgIcon="kom:double-chevron-small-left-medium"
-                          height="16px" width="16px"
-                          aria-hidden="false"></sbb-icon>
+              <button
+                type="button"
+                height="16px"
+                width="16px"
+                class="SimpleButton TogglePathNode"
+                [title]="
+                  'app.streckengrafik.components.close-all-path-nodes'
+                    | translate
+                "
+                (click)="collapseAllPathNodes()"
+              >
+                <sbb-icon
+                  svgIcon="kom:double-chevron-small-left-medium"
+                  height="16px"
+                  width="16px"
+                  aria-hidden="false"
+                ></sbb-icon>
               </button>
             </ng-container>
             <ng-container *ngIf="allPathNodeClosed()">
-              <button type="button"
-                      height="16px" width="16px"
-                      class="SimpleButton TogglePathNode"
-                      [title]="'app.streckengrafik.components.open-all-path-nodes' | translate"
-                      (click)="expandAllPathNodes()">
-                <sbb-icon svgIcon="kom:adouble-chevron-small-right-medium"
-                          height="16px" width="16px"
-                          aria-hidden="false"></sbb-icon>
+              <button
+                type="button"
+                height="16px"
+                width="16px"
+                class="SimpleButton TogglePathNode"
+                [title]="
+                  'app.streckengrafik.components.open-all-path-nodes'
+                    | translate
+                "
+                (click)="expandAllPathNodes()"
+              >
+                <sbb-icon
+                  svgIcon="kom:adouble-chevron-small-right-medium"
+                  height="16px"
+                  width="16px"
+                  aria-hidden="false"
+                ></sbb-icon>
               </button>
             </ng-container>
           </div>
         </div>
         <div class="head_4 background"></div>
 
-        <!---   new line  --->
+        <!-- new line -->
         <div class="main_1 background">
           <ng-container *ngIf="showTimeSlider()">
-            <sbb-time-slider margin="1px"
-                             [horizontal]="false"
-                             [roundTimeLine]="0.0"
-                             [enableTimeLine]="true"
-                             [sliderLinePos]="40"
-                             [sliderTextPos]="32">
-            </sbb-time-slider>
+            <sbb-time-slider
+              margin="1px"
+              [horizontal]="false"
+              [roundTimeLine]="0.0"
+              [enableTimeLine]="true"
+              [sliderLinePos]="40"
+              [sliderTextPos]="32"
+            ></sbb-time-slider>
           </ng-container>
         </div>
 
         <div class="main_2 background mainDrawingArea">
           <sbb-drawing-background-mouse-listener style="border: none">
-            <svg #svg
-                 id="StreckengrafikMainSVG"
-                 class="StreckengrafikMainSVG"
-                 [attr.viewBox]="viewBox"
-                 width="100%"
-                 height="100%"
-                 xmlns="http://www.w3.org/2000/svg">
-              <g sbb-path-grid
-                 [renderOnlyGrid]="true">
-              </g>
+            <svg
+              #svg
+              id="StreckengrafikMainSVG"
+              class="StreckengrafikMainSVG"
+              [attr.viewBox]="viewBox"
+              width="100%"
+              height="100%"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <g sbb-path-grid [renderOnlyGrid]="true"></g>
               <g sbb-time-grid></g>
-              <g sbb-path-grid
-                 [renderOnlyGrid]="false">
-              </g>
-              <g sbb-train-run
-                 [doShowTrainruns]="getShowTrainruns()"
-              ></g>
-              <g sbb-timeline
-                 [roundTimeLine]="1.0">
-              </g>
+              <g sbb-path-grid [renderOnlyGrid]="false"></g>
+              <g sbb-train-run [doShowTrainruns]="getShowTrainruns()"></g>
+              <g sbb-timeline [roundTimeLine]="1.0"></g>
             </svg>
           </sbb-drawing-background-mouse-listener>
 
           <ng-container *ngIf="getIsLoading()">
-            <sbb-loading-indicator mode="fullbox" aria-label="Loading, please wait"></sbb-loading-indicator>
+            <sbb-loading-indicator
+              mode="fullbox"
+              aria-label="Loading, please wait"
+            ></sbb-loading-indicator>
           </ng-container>
-
         </div>
 
         <div class="main_3 background">
@@ -99,96 +121,153 @@
               [roundTimeLine]="1.0"
               [enableTimeLine]="false"
               [sliderLinePos]="0"
-              [sliderTextPos]="32">
-            </sbb-time-slider>
+              [sliderTextPos]="32"
+            ></sbb-time-slider>
           </ng-container>
         </div>
         <div class="main_4 background"></div>
 
-        <!---   new line  --->
+        <!-- new line -->
         <div class="footer_1 background"></div>
         <div class="footer_2 background">
-          <button type="button"
-                  [class]="getZoomButtonClassTag('SimpleButton',41.6)"
-                  title="1/4h"
-                  (click)="onFixZoom(41.6)">
+          <button
+            type="button"
+            [class]="getZoomButtonClassTag('SimpleButton', 41.6)"
+            title="15'"
+            (click)="onFixZoom(41.6)"
+          >
             15'
           </button>
-          <button type="button"
-                  [class]="getZoomButtonClassTag('SimpleButton',20.8)"
-                  title="1/2h"
-                  (click)="onFixZoom(20.8)">
+          <button
+            type="button"
+            [class]="getZoomButtonClassTag('SimpleButton', 20.8)"
+            title="30'"
+            (click)="onFixZoom(20.8)"
+          >
             30'
           </button>
-
-          <button type="button"
-                  [class]="getZoomButtonClassTag('SimpleButton',10.4)"
-                  title="1h"
-                  (click)="onFixZoom(10.4)">
+          <button
+            type="button"
+            [class]="getZoomButtonClassTag('SimpleButton', 10.4)"
+            title="1h"
+            (click)="onFixZoom(10.4)"
+          >
             1h
           </button>
-          <button type="button"
-                  [class]="getZoomButtonClassTag('SimpleButton',5.2)"
-                  title="2h"
-                  (click)="onFixZoom(5.2)">
+          <button
+            type="button"
+            [class]="getZoomButtonClassTag('SimpleButton', 5.2)"
+            title="2h"
+            (click)="onFixZoom(5.2)"
+          >
             2h
           </button>
-          <button type="button"
-                  [class]="getZoomButtonClassTag('SimpleButton',2.6)"
-                  title="4h"
-                  (click)="onFixZoom(2.6)">
+          <button
+            type="button"
+            [class]="getZoomButtonClassTag('SimpleButton', 2.6)"
+            title="4h"
+            (click)="onFixZoom(2.6)"
+          >
             4h
           </button>
 
           <ng-container *ngIf="disabledDisplayTools">
-            <button type="button" class="SimpleButton Empty" (click)="toggleDisplayTools()"
-                    [title]="'app.streckengrafik.components.show-advanced-display-functions' | translate">
+            <button
+              type="button"
+              class="SimpleButton Empty"
+              (click)="toggleDisplayTools()"
+              [title]="
+                'app.streckengrafik.components.show-advanced-display-functions'
+                  | translate
+              "
+            >
               &#8942;
             </button>
           </ng-container>
 
           <ng-container *ngIf="!disabledDisplayTools">
-            <br>
-            <button type="button"
-                    [class]="getStreckengrafikTimeNotFocusNorEnabledButtonClassTag('SimpleButton Time')"
-                    [title]="'app.streckengrafik.components.show-or-hide-time-for-non-selected-trainruns' | translate"
-                    (click)="toggleStreckengrafikTimeNotFocusNorEnabledButton()"
-                    [attr.title]="'app.streckengrafik.components.show-or-hide' | translate:{ 'component': getTimeButtonText() }">
-              {{getTimeButtonText()}}
+            <button
+              type="button"
+              [class]="
+                getStreckengrafikTimeNotFocusNorEnabledButtonClassTag(
+                  'SimpleButton Time'
+                )
+              "
+              [title]="
+                'app.streckengrafik.components.show-or-hide-time-for-non-selected-trainruns'
+                  | translate
+              "
+              (click)="toggleStreckengrafikTimeNotFocusNorEnabledButton()"
+              [attr.title]="
+                'app.streckengrafik.components.show-or-hide'
+                  | translate: {component: getTimeButtonText()}
+              "
+            >
+              {{ getTimeButtonText() }}
             </button>
-
-            <button type="button"
-                    [class]="getStreckengrafikNameNotFocusNorEnabledButtonClassTag('SimpleButton Name')"
-                    [title]="'app.streckengrafik.components.show-or-hide-name-for-non-selected-trains' | translate"
-                    (click)="toggleStreckengrafikNameNotFocusNorEnabledButton()"
-                    [attr.title]="'app.streckengrafik.components.show-or-hide' | translate:{ 'component': getNameButtonText() }">
-              {{getNameButtonText()}}
+            <button
+              type="button"
+              [class]="
+                getStreckengrafikNameNotFocusNorEnabledButtonClassTag(
+                  'SimpleButton Name'
+                )
+              "
+              [title]="
+                'app.streckengrafik.components.show-or-hide-name-for-non-selected-trains'
+                  | translate
+              "
+              (click)="toggleStreckengrafikNameNotFocusNorEnabledButton()"
+              [attr.title]="
+                'app.streckengrafik.components.show-or-hide'
+                  | translate: {component: getNameButtonText()}
+              "
+            >
+              {{ getNameButtonText() }}
             </button>
-
-            <button type="button"
-                    [class]="getHeadwayVisibleButtonClassTag('SimpleButton HeadwayBand')"
-                    (click)="toggleHeadwayBandVisbility()"
-                    [attr.title]="'app.streckengrafik.components.show-or-hide' | translate:{ 'component': getHeadwayBandButtonText() }">
-              {{getHeadwayBandButtonText()}}
+            <button
+              type="button"
+              [class]="
+                getHeadwayVisibleButtonClassTag('SimpleButton HeadwayBand')
+              "
+              (click)="toggleHeadwayBandVisbility()"
+              [attr.title]="
+                'app.streckengrafik.components.show-or-hide'
+                  | translate: {component: getHeadwayBandButtonText()}
+              "
+            >
+              {{ getHeadwayBandButtonText() }}
             </button>
-
-            <button type="button"
-                    [class]="getRailTrackSliderVisibleButtonClassTag('SimpleButton RailTrackSlider')"
-                    (click)="toggleRailTrackSliderVisbility()"
-                    [attr.title]="'app.streckengrafik.components.show-or-hide' | translate:{ 'component': getRailTrackSliderButtonText() }">
-              {{getRailTrackSliderButtonText()}}
+            <button
+              type="button"
+              [class]="
+                getRailTrackSliderVisibleButtonClassTag(
+                  'SimpleButton RailTrackSlider'
+                )
+              "
+              (click)="toggleRailTrackSliderVisbility()"
+              [attr.title]="
+                'app.streckengrafik.components.show-or-hide'
+                  | translate: {component: getRailTrackSliderButtonText()}
+              "
+            >
+              {{ getRailTrackSliderButtonText() }}
             </button>
-
-            <button type="button" class="SimpleButton Empty" style='background: none;'
-                    (click)="toggleDisplayTools()"
-                    [title]="'app.streckengrafik.components.hide-advanced-display-functions' | translate">
+            <button
+              type="button"
+              class="SimpleButton Empty"
+              style="background: none"
+              (click)="toggleDisplayTools()"
+              [title]="
+                'app.streckengrafik.components.hide-advanced-display-functions'
+                  | translate
+              "
+            >
               &#x2715;
             </button>
           </ng-container>
         </div>
         <div class="footer_3 background"></div>
         <div class="footer_4 background"></div>
-
       </div>
     </foreignObject>
   </svg>

--- a/src/app/streckengrafik/components/streckengrafik.component.ts
+++ b/src/app/streckengrafik/components/streckengrafik.component.ts
@@ -20,9 +20,7 @@ import {SliderChangeInfo} from "../model/util/sliderChangeInfo";
 import {TimeSliderService} from "../services/time-slider.service";
 import {UpdateCounterTriggerService} from "../services/util/update-counter.service";
 import {Sg4ToggleTrackOccupierService} from "../services/sg-4-toggle-track-occupier.service";
-import {
-  StreckengrafikDisplayElementService
-} from "../services/util/streckengrafik-display-element.service";
+import {StreckengrafikDisplayElementService} from "../services/util/streckengrafik-display-element.service";
 import {StreckengrafikDrawingContext} from "../model/util/streckengrafik.drawing.context";
 
 @Component({
@@ -31,7 +29,8 @@ import {StreckengrafikDrawingContext} from "../model/util/streckengrafik.drawing
   styleUrls: ["./streckengrafik.component.scss"],
 })
 export class StreckengrafikComponent
-  implements OnInit, OnDestroy, AfterViewInit {
+  implements OnInit, OnDestroy, AfterViewInit
+{
   @ViewChild("svg") svgRef: ElementRef;
 
   viewBox: string;
@@ -61,8 +60,7 @@ export class StreckengrafikComponent
     private resizeService: ResizeService,
     private streckengrafikDisplayElementService: StreckengrafikDisplayElementService,
     private ngZone: NgZone,
-  ) {
-  }
+  ) {}
 
   ngOnInit(): void {
     this.oldRect = undefined;
@@ -101,7 +99,7 @@ export class StreckengrafikComponent
   }
 
   getIsLoading(): boolean {
-    return !this.doShowTrainruns;//this.isLoading;
+    return !this.doShowTrainruns; //this.isLoading;
   }
 
   onResetButton() {
@@ -281,7 +279,10 @@ export class StreckengrafikComponent
   }
 
   private renderViewBox() {
-    if (this.viewBoxChangeInfo.width === 0 && this.viewBoxChangeInfo.height === 0) {
+    if (
+      this.viewBoxChangeInfo.width === 0 &&
+      this.viewBoxChangeInfo.height === 0
+    ) {
       return;
     }
     let viewBox = "";

--- a/src/app/streckengrafik/components/train-run-item/train-run-item.component.html
+++ b/src/app/streckengrafik/components/train-run-item/train-run-item.component.html
@@ -1,7 +1,9 @@
 <svg:g class="AllTrainrunSections">
   <ng-container *ngFor="let offset of offsets">
     <ng-container *ngFor="let trainrunItem of trainrun.sgTrainrunItems">
-      <ng-container *ngIf="isElementNotFrustumCulled(trainrunItem, offset, yZoom)">
+      <ng-container
+        *ngIf="isElementNotFrustumCulled(trainrunItem, offset, yZoom)"
+      >
         <svg:g
           [attr.id]="getId(trainrun, trainrunItem)"
           (mouseover)="bringToFront(trainrun, trainrunItem, $event)"
@@ -9,8 +11,8 @@
           <svg:g [attr.transform]="'translate(0.0,' + offset * yZoom + ')'">
             <svg:g
               [attr.transform]="
-              'translate(' + getTranslate(trainrunItem) + ',0.0)'
-            "
+                'translate(' + getTranslate(trainrunItem) + ',0.0)'
+              "
             >
               <ng-container *ngIf="showSection(trainrunItem)">
                 <svg:g

--- a/src/app/streckengrafik/components/train-run-item/train-run-item.component.ts
+++ b/src/app/streckengrafik/components/train-run-item/train-run-item.component.ts
@@ -1,4 +1,11 @@
-import {ChangeDetectorRef, Component, Input, NgZone, OnDestroy, OnInit} from "@angular/core";
+import {
+  ChangeDetectorRef,
+  Component,
+  Input,
+  NgZone,
+  OnDestroy,
+  OnInit,
+} from "@angular/core";
 import {SgTrainrun} from "../../model/streckengrafik-model/sg-trainrun";
 import {SgTrainrunItem} from "../../model/streckengrafik-model/sg-trainrun-item";
 import {TimeSliderService} from "../../services/time-slider.service";
@@ -21,7 +28,8 @@ import {
   styleUrls: ["./train-run-item.component.scss"],
 })
 export class TrainRunItemComponent
-  implements OnInit, OnDestroy, UpdateCounterHandler {
+  implements OnInit, OnDestroy, UpdateCounterHandler
+{
   @Input()
   trainrun: SgTrainrun;
 
@@ -116,7 +124,11 @@ export class TrainRunItemComponent
     return "" + path.getStartposition();
   }
 
-  isElementNotFrustumCulled(item: SgTrainrunItem, offset: number, yZoom: number): boolean {
+  isElementNotFrustumCulled(
+    item: SgTrainrunItem,
+    offset: number,
+    yZoom: number,
+  ): boolean {
     if (!this.internalDoShowTrainruns) {
       return false;
     }
@@ -129,7 +141,8 @@ export class TrainRunItemComponent
     // extend view box for frustum culling (the 2 * yZoom extra space is just a heuristics - might
     // thus must be more calculated based on pixel height !!!
     const fromTime = this.viewBoxChangeInfo.y - 2 * yZoom;
-    const toTime = this.viewBoxChangeInfo.height + this.viewBoxChangeInfo.y + 2 * yZoom;
+    const toTime =
+      this.viewBoxChangeInfo.height + this.viewBoxChangeInfo.y + 2 * yZoom;
     let fromPoint = 0;
     let toPoint = 0;
     if (item.isNode()) {
@@ -151,16 +164,17 @@ export class TrainRunItemComponent
           return false;
         }
       }
-
     }
     if (item.isSection()) {
       const ts = item.getTrainrunSection();
       fromPoint = (ts.departureTime + offset) * yZoom;
       toPoint = (ts.arrivalTime + offset + ts.minimumHeadwayTime) * yZoom;
     }
-    return (fromPoint >= fromTime && fromPoint <= toTime) ||
+    return (
+      (fromPoint >= fromTime && fromPoint <= toTime) ||
       (toPoint >= fromTime && toPoint <= toTime) ||
-      (fromPoint <= fromTime && toPoint >= toTime);
+      (fromPoint <= fromTime && toPoint >= toTime)
+    );
   }
 
   getId(trainrun: SgTrainrun, trainrunItem: SgTrainrunItem) {

--- a/src/app/streckengrafik/components/train-run-section/train-run-section.component.scss
+++ b/src/app/streckengrafik/components/train-run-section/train-run-section.component.scss
@@ -3,8 +3,8 @@ text.edge_text {
   font-size: 10px;
   stroke: var(--NODE_DOCKABLE);
   stroke-width: 0.5em;
-  paint-order:stroke;
-  stroke-linejoin:round
+  paint-order: stroke;
+  stroke-linejoin: round;
 }
 
 text.edge_text.selected.Streckengrafik {

--- a/src/app/streckengrafik/components/train-run-section/train-run-section.component.ts
+++ b/src/app/streckengrafik/components/train-run-section/train-run-section.component.ts
@@ -33,9 +33,7 @@ import {
 import {SliderChangeInfo} from "../../model/util/sliderChangeInfo";
 import {NodeService} from "../../../services/data/node.service";
 import {SgTrainrunSection} from "../../model/streckengrafik-model/sg-trainrun-section";
-import {
-  StreckengrafikDisplayElementService
-} from "../../services/util/streckengrafik-display-element.service";
+import {StreckengrafikDisplayElementService} from "../../services/util/streckengrafik-display-element.service";
 import {ViewBoxChangeInfo} from "../../model/util/viewBoxChangeInfo";
 import {ViewBoxService} from "../../services/util/view-box.service";
 import {Sg4ToggleTrackOccupierService} from "../../services/sg-4-toggle-track-occupier.service";
@@ -48,7 +46,8 @@ import {Sg4ToggleTrackOccupierService} from "../../services/sg-4-toggle-track-oc
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TrainRunSectionComponent
-  implements OnDestroy, UpdateCounterHandler {
+  implements OnDestroy, UpdateCounterHandler
+{
   @Input()
   trainrun: SgTrainrun;
 
@@ -121,7 +120,6 @@ export class TrainRunSectionComponent
       .subscribe(() => {
         this.cd.markForCheck();
       });
-
   }
 
   ngOnDestroy(): void {
@@ -141,7 +139,7 @@ export class TrainRunSectionComponent
     } else {
       const param: InformSelectedTrainrunClick = {
         trainrunSectionId:
-        this.trainrunItem.getTrainrunSection().trainrunSectionId,
+          this.trainrunItem.getTrainrunSection().trainrunSectionId,
         open: true,
       };
       this.trainrunSectionService.clickSelectedTrainrunSection(param);
@@ -156,7 +154,7 @@ export class TrainRunSectionComponent
       " trainrunBranchType_" +
       TrainrunBranchType[
         this.trainrunItem.getTrainrunSection().trainrunBranchType
-        ];
+      ];
 
     retTag += " Streckengrafik ";
     return retTag;
@@ -313,15 +311,15 @@ export class TrainRunSectionComponent
   private showArrivalBranch() {
     if (
       this.trainrunItem.getTrainrunSection().trainrunBranchType ===
-      TrainrunBranchType.ArrivalBranchWithSection ||
+        TrainrunBranchType.ArrivalBranchWithSection ||
       this.trainrunItem.getTrainrunSection().trainrunBranchType ===
-      TrainrunBranchType.ArrivalBranchFilter
+        TrainrunBranchType.ArrivalBranchFilter
     ) {
       return true;
     }
     if (
       this.trainrunItem.getTrainrunSection().trainrunBranchType ===
-      TrainrunBranchType.ArrivalBranchOnly &&
+        TrainrunBranchType.ArrivalBranchOnly &&
       !this.trainrunItem.backward &&
       this.trainrunItem.getPathSection().arrivalPathNode &&
       this.trainrunItem.getPathSection().arrivalPathNode.trackOccupier
@@ -330,7 +328,7 @@ export class TrainRunSectionComponent
     }
     return (
       this.trainrunItem.getTrainrunSection().trainrunBranchType ===
-      TrainrunBranchType.ArrivalBranchOnly &&
+        TrainrunBranchType.ArrivalBranchOnly &&
       this.trainrunItem.backward &&
       this.trainrunItem.getPathSection().departurePathNode &&
       this.trainrunItem.getPathSection().departurePathNode.trackOccupier
@@ -340,15 +338,15 @@ export class TrainRunSectionComponent
   private showDepartureBranch() {
     if (
       this.trainrunItem.getTrainrunSection().trainrunBranchType ===
-      TrainrunBranchType.DepartureBranchWithSection ||
+        TrainrunBranchType.DepartureBranchWithSection ||
       this.trainrunItem.getTrainrunSection().trainrunBranchType ===
-      TrainrunBranchType.DepartureBranchFilter
+        TrainrunBranchType.DepartureBranchFilter
     ) {
       return true;
     }
     if (
       this.trainrunItem.getTrainrunSection().trainrunBranchType ===
-      TrainrunBranchType.DepartureBranchOnly &&
+        TrainrunBranchType.DepartureBranchOnly &&
       !this.trainrunItem.backward &&
       this.trainrunItem.getPathSection().departurePathNode &&
       this.trainrunItem.getPathSection().departurePathNode.trackOccupier
@@ -357,7 +355,7 @@ export class TrainRunSectionComponent
     }
     return (
       this.trainrunItem.getTrainrunSection().trainrunBranchType ===
-      TrainrunBranchType.DepartureBranchOnly &&
+        TrainrunBranchType.DepartureBranchOnly &&
       this.trainrunItem.backward &&
       this.trainrunItem.getPathSection().arrivalPathNode &&
       this.trainrunItem.getPathSection().arrivalPathNode.trackOccupier
@@ -509,11 +507,11 @@ export class TrainRunSectionComponent
     let orgTime = this.trainrunItem.departureTime;
     if (
       this.trainrunItem.getTrainrunSection().trainrunBranchType ===
-      TrainrunBranchType.ArrivalBranchWithSection ||
+        TrainrunBranchType.ArrivalBranchWithSection ||
       this.trainrunItem.getTrainrunSection().trainrunBranchType ===
-      TrainrunBranchType.ArrivalBranchOnly ||
+        TrainrunBranchType.ArrivalBranchOnly ||
       this.trainrunItem.getTrainrunSection().trainrunBranchType ===
-      TrainrunBranchType.ArrivalBranchFilter
+        TrainrunBranchType.ArrivalBranchFilter
     ) {
       orgTime = this.trainrunItem.arrivalTime;
     }
@@ -532,11 +530,11 @@ export class TrainRunSectionComponent
   getArrivalText(): string {
     if (
       this.trainrunItem.getTrainrunSection().trainrunBranchType ===
-      TrainrunBranchType.ArrivalBranchWithSection ||
+        TrainrunBranchType.ArrivalBranchWithSection ||
       this.trainrunItem.getTrainrunSection().trainrunBranchType ===
-      TrainrunBranchType.ArrivalBranchOnly ||
+        TrainrunBranchType.ArrivalBranchOnly ||
       this.trainrunItem.getTrainrunSection().trainrunBranchType ===
-      TrainrunBranchType.ArrivalBranchFilter
+        TrainrunBranchType.ArrivalBranchFilter
     ) {
       if (this.trainrunItem.backward) {
         if (
@@ -557,11 +555,11 @@ export class TrainRunSectionComponent
     }
     if (
       this.trainrunItem.getTrainrunSection().trainrunBranchType ===
-      TrainrunBranchType.DepartureBranchWithSection ||
+        TrainrunBranchType.DepartureBranchWithSection ||
       this.trainrunItem.getTrainrunSection().trainrunBranchType ===
-      TrainrunBranchType.DepartureBranchOnly ||
+        TrainrunBranchType.DepartureBranchOnly ||
       this.trainrunItem.getTrainrunSection().trainrunBranchType ===
-      TrainrunBranchType.DepartureBranchFilter
+        TrainrunBranchType.DepartureBranchFilter
     ) {
       if (this.trainrunItem.backward) {
         if (
@@ -602,11 +600,11 @@ export class TrainRunSectionComponent
     if (!this.filterService.isFilterShowNonStopTimeEnabled()) {
       if (
         this.trainrunItem.getTrainrunSection().trainrunBranchType ===
-        TrainrunBranchType.ArrivalBranchWithSection ||
+          TrainrunBranchType.ArrivalBranchWithSection ||
         this.trainrunItem.getTrainrunSection().trainrunBranchType ===
-        TrainrunBranchType.ArrivalBranchOnly ||
+          TrainrunBranchType.ArrivalBranchOnly ||
         this.trainrunItem.getTrainrunSection().trainrunBranchType ===
-        TrainrunBranchType.ArrivalBranchFilter
+          TrainrunBranchType.ArrivalBranchFilter
       ) {
         if (this.trainrunItem.backward) {
           if (
@@ -632,11 +630,11 @@ export class TrainRunSectionComponent
       }
       if (
         this.trainrunItem.getTrainrunSection().trainrunBranchType ===
-        TrainrunBranchType.DepartureBranchWithSection ||
+          TrainrunBranchType.DepartureBranchWithSection ||
         this.trainrunItem.getTrainrunSection().trainrunBranchType ===
-        TrainrunBranchType.DepartureBranchOnly ||
+          TrainrunBranchType.DepartureBranchOnly ||
         this.trainrunItem.getTrainrunSection().trainrunBranchType ===
-        TrainrunBranchType.DepartureBranchFilter
+          TrainrunBranchType.DepartureBranchFilter
       ) {
         if (this.trainrunItem.backward) {
           if (
@@ -756,9 +754,9 @@ export class TrainRunSectionComponent
       this.trainrunSectionService.getSelectedTrainrunSection();
     if (
       selectedTrainrunSection.getTargetNode().getId() ===
-      this.trainrunItem.getTrainrunSection().departureNodeId &&
+        this.trainrunItem.getTrainrunSection().departureNodeId &&
       selectedTrainrunSection.getSourceNode().getId() ===
-      this.trainrunItem.getTrainrunSection().arrivalNodeId
+        this.trainrunItem.getTrainrunSection().arrivalNodeId
     ) {
       if (sgTrainrunItem.backward) {
         parameter.trainrunSectionText = TrainrunSectionText.SourceArrival;
@@ -768,9 +766,9 @@ export class TrainRunSectionComponent
     }
     if (
       selectedTrainrunSection.getTargetNode().getId() ===
-      this.trainrunItem.getTrainrunSection().arrivalNodeId &&
+        this.trainrunItem.getTrainrunSection().arrivalNodeId &&
       selectedTrainrunSection.getSourceNode().getId() ===
-      this.trainrunItem.getTrainrunSection().departureNodeId
+        this.trainrunItem.getTrainrunSection().departureNodeId
     ) {
       if (sgTrainrunItem.backward) {
         parameter.trainrunSectionText = TrainrunSectionText.TargetArrival;
@@ -803,9 +801,9 @@ export class TrainRunSectionComponent
       this.trainrunSectionService.getSelectedTrainrunSection();
     if (
       selectedTrainrunSection.getTargetNode().getId() ===
-      this.trainrunItem.getTrainrunSection().departureNodeId &&
+        this.trainrunItem.getTrainrunSection().departureNodeId &&
       selectedTrainrunSection.getSourceNode().getId() ===
-      this.trainrunItem.getTrainrunSection().arrivalNodeId
+        this.trainrunItem.getTrainrunSection().arrivalNodeId
     ) {
       if (sgTrainrunItem.backward) {
         parameter.trainrunSectionText = TrainrunSectionText.TargetDeparture;
@@ -815,9 +813,9 @@ export class TrainRunSectionComponent
     }
     if (
       selectedTrainrunSection.getTargetNode().getId() ===
-      this.trainrunItem.getTrainrunSection().arrivalNodeId &&
+        this.trainrunItem.getTrainrunSection().arrivalNodeId &&
       selectedTrainrunSection.getSourceNode().getId() ===
-      this.trainrunItem.getTrainrunSection().departureNodeId
+        this.trainrunItem.getTrainrunSection().departureNodeId
     ) {
       if (sgTrainrunItem.backward) {
         parameter.trainrunSectionText = TrainrunSectionText.SourceDeparture;
@@ -936,9 +934,9 @@ export class TrainRunSectionComponent
 
     if (
       this.trainrunItem.getTrainrunSection().trainrunBranchType ===
-      TrainrunBranchType.Trainrun ||
+        TrainrunBranchType.Trainrun ||
       this.trainrunItem.getTrainrunSection().trainrunBranchType ===
-      TrainrunBranchType.Filter
+        TrainrunBranchType.Filter
     ) {
       if (
         this.streckengrafikDisplayElementService.isFilterStreckengrafikTimeNotFocusNorEnabled()
@@ -951,7 +949,7 @@ export class TrainRunSectionComponent
       this.trainrunItem &&
       this.trainrunItem.isSection() &&
       this.trainrunItem.getTrainrunSection().trainrunBranchType ===
-      TrainrunBranchType.Trainrun
+        TrainrunBranchType.Trainrun
     ) {
       return this.isArrivalTimeTextFiltering();
     }
@@ -972,7 +970,7 @@ export class TrainRunSectionComponent
       this.trainrunItem &&
       this.trainrunItem.isSection() &&
       this.trainrunItem.getTrainrunSection().trainrunBranchType ===
-      TrainrunBranchType.Trainrun
+        TrainrunBranchType.Trainrun
     ) {
       return this.isDepatureTimeTextFiltering(true);
     }
@@ -983,11 +981,11 @@ export class TrainRunSectionComponent
       (this.trainrunItem.getTrainrunSection().trainrunBranchType ===
         TrainrunBranchType.ArrivalBranchWithSection ||
         this.trainrunItem.getTrainrunSection().trainrunBranchType ===
-        TrainrunBranchType.DepartureBranchWithSection ||
+          TrainrunBranchType.DepartureBranchWithSection ||
         this.trainrunItem.getTrainrunSection().trainrunBranchType ===
-        TrainrunBranchType.ArrivalBranchOnly ||
+          TrainrunBranchType.ArrivalBranchOnly ||
         this.trainrunItem.getTrainrunSection().trainrunBranchType ===
-        TrainrunBranchType.DepartureBranchOnly)
+          TrainrunBranchType.DepartureBranchOnly)
     ) {
       return this.isDepatureTimeTextFiltering(false);
     }
@@ -1036,6 +1034,5 @@ export class ScaledPath {
   constructor(
     public scaledPathFrom: Vec2D,
     public scaledPathTo: Vec2D,
-  ) {
-  }
+  ) {}
 }

--- a/src/app/streckengrafik/components/train-run/train-run.component.ts
+++ b/src/app/streckengrafik/components/train-run/train-run.component.ts
@@ -11,7 +11,6 @@ import * as d3 from "d3";
   styleUrls: ["./train-run.component.scss"],
 })
 export class TrainRunComponent {
-
   @Input()
   doShowTrainruns = false;
 

--- a/src/app/streckengrafik/services/sg-1-load-trainrun-item.service.ts
+++ b/src/app/streckengrafik/services/sg-1-load-trainrun-item.service.ts
@@ -16,14 +16,11 @@ import {TrainrunSectionService} from "../../services/data/trainrunsection.servic
 import {TrackData} from "../model/trackData";
 import {UiInteractionService} from "../../services/ui/ui.interaction.service";
 import {EditorMode} from "../../view/editor-menu/editor-mode";
-import {
-  TrainrunTemplatePathAlignmentType
-} from "../model/enum/trainrun-template-path-alignment-type";
+import {TrainrunTemplatePathAlignmentType} from "../model/enum/trainrun-template-path-alignment-type";
 import {IsTrainrunSelectedService} from "../../services/data/is-trainrun-section.service";
 import {NodeService} from "../../services/data/node.service";
 import {TrainrunBranchType} from "../model/enum/trainrun-branch-type-type";
 import {MultiSelectNodeGraph} from "../../utils/multi-select-node-graph";
-
 
 @Injectable({
   providedIn: "root",
@@ -108,7 +105,10 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
   }
 
   private render() {
-    if (this.uiInteractionService.getEditorMode() !== EditorMode.StreckengrafikEditing) {
+    if (
+      this.uiInteractionService.getEditorMode() !==
+      EditorMode.StreckengrafikEditing
+    ) {
       return;
     }
 
@@ -128,7 +128,10 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
       return;
     }
 
-    if (!this.uiInteractionService.isMultiSelectedNodesCorridorEnabled() || this.doInit) {
+    if (
+      !this.uiInteractionService.isMultiSelectedNodesCorridorEnabled() ||
+      this.doInit
+    ) {
       // if 1st time called rendering, prepare data
       this.doInit = false;
 
@@ -144,7 +147,9 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
     if (this.cachedTrainrunItems !== undefined) {
       // inform all listeners that the trainrunItem (cached or loaded has changed)
       this.trainrunItemSubject.next(this.cachedTrainrunItems);
-      this.trainrunItemsSubject.next(this.loadTrainrunItems(this.cachedTrainrunItems));
+      this.trainrunItemsSubject.next(
+        this.loadTrainrunItems(this.cachedTrainrunItems),
+      );
     }
   }
 
@@ -156,7 +161,7 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
         // not support current trains with partial cancellations.
         const ts: TrainrunSection = this.trainrunSectionService
           .getAllTrainrunSectionsForTrainrun(selectedTrainrun.getId())
-          .find(ts => true);
+          .find((ts) => true);
         const loadeddata = this.loadTrainrunItem(ts, true);
         this.cachedTrainrunItems = loadeddata.trainrunItem;
       }
@@ -180,13 +185,14 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
       undefined,
       undefined,
       undefined,
-      []
+      [],
     );
 
     // create a new graph object
     const graph = new MultiSelectNodeGraph(
       this.nodeService,
-      this.trainrunSectionService);
+      this.trainrunSectionService,
+    );
 
     // create graph from nodes (Netzgrafik data)
     const edgeLists = graph.convertNetzgrafikSubNodesToGraph(nodes);
@@ -195,18 +201,31 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
     const endStartingVertices = graph.getStartEndingVertices();
 
     // build corridor
-    const corridor = endStartingVertices.length === 2 ?
-      this.createSimplePathFromStartToEndingNodes(graph, nodes, endStartingVertices) :
-      this.createLongestPathFromNodes(graph, nodes);
+    const corridor =
+      endStartingVertices.length === 2
+        ? this.createSimplePathFromStartToEndingNodes(
+            graph,
+            nodes,
+            endStartingVertices,
+          )
+        : this.createLongestPathFromNodes(graph, nodes);
 
     // convert corridor to path elements
     corridor.forEach((n, idx, nodArray) => {
       if (idx > 0) {
-        const e = edgeLists.find(e =>
-          (e.from === nodArray[idx - 1].getId() && e.to === nodArray[idx].getId()) ||
-          (e.to === nodArray[idx - 1].getId() && e.from === nodArray[idx].getId()));
+        const e = edgeLists.find(
+          (e) =>
+            (e.from === nodArray[idx - 1].getId() &&
+              e.to === nodArray[idx].getId()) ||
+            (e.to === nodArray[idx - 1].getId() &&
+              e.from === nodArray[idx].getId()),
+        );
         const meanTravelTime = e === undefined ? 1 : e.meanTravelTime;
-        this.makePathElement(nodArray[idx - 1].getId(), nodArray[idx].getId(), meanTravelTime);
+        this.makePathElement(
+          nodArray[idx - 1].getId(),
+          nodArray[idx].getId(),
+          meanTravelTime,
+        );
       }
     });
 
@@ -215,8 +234,10 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
     this.nodeService.unselectAllNodes(false);
   }
 
-  private createLongestPathFromNodes(graph: MultiSelectNodeGraph,
-                                     nodes: Node[]) {
+  private createLongestPathFromNodes(
+    graph: MultiSelectNodeGraph,
+    nodes: Node[],
+  ) {
     // sort from left top - down (1st draft)
     const sortedNode = nodes.sort((n1, n2) => {
       if (n1.getPositionX() === n2.getPositionX()) {
@@ -245,11 +266,13 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
     return corridor;
   }
 
-  private createSimplePathFromStartToEndingNodes(graph: MultiSelectNodeGraph,
-                                                 nodes: Node[],
-                                                 endStartingVertices: number[]): number[] {
-    const n1 = nodes.find(n => n.getId() === endStartingVertices[0]);
-    const n2 = nodes.find(n => n.getId() === endStartingVertices[1]);
+  private createSimplePathFromStartToEndingNodes(
+    graph: MultiSelectNodeGraph,
+    nodes: Node[],
+    endStartingVertices: number[],
+  ): number[] {
+    const n1 = nodes.find((n) => n.getId() === endStartingVertices[0]);
+    const n2 = nodes.find((n) => n.getId() === endStartingVertices[1]);
     const startEndNodes = [n1, n2];
     const sortedStartEndNodes = startEndNodes.sort((n1, n2) => {
       if (n1.getPositionX() === n2.getPositionX()) {
@@ -257,21 +280,19 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
       }
       return n1.getPositionX() - n2.getPositionX();
     });
-    const p = graph.getPath(sortedStartEndNodes[0].getId(), sortedStartEndNodes[1].getId());
+    const p = graph.getPath(
+      sortedStartEndNodes[0].getId(),
+      sortedStartEndNodes[1].getId(),
+    );
     return Object.assign([], p.path);
   }
 
-  private makePathElement(nodeId1: number, nodeId2: number, travelTime: number) {
-
-    const n1 = new PathNode(
-      0,
-      0,
-      nodeId1,
-      undefined,
-      0,
-      undefined,
-      false
-    );
+  private makePathElement(
+    nodeId1: number,
+    nodeId2: number,
+    travelTime: number,
+  ) {
+    const n1 = new PathNode(0, 0, nodeId1, undefined, 0, undefined, false);
     const n2 = new PathNode(
       travelTime,
       travelTime,
@@ -279,17 +300,22 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
       undefined,
       1,
       undefined,
-      false
+      false,
     );
     const node1 = this.nodeService.getNodeFromId(n1.nodeId);
     n1.nodeShortName = node1.getBetriebspunktName();
     const node2 = this.nodeService.getNodeFromId(n2.nodeId);
     n2.nodeShortName = node2.getBetriebspunktName();
 
-    let ts12 = this.trainrunSectionService.getTrainrunSections().find((ts: TrainrunSection) =>
-      (ts.getSourceNodeId() === n1.nodeId && ts.getTargetNodeId() === n2.nodeId) ||
-      (ts.getSourceNodeId() === n2.nodeId && ts.getTargetNodeId() === n1.nodeId)
-    );
+    let ts12 = this.trainrunSectionService
+      .getTrainrunSections()
+      .find(
+        (ts: TrainrunSection) =>
+          (ts.getSourceNodeId() === n1.nodeId &&
+            ts.getTargetNodeId() === n2.nodeId) ||
+          (ts.getSourceNodeId() === n2.nodeId &&
+            ts.getTargetNodeId() === n1.nodeId),
+      );
     if (ts12 === undefined) {
       ts12 = new TrainrunSection();
       ts12.setSourceNode(node1);
@@ -302,7 +328,7 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
       travelTime,
       0,
       undefined,
-      false,//(ts12.getSourceNodeId() === n2.nodeId && ts12.getTargetNodeId() === n1.nodeId),
+      false, //(ts12.getSourceNodeId() === n2.nodeId && ts12.getTargetNodeId() === n1.nodeId),
       undefined,
       undefined,
       TrainrunBranchType.Trainrun,
@@ -314,7 +340,6 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
     }
     this.cachedTrainrunItems.pathItems.push(s12);
     this.cachedTrainrunItems.pathItems.push(n2);
-
   }
 
   private getTurnaroundStartNodeForward(
@@ -383,7 +408,8 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
 
   private determineForwardBackwardNodes(
     trainrunSection: TrainrunSection,
-    onlyForward: boolean): {
+    onlyForward: boolean,
+  ): {
     startForwardNode: Node;
     startBackwardNode: Node;
     visitedTrainrunSections: TrainrunSection[];
@@ -394,16 +420,17 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
     const bothEndNodes =
       this.trainrunService.getBothEndNodesFromTrainrunPart(trainrunSection);
 
-    const startForwardBackwardNode = GeneralViewFunctions.getStartForwardAndBackwardNode(
-      bothEndNodes.endNode1,
-      bothEndNodes.endNode2,
-    );
+    const startForwardBackwardNode =
+      GeneralViewFunctions.getStartForwardAndBackwardNode(
+        bothEndNodes.endNode1,
+        bothEndNodes.endNode2,
+      );
 
     if (onlyForward) {
       const tsg = this.trainrunSectionGroup(
         trainrun.getId(),
         startForwardBackwardNode.startForwardNode,
-        true
+        true,
       );
       this.forwardTrainrunSectionGroup = tsg.trainrunSectionGroups;
       visitedTrainrunSections = tsg.visitedTrainrunSections;
@@ -441,8 +468,9 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
     let trainrunStartTime = 0;
     let trainrunEndTime = 0;
 
-    const trainrun: Trainrun =
-      this.trainrunService.getTrainrunFromId(trainrunSection.getTrainrunId());
+    const trainrun: Trainrun = this.trainrunService.getTrainrunFromId(
+      trainrunSection.getTrainrunId(),
+    );
 
     const pathItems: PathItem[] = [];
     if (
@@ -451,24 +479,30 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
       return undefined;
     }
 
-    const forwardBackwardNodes =
-      this.determineForwardBackwardNodes(trainrunSection, onlyForward);
+    const forwardBackwardNodes = this.determineForwardBackwardNodes(
+      trainrunSection,
+      onlyForward,
+    );
 
     const tsgForward = this.trainrunSectionGroup(
       trainrun.getId(),
       forwardBackwardNodes.startForwardNode,
-      true
+      true,
     );
     const forwardTrainrunSectionGroup = tsgForward.trainrunSectionGroups;
-    visitedTrainrunSections = visitedTrainrunSections.concat(tsgForward.visitedTrainrunSections);
+    visitedTrainrunSections = visitedTrainrunSections.concat(
+      tsgForward.visitedTrainrunSections,
+    );
 
     const tsgBackward = this.trainrunSectionGroup(
       trainrun.getId(),
       forwardBackwardNodes.startBackwardNode,
-      false
+      false,
     );
     const backwardTrainrunSectionGroup = tsgBackward.trainrunSectionGroups;
-    visitedTrainrunSections = visitedTrainrunSections.concat(tsgBackward.visitedTrainrunSections);
+    visitedTrainrunSections = visitedTrainrunSections.concat(
+      tsgBackward.visitedTrainrunSections,
+    );
 
     let forwardStartNode: PathNode = undefined;
     let forwardEndNode: PathNode = undefined;
@@ -554,7 +588,9 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
             trainrunSectionGroup.toTrainrunSectionWithNodes.trainrunSection;
         }
         // Erster Node
-        if (fromNode.getId() === forwardBackwardNodes.startBackwardNode.getId()) {
+        if (
+          fromNode.getId() === forwardBackwardNodes.startBackwardNode.getId()
+        ) {
           const sourcePathNode = new PathNode(
             fromNode.getDepartureConsecutiveTime(trainrunSection),
             this.getTurnaroundStartNodeBackward(
@@ -668,15 +704,13 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
         trainrun.getTitle(),
         trainrun.getCategoryShortName(),
         trainrun.getCategoryColorRef(),
-        pathItems
+        pathItems,
       ),
-      visitedTrainrunSections: visitedTrainrunSections
+      visitedTrainrunSections: visitedTrainrunSections,
     };
   }
 
-  public loadTrainrunItems(
-    templateTrainrunItem: TrainrunItem,
-  ): TrainrunItem[] {
+  public loadTrainrunItems(templateTrainrunItem: TrainrunItem): TrainrunItem[] {
     // Extract for all trainruns the sections which are part of the
     // template path (along which the graphical timetable is projected) and it does
     // support current for those trains with partial cancellations.
@@ -685,14 +719,16 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
       this.trainruns.forEach((trainrun: Trainrun) => {
         if (this.filterService.filterTrainrun(trainrun)) {
           // get all trainrun section for given trainrun
-          let alltrainrunsections = this.trainrunSectionService
-            .getAllTrainrunSectionsForTrainrun(trainrun.getId());
+          let alltrainrunsections =
+            this.trainrunSectionService.getAllTrainrunSectionsForTrainrun(
+              trainrun.getId(),
+            );
 
           // As long not all trainrun section are visited (process) continue
           // this part of code supports partial cancellations, e.g., trainrun runs from
           // A - B - C [ partial canceled ] D - E
           while (alltrainrunsections.length > 0) {
-            const ts: TrainrunSection = alltrainrunsections.find(ts => true);
+            const ts: TrainrunSection = alltrainrunsections.find((ts) => true);
             const loadeddata = this.loadTrainrunItem(ts, false);
 
             // correct projections directions
@@ -704,8 +740,8 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
             trainrunItems.push(loadeddata.trainrunItem);
 
             // filter all still visited trainrun sections
-            alltrainrunsections = alltrainrunsections.filter(ts =>
-              loadeddata.visitedTrainrunSections.indexOf(ts) === -1
+            alltrainrunsections = alltrainrunsections.filter(
+              (ts) => loadeddata.visitedTrainrunSections.indexOf(ts) === -1,
             );
           }
         }
@@ -901,9 +937,9 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
             const tempSection = tempItem.getPathSection();
             return (
               section.departurePathNode.nodeId ===
-              tempSection.departurePathNode.nodeId &&
+                tempSection.departurePathNode.nodeId &&
               section.arrivalPathNode.nodeId ===
-              tempSection.arrivalPathNode.nodeId
+                tempSection.arrivalPathNode.nodeId
             );
           },
         );
@@ -921,9 +957,9 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
               const tempSection = tempItem.getPathSection();
               return (
                 section.arrivalPathNode.nodeId ===
-                tempSection.departurePathNode.nodeId &&
+                  tempSection.departurePathNode.nodeId &&
                 section.departurePathNode.nodeId ===
-                tempSection.arrivalPathNode.nodeId
+                  tempSection.arrivalPathNode.nodeId
               );
             },
           );
@@ -968,18 +1004,22 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
     const tsgForward = this.trainrunSectionGroup(
       trainrun.getId(),
       startForwardNode,
-      true
+      true,
     );
     const forwardTrainrunSectionGroups = tsgForward.trainrunSectionGroups;
-    visitedTrainrunSections = visitedTrainrunSections.concat(tsgForward.visitedTrainrunSections);
+    visitedTrainrunSections = visitedTrainrunSections.concat(
+      tsgForward.visitedTrainrunSections,
+    );
 
     const tsgBackward = this.trainrunSectionGroup(
       trainrun.getId(),
       startBackwardNode,
-      false
+      false,
     );
     const backwardTrainrunSectionGroups = tsgBackward.trainrunSectionGroups;
-    visitedTrainrunSections = visitedTrainrunSections.concat(tsgBackward.visitedTrainrunSections);
+    visitedTrainrunSections = visitedTrainrunSections.concat(
+      tsgBackward.visitedTrainrunSections,
+    );
 
     const selectedPaths = this.betriebspunktNamePaths(
       selectedForwardTrainrunSectionGroups,
@@ -1011,7 +1051,7 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
     }
     return {
       check: rateForward < rateBackward,
-      visitedTrainrunSections: visitedTrainrunSections
+      visitedTrainrunSections: visitedTrainrunSections,
     };
   }
 
@@ -1209,7 +1249,7 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
   private trainrunSectionGroup(
     trainrunId: number,
     node: Node,
-    returnForwardStartNode: boolean
+    returnForwardStartNode: boolean,
   ): {
     trainrunSectionGroups: TrainrunSectionGroup[];
     visitedTrainrunSections: TrainrunSection[];
@@ -1220,12 +1260,14 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
     let trainrunSectionGroup: TrainrunSectionGroup = undefined;
     let fromNode = node;
     let toNode = undefined;
-    const startTrainrunSection =
-      node.getStartTrainrunSection(trainrunId, returnForwardStartNode);
+    const startTrainrunSection = node.getStartTrainrunSection(
+      trainrunId,
+      returnForwardStartNode,
+    );
     if (startTrainrunSection === undefined) {
       return {
         trainrunSectionGroups: trainrunSectionGroups,
-        visitedTrainrunSections: visitedTrainrunSections
+        visitedTrainrunSections: visitedTrainrunSections,
       };
     }
     const iterator: TrainrunIterator = this.trainrunService.getIterator(
@@ -1235,7 +1277,9 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
     visitedTrainrunSections.push(startTrainrunSection);
     while (iterator.hasNext()) {
       const currentTrainrunSectionNodePair = iterator.next();
-      visitedTrainrunSections.push(currentTrainrunSectionNodePair.trainrunSection);
+      visitedTrainrunSections.push(
+        currentTrainrunSectionNodePair.trainrunSection,
+      );
 
       if (trainrunSectionGroup) {
         trainrunSectionGroup.toTrainrunSectionWithNodes =
@@ -1274,7 +1318,7 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
 
     return {
       trainrunSectionGroups: trainrunSectionGroups,
-      visitedTrainrunSections: visitedTrainrunSections
+      visitedTrainrunSections: visitedTrainrunSections,
     };
   }
 }
@@ -1284,8 +1328,7 @@ class TrainrunSectionGroup {
     public fromTrainrunSectionWithNodes: TrainrunSectionWithNodes,
     public trainrunSectionWithNodes: TrainrunSectionWithNodes,
     public toTrainrunSectionWithNodes: TrainrunSectionWithNodes,
-  ) {
-  }
+  ) {}
 }
 
 class TrainrunSectionWithNodes {
@@ -1293,6 +1336,5 @@ class TrainrunSectionWithNodes {
     public fromNode: Node,
     public trainrunSection: TrainrunSection,
     public toNode: Node,
-  ) {
-  }
+  ) {}
 }

--- a/src/app/streckengrafik/services/sg-6-track.service.ts
+++ b/src/app/streckengrafik/services/sg-6-track.service.ts
@@ -49,11 +49,11 @@ export class Sg6TrackService implements OnDestroy {
         this.dataService
           .getNetzgrafikDto()
           .metadata.trainrunFrequencies.forEach((freq: TrainrunFrequency) => {
-          this.maxFrequency = Math.max(
-            (this.maxFrequency = 0),
-            freq.frequency,
-          );
-        });
+            this.maxFrequency = Math.max(
+              (this.maxFrequency = 0),
+              freq.frequency,
+            );
+          });
         this.selectedTrainrun = selectedTrainrun;
         this.render();
       });
@@ -444,7 +444,8 @@ export class Sg6TrackService implements OnDestroy {
       // second track
       // tag / mark for further processing
       let estimateFreqOffset =
-        (backwardNode.departureTime - forwardNode.arrivalTime) / trainrun.frequency;
+        (backwardNode.departureTime - forwardNode.arrivalTime) /
+        trainrun.frequency;
       estimateFreqOffset = Math.floor(estimateFreqOffset);
       forwardNode.unrollOnlyEvenFrequencyOffsets = estimateFreqOffset % 2;
       backwardNode.unrollOnlyEvenFrequencyOffsets = 1;
@@ -499,10 +500,12 @@ export class Sg6TrackService implements OnDestroy {
     if (!item.backward && item.index === minIndexEndNode) {
       // forward starting node (case 1)
       const forwardNode = item;
-      const backwardNodes = trainrun.sgTrainrunItems
-        .filter((el) => el.backward && el.index === item.index);
+      const backwardNodes = trainrun.sgTrainrunItems.filter(
+        (el) => el.backward && el.index === item.index,
+      );
       if (backwardNodes.length > 0) {
-        const backwardNode = backwardNodes[backwardNodes.length - 1].getTrainrunNode();
+        const backwardNode =
+          backwardNodes[backwardNodes.length - 1].getTrainrunNode();
         this.transformUmlaufNodePair(
           forwardNode,
           backwardNode,
@@ -516,8 +519,9 @@ export class Sg6TrackService implements OnDestroy {
     if (item.backward && item.index !== minIndexEndNode) {
       // backward starting node (case 2)
       const backwardNode = item;
-      const forwardNodes = trainrun.sgTrainrunItems
-        .filter((el) => !el.backward && el.index === item.index);
+      const forwardNodes = trainrun.sgTrainrunItems.filter(
+        (el) => !el.backward && el.index === item.index,
+      );
 
       if (forwardNodes.length > 0) {
         const forwardNode = forwardNodes[0].getTrainrunNode();
@@ -1184,8 +1188,8 @@ export class Sg6TrackService implements OnDestroy {
               ps.trackData.sectionTrackSegments = convertedTrackSegments;
               maxTrackMap.set(
                 pathItem.getTrainrunSection().departureNodeId +
-                ":" +
-                pathItem.getTrainrunSection().arrivalNodeId,
+                  ":" +
+                  pathItem.getTrainrunSection().arrivalNodeId,
                 ps.trackData,
               );
             }
@@ -1209,8 +1213,8 @@ export class Sg6TrackService implements OnDestroy {
         if (path.isSection()) {
           if (
             path.getPathSection().arrivalNodeId +
-            ":" +
-            path.getPathSection().departureNodeId ===
+              ":" +
+              path.getPathSection().departureNodeId ===
             key
           ) {
             path.getPathSection().trackData = trackData;
@@ -1253,6 +1257,5 @@ class PathNodeNeighbour {
     public trackNbr: number,
     public mainTrackIdx: number,
     public pathNodes: SgTrainrunNode[],
-  ) {
-  }
+  ) {}
 }

--- a/src/app/streckengrafik/services/streckengrafik.services.spec.ts
+++ b/src/app/streckengrafik/services/streckengrafik.services.spec.ts
@@ -114,7 +114,7 @@ describe("StreckengrafikServicesTests", () => {
       trainrunService,
       trainrunSectionService,
       nodeService,
-      filterService
+      filterService,
     );
 
     uiInteractionService = new UiInteractionService(
@@ -260,9 +260,9 @@ describe("StreckengrafikServicesTests", () => {
           [
             101,
             sgSelectedTrainrun.frequency -
-            (101 % sgSelectedTrainrun.frequency) +
-            Math.floor(101 / sgSelectedTrainrun.frequency) *
-            sgSelectedTrainrun.frequency,
+              (101 % sgSelectedTrainrun.frequency) +
+              Math.floor(101 / sgSelectedTrainrun.frequency) *
+                sgSelectedTrainrun.frequency,
           ],
         ];
         for (
@@ -478,10 +478,10 @@ describe("StreckengrafikServicesTests", () => {
         const trackSegments = section.trackData.sectionTrackSegments;
         expect(trackSegments.length).toBe(12);
         const trackSegDataTracks: number[] = [
-          4, 4, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2
+          4, 4, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
         ];
         const trackSegDataMinTracks: number[] = [
-          4, 3, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1
+          4, 3, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1,
         ];
         for (let idx = 0; idx < trackSegments.length; idx++) {
           expect(trackSegments[idx].nbrTracks).toBe(trackSegDataTracks[idx]);

--- a/src/app/utils/multi-select-node-graph.ts
+++ b/src/app/utils/multi-select-node-graph.ts
@@ -4,11 +4,12 @@ import {TrainrunSection} from "../models/trainrunsection.model";
 import {Node} from "../models/node.model";
 
 export class MultiSelectNodeGraph {
-
   private adjList = new Map();
 
-  constructor(readonly nodeService: NodeService,
-              readonly trainrunSectionService: TrainrunSectionService) {
+  constructor(
+    readonly nodeService: NodeService,
+    readonly trainrunSectionService: TrainrunSectionService,
+  ) {
     this.adjList = new Map();
   }
 
@@ -21,12 +22,12 @@ export class MultiSelectNodeGraph {
   }
 
   createAdjList(edgeList) {
-    edgeList.forEach(edge => {
+    edgeList.forEach((edge) => {
       this.addVertex(edge[0]);
       this.addVertex(edge[1]);
     });
 
-    edgeList.forEach(edge => {
+    edgeList.forEach((edge) => {
       this.addEdge(edge[0], edge[1]);
       this.addEdge(edge[1], edge[0]);
     });
@@ -60,7 +61,12 @@ export class MultiSelectNodeGraph {
     }
     for (const node of childrens) {
       if (!visited[node]) {
-        const result = this.getPath(node, end, {...visited}, Object.assign([], retPath));
+        const result = this.getPath(
+          node,
+          end,
+          {...visited},
+          Object.assign([], retPath),
+        );
         if (result.end) {
           return {path: result.path, end: true};
         }
@@ -69,32 +75,43 @@ export class MultiSelectNodeGraph {
     return {path: retPath, end: false};
   }
 
-
   convertNetzgrafikSubNodesToGraph(nodes: Node[]): any[] {
     const edgeList = [];
 
     // retrieve edges
     nodes.forEach((node1) => {
       nodes.forEach((node2) => {
-        const n1 = node1.getId() < node2.getId() ? node1.getId() : node2.getId();
-        const n2 = node1.getId() < node2.getId() ? node2.getId() : node1.getId();
-        const ts12 = this.trainrunSectionService.getTrainrunSections().filter((ts: TrainrunSection) =>
-          (ts.getSourceNodeId() === n1 && ts.getTargetNodeId() === n2)
-        );
+        const n1 =
+          node1.getId() < node2.getId() ? node1.getId() : node2.getId();
+        const n2 =
+          node1.getId() < node2.getId() ? node2.getId() : node1.getId();
+        const ts12 = this.trainrunSectionService
+          .getTrainrunSections()
+          .filter(
+            (ts: TrainrunSection) =>
+              ts.getSourceNodeId() === n1 && ts.getTargetNodeId() === n2,
+          );
         if (ts12.length > 0) {
           const meanTravelTime =
-            ts12.reduce((sum, obj) => sum + obj.getTravelTime(), 0) / ts12.length;
-          if (edgeList.find((a) => (a[0] === n1 && a[1] === n2)) === undefined) {
+            ts12.reduce((sum, obj) => sum + obj.getTravelTime(), 0) /
+            ts12.length;
+          if (edgeList.find((a) => a[0] === n1 && a[1] === n2) === undefined) {
             edgeList.push([n1, n2, meanTravelTime]);
           }
         } else {
-          const ts21 = this.trainrunSectionService.getTrainrunSections().filter((ts: TrainrunSection) =>
-            (ts.getSourceNodeId() === n2 && ts.getTargetNodeId() === n1)
-          );
+          const ts21 = this.trainrunSectionService
+            .getTrainrunSections()
+            .filter(
+              (ts: TrainrunSection) =>
+                ts.getSourceNodeId() === n2 && ts.getTargetNodeId() === n1,
+            );
           if (ts21.length > 0) {
             const meanTravelTime =
-              ts21.reduce((sum, obj) => sum + obj.getTravelTime(), 0) / ts21.length;
-            if (edgeList.find((a) => (a[0] === n2 && a[1] === n1)) === undefined) {
+              ts21.reduce((sum, obj) => sum + obj.getTravelTime(), 0) /
+              ts21.length;
+            if (
+              edgeList.find((a) => a[0] === n2 && a[1] === n1) === undefined
+            ) {
               edgeList.push([n2, n1, meanTravelTime]);
             }
           }
@@ -109,7 +126,7 @@ export class MultiSelectNodeGraph {
       ret.push({
         from: e[0],
         to: e[1],
-        meanTravelTime: e[2]
+        meanTravelTime: e[2],
       });
     });
     return ret;

--- a/src/app/utils/navigation-parameters.ts
+++ b/src/app/utils/navigation-parameters.ts
@@ -11,7 +11,9 @@ export class NavigationParameters {
   getProjectId(): number {
     const id = this.tryGetProjectId();
     if (!id) {
-      throw new Error($localize`:@@app.utils.navigation-parameters.no-project-id:No project ID available`);
+      throw new Error(
+        $localize`:@@app.utils.navigation-parameters.no-project-id:No project ID available`,
+      );
     }
     return id;
   }
@@ -24,7 +26,9 @@ export class NavigationParameters {
   getVariantId(): number {
     const id = this.tryGetVariantId();
     if (!id) {
-      throw new Error($localize`:@@app.utils.navigation-parameters.no-variant-id:No variant ID available`);
+      throw new Error(
+        $localize`:@@app.utils.navigation-parameters.no-variant-id:No variant ID available`,
+      );
     }
     return id;
   }
@@ -37,7 +41,9 @@ export class NavigationParameters {
   getVersionId(): number {
     const id = this.tryGetVersionId();
     if (!id) {
-      throw new Error($localize`:@@app.utils.navigation-parameters.no-version-id:No version ID available`);
+      throw new Error(
+        $localize`:@@app.utils.navigation-parameters.no-version-id:No version ID available`,
+      );
     }
     return id;
   }

--- a/src/app/view/card-grid/card/card.component.html
+++ b/src/app/view/card-grid/card/card.component.html
@@ -8,7 +8,14 @@
   <div *ngIf="subtitle" class="subtitle">
     {{ subtitle }}
   </div>
-  <a [attr.id]="getCardComponentRouterLinkId(route)" *ngIf="route" sbb-link [routerLink]="route"> {{ 'app.view.card-grid.card.open' | translate }} </a>
+  <a
+    [attr.id]="getCardComponentRouterLinkId(route)"
+    *ngIf="route"
+    sbb-link
+    [routerLink]="route"
+  >
+    {{ "app.view.card-grid.card.open" | translate }}
+  </a>
 </div>
 <div
   *ngIf="icon"

--- a/src/app/view/card-grid/card/card.component.ts
+++ b/src/app/view/card-grid/card/card.component.ts
@@ -27,8 +27,9 @@ export class CardComponent {
   actions?: Observable<SlotAction[]>;
 
   openLink(route: string | any[]) {
-    const element: HTMLElement =
-      document.getElementById(this.getCardComponentRouterLinkId(route)) as HTMLElement;
+    const element: HTMLElement = document.getElementById(
+      this.getCardComponentRouterLinkId(route),
+    ) as HTMLElement;
     if (element) {
       element.click();
     }

--- a/src/app/view/dialogs/filterable-labels-dialog/filterable-label-dialog.component.html
+++ b/src/app/view/dialogs/filterable-labels-dialog/filterable-label-dialog.component.html
@@ -1,6 +1,9 @@
 <div sbbDialogTitle>
   <ng-container>
-    {{ 'app.view.dialogs.filterable-labels-dialog.filterable-label-dialog-component.edit-filterable-labels' | translate:{ 'element': this.dialogTitle} }}
+    {{
+      "app.view.dialogs.filterable-labels-dialog.filterable-label-dialog-component.edit-filterable-labels"
+        | translate: {element: this.dialogTitle}
+    }}
   </ng-container>
 </div>
 <div sbbDialogContent sy>
@@ -12,7 +15,10 @@
     tabindex="-1"
     mode="icon"
     (click)="onTransferClicked()"
-    [title]="'app.view.dialogs.filterable-labels-dialog.filterable-label-dialog-component.transfer-to-all-visible' | translate"
+    [title]="
+      'app.view.dialogs.filterable-labels-dialog.filterable-label-dialog-component.transfer-to-all-visible'
+        | translate
+    "
   >
     <sbb-icon
       svgIcon="arrow-change-horizontal-medium"
@@ -26,7 +32,10 @@
     tabindex="-1"
     mode="icon"
     (click)="onDeleteClicked()"
-    [title]="'app.view.dialogs.filterable-labels-dialog.filterable-label-dialog-component.delete-from-all-visible' | translate"
+    [title]="
+      'app.view.dialogs.filterable-labels-dialog.filterable-label-dialog-component.delete-from-all-visible'
+        | translate
+    "
   >
     <sbb-icon
       svgIcon="trash-medium"

--- a/src/app/view/dialogs/filterable-labels-dialog/filterable-labels-form/filterable-label-form.component.html
+++ b/src/app/view/dialogs/filterable-labels-dialog/filterable-labels-form/filterable-label-form.component.html
@@ -9,8 +9,9 @@
       (keydown)="onKeydown($event)"
       placeholder="Name"
     />
-    <sbb-error *ngIf="model.getControl('name').errors?.required"
-      >{{ 'app.view.dialogs.filterable-labels-dialog.filterable-labels-form.mandatory-field' | translate }}</sbb-error
-    >
+    <sbb-error *ngIf="model.getControl('name').errors?.required">{{
+      "app.view.dialogs.filterable-labels-dialog.filterable-labels-form.mandatory-field"
+        | translate
+    }}</sbb-error>
   </sbb-form-field>
 </div>

--- a/src/app/view/dialogs/note-dialog/htmlEditor/html-editor.component.html
+++ b/src/app/view/dialogs/note-dialog/htmlEditor/html-editor.component.html
@@ -6,7 +6,9 @@
       class="ngx-html-editor-color trash {{ setClassedTag(undefined) }}"
       [style]="getColorStyle(undefined)"
       (click)="onRemoveColor()"
-      [title]="'app.view.dialogs.note-dialog.html-editor.reset-color' | translate"
+      [title]="
+        'app.view.dialogs.note-dialog.html-editor.reset-color' | translate
+      "
     >
       <sbb-icon svgIcon="trash-small"></sbb-icon>
     </button>
@@ -29,11 +31,13 @@
     cdkFocusInitial
     [editor]="editor"
     [formControl]="model.getControl('noteText')"
-    [placeholder]="'app.view.dialogs.note-dialog.html-editor.editor-placeholder' | translate"
+    [placeholder]="
+      'app.view.dialogs.note-dialog.html-editor.editor-placeholder' | translate
+    "
     (focusout)="onUpdate()"
     (keydown)="onKeydown($event)"
   ></ngx-editor>
-  <sbb-error *ngIf="model.getControl('noteText').errors?.required"
-    >{{ 'app.view.dialogs.note-dialog.html-editor.mandatory-field' | translate }}</sbb-error
-  >
+  <sbb-error *ngIf="model.getControl('noteText').errors?.required">{{
+    "app.view.dialogs.note-dialog.html-editor.mandatory-field" | translate
+  }}</sbb-error>
 </div>

--- a/src/app/view/dialogs/note-dialog/htmlEditor/html-editor.component.scss
+++ b/src/app/view/dialogs/note-dialog/htmlEditor/html-editor.component.scss
@@ -45,8 +45,8 @@
   flex-wrap: wrap;
   margin: 1px;
   background: var(--sbb-header-lean-background-color);
-  border-right: 1px solid  var(--sbb-header-lean-border-bottom-color);
-  border-bottom: 1px solid  var(--sbb-header-lean-border-bottom-color);
+  border-right: 1px solid var(--sbb-header-lean-border-bottom-color);
+  border-bottom: 1px solid var(--sbb-header-lean-border-bottom-color);
 }
 
 ::ng-deep button.ngx-html-editor-color {

--- a/src/app/view/dialogs/note-dialog/htmlEditor/html-editor.component.ts
+++ b/src/app/view/dialogs/note-dialog/htmlEditor/html-editor.component.ts
@@ -21,43 +21,91 @@ export class HtmlEditorComponent implements OnInit, OnDestroy {
     new HtmlEditorColor(
       $localize`:@@app.view.dialogs.note-dialog.html-editor.color-presets.ec.title:Use color of the color scheme for EC`,
       "EC",
-      "var(--" + StaticDomTags.PREFIX_COLOR_VARIABLE + "_EC_" + StaticDomTags.TAG_FOCUS.toUpperCase() + ")",
+      "var(--" +
+        StaticDomTags.PREFIX_COLOR_VARIABLE +
+        "_EC_" +
+        StaticDomTags.TAG_FOCUS.toUpperCase() +
+        ")",
     ),
     new HtmlEditorColor(
       $localize`:@@app.view.dialogs.note-dialog.html-editor.color-presets.ic.title:Use color of the color scheme for IC`,
       "IC",
-      "var(--" + StaticDomTags.PREFIX_COLOR_VARIABLE + "_IC_" + StaticDomTags.TAG_FOCUS.toUpperCase() + ")",
+      "var(--" +
+        StaticDomTags.PREFIX_COLOR_VARIABLE +
+        "_IC_" +
+        StaticDomTags.TAG_FOCUS.toUpperCase() +
+        ")",
     ),
     new HtmlEditorColor(
       $localize`:@@app.view.dialogs.note-dialog.html-editor.color-presets.ir.title:Use color of the color scheme for IR`,
       "IR",
-      "var(--" + StaticDomTags.PREFIX_COLOR_VARIABLE + "_IR_" + StaticDomTags.TAG_FOCUS.toUpperCase() + ")",
+      "var(--" +
+        StaticDomTags.PREFIX_COLOR_VARIABLE +
+        "_IR_" +
+        StaticDomTags.TAG_FOCUS.toUpperCase() +
+        ")",
     ),
     new HtmlEditorColor(
       $localize`:@@app.view.dialogs.note-dialog.html-editor.color-presets.re.title:Use color of the color scheme for RE`,
       "RE",
-      "var(--" + StaticDomTags.PREFIX_COLOR_VARIABLE + "_RE_" + StaticDomTags.TAG_FOCUS.toUpperCase() + ")",
+      "var(--" +
+        StaticDomTags.PREFIX_COLOR_VARIABLE +
+        "_RE_" +
+        StaticDomTags.TAG_FOCUS.toUpperCase() +
+        ")",
     ),
     new HtmlEditorColor(
       $localize`:@@app.view.dialogs.note-dialog.html-editor.color-presets.s.title:Use color of the color scheme for S`,
       "S",
-      "var(--" + StaticDomTags.PREFIX_COLOR_VARIABLE + "_S_" + StaticDomTags.TAG_FOCUS.toUpperCase() + ")",
+      "var(--" +
+        StaticDomTags.PREFIX_COLOR_VARIABLE +
+        "_S_" +
+        StaticDomTags.TAG_FOCUS.toUpperCase() +
+        ")",
     ),
     new HtmlEditorColor(
       $localize`:@@app.view.dialogs.note-dialog.html-editor.color-presets.gex.title:Use color of the color scheme for GEX`,
       "GEX",
-      "var(--" + StaticDomTags.PREFIX_COLOR_VARIABLE + "_GEX_" + StaticDomTags.TAG_FOCUS.toUpperCase() + ")",
+      "var(--" +
+        StaticDomTags.PREFIX_COLOR_VARIABLE +
+        "_GEX_" +
+        StaticDomTags.TAG_FOCUS.toUpperCase() +
+        ")",
     ),
     new HtmlEditorColor(
       $localize`:@@app.view.dialogs.note-dialog.html-editor.color-presets.g.title:Use color of the color scheme for G`,
       "G",
-      "var(--" + StaticDomTags.PREFIX_COLOR_VARIABLE + "_G_" + StaticDomTags.TAG_FOCUS.toUpperCase() + ")",
+      "var(--" +
+        StaticDomTags.PREFIX_COLOR_VARIABLE +
+        "_G_" +
+        StaticDomTags.TAG_FOCUS.toUpperCase() +
+        ")",
     ),
-    new HtmlEditorColor($localize`:@@app.view.dialogs.note-dialog.html-editor.color-presets.green.title:green`, "", "green"),
-    new HtmlEditorColor($localize`:@@app.view.dialogs.note-dialog.html-editor.color-presets.blue.title:blue`, "", "blue"),
-    new HtmlEditorColor($localize`:@@app.view.dialogs.note-dialog.html-editor.color-presets.magenta.title:magenta`, "", "magenta"),
-    new HtmlEditorColor($localize`:@@app.view.dialogs.note-dialog.html-editor.color-presets.red.title:red`, "", "red"),
-    new HtmlEditorColor($localize`:@@app.view.dialogs.note-dialog.html-editor.color-presets.warning.title:warning color`, "!", "var(--COLOR_Warning)"),
+    new HtmlEditorColor(
+      $localize`:@@app.view.dialogs.note-dialog.html-editor.color-presets.green.title:green`,
+      "",
+      "green",
+    ),
+    new HtmlEditorColor(
+      $localize`:@@app.view.dialogs.note-dialog.html-editor.color-presets.blue.title:blue`,
+      "",
+      "blue",
+    ),
+    new HtmlEditorColor(
+      $localize`:@@app.view.dialogs.note-dialog.html-editor.color-presets.magenta.title:magenta`,
+      "",
+      "magenta",
+    ),
+    new HtmlEditorColor(
+      $localize`:@@app.view.dialogs.note-dialog.html-editor.color-presets.red.title:red`,
+      "",
+      "red",
+    ),
+    new HtmlEditorColor(
+      $localize`:@@app.view.dialogs.note-dialog.html-editor.color-presets.warning.title:warning color`,
+      "!",
+      "var(--COLOR_Warning)",
+    ),
   ];
 
   updateSubscription: Subscription;
@@ -111,7 +159,9 @@ export class HtmlEditorComponent implements OnInit, OnDestroy {
       }
       return "opacity: 0.25";
     }
-    return "background: " + color.colorCode + "; color: var(--sbb-color-white);";
+    return (
+      "background: " + color.colorCode + "; color: var(--sbb-color-white);"
+    );
   }
 
   setClassedTag(color: HtmlEditorColor): string {

--- a/src/app/view/dialogs/note-dialog/note-dialog.component.html
+++ b/src/app/view/dialogs/note-dialog/note-dialog.component.html
@@ -14,14 +14,20 @@
     ></sbb-icon>
     <div class="NoteTabGrupe">
       <sbb-tab-group>
-        <sbb-tab [label]="'app.view.dialogs.note-dialog.note-tab' | translate" id="note-tab">
+        <sbb-tab
+          [label]="'app.view.dialogs.note-dialog.note-tab' | translate"
+          id="note-tab"
+        >
           <sbb-note-edit-element
             [noteDialogParameter]="data"
             (noteDeleted)="closeDialog()"
           ></sbb-note-edit-element>
         </sbb-tab>
         <sbb-tab
-          [label]="'app.view.dialogs.note-dialog.filterable-labels-tab' | translate" id="note-filterable-labels-tab"
+          [label]="
+            'app.view.dialogs.note-dialog.filterable-labels-tab' | translate
+          "
+          id="note-filterable-labels-tab"
           *ngIf="!disableBackend"
         >
           <sbb-note-filter-tab

--- a/src/app/view/dialogs/note-dialog/note-filter-tab/note-filter-tab.component.html
+++ b/src/app/view/dialogs/note-dialog/note-filter-tab/note-filter-tab.component.html
@@ -1,9 +1,9 @@
 <div sbbDialogContent class="EditNoteFilterableLabelsDialogTabContent">
-  <sbb-form-field class="sbb-form-field-long" [label]="'app.view.dialogs.note-dialog.note-filter-tab.labels' | translate">
-    <sbb-chip-list
-      [value]="noteLabels"
-      (focusout)="onLabelsFocusout()"
-    >
+  <sbb-form-field
+    class="sbb-form-field-long"
+    [label]="'app.view.dialogs.note-dialog.note-filter-tab.labels' | translate"
+  >
+    <sbb-chip-list [value]="noteLabels" (focusout)="onLabelsFocusout()">
       <sbb-chip
         *ngFor="let element of noteLabels"
         [value]="element"
@@ -13,7 +13,10 @@
       </sbb-chip>
       <input
         id="noteLabelsInput"
-        [placeholder]="'app.view.dialogs.note-dialog.note-filter-tab.label-placeholder' | translate"
+        [placeholder]="
+          'app.view.dialogs.note-dialog.note-filter-tab.label-placeholder'
+            | translate
+        "
         sbbChipInput
         cdkFocusInitial
         [sbbChipInputSeparatorKeyCodes]="separatorKeysCodes"

--- a/src/app/view/dialogs/note-dialog/note-filter-tab/note-filter-tab.component.ts
+++ b/src/app/view/dialogs/note-dialog/note-filter-tab/note-filter-tab.component.ts
@@ -49,9 +49,7 @@ export class NoteFilterTabComponent implements OnInit, OnDestroy {
     this.noteService.notes.pipe(takeUntil(this.destroyed)).subscribe(() => {
       this.updateNoteLabelsAutoCompleteOptions();
     });
-    this.noteService.notes
-    .pipe(takeUntil(this.destroyed))
-    .subscribe(() => {
+    this.noteService.notes.pipe(takeUntil(this.destroyed)).subscribe(() => {
       this.initializeWithCurrentNote();
     });
     this.updateNoteLabelsAutoCompleteOptions();
@@ -137,12 +135,11 @@ export class NoteFilterTabComponent implements OnInit, OnDestroy {
   private checkAndSetLabels() {
     if (
       this.noteLabels.length !== this.initialNoteLabels.length ||
-      !this.noteLabels.every((label, index) => label === this.initialNoteLabels[index])
+      !this.noteLabels.every(
+        (label, index) => label === this.initialNoteLabels[index],
+      )
     ) {
-      this.noteService.setLabels(
-        this.note.getId(),
-        this.noteLabels
-      );
+      this.noteService.setLabels(this.note.getId(), this.noteLabels);
       this.initialNoteLabels = [...this.noteLabels];
     }
   }

--- a/src/app/view/dialogs/note-dialog/note-form/note-form.component.html
+++ b/src/app/view/dialogs/note-dialog/note-form/note-form.component.html
@@ -1,4 +1,7 @@
-<sbb-form-field [label]="'app.view.dialogs.note-dialog.note-form.title' | translate" class="sbb-form-field-long">
+<sbb-form-field
+  [label]="'app.view.dialogs.note-dialog.note-form.title' | translate"
+  class="sbb-form-field-long"
+>
   <input
     type="text"
     sbbInput

--- a/src/app/view/dialogs/stammdaten-dialog/stammdaten-dialog.component.html
+++ b/src/app/view/dialogs/stammdaten-dialog/stammdaten-dialog.component.html
@@ -1,18 +1,24 @@
 <ng-template #stammdatenTemplate>
   <div>
     <div sbbDialogTitle>
-      <b>{{ 'app.view.dialogs.stammdaten-dialog.base-data' | translate }}</b>
+      <b>{{ "app.view.dialogs.stammdaten-dialog.base-data" | translate }}</b>
     </div>
     <div sbbDialogContent>
       <table sbb-table [dataSource]="dataSource">
         <ng-container sbbColumnDef="betriebspunkt">
-          <th sbb-header-cell *sbbHeaderCellDef>{{ 'app.view.dialogs.stammdaten-dialog.operationalPoint' | translate }}</th>
+          <th sbb-header-cell *sbbHeaderCellDef>
+            {{
+              "app.view.dialogs.stammdaten-dialog.operationalPoint" | translate
+            }}
+          </th>
           <td sbb-cell *sbbCellDef="let element">
             {{ element.betriebspunkt }}
           </td>
         </ng-container>
         <ng-container sbbColumnDef="haltezeit_I_P_V">
-          <th sbb-header-cell *sbbHeaderCellDef>{{ 'app.view.dialogs.stammdaten-dialog.ipv-stop-time' | translate }}</th>
+          <th sbb-header-cell *sbbHeaderCellDef>
+            {{ "app.view.dialogs.stammdaten-dialog.ipv-stop-time" | translate }}
+          </th>
           <td sbb-cell *sbbCellDef="let element">
             <div *ngIf="!element['HaltezeitIPV'].no_halt; else noHalt">
               {{ element["HaltezeitIPV"].haltezeit }}
@@ -21,7 +27,9 @@
           </td>
         </ng-container>
         <ng-container sbbColumnDef="haltezeit_A">
-          <th sbb-header-cell *sbbHeaderCellDef>{{ 'app.view.dialogs.stammdaten-dialog.a-stop-time' | translate }}</th>
+          <th sbb-header-cell *sbbHeaderCellDef>
+            {{ "app.view.dialogs.stammdaten-dialog.a-stop-time" | translate }}
+          </th>
           <td sbb-cell *sbbCellDef="let element">
             <div *ngIf="!element['HaltezeitA'].no_halt; else noHalt">
               {{ element["HaltezeitA"].haltezeit }}
@@ -30,7 +38,9 @@
           </td>
         </ng-container>
         <ng-container sbbColumnDef="haltezeit_B">
-          <th sbb-header-cell *sbbHeaderCellDef>{{ 'app.view.dialogs.stammdaten-dialog.b-stop-time' | translate }}</th>
+          <th sbb-header-cell *sbbHeaderCellDef>
+            {{ "app.view.dialogs.stammdaten-dialog.b-stop-time" | translate }}
+          </th>
           <td sbb-cell *sbbCellDef="let element">
             <div *ngIf="!element['HaltezeitB'].no_halt; else noHalt">
               {{ element["HaltezeitB"].haltezeit }}
@@ -39,7 +49,9 @@
           </td>
         </ng-container>
         <ng-container sbbColumnDef="haltezeit_C">
-          <th sbb-header-cell *sbbHeaderCellDef>{{ 'app.view.dialogs.stammdaten-dialog.c-stop-time' | translate }}</th>
+          <th sbb-header-cell *sbbHeaderCellDef>
+            {{ "app.view.dialogs.stammdaten-dialog.c-stop-time" | translate }}
+          </th>
           <td sbb-cell *sbbCellDef="let element">
             <div *ngIf="!element['HaltezeitC'].no_halt; else noHalt">
               {{ element["HaltezeitC"].haltezeit }}
@@ -48,7 +60,9 @@
           </td>
         </ng-container>
         <ng-container sbbColumnDef="haltezeit_D">
-          <th sbb-header-cell *sbbHeaderCellDef>{{ 'app.view.dialogs.stammdaten-dialog.d-stop-time' | translate }}</th>
+          <th sbb-header-cell *sbbHeaderCellDef>
+            {{ "app.view.dialogs.stammdaten-dialog.d-stop-time" | translate }}
+          </th>
           <td sbb-cell *sbbCellDef="let element">
             <div *ngIf="!element['HaltezeitD'].no_halt; else noHalt">
               {{ element["HaltezeitD"].haltezeit }}
@@ -57,7 +71,9 @@
           </td>
         </ng-container>
         <ng-container sbbColumnDef="zaz">
-          <th sbb-header-cell *sbbHeaderCellDef>{{ 'app.view.dialogs.stammdaten-dialog.zaz' | translate }}</th>
+          <th sbb-header-cell *sbbHeaderCellDef>
+            {{ "app.view.dialogs.stammdaten-dialog.zaz" | translate }}
+          </th>
           <td sbb-cell *sbbCellDef="let element">
             <div *ngIf="element.zaz !== 0; else noZAZ">
               {{ element.zaz }}
@@ -66,7 +82,11 @@
           </td>
         </ng-container>
         <ng-container sbbColumnDef="connection_time">
-          <th sbb-header-cell *sbbHeaderCellDef>{{ 'app.view.dialogs.stammdaten-dialog.connection-time' | translate }}</th>
+          <th sbb-header-cell *sbbHeaderCellDef>
+            {{
+              "app.view.dialogs.stammdaten-dialog.connection-time" | translate
+            }}
+          </th>
           <td sbb-cell *sbbCellDef="let element">
             <div *ngIf="element.connection_time !== 0; else noHalt">
               {{ element.connection_time }}
@@ -75,7 +95,9 @@
           </td>
         </ng-container>
         <ng-container sbbColumnDef="region">
-          <th sbb-header-cell *sbbHeaderCellDef>{{ 'app.view.dialogs.stammdaten-dialog.region' | translate }}</th>
+          <th sbb-header-cell *sbbHeaderCellDef>
+            {{ "app.view.dialogs.stammdaten-dialog.region" | translate }}
+          </th>
           <td sbb-cell *sbbCellDef="let element">
             <div *ngIf="element.region !== ''; else noRegion">
               {{ element.region }}
@@ -84,7 +106,9 @@
           </td>
         </ng-container>
         <ng-container sbbColumnDef="kategorie">
-          <th sbb-header-cell *sbbHeaderCellDef>{{ 'app.view.dialogs.stammdaten-dialog.category' | translate }}</th>
+          <th sbb-header-cell *sbbHeaderCellDef>
+            {{ "app.view.dialogs.stammdaten-dialog.category" | translate }}
+          </th>
           <td sbb-cell *sbbCellDef="let element">
             <div *ngIf="element.kategorie !== ''; else noKategorie">
               {{ element.kategorie }}
@@ -93,7 +117,11 @@
           </td>
         </ng-container>
         <ng-container sbbColumnDef="filterableLabels">
-          <th sbb-header-cell *sbbHeaderCellDef>{{ 'app.view.dialogs.stammdaten-dialog.filterable-labels' | translate }}</th>
+          <th sbb-header-cell *sbbHeaderCellDef>
+            {{
+              "app.view.dialogs.stammdaten-dialog.filterable-labels" | translate
+            }}
+          </th>
           <td sbb-cell *sbbCellDef="let element">
             <div *ngIf="element.filterableLabels.length !== 0; else noLabels">
               {{ element.filterableLabels }}
@@ -102,7 +130,9 @@
           </td>
         </ng-container>
         <ng-container sbbColumnDef="pos">
-          <th sbb-header-cell *sbbHeaderCellDef>{{ 'app.view.dialogs.stammdaten-dialog.position' | translate }}</th>
+          <th sbb-header-cell *sbbHeaderCellDef>
+            {{ "app.view.dialogs.stammdaten-dialog.position" | translate }}
+          </th>
           <td sbb-cell *sbbCellDef="let element">
             <div *ngIf="element.pos !== undefined; else noPos">
               {{ element.pos.getX() }} <br />
@@ -118,7 +148,7 @@
     </div>
     <div sbbDialogActions>
       <button sbb-alt-button sbbDialogClose [sbbDialogClose]="false">
-        {{ 'app.view.dialogs.stammdaten-dialog.close' | translate }}
+        {{ "app.view.dialogs.stammdaten-dialog.close" | translate }}
       </button>
     </div>
   </div>

--- a/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-and-section-dialog.component.html
+++ b/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-and-section-dialog.component.html
@@ -34,8 +34,13 @@
             [trainrunDialogParameter]="data"
           ></sbb-trainrunsection-tab>
         </sbb-tab>
-        <sbb-tab [label]="'app.view.dialogs.trainrun-and-section-dialog.filterableLabels' | translate"
-                 id="trainrun-filterable-labels-tab">
+        <sbb-tab
+          [label]="
+            'app.view.dialogs.trainrun-and-section-dialog.filterableLabels'
+              | translate
+          "
+          id="trainrun-filterable-labels-tab"
+        >
           <sbb-trainrun-filter-tab
             (trainrunDeleted)="closeDialog()"
           ></sbb-trainrun-filter-tab>

--- a/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-filter-tab/trainrun-filter-tab.component.html
+++ b/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-filter-tab/trainrun-filter-tab.component.html
@@ -1,9 +1,12 @@
 <div sbbDialogContent [class]="getContentClassTag()">
-  <sbb-form-field class="sbb-form-field-long" [label]="'app.view.dialogs.trainrun-and-section-dialog.trainrun-filter-tab.labels' | translate">
-    <sbb-chip-list
-      [value]="trainrunLabels"
-      (focusout)="onLabelsFocusout()"
-    >
+  <sbb-form-field
+    class="sbb-form-field-long"
+    [label]="
+      'app.view.dialogs.trainrun-and-section-dialog.trainrun-filter-tab.labels'
+        | translate
+    "
+  >
+    <sbb-chip-list [value]="trainrunLabels" (focusout)="onLabelsFocusout()">
       <sbb-chip
         *ngFor="let element of trainrunLabels"
         [value]="element"
@@ -13,7 +16,10 @@
       </sbb-chip>
       <input
         id="trainrunLabelsInput"
-        [placeholder]="'app.view.dialogs.trainrun-and-section-dialog.trainrun-filter-tab.newLabels' | translate"
+        [placeholder]="
+          'app.view.dialogs.trainrun-and-section-dialog.trainrun-filter-tab.newLabels'
+            | translate
+        "
         sbbChipInput
         cdkFocusInitial
         [sbbChipInputSeparatorKeyCodes]="separatorKeysCodes"
@@ -35,7 +41,10 @@
     class="FunctionButton"
     tabindex="-1"
     (click)="onDuplicateTrainrun()"
-    [title]="'app.view.dialogs.trainrun-and-section-dialog.trainrun-tab.trainrunDuplicate' | translate"
+    [title]="
+      'app.view.dialogs.trainrun-and-section-dialog.trainrun-tab.trainrunDuplicate'
+        | translate
+    "
   >
     <sbb-icon svgIcon="plus-medium" aria-hidden="false"></sbb-icon>
   </button>
@@ -43,7 +52,10 @@
     class="FunctionButton"
     tabindex="-1"
     (click)="onDeleteTrainrun()"
-    [title]="'app.view.dialogs.trainrun-and-section-dialog.trainrun-tab.trainrunDelete' | translate"
+    [title]="
+      'app.view.dialogs.trainrun-and-section-dialog.trainrun-tab.trainrunDelete'
+        | translate
+    "
   >
     <sbb-icon svgIcon="trash-medium" aria-hidden="false"></sbb-icon>
   </button>

--- a/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-filter-tab/trainrun-filter-tab.component.ts
+++ b/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-filter-tab/trainrun-filter-tab.component.ts
@@ -71,9 +71,9 @@ export class TrainrunFilterTabComponent implements OnInit, OnDestroy {
     this.destroyed.complete();
   }
 
-  getContentClassTag() : string {
+  getContentClassTag(): string {
     const retVal = "EditTrainrunFilterableLabelsDialogTabContent";
-    if (this.versionControlService.getVariantIsWritable()){
+    if (this.versionControlService.getVariantIsWritable()) {
       return retVal;
     }
     return retVal + " readonly";
@@ -86,7 +86,6 @@ export class TrainrunFilterTabComponent implements OnInit, OnDestroy {
     }
     return retVal + " readonly";
   }
-
 
   remove(chipEvent: SbbChipEvent): void {
     const valueDelete = chipEvent.chip.value as string;
@@ -134,7 +133,9 @@ export class TrainrunFilterTabComponent implements OnInit, OnDestroy {
   }
 
   onDuplicateTrainrun() {
-    this.trainrunService.duplicateTrainrunAndSections(this.selectedTrainrun.getId());
+    this.trainrunService.duplicateTrainrunAndSections(
+      this.selectedTrainrun.getId(),
+    );
     this.initializeWithCurrentSelectedTrainrun();
   }
 
@@ -178,11 +179,13 @@ export class TrainrunFilterTabComponent implements OnInit, OnDestroy {
   private checkAndSetLabels() {
     if (
       this.trainrunLabels.length !== this.initialTrainrunLabels.length ||
-      !this.trainrunLabels.every((label, index) => label === this.initialTrainrunLabels[index])
+      !this.trainrunLabels.every(
+        (label, index) => label === this.initialTrainrunLabels[index],
+      )
     ) {
       this.trainrunService.setLabels(
         this.selectedTrainrun.getId(),
-        this.trainrunLabels
+        this.trainrunLabels,
       );
       this.initialTrainrunLabels = [...this.trainrunLabels];
     }

--- a/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-tab/trainrun-tab.component.html
+++ b/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-tab/trainrun-tab.component.html
@@ -1,5 +1,11 @@
 <div sbbDialogContent [class]="getContentClassTag()">
-  <sbb-form-field [label]="'app.view.dialogs.trainrun-and-section-dialog.trainrun-tab.tabName' | translate" class="sbb-form-field-long">
+  <sbb-form-field
+    [label]="
+      'app.view.dialogs.trainrun-and-section-dialog.trainrun-tab.tabName'
+        | translate
+    "
+    class="sbb-form-field-long"
+  >
     <input
       id="trainrunTitleField"
       type="text"
@@ -13,7 +19,10 @@
       (change)="onTrainrunTitleChanged()"
     />
   </sbb-form-field>
-  <sbb-label>{{ 'app.view.dialogs.trainrun-and-section-dialog.trainrun-tab.category' | translate }}</sbb-label>
+  <sbb-label>{{
+    "app.view.dialogs.trainrun-and-section-dialog.trainrun-tab.category"
+      | translate
+  }}</sbb-label>
   <div class="sbb-trainrun-chip-group">
     <button
       [class]="getCategoryClassname(trainrunCategory)"
@@ -27,7 +36,10 @@
   </div>
   <div class="row">
     <div class="column" style="float: left; width: auto">
-      <sbb-label>{{ 'app.view.dialogs.trainrun-and-section-dialog.trainrun-tab.frequency' | translate }}</sbb-label>
+      <sbb-label>{{
+        "app.view.dialogs.trainrun-and-section-dialog.trainrun-tab.frequency"
+          | translate
+      }}</sbb-label>
       <div class="sbb-trainrun-chip-group">
         <button
           [class]="getFrequencyClassname(trainrunFrequency)"
@@ -41,7 +53,10 @@
       </div>
     </div>
     <div class="column" style="float: left; width: 150px">
-      <sbb-label>{{ 'app.view.dialogs.trainrun-and-section-dialog.trainrun-tab.verkehrt' | translate }}</sbb-label>
+      <sbb-label>{{
+        "app.view.dialogs.trainrun-and-section-dialog.trainrun-tab.verkehrt"
+          | translate
+      }}</sbb-label>
       <div class="sbb-trainrun-chip-group">
         <button
           [class]="getTimeCategoryClassname(trainrunTimeCategory)"
@@ -64,7 +79,10 @@
       class="FunctionButton"
       tabindex="-1"
       (click)="onDuplicateTrainrun()"
-      [title]="'app.view.dialogs.trainrun-and-section-dialog.trainrun-tab.trainrunDuplicate' | translate "
+      [title]="
+        'app.view.dialogs.trainrun-and-section-dialog.trainrun-tab.trainrunDuplicate'
+          | translate
+      "
     >
       <sbb-icon svgIcon="plus-medium" aria-hidden="false"></sbb-icon>
     </button>
@@ -72,7 +90,10 @@
       class="FunctionButton"
       tabindex="-1"
       (click)="onDeleteTrainrun()"
-      [title]="'app.view.dialogs.trainrun-and-section-dialog.trainrun-tab.trainrunDelete' | translate"
+      [title]="
+        'app.view.dialogs.trainrun-and-section-dialog.trainrun-tab.trainrunDelete'
+          | translate
+      "
     >
       <sbb-icon svgIcon="trash-medium" aria-hidden="false"></sbb-icon>
     </button>

--- a/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-tab/trainrun-tab.component.scss
+++ b/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-tab/trainrun-tab.component.scss
@@ -28,15 +28,14 @@
   border-radius: 16px;
   background-color: $COLOR_BACKGROUND;
 
-
   opacity: var(--Button_TrainrunDialog_opacity);
 
   &.FilterableLabel {
-    opacity: 1.0;
+    opacity: 1;
   }
 
   &.EditorToolButton {
-    opacity: 1.0;
+    opacity: 1;
     border: none;
   }
 
@@ -45,7 +44,7 @@
     background-color: white;
     border-color: $COLOR_Focus;
 
-    opacity: 1.0;
+    opacity: 1;
   }
 }
 
@@ -73,28 +72,28 @@
   color: var(--NODE_TEXT_FOCUS);
   background-color: var(--NODE_COLOR_BACKGROUND);
   border-color: transparent;
-  opacity: 1.0;
+  opacity: 1;
 }
 
 ::ng-deep button.Frequency.selected {
   color: white;
   background-color: $COLOR_Default;
   border-color: transparent;
-  opacity: 1.0;
+  opacity: 1;
 }
 
 ::ng-deep button.TimeCategory {
   color: var(--NODE_TEXT_FOCUS);
   background-color: var(--NODE_COLOR_BACKGROUND);
   border-color: transparent;
-  opacity: 1.0;
+  opacity: 1;
 }
 
 ::ng-deep button.TimeCategory.selected {
   color: white;
   background-color: $COLOR_Default;
   border-color: transparent;
-  opacity: 1.0;
+  opacity: 1;
 }
 
 ::ng-deep div.EditTrainrunDialogTabContent {
@@ -113,7 +112,6 @@
   padding: 0px;
   min-height: 270px;
 }
-
 
 ::ng-deep div.EditTrainrunDialogTabContent.readonly {
   pointer-events: none;

--- a/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-tab/trainrun-tab.component.ts
+++ b/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-tab/trainrun-tab.component.ts
@@ -56,7 +56,8 @@ export class TrainrunTabComponent implements OnDestroy {
   }
 
   getContentClassTag(): string {
-    const readonlyTag: string = this.versionControlService.getVariantIsWritable() ? " " : " readonly";
+    const readonlyTag: string =
+      this.versionControlService.getVariantIsWritable() ? " " : " readonly";
     if (this.isIntegratedComponent) {
       return "EditTrainrunDialogTabContent IntegratedComponent" + readonlyTag;
     }
@@ -70,7 +71,6 @@ export class TrainrunTabComponent implements OnDestroy {
     }
     return retVal + " readonly";
   }
-
 
   getFrequencyClassname(trainrunFrequency: TrainrunFrequency): string {
     if (trainrunFrequency.id === this.selectedFrequency.id) {
@@ -192,7 +192,9 @@ export class TrainrunTabComponent implements OnDestroy {
   }
 
   onDuplicateTrainrun() {
-    this.trainrunService.duplicateTrainrunAndSections(this.selectedTrainrun.getId());
+    this.trainrunService.duplicateTrainrunAndSections(
+      this.selectedTrainrun.getId(),
+    );
     this.initializeWithCurrentSelectedTrainrun();
   }
 

--- a/src/app/view/dialogs/trainrun-and-section-dialog/trainrunsection-tab/trainrun-section-tab.component.html
+++ b/src/app/view/dialogs/trainrun-and-section-dialog/trainrunsection-tab/trainrun-section-tab.component.html
@@ -473,7 +473,10 @@
     *ngIf="trainrunSectionTimesService.getShowWarningTwoLocks() === true"
     disabled
   >
-    {{ 'app.view.dialogs.trainrun-and-section-dialog.trainrun-section-tab.warningTwoLocks' | translate }}
+    {{
+      "app.view.dialogs.trainrun-and-section-dialog.trainrun-section-tab.warningTwoLocks"
+        | translate
+    }}
   </button>
   <button
     class="FunctionButton"
@@ -482,7 +485,10 @@
     (click)="
       trainrunSectionTimesService.onPropagateTimeLeft(selectedTrainrunSection)
     "
-    [title]="'app.view.dialogs.trainrun-and-section-dialog.trainrun-section-tab.propagateTimesToLeft' | translate"
+    [title]="
+      'app.view.dialogs.trainrun-and-section-dialog.trainrun-section-tab.propagateTimesToLeft'
+        | translate
+    "
   >
     <sbb-icon
       svgIcon="arrow-long-left-medium"
@@ -498,7 +504,10 @@
     (click)="
       trainrunSectionTimesService.onPropagateTimeRight(selectedTrainrunSection)
     "
-    [title]="'app.view.dialogs.trainrun-and-section-dialog.trainrun-section-tab.propagateTimesToRight' | translate"
+    [title]="
+      'app.view.dialogs.trainrun-and-section-dialog.trainrun-section-tab.propagateTimesToRight'
+        | translate
+    "
   >
     <sbb-icon
       svgIcon="arrow-long-right-medium"

--- a/src/app/view/dialogs/trainrun-and-section-dialog/trainrunsection-tab/trainrun-section-tab.component.scss
+++ b/src/app/view/dialogs/trainrun-and-section-dialog/trainrunsection-tab/trainrun-section-tab.component.scss
@@ -337,7 +337,7 @@ input.NumberOfStopsInputElement.IsActive {
 }
 
 ::ng-deep button.warning {
-  background-color: var(--sbb-header-lean-background-color);;
+  background-color: var(--sbb-header-lean-background-color);
   border: none;
   color: $COLOR_Warning;
   text-align: center;
@@ -392,7 +392,7 @@ input.NumberOfStopsInputElement.IsActive {
 }
 
 ::ng-deep
-div.sbb-dialog-content.sbb-scrollbar.EditTrainrunSectionDialogTabContent {
+  div.sbb-dialog-content.sbb-scrollbar.EditTrainrunSectionDialogTabContent {
   border-style: none;
   min-height: 250px;
   max-height: 250px;
@@ -406,7 +406,6 @@ div.sbb-dialog-content.sbb-scrollbar.EditTrainrunSectionDialogTabContent {
   max-height: 48px;
   min-height: 48px;
 }
-
 
 ::ng-deep div.EditTrainrunSectionDialogTabContent.readonly {
   pointer-events: none;

--- a/src/app/view/dialogs/trainrun-and-section-dialog/trainrunsection-tab/trainrun-section-tab.component.ts
+++ b/src/app/view/dialogs/trainrun-and-section-dialog/trainrunsection-tab/trainrun-section-tab.component.ts
@@ -22,9 +22,7 @@ import {Subject} from "rxjs";
 import {LinePatternRefs} from "../../../../data-structures/business.data.structures";
 import {StaticDomTags} from "../../../editor-main-view/data-views/static.dom.tags";
 import {ColorRefType} from "../../../../data-structures/technical.data.structures";
-import {
-  TrainrunSectionTimesService
-} from "../../../../services/data/trainrun-section-times.service";
+import {TrainrunSectionTimesService} from "../../../../services/data/trainrun-section-times.service";
 import {VersionControlService} from "../../../../services/data/version-control.service";
 
 export interface LeftAndRightTimeStructure {
@@ -76,7 +74,6 @@ export class TrainrunSectionTabComponent implements AfterViewInit, OnDestroy {
   private trainrunSectionHelper: TrainrunsectionHelper;
   private destroyed = new Subject<void>();
 
-
   constructor(
     private dataService: DataService,
     private filterService: FilterService,
@@ -86,7 +83,6 @@ export class TrainrunSectionTabComponent implements AfterViewInit, OnDestroy {
     public trainrunSectionTimesService: TrainrunSectionTimesService,
     private versionControlService: VersionControlService,
   ) {
-
     this.trainrunSectionHelper = new TrainrunsectionHelper(
       this.trainrunService,
     );
@@ -98,9 +94,13 @@ export class TrainrunSectionTabComponent implements AfterViewInit, OnDestroy {
         this.resetOffsetAfterTrainrunChanged();
         this.updateAllValues();
       });
-    this.trainrunSectionService.trainrunSections.pipe(takeUntil(this.destroyed))
+    this.trainrunSectionService.trainrunSections
+      .pipe(takeUntil(this.destroyed))
       .subscribe(() => {
-        if (this.selectedTrainrunSection !== this.trainrunSectionService.getSelectedTrainrunSection()) {
+        if (
+          this.selectedTrainrunSection !==
+          this.trainrunSectionService.getSelectedTrainrunSection()
+        ) {
           this.resetOffsetAfterTrainrunChanged();
           this.updateAllValues();
         }
@@ -182,17 +182,17 @@ export class TrainrunSectionTabComponent implements AfterViewInit, OnDestroy {
     this.changeDetection.detectChanges();
   }
 
-  getContentClassTag() : string {
+  getContentClassTag(): string {
     const retVal: string = "EditTrainrunSectionDialogTabContent";
-    if (this.versionControlService.getVariantIsWritable()){
+    if (this.versionControlService.getVariantIsWritable()) {
       return retVal;
     }
     return retVal + " readonly";
   }
 
-  getContentFooterClassTag() : string {
+  getContentFooterClassTag(): string {
     const retVal: string = "EditTrainrunDialogTabFooter";
-    if (this.versionControlService.getVariantIsWritable()){
+    if (this.versionControlService.getVariantIsWritable()) {
       return retVal;
     }
     return retVal + " readonly";
@@ -329,7 +329,7 @@ export class TrainrunSectionTabComponent implements AfterViewInit, OnDestroy {
     if (this.trainrunDialogParameter.offset < 0) {
       this.trainrunSectionTimesService.setOffset(
         Math.ceil(Math.abs(this.trainrunDialogParameter.offset) / 60) * 60 -
-        Math.abs(this.trainrunDialogParameter.offset),
+          Math.abs(this.trainrunDialogParameter.offset),
       );
     } else {
       this.trainrunSectionTimesService.setOffset(

--- a/src/app/view/editor-edit-tools-view-component/editor-edit-tools-view.component.html
+++ b/src/app/view/editor-edit-tools-view-component/editor-edit-tools-view.component.html
@@ -1,27 +1,37 @@
-<h2 class="SummaryTitle">{{ 'app.view.editor-edit-tools-view-component.edit' | translate }}</h2>
+<h2 class="SummaryTitle">
+  {{ "app.view.editor-edit-tools-view-component.edit" | translate }}
+</h2>
 <sbb-accordion [multi]="false">
   <sbb-expansion-panel
     [expanded]="false"
     [hideToggle]="false"
     [disabled]="!getVariantIsWritable()"
   >
-    <sbb-expansion-panel-header>{{ 'app.view.editor-edit-tools-view-component.filterable-labels' | translate }}</sbb-expansion-panel-header>
+    <sbb-expansion-panel-header>{{
+      "app.view.editor-edit-tools-view-component.filterable-labels" | translate
+    }}</sbb-expansion-panel-header>
     <sbb-accordion [multi]="false">
       <sbb-expansion-panel [expanded]="true">
-        <sbb-expansion-panel-header>{{ 'app.view.editor-edit-tools-view-component.trainruns' | translate }}</sbb-expansion-panel-header>
+        <sbb-expansion-panel-header>{{
+          "app.view.editor-edit-tools-view-component.trainruns" | translate
+        }}</sbb-expansion-panel-header>
         <sbb-label-drop-list-component
           [componentLabelRef]="'Trainrun'"
         ></sbb-label-drop-list-component>
       </sbb-expansion-panel>
       <sbb-expansion-panel [expanded]="false">
-        <sbb-expansion-panel-header>{{ 'app.view.editor-edit-tools-view-component.nodes' | translate }}</sbb-expansion-panel-header>
+        <sbb-expansion-panel-header>{{
+          "app.view.editor-edit-tools-view-component.nodes" | translate
+        }}</sbb-expansion-panel-header>
         <sbb-label-drop-list-component
           [componentLabelRef]="'Node'"
         ></sbb-label-drop-list-component>
       </sbb-expansion-panel>
 
       <sbb-expansion-panel [expanded]="false" *ngIf="!disableBackend">
-        <sbb-expansion-panel-header>{{ 'app.view.editor-edit-tools-view-component.notes' | translate }}</sbb-expansion-panel-header>
+        <sbb-expansion-panel-header>{{
+          "app.view.editor-edit-tools-view-component.notes" | translate
+        }}</sbb-expansion-panel-header>
         <sbb-label-drop-list-component
           [componentLabelRef]="'Note'"
         ></sbb-label-drop-list-component>
@@ -31,8 +41,12 @@
 
   <sbb-expansion-panel
     [expanded]="getVariantIsWritable() && !getAreMultiObjectSelected()"
-    [disabled]="!getVariantIsWritable()">
-    <sbb-expansion-panel-header>{{ 'app.view.editor-edit-tools-view-component.delete-netzgrafik-title' | translate }}</sbb-expansion-panel-header>
+    [disabled]="!getVariantIsWritable()"
+  >
+    <sbb-expansion-panel-header>{{
+      "app.view.editor-edit-tools-view-component.delete-netzgrafik-title"
+        | translate
+    }}</sbb-expansion-panel-header>
 
     <ng-container
       *ngIf="
@@ -40,64 +54,100 @@
         !this.filterService.isTemporaryDisableFilteringOfItemsInViewEnabled()
       "
     >
-      <br/>
-      <sbb-label>{{ 'app.view.editor-edit-tools-view-component.non-visible-elements' | translate }}</sbb-label>
-      <br/>
+      <br />
+      <sbb-label>{{
+        "app.view.editor-edit-tools-view-component.non-visible-elements"
+          | translate
+      }}</sbb-label>
+      <br />
       <button
         (click)="onClearAllFiltered()"
-        [title]="'app.view.editor-edit-tools-view-component.delete-all-non-visible-elements-tooltip' | translate"
+        [title]="
+          'app.view.editor-edit-tools-view-component.delete-all-non-visible-elements-tooltip'
+            | translate
+        "
         class="TrainrunDialog EditorToolButton"
       >
         <sbb-icon svgIcon="bucket-foam-broom-small"></sbb-icon>
       </button>
-      {{ 'app.view.editor-edit-tools-view-component.delete-all-non-visible-elements' | translate }}
-      <br/>
+      {{
+        "app.view.editor-edit-tools-view-component.delete-all-non-visible-elements"
+          | translate
+      }}
+      <br />
     </ng-container>
-    <br/>
-    <sbb-label>{{ 'app.view.editor-edit-tools-view-component.visible-elements' | translate }}</sbb-label>
-    <br/>
+    <br />
+    <sbb-label>{{
+      "app.view.editor-edit-tools-view-component.visible-elements" | translate
+    }}</sbb-label>
+    <br />
     <button
       (click)="onClearAllTrainruns()"
-      [title]="'app.view.editor-edit-tools-view-component.delete-all-visible-trainruns-tooltip' | translate"
+      [title]="
+        'app.view.editor-edit-tools-view-component.delete-all-visible-trainruns-tooltip'
+          | translate
+      "
       class="TrainrunDialog EditorToolButton"
     >
       <sbb-icon svgIcon="trash-small"></sbb-icon>
     </button>
-    {{ 'app.view.editor-edit-tools-view-component.delete-all-visible-trainruns' | translate }}
-    <br/>
+    {{
+      "app.view.editor-edit-tools-view-component.delete-all-visible-trainruns"
+        | translate
+    }}
+    <br />
     <button
       (click)="onClearAllNotes()"
-      [title]="'app.view.editor-edit-tools-view-component.delete-all-visible-notes-tooltip' | translate"
+      [title]="
+        'app.view.editor-edit-tools-view-component.delete-all-visible-notes-tooltip'
+          | translate
+      "
       class="TrainrunDialog EditorToolButton"
     >
       <sbb-icon svgIcon="trash-small"></sbb-icon>
     </button>
-    {{ 'app.view.editor-edit-tools-view-component.delete-all-visible-notes' | translate }}
-    <br/>
+    {{
+      "app.view.editor-edit-tools-view-component.delete-all-visible-notes"
+        | translate
+    }}
+    <br />
     <button
       (click)="onClear()"
-      [title]="'app.view.editor-edit-tools-view-component.delete-all-visible-elements-tooltip' | translate"
+      [title]="
+        'app.view.editor-edit-tools-view-component.delete-all-visible-elements-tooltip'
+          | translate
+      "
       class="TrainrunDialog EditorToolButton"
     >
       <sbb-icon svgIcon="trash-small"></sbb-icon>
     </button>
-    {{ 'app.view.editor-edit-tools-view-component.delete-all-visible-elements' | translate }}
+    {{
+      "app.view.editor-edit-tools-view-component.delete-all-visible-elements"
+        | translate
+    }}
   </sbb-expansion-panel>
-  <sbb-expansion-panel
-    [expanded]="false"
-    [disabled]="!getVariantIsWritable()">
+  <sbb-expansion-panel [expanded]="false" [disabled]="!getVariantIsWritable()">
     <sbb-expansion-panel-header>
-      {{ 'app.view.editor-edit-tools-view-component.merge-netzgrafik-title' | translate }}
+      {{
+        "app.view.editor-edit-tools-view-component.merge-netzgrafik-title"
+          | translate
+      }}
     </sbb-expansion-panel-header>
-    <br/>
+    <br />
     <button
       (click)="onLoadNetzgrafikToInsertCopieButton()"
-      [title]="'app.view.editor-edit-tools-view-component.add-netzgrafik-as-copy-tooltip' | translate"
+      [title]="
+        'app.view.editor-edit-tools-view-component.add-netzgrafik-as-copy-tooltip'
+          | translate
+      "
       class="TrainrunDialog EditorToolButton"
     >
       <sbb-icon svgIcon="hierarchy-small"></sbb-icon>
     </button>
-    {{ 'app.view.editor-edit-tools-view-component.add-netzgrafik-as-copy' | translate }}
+    {{
+      "app.view.editor-edit-tools-view-component.add-netzgrafik-as-copy"
+        | translate
+    }}
     <input
       hidden
       #netzgrafikMergeAsACopyFileInput
@@ -106,15 +156,20 @@
       (change)="onLoadNetzgrafikToMergeAsACopy($event)"
     />
 
-    <br/>
+    <br />
     <button
       (click)="onLoadNetzgrafikToMergeButton()"
-      [title]="'app.view.editor-edit-tools-view-component.merge-netzgrafik-tooltip' | translate"
+      [title]="
+        'app.view.editor-edit-tools-view-component.merge-netzgrafik-tooltip'
+          | translate
+      "
       class="TrainrunDialog EditorToolButton"
     >
       <sbb-icon svgIcon="hierarchy-small"></sbb-icon>
     </button>
-    {{ 'app.view.editor-edit-tools-view-component.merge-netzgrafik' | translate }}
+    {{
+      "app.view.editor-edit-tools-view-component.merge-netzgrafik" | translate
+    }}
     <input
       hidden
       #netzgrafikMergeFileInput
@@ -124,56 +179,79 @@
     />
   </sbb-expansion-panel>
 
-
   <sbb-expansion-panel
     *ngIf="getAreMultiObjectSelected()"
-    [expanded]="getAreMultiObjectSelected()">
+    [expanded]="getAreMultiObjectSelected()"
+  >
     <sbb-expansion-panel-header>
       <label style="color: red">
-        {{ 'app.view.editor-edit-tools-view-component.align-elements-netzgrafik-title' | translate }}
+        {{
+          "app.view.editor-edit-tools-view-component.align-elements-netzgrafik-title"
+            | translate
+        }}
       </label>
     </sbb-expansion-panel-header>
-    <br/>
+    <br />
     <button
       (click)="onAlignElementsLeft()"
-      [title]="'app.view.editor-edit-tools-view-component.align-elements-left' | translate"
+      [title]="
+        'app.view.editor-edit-tools-view-component.align-elements-left'
+          | translate
+      "
       class="TrainrunDialog EditorToolButton"
     >
       <sbb-icon svgIcon="arrow-left-small"></sbb-icon>
     </button>
-    {{ 'app.view.editor-edit-tools-view-component.align-elements-left' | translate }}
+    {{
+      "app.view.editor-edit-tools-view-component.align-elements-left"
+        | translate
+    }}
 
-    <br/>
+    <br />
     <button
       (click)="onAlignElementsRight()"
-      [title]="'app.view.editor-edit-tools-view-component.align-elements-right' | translate"
+      [title]="
+        'app.view.editor-edit-tools-view-component.align-elements-right'
+          | translate
+      "
       class="TrainrunDialog EditorToolButton"
     >
       <sbb-icon svgIcon="arrow-right-small"></sbb-icon>
     </button>
-    {{ 'app.view.editor-edit-tools-view-component.align-elements-right' | translate }}
+    {{
+      "app.view.editor-edit-tools-view-component.align-elements-right"
+        | translate
+    }}
 
-    <br/>
+    <br />
     <button
       (click)="onAlignElementsTop()"
-      [title]="'app.view.editor-edit-tools-view-component.align-elements-top' | translate"
+      [title]="
+        'app.view.editor-edit-tools-view-component.align-elements-top'
+          | translate
+      "
       class="TrainrunDialog EditorToolButton"
     >
       <sbb-icon svgIcon="arrow-up-small"></sbb-icon>
     </button>
-    {{ 'app.view.editor-edit-tools-view-component.align-elements-top' | translate }}
+    {{
+      "app.view.editor-edit-tools-view-component.align-elements-top" | translate
+    }}
 
-    <br/>
+    <br />
     <button
       (click)="onAlignElementsBottom()"
-      [title]="'app.view.editor-edit-tools-view-component.align-elements-bottom' | translate"
+      [title]="
+        'app.view.editor-edit-tools-view-component.align-elements-bottom'
+          | translate
+      "
       class="TrainrunDialog EditorToolButton"
     >
       <sbb-icon svgIcon="arrow-down-small"></sbb-icon>
     </button>
-    {{ 'app.view.editor-edit-tools-view-component.align-elements-bottom' | translate }}
-
+    {{
+      "app.view.editor-edit-tools-view-component.align-elements-bottom"
+        | translate
+    }}
   </sbb-expansion-panel>
-
-
 </sbb-accordion>

--- a/src/app/view/editor-edit-tools-view-component/editor-edit-tools-view.component.ts
+++ b/src/app/view/editor-edit-tools-view-component/editor-edit-tools-view.component.ts
@@ -1,9 +1,7 @@
 import {Component, ElementRef, OnDestroy, ViewChild} from "@angular/core";
 import {DataService} from "../../services/data/data.service";
 import {UiInteractionService} from "../../services/ui/ui.interaction.service";
-import {
-  ConfirmationDialogParameter
-} from "../dialogs/confirmation-dialog/confirmation-dialog.component";
+import {ConfirmationDialogParameter} from "../dialogs/confirmation-dialog/confirmation-dialog.component";
 import {NodeService} from "../../services/data/node.service";
 import {TrainrunSectionService} from "../../services/data/trainrunsection.service";
 import {EditorMode} from "../editor-menu/editor-mode";
@@ -51,7 +49,7 @@ export class EditorEditToolsViewComponent implements OnDestroy {
     public filterService: FilterService,
     private uiInteractionService: UiInteractionService,
     private versionControlService: VersionControlService,
-    private positionTransformationService: PositionTransformationService
+    private positionTransformationService: PositionTransformationService,
   ) {
     this.nodeLabelGroups = this.labelGroupService.getLabelGroupsFromLabelRef(
       LabelRef.Node,
@@ -87,7 +85,9 @@ export class EditorEditToolsViewComponent implements OnDestroy {
   }
 
   getAreMultiObjectSelected(): boolean {
-    return this.uiInteractionService.getEditorMode() === EditorMode.MultiNodeMoving;
+    return (
+      this.uiInteractionService.getEditorMode() === EditorMode.MultiNodeMoving
+    );
   }
 
   onClearAllFiltered() {

--- a/src/app/view/editor-edit-tools-view-component/label-drop-list/label-drop-list.component.html
+++ b/src/app/view/editor-edit-tools-view-component/label-drop-list/label-drop-list.component.html
@@ -1,7 +1,10 @@
 <div *ngIf="hasNoFilterableLabels()">
   <sbb-label class="sbb-mt-m"
-    >&nbsp;&nbsp;&nbsp;&nbsp;{{ 'app.view.editor-edit-tools-view-component.label-drop-list.no-labels-available' | translate }} </sbb-label
-  >
+    >&nbsp;&nbsp;&nbsp;&nbsp;{{
+      "app.view.editor-edit-tools-view-component.label-drop-list.no-labels-available"
+        | translate
+    }}
+  </sbb-label>
 </div>
 <div *ngIf="!hasNoFilterableLabels()">
   <div cdkDropListGroup>
@@ -68,7 +71,10 @@
             <button
               class="filterable-label-grp-delete-add-button-button"
               (click)="onRemoveLabelGroup(labelGrp.getId())"
-              [title]="'app.view.editor-edit-tools-view-component.label-drop-list.delete-group' | translate"
+              [title]="
+                'app.view.editor-edit-tools-view-component.label-drop-list.delete-group'
+                  | translate
+              "
             >
               <sbb-icon
                 class="LabelAddGroupButton"
@@ -83,7 +89,10 @@
             <button
               class="filterable-label-grp-delete-add-button-button"
               (click)="onCreateNewLabelGroup(labelGrp.getId())"
-              [title]="'app.view.editor-edit-tools-view-component.label-drop-list.add-new-group' | translate"
+              [title]="
+                'app.view.editor-edit-tools-view-component.label-drop-list.add-new-group'
+                  | translate
+              "
             >
               <sbb-icon
                 class="LabelAddGroupButton"

--- a/src/app/view/editor-filter-view/editor-filter-view.component.html
+++ b/src/app/view/editor-filter-view/editor-filter-view.component.html
@@ -1,17 +1,23 @@
-<h2 class="SummaryTitle">{{ 'app.view.editor-filter-view.filter' | translate }}</h2>
+<h2 class="SummaryTitle">
+  {{ "app.view.editor-filter-view.filter" | translate }}
+</h2>
 
 <sbb-accordion [multi]="true">
   <sbb-expansion-panel [expanded]="true">
     <sbb-expansion-panel-header>
       <ng-container *ngIf="isTrainrunFilteringActive()">
-        {{ 'app.view.editor-filter-view.general' | translate }}
+        {{ "app.view.editor-filter-view.general" | translate }}
       </ng-container>
       <ng-container *ngIf="!isTrainrunFilteringActive()">
-        <label style="color: red">{{ 'app.view.editor-filter-view.general' | translate }}</label>
+        <label style="color: red">{{
+          "app.view.editor-filter-view.general" | translate
+        }}</label>
       </ng-container>
     </sbb-expansion-panel-header>
 
-    <sbb-label>{{ 'app.view.editor-filter-view.category' | translate }}</sbb-label>
+    <sbb-label>{{
+      "app.view.editor-filter-view.category" | translate
+    }}</sbb-label>
     <div class="sbb-trainrun-chip-group">
       <button
         [class]="getCategoryClassname(trainrunCategory)"
@@ -24,7 +30,9 @@
       </button>
     </div>
 
-    <sbb-label class="sbb-mt-m">{{ 'app.view.editor-filter-view.frequency' | translate }}</sbb-label>
+    <sbb-label class="sbb-mt-m">{{
+      "app.view.editor-filter-view.frequency" | translate
+    }}</sbb-label>
     <div class="sbb-trainrun-chip-group">
       <button
         [class]="getFrequencyClassname(trainrunFrequency)"
@@ -37,7 +45,9 @@
       </button>
     </div>
 
-    <sbb-label class="sbb-mt-m">{{ 'app.view.editor-filter-view.time-category' | translate }}</sbb-label>
+    <sbb-label class="sbb-mt-m">{{
+      "app.view.editor-filter-view.time-category" | translate
+    }}</sbb-label>
     <div class="sbb-trainrun-chip-group">
       <button
         [class]="getTimeCategoryClassname(trainrunTimeCategory)"
@@ -59,17 +69,21 @@
       [title]="'app.view.editor-filter-view.display-all-trainruns' | translate"
       (click)="onResetTrainrunFilter()"
     >
-      {{ 'app.view.editor-filter-view.reset-trainrun-filter' | translate }}
+      {{ "app.view.editor-filter-view.reset-trainrun-filter" | translate }}
     </button>
   </sbb-expansion-panel>
 
   <sbb-expansion-panel [expanded]="hasFilteringTrainrunLabels">
     <sbb-expansion-panel-header>
       <ng-container *ngIf="!isFilteringTrainrunLabels()">
-        {{ 'app.view.editor-filter-view.filterable-labels-trainruns' | translate }}
+        {{
+          "app.view.editor-filter-view.filterable-labels-trainruns" | translate
+        }}
       </ng-container>
       <ng-container *ngIf="isFilteringTrainrunLabels()">
-        <label style="color: red">{{ 'app.view.editor-filter-view.filterable-labels-trainruns' | translate }}</label>
+        <label style="color: red">{{
+          "app.view.editor-filter-view.filterable-labels-trainruns" | translate
+        }}</label>
       </ng-container>
     </sbb-expansion-panel-header>
 
@@ -81,10 +95,12 @@
   <sbb-expansion-panel [expanded]="hasFilteringNodeLabels">
     <sbb-expansion-panel-header>
       <ng-container *ngIf="!isFilteringNodeLabels()">
-        {{ 'app.view.editor-filter-view.filterable-labels-nodes' | translate }}
+        {{ "app.view.editor-filter-view.filterable-labels-nodes" | translate }}
       </ng-container>
       <ng-container *ngIf="isFilteringNodeLabels()">
-        <label style="color: red">{{ 'app.view.editor-filter-view.filterable-labels-nodes' | translate }}</label>
+        <label style="color: red">{{
+          "app.view.editor-filter-view.filterable-labels-nodes" | translate
+        }}</label>
       </ng-container>
     </sbb-expansion-panel-header>
 
@@ -93,13 +109,18 @@
     ></sbb-filterable-label-filter-view>
   </sbb-expansion-panel>
 
-  <sbb-expansion-panel [expanded]="hasFilteringNoteLabels" *ngIf="!disableBackend">
+  <sbb-expansion-panel
+    [expanded]="hasFilteringNoteLabels"
+    *ngIf="!disableBackend"
+  >
     <sbb-expansion-panel-header>
       <ng-container *ngIf="!isFilteringNoteLabels()">
-        {{ 'app.view.editor-filter-view.filterable-labels-notes' | translate }}
+        {{ "app.view.editor-filter-view.filterable-labels-notes" | translate }}
       </ng-container>
       <ng-container *ngIf="isFilteringNoteLabels()">
-        <label style="color: red">{{ 'app.view.editor-filter-view.filterable-labels-notes' | translate }}</label>
+        <label style="color: red">{{
+          "app.view.editor-filter-view.filterable-labels-notes" | translate
+        }}</label>
       </ng-container>
     </sbb-expansion-panel-header>
 
@@ -110,15 +131,21 @@
 
   <sbb-expansion-panel [expanded]="false">
     <sbb-expansion-panel-header>
-      <ng-container *ngIf="isDisplayFilteringActive()">{{ 'app.view.editor-filter-view.display' | translate }}</ng-container>
+      <ng-container *ngIf="isDisplayFilteringActive()">{{
+        "app.view.editor-filter-view.display" | translate
+      }}</ng-container>
       <ng-container *ngIf="!isDisplayFilteringActive()">
-        <label style="color: red">{{ 'app.view.editor-filter-view.display' | translate }}</label>
+        <label style="color: red">{{
+          "app.view.editor-filter-view.display" | translate
+        }}</label>
       </ng-container>
     </sbb-expansion-panel-header>
 
-    <sbb-label>{{ 'app.view.editor-filter-view.times' | translate }}</sbb-label>
+    <sbb-label>{{ "app.view.editor-filter-view.times" | translate }}</sbb-label>
     <div class="sbb-mt-m">
-      <sbb-form-field [label]="'app.view.editor-filter-view.decimal-displayed' | translate">
+      <sbb-form-field
+        [label]="'app.view.editor-filter-view.decimal-displayed' | translate"
+      >
         <input
           sbbInput
           type="number"
@@ -132,57 +159,73 @@
       <sbb-checkbox
         [(ngModel)]="filterArrivalDepartureTime"
         (change)="filterArrivalDepartureTimeChanged()"
-        >{{ 'app.view.editor-filter-view.display-arrival-departure-times' | translate }}
+        >{{
+          "app.view.editor-filter-view.display-arrival-departure-times"
+            | translate
+        }}
       </sbb-checkbox>
       <sbb-checkbox
         [(ngModel)]="filterShowNonStopTime"
         (change)="filterShowNonStopTimeChanged()"
       >
-        {{ 'app.view.editor-filter-view.display-arrival-departure-times-for-connections' | translate }}
+        {{
+          "app.view.editor-filter-view.display-arrival-departure-times-for-connections"
+            | translate
+        }}
       </sbb-checkbox>
       <sbb-checkbox
         [(ngModel)]="filterTravelTime"
         (change)="filterTravelTimeChanged()"
-        >{{ 'app.view.editor-filter-view.display-travel-times' | translate }}
+        >{{ "app.view.editor-filter-view.display-travel-times" | translate }}
       </sbb-checkbox>
       <sbb-checkbox
         [(ngModel)]="filterTrainrunName"
         (change)="filterTrainrunNameChanged()"
-        >{{ 'app.view.editor-filter-view.display-trainrun-name' | translate }}
+        >{{ "app.view.editor-filter-view.display-trainrun-name" | translate }}
       </sbb-checkbox>
     </div>
 
     <br />
-    <sbb-label>{{ 'app.view.editor-filter-view.connections' | translate }}</sbb-label>
+    <sbb-label>{{
+      "app.view.editor-filter-view.connections" | translate
+    }}</sbb-label>
     <div class="sbb-checkbox-group-vertical">
       <sbb-checkbox
         [(ngModel)]="filterConnections"
         (change)="filterConnectionsChanged()"
-        >{{ 'app.view.editor-filter-view.display-connections' | translate }}
+        >{{ "app.view.editor-filter-view.display-connections" | translate }}
       </sbb-checkbox>
     </div>
 
     <br />
-    <sbb-label>{{ 'app.view.editor-filter-view.nodes' | translate }}</sbb-label>
+    <sbb-label>{{ "app.view.editor-filter-view.nodes" | translate }}</sbb-label>
     <div class="sbb-checkbox-group-vertical">
       <sbb-checkbox
         [(ngModel)]="filterAllEmptyNodes"
         (change)="filterAllEmptyNodesChanged()"
-        >{{ 'app.view.editor-filter-view.display-nodes-without-visible-trainruns' | translate }}
+        >{{
+          "app.view.editor-filter-view.display-nodes-without-visible-trainruns"
+            | translate
+        }}
       </sbb-checkbox>
       <sbb-checkbox
         [(ngModel)]="filterAllNonStopNodes"
         (change)="filterAllNonStopNodesChanged()"
-        >{{ 'app.view.editor-filter-view.display-nodes-with-only-stopping-trainruns' | translate }}
+        >{{
+          "app.view.editor-filter-view.display-nodes-with-only-stopping-trainruns"
+            | translate
+        }}
       </sbb-checkbox>
     </div>
 
     <ng-container *ngIf="!disableBackend">
       <br />
-      <sbb-label>{{ 'app.view.editor-filter-view.notes' | translate }}</sbb-label>
+      <sbb-label>{{
+        "app.view.editor-filter-view.notes" | translate
+      }}</sbb-label>
       <div class="sbb-checkbox-group-vertical">
         <sbb-checkbox [(ngModel)]="filterNotes" (change)="filterNotesChanged()"
-          >{{ 'app.view.editor-filter-view.display-notes' | translate }}
+          >{{ "app.view.editor-filter-view.display-notes" | translate }}
         </sbb-checkbox>
       </div>
     </ng-container>
@@ -194,14 +237,14 @@
       [title]="'app.view.editor-filter-view.reset-display-filter' | translate"
       (click)="onResetDisplayFilter()"
     >
-      {{ 'app.view.editor-filter-view.reset-display-filter' | translate }}
+      {{ "app.view.editor-filter-view.reset-display-filter" | translate }}
     </button>
   </sbb-expansion-panel>
 
   <ng-container *ngIf="versionControlService.getVariantIsWritable()">
     <sbb-expansion-panel [expanded]="false">
       <sbb-expansion-panel-header>
-        {{ 'app.view.editor-filter-view.saved-filters' | translate }}
+        {{ "app.view.editor-filter-view.saved-filters" | translate }}
       </sbb-expansion-panel-header>
       <div class="sbb-filtersetting-chip-group">
         <ng-container
@@ -228,7 +271,7 @@
                   height="13px"
                   width="13px"
                   aria-hidden="false"
-                  style="transform: translate(-4px, 2px);"
+                  style="transform: translate(-4px, 2px)"
                 >
                 </sbb-icon>
               </ng-container>
@@ -239,7 +282,7 @@
                   height="13px"
                   width="13px"
                   aria-hidden="false"
-                  style="transform: translate(-4px, 2px);"
+                  style="transform: translate(-4px, 2px)"
                 >
                 </sbb-icon>
               </ng-container>
@@ -265,8 +308,7 @@
                 height="13px"
                 width="13px"
                 aria-hidden="false"
-                style="transform: translate(-4px, 2px);"
-
+                style="transform: translate(-4px, 2px)"
               >
               </sbb-icon>
             </button>
@@ -281,7 +323,7 @@
               height="13px"
               width="13px"
               aria-hidden="false"
-              style="transform: translate(-4px, 2px);"
+              style="transform: translate(-4px, 2px)"
             >
             </sbb-icon>
           </button>
@@ -295,7 +337,7 @@
         >
           <sbb-icon
             svgIcon="circle-plus-medium"
-            style="margin-top: 3px; transform: translate(-4px, 2px);"
+            style="margin-top: 3px; transform: translate(-4px, 2px)"
           ></sbb-icon>
         </button>
       </div>
@@ -308,9 +350,11 @@
     sbb-secondary-button
     class="sbb-mt-m"
     [disabled]="!this.filterService.isAnyFilterActive()"
-    [title]="'app.view.editor-filter-view.reset-all-display-filters' | translate"
+    [title]="
+      'app.view.editor-filter-view.reset-all-display-filters' | translate
+    "
     (click)="onResetAllFilter()"
   >
-    {{ 'app.view.editor-filter-view.reset-all-display-filters' | translate }}
+    {{ "app.view.editor-filter-view.reset-all-display-filters" | translate }}
   </button>
 </div>

--- a/src/app/view/editor-filter-view/editor-filter-view.component.ts
+++ b/src/app/view/editor-filter-view/editor-filter-view.component.ts
@@ -46,7 +46,7 @@ export class EditorFilterViewComponent implements OnInit, OnDestroy {
     public dataService: DataService,
     public uiInteractionService: UiInteractionService,
     public filterService: FilterService,
-    public versionControlService : VersionControlService,
+    public versionControlService: VersionControlService,
   ) {
     this.activeFilterName = undefined;
     this.activeEditFilterSettingId = undefined;

--- a/src/app/view/editor-filter-view/filterable-label-filter/filterable-label-filter.component.html
+++ b/src/app/view/editor-filter-view/filterable-label-filter/filterable-label-filter.component.html
@@ -1,5 +1,8 @@
 <div *ngIf="hasNoFilterableLabels()">
-  <sbb-label class="sbb-mt-m">{{ 'app.view.editor-filter-view.filterable-label-filter.no-labels-available' | translate }}</sbb-label>
+  <sbb-label class="sbb-mt-m">{{
+    "app.view.editor-filter-view.filterable-label-filter.no-labels-available"
+      | translate
+  }}</sbb-label>
 </div>
 <ng-container *ngIf="!hasNoFilterableLabels()">
   <div class="sbb-filter-chip-group-main">
@@ -11,7 +14,10 @@
             class="TrainrunDialog FilterableLabel LogicalOperator"
             (click)="enableLogicalFilterOperatorAnd(nodeLabelGrp)"
           >
-            {{ 'app.view.editor-filter-view.filterable-label-filter.or' | translate }}
+            {{
+              "app.view.editor-filter-view.filterable-label-filter.or"
+                | translate
+            }}
           </button>
         </ng-container>
         <ng-container *ngIf="!isFilterFunctionOrEnabled(nodeLabelGrp)">
@@ -19,7 +25,10 @@
             class="TrainrunDialog FilterableLabel LogicalOperator"
             (click)="enableLogicalFilterOperatorOr(nodeLabelGrp)"
           >
-            {{ 'app.view.editor-filter-view.filterable-label-filter.and' | translate }}
+            {{
+              "app.view.editor-filter-view.filterable-label-filter.and"
+                | translate
+            }}
           </button>
         </ng-container>
       </div>
@@ -46,9 +55,14 @@
     sbb-secondary-button
     class="sbb-mt-m"
     [disabled]="isFilteringLabels()"
-    [title]="'app.view.editor-filter-view.filterable-label-filter.show-all' | translate"
+    [title]="
+      'app.view.editor-filter-view.filterable-label-filter.show-all' | translate
+    "
     (click)="OnResetFilterableLabels()"
   >
-    {{ 'app.view.editor-filter-view.filterable-label-filter.reset-filter' | translate }}
+    {{
+      "app.view.editor-filter-view.filterable-label-filter.reset-filter"
+        | translate
+    }}
   </button>
 </div>

--- a/src/app/view/editor-filter-view/filterable-label-filter/filterable-label-filter.component.ts
+++ b/src/app/view/editor-filter-view/filterable-label-filter/filterable-label-filter.component.ts
@@ -165,9 +165,17 @@ export class FilterableLabelFilterComponent implements OnInit, OnDestroy {
         (filterLabel) => filterLabel === labelObject.getId(),
       ) !== undefined
     ) {
-      return labelObject.getLabel() + ": " + $localize`:@@app.view.editor-filter-view.filterable-label-filter.show:show`;
+      return (
+        labelObject.getLabel() +
+        ": " +
+        $localize`:@@app.view.editor-filter-view.filterable-label-filter.show:show`
+      );
     }
-    return labelObject.getLabel() + ": " + $localize`:@@app.view.editor-filter-view.filterable-label-filter.hide:hide`;
+    return (
+      labelObject.getLabel() +
+      ": " +
+      $localize`:@@app.view.editor-filter-view.filterable-label-filter.hide:hide`
+    );
   }
 
   isFilteringLabels(): boolean {

--- a/src/app/view/editor-main-view/data-views/connectionViewObject.ts
+++ b/src/app/view/editor-main-view/data-views/connectionViewObject.ts
@@ -52,7 +52,7 @@ export class ConnectionsViewObject {
       "_" +
       editorView.isTemporaryDisableFilteringOfItemsInViewEnabled() +
       "_" +
-      editorView.getLevelOfDetail()  +
+      editorView.getLevelOfDetail() +
       "_" +
       editorView.trainrunSectionPreviewLineView.getVariantIsWritable();
 

--- a/src/app/view/editor-main-view/data-views/connections.view.spec.ts
+++ b/src/app/view/editor-main-view/data-views/connections.view.spec.ts
@@ -90,7 +90,7 @@ describe("Connections View", () => {
       trainrunService,
       trainrunSectionService,
       nodeService,
-      filterService
+      filterService,
     );
 
     uiInteractionService = new UiInteractionService(

--- a/src/app/view/editor-main-view/data-views/connections.view.ts
+++ b/src/app/view/editor-main-view/data-views/connections.view.ts
@@ -131,7 +131,6 @@ export class ConnectionsView {
   }
 
   createConnectionCurve(drawingGroup: d3.selector) {
-
     drawingGroup
       .append(StaticDomTags.CONNECTION_LINE_SVG)
       .attr("class", StaticDomTags.CONNECTION_LINE_CLASS)
@@ -292,9 +291,10 @@ export class ConnectionsView {
   }
 
   displayConnections(inputConnections: Connection[]) {
-    const connections = inputConnections.filter((c) =>
-      this.editorView.doCullCheckPositionsInViewport(c.getPath()) &&
-      this.filterConnectionsToDisplay(c)
+    const connections = inputConnections.filter(
+      (c) =>
+        this.editorView.doCullCheckPositionsInViewport(c.getPath()) &&
+        this.filterConnectionsToDisplay(c),
     );
 
     const connectionsGroup = this.connectionsGroup
@@ -319,8 +319,8 @@ export class ConnectionsView {
 
     d3.selectAll(
       StaticDomTags.CONNECTION_ROOT_CONTAINER_DOM_REF +
-      "." +
-      StaticDomTags.TAG_SELECTED,
+        "." +
+        StaticDomTags.TAG_SELECTED,
     ).raise();
   }
 
@@ -371,8 +371,7 @@ export class ConnectionsView {
     this.createConnectionCurve(groupEnter);
   }
 
-  makeConnectionLOD0(groupEnter: any) {
-  }
+  makeConnectionLOD0(groupEnter: any) {}
 
   onConnectionMouseup(connection: Connection, domObj: any, node: Node) {
     d3.event.stopPropagation();

--- a/src/app/view/editor-main-view/data-views/d3.utils.spec.ts
+++ b/src/app/view/editor-main-view/data-views/d3.utils.spec.ts
@@ -24,9 +24,7 @@ import {NetzgrafikUnitTesting} from "../../../../integration-testing/netzgrafik.
 import {Vec2D} from "../../../utils/vec2D";
 import {LevelOfDetailService} from "../../../services/ui/level.of.detail.service";
 import {ViewportCullService} from "../../../services/ui/viewport.cull.service";
-import {
-  PositionTransformationService
-} from "../../../services/util/position.transformation.service";
+import {PositionTransformationService} from "../../../services/util/position.transformation.service";
 
 describe("3d.Utils.tests", () => {
   let dataService: DataService;
@@ -99,7 +97,7 @@ describe("3d.Utils.tests", () => {
       trainrunService,
       trainrunSectionService,
       nodeService,
-      filterService
+      filterService,
     );
 
     uiInteractionService = new UiInteractionService(
@@ -132,14 +130,12 @@ describe("3d.Utils.tests", () => {
       undoService,
     );
 
-    const levelOfDetailService = new LevelOfDetailService(
-      uiInteractionService
-    );
+    const levelOfDetailService = new LevelOfDetailService(uiInteractionService);
     const viewportCullService = new ViewportCullService(
       uiInteractionService,
       nodeService,
       noteService,
-      trainrunSectionService
+      trainrunSectionService,
     );
 
     const positionTransformationService = new PositionTransformationService(
@@ -147,7 +143,7 @@ describe("3d.Utils.tests", () => {
       nodeService,
       noteService,
       uiInteractionService,
-      viewportCullService
+      viewportCullService,
     );
 
     const controller = new EditorMainViewComponent(
@@ -164,7 +160,7 @@ describe("3d.Utils.tests", () => {
       viewportCullService,
       levelOfDetailService,
       undefined,
-      positionTransformationService
+      positionTransformationService,
     );
 
     new EditorView(
@@ -181,7 +177,7 @@ describe("3d.Utils.tests", () => {
       viewportCullService,
       levelOfDetailService,
       undefined,
-      positionTransformationService
+      positionTransformationService,
     );
     controller.bindViewToServices();
     editorView = controller.editorView;

--- a/src/app/view/editor-main-view/data-views/d3.utils.ts
+++ b/src/app/view/editor-main-view/data-views/d3.utils.ts
@@ -38,12 +38,16 @@ export class D3Utils {
     //).raise();
     d3.selectAll(
       StaticDomTags.EDGE_ROOT_CONTAINER_DOM_REF +
-      "." +
-      StaticDomTags.TAG_SELECTED,
+        "." +
+        StaticDomTags.TAG_SELECTED,
     ).raise();
   }
 
-  static hoverTrainrunSection(trainrunSection: TrainrunSection, bringToFront = true, domObj: any) {
+  static hoverTrainrunSection(
+    trainrunSection: TrainrunSection,
+    bringToFront = true,
+    domObj: any,
+  ) {
     d3.selectAll(StaticDomTags.EDGE_LINE_DOM_REF)
       .filter(
         (d: TrainrunSectionViewObject) =>
@@ -76,7 +80,9 @@ export class D3Utils {
     } else {
       if (domObj !== undefined) {
         const attrId = d3.select(domObj).attr("id");
-        const objs = d3.selectAll(StaticDomTags.EDGE_ROOT_CONTAINER_DOM_REF + "[id='" + attrId + "']");
+        const objs = d3.selectAll(
+          StaticDomTags.EDGE_ROOT_CONTAINER_DOM_REF + "[id='" + attrId + "']",
+        );
         objs.raise();
       }
     }

--- a/src/app/view/editor-main-view/data-views/data.view.spec.ts
+++ b/src/app/view/editor-main-view/data-views/data.view.spec.ts
@@ -28,9 +28,7 @@ import {TransitionViewObject} from "./transitionViewObject";
 import {StaticDomTags} from "./static.dom.tags";
 import {LevelOfDetailService} from "../../../services/ui/level.of.detail.service";
 import {ViewportCullService} from "../../../services/ui/viewport.cull.service";
-import {
-  PositionTransformationService
-} from "../../../services/util/position.transformation.service";
+import {PositionTransformationService} from "../../../services/util/position.transformation.service";
 
 describe("Editor-DataView", () => {
   let dataService: DataService;
@@ -103,7 +101,7 @@ describe("Editor-DataView", () => {
       trainrunService,
       trainrunSectionService,
       nodeService,
-      filterService
+      filterService,
     );
 
     uiInteractionService = new UiInteractionService(
@@ -136,26 +134,22 @@ describe("Editor-DataView", () => {
       undoService,
     );
 
-
     const viewportCullService = new ViewportCullService(
       uiInteractionService,
       nodeService,
       noteService,
-      trainrunSectionService
+      trainrunSectionService,
     );
 
-    const levelOfDetailService = new LevelOfDetailService(
-      uiInteractionService
-    );
+    const levelOfDetailService = new LevelOfDetailService(uiInteractionService);
 
     const positionTransformationService = new PositionTransformationService(
       trainrunSectionService,
       nodeService,
       noteService,
       uiInteractionService,
-      viewportCullService
+      viewportCullService,
     );
-
 
     const controller = new EditorMainViewComponent(
       nodeService,
@@ -171,7 +165,7 @@ describe("Editor-DataView", () => {
       viewportCullService,
       levelOfDetailService,
       undefined,
-      positionTransformationService
+      positionTransformationService,
     );
 
     new EditorView(
@@ -188,7 +182,7 @@ describe("Editor-DataView", () => {
       viewportCullService,
       levelOfDetailService,
       undefined,
-      positionTransformationService
+      positionTransformationService,
     );
 
     controller.bindViewToServices();
@@ -215,10 +209,14 @@ describe("Editor-DataView", () => {
     const node = nodeService.getNodeFromId(2);
 
     const cvo1 = new NodeViewObject(editorView, node, false);
-    expect(cvo1.key).toBe("#2@736_64_ZUE_6_5_96_124_false_2_false_true_false_0_false");
+    expect(cvo1.key).toBe(
+      "#2@736_64_ZUE_6_5_96_124_false_2_false_true_false_0_false",
+    );
 
     const cvo2 = new NodeViewObject(editorView, node, true);
-    expect(cvo2.key).toBe("#2@736_64_ZUE_6_5_96_124_false_2_true_true_false_0_false");
+    expect(cvo2.key).toBe(
+      "#2@736_64_ZUE_6_5_96_124_false_2_true_true_false_0_false",
+    );
   });
 
   it("NodeViewObject   - 001", () => {

--- a/src/app/view/editor-main-view/data-views/editor.keyEvents.ts
+++ b/src/app/view/editor-main-view/data-views/editor.keyEvents.ts
@@ -16,12 +16,13 @@ import {CopyService} from "../../../services/data/copy.service";
 import {Port} from "../../../models/port.model";
 import {FilterService} from "../../../services/ui/filter.service";
 import {Connection} from "../../../models/connection.model";
-import {PreviewLineMode, TrainrunSectionPreviewLineView,} from "./trainrunsection.previewline.view";
+import {
+  PreviewLineMode,
+  TrainrunSectionPreviewLineView,
+} from "./trainrunsection.previewline.view";
 import {TrainrunSection} from "../../../models/trainrunsection.model";
 import {Trainrun} from "../../../models/trainrun.model";
-import {
-  PositionTransformationService
-} from "../../../services/util/position.transformation.service";
+import {PositionTransformationService} from "../../../services/util/position.transformation.service";
 
 export class EditorKeyEvents {
   private editorMode: EditorMode;
@@ -38,14 +39,13 @@ export class EditorKeyEvents {
     private copyService: CopyService,
     private svgMouseController: SVGMouseController,
     private trainrunSectionPreviewLineView: TrainrunSectionPreviewLineView,
-    private positionTransformationService: PositionTransformationService
+    private positionTransformationService: PositionTransformationService,
   ) {
     this.activateMousekeyDownHandler(EditorMode.NetzgrafikEditing);
   }
 
   deactivateMousekeyDownHandler() {
-    d3.select("body").on("keydown", () => {
-    });
+    d3.select("body").on("keydown", () => {});
   }
 
   ignoreKeyEvent(event: KeyboardEvent): boolean {
@@ -274,7 +274,9 @@ export class EditorKeyEvents {
   private doDuplicateTrainrun(): boolean {
     const selectedTrainrunSectionId = this.getSelectedTrainSectionId();
     if (selectedTrainrunSectionId !== undefined) {
-      this.trainrunService.duplicateTrainrunAndSections(selectedTrainrunSectionId);
+      this.trainrunService.duplicateTrainrunAndSections(
+        selectedTrainrunSectionId,
+      );
       return true;
     }
     return false;
@@ -528,7 +530,7 @@ export class EditorKeyEvents {
   private onSelectAll(): boolean {
     if (
       this.uiInteractionService.getEditorMode() ===
-      EditorMode.MultiNodeMoving ||
+        EditorMode.MultiNodeMoving ||
       this.uiInteractionService.getEditorMode() === EditorMode.NetzgrafikEditing
     ) {
       this.uiInteractionService.setEditorMode(EditorMode.MultiNodeMoving);
@@ -700,7 +702,6 @@ export class EditorKeyEvents {
 
     return false;
   }
-
 
   private netzgrafikElementsUpdated() {
     this.trainrunSectionService.trainrunSectionsUpdated();

--- a/src/app/view/editor-main-view/data-views/editor.view.ts
+++ b/src/app/view/editor-main-view/data-views/editor.view.ts
@@ -12,7 +12,10 @@ import {
 } from "../../../services/ui/ui.interaction.service";
 import {EditorMode} from "../../editor-menu/editor-mode";
 import {ConnectionsView} from "./connections.view";
-import {SVGMouseController, SVGMouseControllerObserver,} from "../../util/svg.mouse.controller";
+import {
+  SVGMouseController,
+  SVGMouseControllerObserver,
+} from "../../util/svg.mouse.controller";
 import {D3Utils} from "./d3.utils";
 import {NotesView} from "./notes.view";
 import {NodeService} from "../../../services/data/node.service";
@@ -27,14 +30,13 @@ import {EditorKeyEvents} from "./editor.keyEvents";
 import {MultiSelectRenderer} from "./multiSelectRenderer";
 import {UndoService} from "../../../services/data/undo.service";
 import {CopyService} from "../../../services/data/copy.service";
-import {
-  PositionTransformationService
-} from "../../../services/util/position.transformation.service";
+import {PositionTransformationService} from "../../../services/util/position.transformation.service";
 
+import {StreckengrafikDrawingContext} from "../../../streckengrafik/model/util/streckengrafik.drawing.context";
 import {
-  StreckengrafikDrawingContext
-} from "../../../streckengrafik/model/util/streckengrafik.drawing.context";
-import {LevelOfDetail, LevelOfDetailService} from "../../../services/ui/level.of.detail.service";
+  LevelOfDetail,
+  LevelOfDetailService,
+} from "../../../services/ui/level.of.detail.service";
 import {ViewportCullService} from "../../../services/ui/viewport.cull.service";
 import {VersionControlService} from "../../../services/data/version-control.service";
 
@@ -134,10 +136,14 @@ export class EditorView implements SVGMouseControllerObserver {
     private viewportCullService: ViewportCullService,
     private levelOfDetailService: LevelOfDetailService,
     private versionControlService: VersionControlService,
-    private positionTransformationService: PositionTransformationService
+    private positionTransformationService: PositionTransformationService,
   ) {
     this.controller = controller;
-    this.svgMouseController = new SVGMouseController(EditorView.svgName, this, undoService);
+    this.svgMouseController = new SVGMouseController(
+      EditorView.svgName,
+      this,
+      undoService,
+    );
     this.nodesView = new NodesView(this);
     this.transitionsView = new TransitionsView(this);
     this.connectionsView = new ConnectionsView(this);
@@ -145,7 +151,7 @@ export class EditorView implements SVGMouseControllerObserver {
     this.trainrunSectionPreviewLineView = new TrainrunSectionPreviewLineView(
       nodeService,
       filterService,
-      versionControlService
+      versionControlService,
     );
     this.multiSelectRenderer = new MultiSelectRenderer();
     this.notesView = new NotesView(this);
@@ -161,7 +167,7 @@ export class EditorView implements SVGMouseControllerObserver {
       copyService,
       this.svgMouseController,
       this.trainrunSectionPreviewLineView,
-      this.positionTransformationService
+      this.positionTransformationService,
     );
   }
 
@@ -582,9 +588,12 @@ export class EditorView implements SVGMouseControllerObserver {
     this.trainrunSectionPreviewLineView.stopPreviewLine();
   }
 
-
   onScaleNetzgrafik(factor: number, scaleCenter: Vec2D) {
-    this.positionTransformationService.scaleNetzgrafikArea(factor, scaleCenter, EditorView.svgName);
+    this.positionTransformationService.scaleNetzgrafikArea(
+      factor,
+      scaleCenter,
+      EditorView.svgName,
+    );
   }
 
   zoomFactorChanged(newZoomFactor: number) {
@@ -600,11 +609,15 @@ export class EditorView implements SVGMouseControllerObserver {
     this.viewportCullService.onViewportChangeUpdateRendering(true);
   }
 
-  doCullCheckPositionsInViewport(positions: Vec2D[], extraPixelsIn = 32): boolean {
+  doCullCheckPositionsInViewport(
+    positions: Vec2D[],
+    extraPixelsIn = 32,
+  ): boolean {
     return this.viewportCullService.cullCheckPositionsInViewport(
       positions,
       EditorView.svgName,
-      extraPixelsIn);
+      extraPixelsIn,
+    );
   }
 
   getLevelOfDetail() {
@@ -614,7 +627,6 @@ export class EditorView implements SVGMouseControllerObserver {
   skipElementLevelOfDetail(lod: LevelOfDetail): boolean {
     return lod < this.getLevelOfDetail();
   }
-
 
   setEditorMode(mode: EditorMode) {
     if (
@@ -681,7 +693,7 @@ export class EditorView implements SVGMouseControllerObserver {
       }
       D3Utils.enableSpecialEditing(
         this.editorMode === EditorMode.TopologyEditing ||
-        this.editorMode === EditorMode.NoteEditing,
+          this.editorMode === EditorMode.NoteEditing,
       );
     }
   }
@@ -698,6 +710,4 @@ export class EditorView implements SVGMouseControllerObserver {
       el.classed("ShowCellCursor", false);
     }
   }
-
-
 }

--- a/src/app/view/editor-main-view/data-views/nodes.view.spec.ts
+++ b/src/app/view/editor-main-view/data-views/nodes.view.spec.ts
@@ -23,9 +23,7 @@ import {EditorView} from "./editor.view";
 import {NodesView} from "./nodes.view";
 import {LevelOfDetailService} from "../../../services/ui/level.of.detail.service";
 import {ViewportCullService} from "../../../services/ui/viewport.cull.service";
-import {
-  PositionTransformationService
-} from "../../../services/util/position.transformation.service";
+import {PositionTransformationService} from "../../../services/util/position.transformation.service";
 
 describe("Nodes-View", () => {
   let dataService: DataService;
@@ -98,7 +96,7 @@ describe("Nodes-View", () => {
       trainrunService,
       trainrunSectionService,
       nodeService,
-      filterService
+      filterService,
     );
 
     uiInteractionService = new UiInteractionService(
@@ -131,15 +129,13 @@ describe("Nodes-View", () => {
       undoService,
     );
 
-    const levelOfDetailService = new LevelOfDetailService(
-      uiInteractionService
-    );
+    const levelOfDetailService = new LevelOfDetailService(uiInteractionService);
 
     const viewportCullService = new ViewportCullService(
       uiInteractionService,
       nodeService,
       noteService,
-      trainrunSectionService
+      trainrunSectionService,
     );
 
     const positionTransformationService = new PositionTransformationService(
@@ -147,7 +143,7 @@ describe("Nodes-View", () => {
       nodeService,
       noteService,
       uiInteractionService,
-      viewportCullService
+      viewportCullService,
     );
 
     const controller = new EditorMainViewComponent(
@@ -164,7 +160,7 @@ describe("Nodes-View", () => {
       viewportCullService,
       levelOfDetailService,
       undefined,
-      positionTransformationService
+      positionTransformationService,
     );
 
     new EditorView(
@@ -181,7 +177,7 @@ describe("Nodes-View", () => {
       viewportCullService,
       levelOfDetailService,
       undefined,
-      positionTransformationService
+      positionTransformationService,
     );
 
     controller.bindViewToServices();

--- a/src/app/view/editor-main-view/data-views/nodes.view.ts
+++ b/src/app/view/editor-main-view/data-views/nodes.view.ts
@@ -98,15 +98,17 @@ export class NodesView {
   }
 
   displayNodes(inputNodes: Node[]) {
-    const nodes = inputNodes.filter((n) =>
-      this.editorView.doCullCheckPositionsInViewport(
-          [
-            new Vec2D(n.getPositionX(), n.getPositionY()),
-            new Vec2D(n.getPositionX() + n.getNodeWidth(), n.getPositionY()),
-            new Vec2D(n.getPositionX(), n.getPositionY() + n.getNodeHeight()),
-            new Vec2D(n.getPositionX() + n.getNodeWidth(), n.getPositionY() + n.getNodeHeight())
-          ]) &&
-      this.filterNodesToDisplay(n)
+    const nodes = inputNodes.filter(
+      (n) =>
+        this.editorView.doCullCheckPositionsInViewport([
+          new Vec2D(n.getPositionX(), n.getPositionY()),
+          new Vec2D(n.getPositionX() + n.getNodeWidth(), n.getPositionY()),
+          new Vec2D(n.getPositionX(), n.getPositionY() + n.getNodeHeight()),
+          new Vec2D(
+            n.getPositionX() + n.getNodeWidth(),
+            n.getPositionY() + n.getNodeHeight(),
+          ),
+        ]) && this.filterNodesToDisplay(n),
     );
 
     const group = this.nodeGroup
@@ -271,7 +273,6 @@ export class NodesView {
   }
 
   private makeBackground(groupEnter: any) {
-
     groupEnter
       .append(StaticDomTags.NODE_BACKGROUND_SVG)
       .attr("class", StaticDomTags.NODE_BACKGROUND_CLASS)
@@ -295,7 +296,6 @@ export class NodesView {
   }
 
   private makeLabelArea(groupEnter: any) {
-
     groupEnter
       .append(StaticDomTags.NODE_LABELAREA_SVG)
       .attr("class", StaticDomTags.NODE_LABELAREA_CLASS)
@@ -324,9 +324,9 @@ export class NodesView {
   }
 
   private makeHoverDragBackground(groupEnter: any) {
-    const added=
-      groupEnter
-        .append(StaticDomTags.NODE_HOVER_DRAG_AREA_BACKGROUND_SVG);
+    const added = groupEnter.append(
+      StaticDomTags.NODE_HOVER_DRAG_AREA_BACKGROUND_SVG,
+    );
     added
       .attr("class", StaticDomTags.NODE_HOVER_DRAG_AREA_BACKGROUND_CLASS)
       .classed(StaticDomTags.TAG_SELECTED, (n: NodeViewObject) =>
@@ -343,12 +343,11 @@ export class NodesView {
       )
       .classed(
         StaticDomTags.NODE_READONLY,
-        !this.editorView.trainrunSectionPreviewLineView.getVariantIsWritable()
+        !this.editorView.trainrunSectionPreviewLineView.getVariantIsWritable(),
       );
 
-    if ( this.editorView.trainrunSectionPreviewLineView.getVariantIsWritable() ){
-      added
-        .call(this.draggable);
+    if (this.editorView.trainrunSectionPreviewLineView.getVariantIsWritable()) {
+      added.call(this.draggable);
     }
 
     added
@@ -363,7 +362,9 @@ export class NodesView {
   }
 
   private makeHoverDragRoot(groupEnter: any) {
-    if ( !this.editorView.trainrunSectionPreviewLineView.getVariantIsWritable() ){
+    if (
+      !this.editorView.trainrunSectionPreviewLineView.getVariantIsWritable()
+    ) {
       return;
     }
     groupEnter
@@ -376,11 +377,11 @@ export class NodesView {
       .attr(
         "d",
         "m11.855 2.398-.356-.36-.356.36-3.841 3.897.712.702L11 " +
-        "3.97V11H3.957l2.647-2.647-.707-.708-3.5 3.5-.354.354.354.354 3.5 " +
-        "3.5.707-.708-2.646-2.645H11v7.03l-2.995-3.027-.71.703 3.852 3.894.356.36.355-.36 " +
-        "3.842-3.898-.712-.701L12 19.032v-7.031h7.041l-2.645 2.645.708.708 " +
-        "3.5-3.5.353-.354-.353-.354-3.5-3.5-.707.708L19.043 11H12V3.967l2.997 " +
-        "3.029.711-.704-3.853-3.894Z",
+          "3.97V11H3.957l2.647-2.647-.707-.708-3.5 3.5-.354.354.354.354 3.5 " +
+          "3.5.707-.708-2.646-2.645H11v7.03l-2.995-3.027-.71.703 3.852 3.894.356.36.355-.36 " +
+          "3.842-3.898-.712-.701L12 19.032v-7.031h7.041l-2.645 2.645.708.708 " +
+          "3.5-3.5.353-.354-.353-.354-3.5-3.5-.707.708L19.043 11H12V3.967l2.997 " +
+          "3.029.711-.704-3.853-3.894Z",
       )
       .attr(
         "transform",
@@ -401,7 +402,6 @@ export class NodesView {
   }
 
   private makeEditButtonBackground(groupEnter: any) {
-
     groupEnter
       .append(StaticDomTags.NODE_EDIT_AREA_BACKGROUND_SVG)
       .attr("class", StaticDomTags.NODE_EDIT_AREA_BACKGROUND_CLASS)
@@ -429,7 +429,6 @@ export class NodesView {
   }
 
   private makeEditButton(groupEnter: any) {
-
     groupEnter
       .append(StaticDomTags.NODE_EDIT_AREA_SVG)
       .attr("class", StaticDomTags.NODE_EDIT_AREA_CLASS)
@@ -440,11 +439,11 @@ export class NodesView {
       .attr(
         "d",
         "m25.853 6.71-.354-.352-.353.353-3.435 3.435-.353.354.353.353 " +
-        "3.435 3.435.355.355.353-.355 3.435-3.449.353-.354-.354-.353-3.435-3.421Zm-" +
-        "3.081 3.79 2.729-2.729 2.727 2.717-2.729 2.739-2.727-2.727Zm-2.918 2.212-." +
-        "354-.354-.354.354-11.25 11.25-.146.146V28.25h4.142l.147-.146 11.25-11.252." +
-        "353-.353-.354-.354-3.434-3.433ZM8.75 24.522l10.75-10.75 2.728 2.727-10.75 " +
-        "10.751H8.75v-2.728Z",
+          "3.435 3.435.355.355.353-.355 3.435-3.449.353-.354-.354-.353-3.435-3.421Zm-" +
+          "3.081 3.79 2.729-2.729 2.727 2.717-2.729 2.739-2.727-2.727Zm-2.918 2.212-." +
+          "354-.354-.354.354-11.25 11.25-.146.146V28.25h4.142l.147-.146 11.25-11.252." +
+          "353-.353-.354-.354-3.434-3.433ZM8.75 24.522l10.75-10.75 2.728 2.727-10.75 " +
+          "10.751H8.75v-2.728Z",
       )
       .attr(
         "transform",
@@ -466,7 +465,6 @@ export class NodesView {
   }
 
   private makeNodeDockable(groupEnter: any) {
-
     groupEnter
       .append(StaticDomTags.NODE_DOCKABLE_SVG)
       .attr("class", StaticDomTags.NODE_DOCKABLE_CLASS)
@@ -503,7 +501,6 @@ export class NodesView {
   }
 
   private makeAnalyticsArea(groupEnter: any) {
-
     groupEnter
       .append(StaticDomTags.NODE_ANALYTICSAREA_SVG)
       .attr("class", StaticDomTags.NODE_ANALYTICSAREA_CLASS)
@@ -538,7 +535,6 @@ export class NodesView {
   }
 
   private makeAnalyticsTextLeftArea(groupEnter: any) {
-
     groupEnter
       .append(StaticDomTags.NODE_ANALYTICSAREA_TEXT_LEFT_SVG)
       .attr("class", StaticDomTags.NODE_ANALYTICSAREA_TEXT_LEFT_CLASS)
@@ -574,8 +570,7 @@ export class NodesView {
   }
 
   private makeLabelText(groupEnter: any) {
-    const added = groupEnter
-      .append(StaticDomTags.NODE_LABELAREA_TEXT_SVG);
+    const added = groupEnter.append(StaticDomTags.NODE_LABELAREA_TEXT_SVG);
     added
       .attr("class", StaticDomTags.NODE_LABELAREA_TEXT_CLASS)
       .attr(StaticDomTags.NODE_ID, (n: NodeViewObject) => n.node.getId())
@@ -591,10 +586,12 @@ export class NodesView {
       )
       .classed(
         StaticDomTags.NODE_READONLY,
-        !this.editorView.trainrunSectionPreviewLineView.getVariantIsWritable()
+        !this.editorView.trainrunSectionPreviewLineView.getVariantIsWritable(),
       );
 
-    if ( !this.editorView.trainrunSectionPreviewLineView.getVariantIsWritable() ){
+    if (
+      !this.editorView.trainrunSectionPreviewLineView.getVariantIsWritable()
+    ) {
       return;
     }
 
@@ -611,7 +608,6 @@ export class NodesView {
   }
 
   private makeLabelConnectionText(groupEnter: any) {
-
     groupEnter
       .append(StaticDomTags.NODE_CONNECTIONTIME_TEXT_SVG)
       .attr("class", StaticDomTags.NODE_CONNECTIONTIME_TEXT_CLASS)
@@ -866,9 +862,9 @@ export class NodesView {
     if (existingTrainrunSection === null) {
       const sourceObj = d3.select(
         StaticDomTags.NODE_DOCKABLE_DOM_REF +
-        '[id="' +
-        startNode.getId() +
-        '"]',
+          '[id="' +
+          startNode.getId() +
+          '"]',
       );
       const sourceRect: DOMRect = sourceObj.node().getBoundingClientRect();
       const sourcePos = new Vec2D(
@@ -928,13 +924,13 @@ export class NodesView {
     if (
       !(
         dragTransitionInfo.trainrunSection1.getSourceNodeId() !==
-        endNode.getId() &&
+          endNode.getId() &&
         dragTransitionInfo.trainrunSection1.getTargetNodeId() !==
-        endNode.getId() &&
+          endNode.getId() &&
         dragTransitionInfo.trainrunSection2.getSourceNodeId() !==
-        endNode.getId() &&
+          endNode.getId() &&
         dragTransitionInfo.trainrunSection2.getTargetNodeId() !==
-        endNode.getId()
+          endNode.getId()
       )
     ) {
       this.editorView.trainrunSectionPreviewLineView.stopPreviewLine();

--- a/src/app/view/editor-main-view/data-views/notes.view.spec.ts
+++ b/src/app/view/editor-main-view/data-views/notes.view.spec.ts
@@ -23,9 +23,7 @@ import {EditorView} from "./editor.view";
 import {NetzgrafikUnitTesting} from "../../../../integration-testing/netzgrafik.unit.testing";
 import {LevelOfDetailService} from "../../../services/ui/level.of.detail.service";
 import {ViewportCullService} from "../../../services/ui/viewport.cull.service";
-import {
-  PositionTransformationService
-} from "../../../services/util/position.transformation.service";
+import {PositionTransformationService} from "../../../services/util/position.transformation.service";
 
 describe("Notes-View", () => {
   let dataService: DataService;
@@ -98,7 +96,7 @@ describe("Notes-View", () => {
       trainrunService,
       trainrunSectionService,
       nodeService,
-      filterService
+      filterService,
     );
 
     uiInteractionService = new UiInteractionService(
@@ -131,15 +129,13 @@ describe("Notes-View", () => {
       undoService,
     );
 
-    const levelOfDetailService = new LevelOfDetailService(
-      uiInteractionService
-    );
+    const levelOfDetailService = new LevelOfDetailService(uiInteractionService);
 
     const viewportCullService = new ViewportCullService(
       uiInteractionService,
       nodeService,
       noteService,
-      trainrunSectionService
+      trainrunSectionService,
     );
 
     const positionTransformationService = new PositionTransformationService(
@@ -147,7 +143,7 @@ describe("Notes-View", () => {
       nodeService,
       noteService,
       uiInteractionService,
-      viewportCullService
+      viewportCullService,
     );
 
     const controller = new EditorMainViewComponent(
@@ -164,7 +160,7 @@ describe("Notes-View", () => {
       viewportCullService,
       levelOfDetailService,
       undefined,
-      positionTransformationService
+      positionTransformationService,
     );
 
     new EditorView(
@@ -181,7 +177,7 @@ describe("Notes-View", () => {
       viewportCullService,
       levelOfDetailService,
       undefined,
-      positionTransformationService
+      positionTransformationService,
     );
     controller.bindViewToServices();
     editorView = controller.editorView;

--- a/src/app/view/editor-main-view/data-views/notes.view.ts
+++ b/src/app/view/editor-main-view/data-views/notes.view.ts
@@ -49,18 +49,18 @@ export class NotesView {
       .split("<br>")
       .join(
         '<tspan x="' +
-        (NOTE_TEXT_LEFT_SPACING - 4) +
-        '" dy="' +
-        TEXT_SIZE +
-        '">&nbsp;</tspan>',
+          (NOTE_TEXT_LEFT_SPACING - 4) +
+          '" dy="' +
+          TEXT_SIZE +
+          '">&nbsp;</tspan>',
       )
       .split("<p>")
       .join(
         '<tspan x="' +
-        NOTE_TEXT_LEFT_SPACING +
-        '" dy="' +
-        1.5 * TEXT_SIZE +
-        '">',
+          NOTE_TEXT_LEFT_SPACING +
+          '" dy="' +
+          1.5 * TEXT_SIZE +
+          '">',
       )
       .split("</p>")
       .join("&nbsp;</tspan>")
@@ -83,10 +83,10 @@ export class NotesView {
   static extractTextBasedHeight(n: Note): number {
     return Math.max(
       n.getText().split("<br>").join("<p>").split("<p>", 9999).length *
-      1.5 *
-      TEXT_SIZE +
-      NOTE_TEXT_AREA_HEIGHT +
-      16,
+        1.5 *
+        TEXT_SIZE +
+        NOTE_TEXT_AREA_HEIGHT +
+        16,
       n.getHeight(),
     );
   }
@@ -128,15 +128,17 @@ export class NotesView {
   }
 
   displayNotes(inputNotes: Note[]) {
-    const notes = inputNotes.filter((n) =>
-      this.editorView.doCullCheckPositionsInViewport(
-        [
+    const notes = inputNotes.filter(
+      (n) =>
+        this.editorView.doCullCheckPositionsInViewport([
           new Vec2D(n.getPositionX(), n.getPositionY()),
           new Vec2D(n.getPositionX() + n.getWidth(), n.getPositionY()),
           new Vec2D(n.getPositionX(), n.getPositionY() + n.getHeight()),
-          new Vec2D(n.getPositionX() + n.getWidth(), n.getPositionY() + n.getHeight())
-        ]) &&
-      this.filterNotesToDisplay(n)
+          new Vec2D(
+            n.getPositionX() + n.getWidth(),
+            n.getPositionY() + n.getHeight(),
+          ),
+        ]) && this.filterNotesToDisplay(n),
     );
 
     const group = this.notesGroup
@@ -236,8 +238,7 @@ export class NotesView {
   }
 
   private makeNoteHoverRoot(groupEnter: any) {
-    const added = groupEnter
-      .append(StaticDomTags.NOTE_HOVER_ROOT_SVG);
+    const added = groupEnter.append(StaticDomTags.NOTE_HOVER_ROOT_SVG);
     added
       .attr("class", StaticDomTags.NOTE_HOVER_ROOT_CLASS)
       .attr(StaticDomTags.NOTE_ID, (n: NoteViewObject) => n.note.getId())
@@ -252,7 +253,9 @@ export class NotesView {
       .attr("x", -24)
       .attr("y", -24);
 
-    if ( !this.editorView.trainrunSectionPreviewLineView.getVariantIsWritable() ){
+    if (
+      !this.editorView.trainrunSectionPreviewLineView.getVariantIsWritable()
+    ) {
       return;
     }
 
@@ -265,7 +268,6 @@ export class NotesView {
   }
 
   private makeNoteRoot(groupEnter: any) {
-
     groupEnter
       .append(StaticDomTags.NOTE_ROOT_SVG)
       .attr("class", StaticDomTags.NOTE_ROOT_CLASS)
@@ -294,11 +296,9 @@ export class NotesView {
       .on("mouseover", (n: NoteViewObject, i, a) =>
         this.onNoteMouseover(n.note, a[i]),
       );
-
   }
 
   private makeNoteTitleArea(groupEnter: any) {
-
     groupEnter
       .append(StaticDomTags.NOTE_TITELAREA_SVG)
       .attr("class", StaticDomTags.NOTE_TITELAREA_CLASS)
@@ -326,7 +326,6 @@ export class NotesView {
   }
 
   private makeNoteTextArea(groupEnter: any) {
-
     groupEnter
       .append(StaticDomTags.NOTE_TEXTAREA_SVG)
       .attr("class", StaticDomTags.NOTE_TEXTAREA_CLASS)
@@ -358,7 +357,6 @@ export class NotesView {
   }
 
   private makeNoteTitleAreaText(groupEnter: any) {
-
     groupEnter
       .append(StaticDomTags.NOTE_TITELAREA_TEXT_SVG)
       .attr("class", StaticDomTags.NOTE_TITELAREA_TEXT_CLASS)
@@ -374,7 +372,6 @@ export class NotesView {
   }
 
   private makeNoteText(groupEnter: any) {
-
     groupEnter
       .append(StaticDomTags.NOTE_TEXT_SVG)
       .attr("class", StaticDomTags.NOTE_TEXT_CLASS)
@@ -387,13 +384,12 @@ export class NotesView {
       .on("mouseover", (n: NoteViewObject, i, a) =>
         this.onNoteMouseover(n.note, a[i]),
       );
-
   }
 
   private makeNoteDragAreaBackground(groupEnter: any) {
-
-    const added = groupEnter
-      .append(StaticDomTags.NOTE_HOVER_DRAG_AREA_BACKGROUND_SVG);
+    const added = groupEnter.append(
+      StaticDomTags.NOTE_HOVER_DRAG_AREA_BACKGROUND_SVG,
+    );
 
     added
       .attr("class", StaticDomTags.NOTE_HOVER_DRAG_AREA_BACKGROUND_CLASS)
@@ -407,7 +403,9 @@ export class NotesView {
       .attr("x", 0)
       .attr("y", 0);
 
-    if ( !this.editorView.trainrunSectionPreviewLineView.getVariantIsWritable() ){
+    if (
+      !this.editorView.trainrunSectionPreviewLineView.getVariantIsWritable()
+    ) {
       return;
     }
 
@@ -422,7 +420,9 @@ export class NotesView {
   }
 
   private makeNoteDragArea(groupEnter: any) {
-    if ( !this.editorView.trainrunSectionPreviewLineView.getVariantIsWritable() ){
+    if (
+      !this.editorView.trainrunSectionPreviewLineView.getVariantIsWritable()
+    ) {
       return;
     }
     groupEnter
@@ -435,11 +435,11 @@ export class NotesView {
       .attr(
         "d",
         "m11.855 2.398-.356-.36-.356.36-3.841 3.897.712.702L11 " +
-        "3.97V11H3.957l2.647-2.647-.707-.708-3.5 3.5-.354.354.354.354 3.5 " +
-        "3.5.707-.708-2.646-2.645H11v7.03l-2.995-3.027-.71.703 3.852 3.894.356.36.355-.36 " +
-        "3.842-3.898-.712-.701L12 19.032v-7.031h7.041l-2.645 2.645.708.708 " +
-        "3.5-3.5.353-.354-.353-.354-3.5-3.5-.707.708L19.043 11H12V3.967l2.997 " +
-        "3.029.711-.704-3.853-3.894Z",
+          "3.97V11H3.957l2.647-2.647-.707-.708-3.5 3.5-.354.354.354.354 3.5 " +
+          "3.5.707-.708-2.646-2.645H11v7.03l-2.995-3.027-.71.703 3.852 3.894.356.36.355-.36 " +
+          "3.842-3.898-.712-.701L12 19.032v-7.031h7.041l-2.645 2.645.708.708 " +
+          "3.5-3.5.353-.354-.353-.354-3.5-3.5-.707.708L19.043 11H12V3.967l2.997 " +
+          "3.029.711-.704-3.853-3.894Z",
       )
       .attr("transform", (n: NoteViewObject) => "translate(-45,-15),scale(1.0)")
       .on("mouseout", (n: NoteViewObject) =>
@@ -452,7 +452,9 @@ export class NotesView {
   }
 
   onNoteMousedown(note: Note) {
-    if ( !this.editorView.trainrunSectionPreviewLineView.getVariantIsWritable() ){
+    if (
+      !this.editorView.trainrunSectionPreviewLineView.getVariantIsWritable()
+    ) {
       d3.event.stopPropagation();
       return;
     }
@@ -469,7 +471,9 @@ export class NotesView {
   }
 
   onNoteMouseup(note: Note, domObj: any) {
-    if ( !this.editorView.trainrunSectionPreviewLineView.getVariantIsWritable() ){
+    if (
+      !this.editorView.trainrunSectionPreviewLineView.getVariantIsWritable()
+    ) {
       d3.event.stopPropagation();
       return;
     }

--- a/src/app/view/editor-main-view/data-views/trainrunSectionViewObject.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunSectionViewObject.ts
@@ -135,7 +135,7 @@ export class TrainrunSectionViewObject {
       "_" +
       editorView.checkFilterNode(d.getTargetNode()) +
       "_" +
-      editorView.getLevelOfDetail()  +
+      editorView.getLevelOfDetail() +
       "_" +
       editorView.trainrunSectionPreviewLineView.getVariantIsWritable();
 

--- a/src/app/view/editor-main-view/data-views/trainrunsection.previewline.view.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunsection.previewline.view.ts
@@ -56,7 +56,7 @@ export class TrainrunSectionPreviewLineView {
   constructor(
     private nodeService: NodeService,
     private filterService: FilterService,
-    private versionControlService : VersionControlService
+    private versionControlService: VersionControlService,
   ) {}
 
   static setGroup(nodeGroup: d3.Selector) {
@@ -71,8 +71,8 @@ export class TrainrunSectionPreviewLineView {
       .attr("class", StaticDomTags.PREVIEW_CONNECTION_LINE_ROOT_CLASS);
   }
 
-  getVariantIsWritable() : boolean {
-    if ( !this.versionControlService?.getVariantIsWritable()){
+  getVariantIsWritable(): boolean {
+    if (!this.versionControlService?.getVariantIsWritable()) {
       return false;
     }
     return true;
@@ -102,7 +102,7 @@ export class TrainrunSectionPreviewLineView {
     dragIntermediateStopInfo: DragIntermediateStopInfo,
     startPosition: Vec2D,
   ) {
-    if ( !this.versionControlService?.getVariantIsWritable()){
+    if (!this.versionControlService?.getVariantIsWritable()) {
       return;
     }
     this.mode = PreviewLineMode.DragIntermediateStop;
@@ -117,7 +117,7 @@ export class TrainrunSectionPreviewLineView {
     dragTransition: DragTransitionInfo,
     startPosition: Vec2D,
   ) {
-    if ( !this.versionControlService?.getVariantIsWritable()){
+    if (!this.versionControlService?.getVariantIsWritable()) {
       return;
     }
     this.filterService.switchOffTemporaryEmptyAndNonStopFiltering();
@@ -158,7 +158,7 @@ export class TrainrunSectionPreviewLineView {
   }
 
   startPreviewLine(nodeId: number) {
-    if ( !this.versionControlService?.getVariantIsWritable()){
+    if (!this.versionControlService?.getVariantIsWritable()) {
       return;
     }
     this.mode = PreviewLineMode.DragNewTrainrunSection;
@@ -171,7 +171,7 @@ export class TrainrunSectionPreviewLineView {
   }
 
   startPreviewLineAtPosition(startNode: Node, startPosition: Vec2D) {
-    if ( !this.versionControlService?.getVariantIsWritable()){
+    if (!this.versionControlService?.getVariantIsWritable()) {
       return;
     }
     this.mode = PreviewLineMode.DragExistingTrainrunSection;
@@ -277,7 +277,7 @@ export class TrainrunSectionPreviewLineView {
         false,
       );
     }
-    if (this.existingTrainrunSection !== null){
+    if (this.existingTrainrunSection !== null) {
       D3Utils.removeGrayout(this.existingTrainrunSection);
     }
     if (this.startNode !== null) {

--- a/src/app/view/editor-main-view/data-views/trainrunsections.view.spec.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunsections.view.spec.ts
@@ -28,9 +28,7 @@ import {TrainrunSectionsView} from "./trainrunsections.view";
 import {Vec2D} from "../../../utils/vec2D";
 import {LevelOfDetailService} from "../../../services/ui/level.of.detail.service";
 import {ViewportCullService} from "../../../services/ui/viewport.cull.service";
-import {
-  PositionTransformationService
-} from "../../../services/util/position.transformation.service";
+import {PositionTransformationService} from "../../../services/util/position.transformation.service";
 
 describe("TrainrunSection-View", () => {
   let dataService: DataService;
@@ -103,7 +101,7 @@ describe("TrainrunSection-View", () => {
       trainrunService,
       trainrunSectionService,
       nodeService,
-      filterService
+      filterService,
     );
 
     uiInteractionService = new UiInteractionService(
@@ -136,15 +134,13 @@ describe("TrainrunSection-View", () => {
       undoService,
     );
 
-    const levelOfDetailService = new LevelOfDetailService(
-      uiInteractionService
-    );
+    const levelOfDetailService = new LevelOfDetailService(uiInteractionService);
 
     const viewportCullService = new ViewportCullService(
       uiInteractionService,
       nodeService,
       noteService,
-      trainrunSectionService
+      trainrunSectionService,
     );
 
     const positionTransformationService = new PositionTransformationService(
@@ -152,7 +148,7 @@ describe("TrainrunSection-View", () => {
       nodeService,
       noteService,
       uiInteractionService,
-      viewportCullService
+      viewportCullService,
     );
 
     const controller = new EditorMainViewComponent(
@@ -169,7 +165,7 @@ describe("TrainrunSection-View", () => {
       viewportCullService,
       levelOfDetailService,
       undefined,
-      positionTransformationService
+      positionTransformationService,
     );
 
     new EditorView(
@@ -186,7 +182,7 @@ describe("TrainrunSection-View", () => {
       viewportCullService,
       levelOfDetailService,
       undefined,
-      positionTransformationService
+      positionTransformationService,
     );
 
     controller.bindViewToServices();

--- a/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
@@ -19,7 +19,10 @@ import {StaticDomTags} from "./static.dom.tags";
 import {TrainrunSection} from "../../../models/trainrunsection.model";
 import {EditorView} from "./editor.view";
 import {D3Utils} from "./d3.utils";
-import {DragIntermediateStopInfo, PreviewLineMode,} from "./trainrunsection.previewline.view";
+import {
+  DragIntermediateStopInfo,
+  PreviewLineMode,
+} from "./trainrunsection.previewline.view";
 import {MathUtils} from "../../../utils/math";
 import {Trainrun} from "../../../models/trainrun.model";
 import {TrainrunSectionViewObject} from "./trainrunSectionViewObject";
@@ -33,8 +36,7 @@ import {LinePatternRefs} from "../../../data-structures/business.data.structures
 export class TrainrunSectionsView {
   trainrunSectionGroup;
 
-  constructor(private editorView: EditorView) {
-  }
+  constructor(private editorView: EditorView) {}
 
   static translateAndRotateText(
     trainrunSection: TrainrunSection,
@@ -188,15 +190,35 @@ export class TrainrunSectionsView {
     }
     switch (textElement) {
       case TrainrunSectionText.SourceDeparture:
-        return trainrunSection.getSourceDepartureWarning().title + ": " + trainrunSection.getSourceDepartureWarning().description;
+        return (
+          trainrunSection.getSourceDepartureWarning().title +
+          ": " +
+          trainrunSection.getSourceDepartureWarning().description
+        );
       case TrainrunSectionText.SourceArrival:
-        return trainrunSection.getSourceArrivalWarning().title + ": " + trainrunSection.getSourceArrivalWarning().description;
+        return (
+          trainrunSection.getSourceArrivalWarning().title +
+          ": " +
+          trainrunSection.getSourceArrivalWarning().description
+        );
       case TrainrunSectionText.TargetDeparture:
-        return trainrunSection.getTargetDepartureWarning().title + ": " + trainrunSection.getTargetDepartureWarning().description;
+        return (
+          trainrunSection.getTargetDepartureWarning().title +
+          ": " +
+          trainrunSection.getTargetDepartureWarning().description
+        );
       case TrainrunSectionText.TargetArrival:
-        return trainrunSection.getTargetArrivalWarning().title + ": " + trainrunSection.getTargetArrivalWarning().description;
+        return (
+          trainrunSection.getTargetArrivalWarning().title +
+          ": " +
+          trainrunSection.getTargetArrivalWarning().description
+        );
       case TrainrunSectionText.TrainrunSectionTravelTime:
-        return trainrunSection.getTravelTimeWarning().title + ": " + trainrunSection.getTravelTimeWarning().description;
+        return (
+          trainrunSection.getTravelTimeWarning().title +
+          ": " +
+          trainrunSection.getTravelTimeWarning().description
+        );
       case TrainrunSectionText.TrainrunSectionName:
       default:
         return "";
@@ -421,9 +443,9 @@ export class TrainrunSectionsView {
       " " +
       (colorRef === undefined
         ? StaticDomTags.makeClassTag(
-          StaticDomTags.TAG_COLOR_REF,
-          trainrunSection.getTrainrun().getCategoryColorRef(),
-        )
+            StaticDomTags.TAG_COLOR_REF,
+            trainrunSection.getTrainrun().getCategoryColorRef(),
+          )
         : colorRef);
     switch (textElement) {
       case TrainrunSectionText.SourceDeparture:
@@ -982,28 +1004,29 @@ export class TrainrunSectionsView {
           !trainrunSection.getTrainrun().selected() &&
           TrainrunSectionsView.isBothSideNonStop(trainrunSection)
         );
-      case TrainrunSectionText.TrainrunSectionName: {
-        if (!this.editorView.isFilterTrainrunNameEnabled()) {
-          return true;
-        }
-        const srcNode = TrainrunSectionsView.getNode(trainrunSection, true);
-        const trgNode = TrainrunSectionsView.getNode(trainrunSection, false);
-        if (
-          !this.editorView.checkFilterNonStopNode(srcNode) ||
-          !this.editorView.checkFilterNonStopNode(trgNode)
-        ) {
-          const transSrc = srcNode.getTransition(trainrunSection.getId());
-          const transTrg = trgNode.getTransition(trainrunSection.getId());
-          if (transSrc !== undefined && transTrg !== undefined) {
-            if (
-              transSrc.getIsNonStopTransit() &&
-              transTrg.getIsNonStopTransit()
-            ) {
-              return true;
+      case TrainrunSectionText.TrainrunSectionName:
+        {
+          if (!this.editorView.isFilterTrainrunNameEnabled()) {
+            return true;
+          }
+          const srcNode = TrainrunSectionsView.getNode(trainrunSection, true);
+          const trgNode = TrainrunSectionsView.getNode(trainrunSection, false);
+          if (
+            !this.editorView.checkFilterNonStopNode(srcNode) ||
+            !this.editorView.checkFilterNonStopNode(trgNode)
+          ) {
+            const transSrc = srcNode.getTransition(trainrunSection.getId());
+            const transTrg = trgNode.getTransition(trainrunSection.getId());
+            if (transSrc !== undefined && transTrg !== undefined) {
+              if (
+                transSrc.getIsNonStopTransit() &&
+                transTrg.getIsNonStopTransit()
+              ) {
+                return true;
+              }
             }
           }
         }
-      }
         return false;
       default:
         return false;
@@ -1023,7 +1046,6 @@ export class TrainrunSectionsView {
     selectedTrainrun: Trainrun,
     connectedTrainIds: any,
   ) {
-
     const atSource =
       lineTextElement === TrainrunSectionText.SourceArrival ||
       lineTextElement === TrainrunSectionText.SourceDeparture;
@@ -1066,7 +1088,7 @@ export class TrainrunSectionsView {
             d.trainrunSection,
             lineTextElement,
           ) /
-          2,
+            2,
       )
       .attr(
         "y",
@@ -1097,7 +1119,9 @@ export class TrainrunSectionsView {
   ) {
     const trainrunSectionElements = groupEnter
       .filter((d: TrainrunSectionViewObject) => {
-        return !levelFreqFilter.includes(d.trainrunSection.getFrequencyLinePatternRef());
+        return !levelFreqFilter.includes(
+          d.trainrunSection.getFrequencyLinePatternRef(),
+        );
       })
       .append(StaticDomTags.EDGE_LINE_SVG)
       .attr(
@@ -1251,7 +1275,9 @@ export class TrainrunSectionsView {
     connectedTrainIds: any,
     atSource: boolean,
   ) {
-    if (!this.editorView.trainrunSectionPreviewLineView.getVariantIsWritable()) {
+    if (
+      !this.editorView.trainrunSectionPreviewLineView.getVariantIsWritable()
+    ) {
       return;
     }
     groupEnter
@@ -1302,8 +1328,8 @@ export class TrainrunSectionsView {
           }
           const port = node.getPortOfTrainrunSection(d.trainrunSection.getId());
           const trans = node.getTransitionFromPortId(port.getId());
-          return (trans === undefined);
-        }
+          return trans === undefined;
+        },
       )
       .classed(
         StaticDomTags.EDGE_IS_NOT_END_NODE,
@@ -1314,8 +1340,8 @@ export class TrainrunSectionsView {
           }
           const port = node.getPortOfTrainrunSection(d.trainrunSection.getId());
           const trans = node.getTransitionFromPortId(port.getId());
-          return (trans !== undefined);
-        }
+          return trans !== undefined;
+        },
       )
 
       .classed(StaticDomTags.TAG_MUTED, (d: TrainrunSectionViewObject) =>
@@ -1350,7 +1376,7 @@ export class TrainrunSectionsView {
     connectedTrainIds: any,
     textElement: TrainrunSectionText,
     enableEvents = true,
-    hasWarning = true
+    hasWarning = true,
   ) {
     const atSource =
       textElement === TrainrunSectionText.SourceArrival ||
@@ -1367,7 +1393,8 @@ export class TrainrunSectionsView {
             atSource,
             isArrival,
           ) &&
-          TrainrunSectionsView.hasWarning(d.trainrunSection, textElement) === hasWarning
+          TrainrunSectionsView.hasWarning(d.trainrunSection, textElement) ===
+            hasWarning,
       )
       .append(StaticDomTags.EDGE_LINE_TEXT_SVG)
       .attr("class", (d: TrainrunSectionViewObject) =>
@@ -1453,7 +1480,10 @@ export class TrainrunSectionsView {
       renderingObjects
         .append("svg:title")
         .text((d: TrainrunSectionViewObject) => {
-          return TrainrunSectionsView.getWarning(d.trainrunSection, textElement);
+          return TrainrunSectionsView.getWarning(
+            d.trainrunSection,
+            textElement,
+          );
         });
     }
   }
@@ -1463,16 +1493,26 @@ export class TrainrunSectionsView {
     selectedTrainrun: Trainrun,
     connectedTrainIds: any,
     textElement: TrainrunSectionText,
-    enableEvents = true
+    enableEvents = true,
   ) {
     // pass(1) : render all elements without warnings
     this.createInternTrainrunSectionElementFilteringWarningElements(
-      groupEnter, selectedTrainrun, connectedTrainIds, textElement, enableEvents, false
+      groupEnter,
+      selectedTrainrun,
+      connectedTrainIds,
+      textElement,
+      enableEvents,
+      false,
     );
     // pass(2) : render all elements with warnings
     //           especially <svg:title>warning_msg</svg:title>
     this.createInternTrainrunSectionElementFilteringWarningElements(
-      groupEnter, selectedTrainrun, connectedTrainIds, textElement, enableEvents, true
+      groupEnter,
+      selectedTrainrun,
+      connectedTrainIds,
+      textElement,
+      enableEvents,
+      true,
     );
   }
 
@@ -1554,14 +1594,14 @@ export class TrainrunSectionsView {
       .attr(
         "class",
         StaticDomTags.EDGE_LINE_TEXT_CLASS +
-        " " +
-        TrainrunSectionsView.createTrainrunSectionFrequencyClassAttribute(
-          trainrunSection,
-          selectedTrainrun,
-          connectedTrainIds,
-        ) +
-        " " +
-        TrainrunSectionText[TrainrunSectionText.TrainrunSectionNumberOfStops],
+          " " +
+          TrainrunSectionsView.createTrainrunSectionFrequencyClassAttribute(
+            trainrunSection,
+            selectedTrainrun,
+            connectedTrainIds,
+          ) +
+          " " +
+          TrainrunSectionText[TrainrunSectionText.TrainrunSectionNumberOfStops],
       )
       .attr(StaticDomTags.EDGE_ID, () => trainrunSection.getId())
       .attr(StaticDomTags.EDGE_LINE_LINE_ID, () =>
@@ -1722,8 +1762,9 @@ export class TrainrunSectionsView {
 
     const filteredTrainrunSections = trainrunSections.filter(
       (trainrunSection: TrainrunSection) =>
-        this.editorView.doCullCheckPositionsInViewport(trainrunSection.getPath()) &&
-        this.filterTrainrunSectionToDisplay(trainrunSection)
+        this.editorView.doCullCheckPositionsInViewport(
+          trainrunSection.getPath(),
+        ) && this.filterTrainrunSectionToDisplay(trainrunSection),
     );
 
     const group = this.trainrunSectionGroup
@@ -1922,9 +1963,11 @@ export class TrainrunSectionsView {
       this.editorView.trainrunSectionPreviewLineView.getMode() ===
       PreviewLineMode.NotDragging
     ) {
-      D3Utils.hoverTrainrunSection(trainrunSection,
+      D3Utils.hoverTrainrunSection(
+        trainrunSection,
         this.editorView.getSelectedTrainrun() !== null,
-        domObj);
+        domObj,
+      );
     }
   }
 
@@ -1962,10 +2005,10 @@ export class TrainrunSectionsView {
     const obj = d3
       .selectAll(
         StaticDomTags.EDGE_LINE_PIN_DOM_REF +
-        "." +
-        (atSource
-          ? StaticDomTags.EDGE_IS_TARGET
-          : StaticDomTags.EDGE_IS_SOURCE),
+          "." +
+          (atSource
+            ? StaticDomTags.EDGE_IS_TARGET
+            : StaticDomTags.EDGE_IS_SOURCE),
       )
       .filter(
         (d: TrainrunSectionViewObject) =>
@@ -2257,7 +2300,8 @@ export class TrainrunSectionsView {
       selectedTrainrun,
       connectedTrainIds,
       inGroupLabels,
-      false);
+      false,
+    );
 
     if (!this.editorView.isElementDragging()) {
       const groupLabels = inGroupLabels.filter(
@@ -2268,25 +2312,29 @@ export class TrainrunSectionsView {
       );
 
       if (this.editorView.getLevelOfDetail() === LevelOfDetail.FULL) {
-        this.createTrainrunSectionTextBackgrounds( // LevelOfDetail.FULL
+        this.createTrainrunSectionTextBackgrounds(
+          // LevelOfDetail.FULL
           groupLabels,
           TrainrunSectionText.SourceArrival,
           selectedTrainrun,
           connectedTrainIds,
         );
-        this.createTrainrunSectionTextBackgrounds( // LevelOfDetail.FULL
+        this.createTrainrunSectionTextBackgrounds(
+          // LevelOfDetail.FULL
           groupLabels,
           TrainrunSectionText.SourceDeparture,
           selectedTrainrun,
           connectedTrainIds,
         );
-        this.createTrainrunSectionTextBackgrounds( // LevelOfDetail.FULL
+        this.createTrainrunSectionTextBackgrounds(
+          // LevelOfDetail.FULL
           groupLabels,
           TrainrunSectionText.TargetArrival,
           selectedTrainrun,
           connectedTrainIds,
         );
-        this.createTrainrunSectionTextBackgrounds( // LevelOfDetail.FULL
+        this.createTrainrunSectionTextBackgrounds(
+          // LevelOfDetail.FULL
           groupLabels,
           TrainrunSectionText.TargetDeparture,
           selectedTrainrun,
@@ -2294,30 +2342,36 @@ export class TrainrunSectionsView {
         );
       }
 
-      if (this.editorView.getLevelOfDetail() === LevelOfDetail.FULL ||
-        this.editorView.getLevelOfDetail() === LevelOfDetail.LEVEL3) {
-        this.createTrainrunSectionElement( // LevelOfDetail.LEVEL3
+      if (
+        this.editorView.getLevelOfDetail() === LevelOfDetail.FULL ||
+        this.editorView.getLevelOfDetail() === LevelOfDetail.LEVEL3
+      ) {
+        this.createTrainrunSectionElement(
+          // LevelOfDetail.LEVEL3
           groupLabels,
           selectedTrainrun,
           connectedTrainIds,
           TrainrunSectionText.SourceArrival,
           false,
         );
-        this.createTrainrunSectionElement( // LevelOfDetail.LEVEL3
+        this.createTrainrunSectionElement(
+          // LevelOfDetail.LEVEL3
           groupLabels,
           selectedTrainrun,
           connectedTrainIds,
           TrainrunSectionText.SourceDeparture,
           false,
         );
-        this.createTrainrunSectionElement( // LevelOfDetail.LEVEL3
+        this.createTrainrunSectionElement(
+          // LevelOfDetail.LEVEL3
           groupLabels,
           selectedTrainrun,
           connectedTrainIds,
           TrainrunSectionText.TargetArrival,
           false,
         );
-        this.createTrainrunSectionElement( // LevelOfDetail.LEVEL3
+        this.createTrainrunSectionElement(
+          // LevelOfDetail.LEVEL3
           groupLabels,
           selectedTrainrun,
           connectedTrainIds,
@@ -2339,10 +2393,13 @@ export class TrainrunSectionsView {
         false,
       );
 
-      if (this.editorView.getLevelOfDetail() === LevelOfDetail.FULL ||
+      if (
+        this.editorView.getLevelOfDetail() === LevelOfDetail.FULL ||
         this.editorView.getLevelOfDetail() === LevelOfDetail.LEVEL3 ||
-        this.editorView.getLevelOfDetail() === LevelOfDetail.LEVEL2) {
-        this.createTrainrunsectionSemicircles( // LevelOfDetail.LEVEL2
+        this.editorView.getLevelOfDetail() === LevelOfDetail.LEVEL2
+      ) {
+        this.createTrainrunsectionSemicircles(
+          // LevelOfDetail.LEVEL2
           groupLabels,
           selectedTrainrun,
           connectedTrainIds,
@@ -2368,7 +2425,8 @@ export class TrainrunSectionsView {
       selectedTrainrun,
       connectedTrainIds,
       inGroupLabels,
-      true);
+      true,
+    );
 
     if (!this.editorView.isElementDragging()) {
       const groupLabels = inGroupLabels.filter((d: TrainrunSectionViewObject) =>
@@ -2377,16 +2435,20 @@ export class TrainrunSectionsView {
         ),
       );
 
-      if (this.editorView.getLevelOfDetail() === LevelOfDetail.FULL ||
+      if (
+        this.editorView.getLevelOfDetail() === LevelOfDetail.FULL ||
         this.editorView.getLevelOfDetail() === LevelOfDetail.LEVEL3 ||
-        this.editorView.getLevelOfDetail() === LevelOfDetail.LEVEL2) {
-        this.createPinOnTrainrunsection( // LevelOfDetail.LEVEL2
+        this.editorView.getLevelOfDetail() === LevelOfDetail.LEVEL2
+      ) {
+        this.createPinOnTrainrunsection(
+          // LevelOfDetail.LEVEL2
           groupLabels,
           selectedTrainrun,
           connectedTrainIds,
           true,
         );
-        this.createPinOnTrainrunsection( // LevelOfDetail.LEVEL2
+        this.createPinOnTrainrunsection(
+          // LevelOfDetail.LEVEL2
           groupLabels,
           selectedTrainrun,
           connectedTrainIds,
@@ -2395,25 +2457,29 @@ export class TrainrunSectionsView {
       }
 
       if (this.editorView.getLevelOfDetail() === LevelOfDetail.FULL) {
-        this.createTrainrunSectionTextBackgrounds( // LevelOfDetail.FULL
+        this.createTrainrunSectionTextBackgrounds(
+          // LevelOfDetail.FULL
           groupLabels,
           TrainrunSectionText.SourceArrival,
           selectedTrainrun,
           connectedTrainIds,
         );
-        this.createTrainrunSectionTextBackgrounds( // LevelOfDetail.FULL
+        this.createTrainrunSectionTextBackgrounds(
+          // LevelOfDetail.FULL
           groupLabels,
           TrainrunSectionText.SourceDeparture,
           selectedTrainrun,
           connectedTrainIds,
         );
-        this.createTrainrunSectionTextBackgrounds( // LevelOfDetail.FULL
+        this.createTrainrunSectionTextBackgrounds(
+          // LevelOfDetail.FULL
           groupLabels,
           TrainrunSectionText.TargetArrival,
           selectedTrainrun,
           connectedTrainIds,
         );
-        this.createTrainrunSectionTextBackgrounds( // LevelOfDetail.FULL
+        this.createTrainrunSectionTextBackgrounds(
+          // LevelOfDetail.FULL
           groupLabels,
           TrainrunSectionText.TargetDeparture,
           selectedTrainrun,
@@ -2421,33 +2487,40 @@ export class TrainrunSectionsView {
         );
       }
 
-      if (this.editorView.getLevelOfDetail() === LevelOfDetail.FULL ||
-        this.editorView.getLevelOfDetail() === LevelOfDetail.LEVEL3) {
-        this.createTrainrunSectionElement(  // LevelOfDetail.LEVEL3
+      if (
+        this.editorView.getLevelOfDetail() === LevelOfDetail.FULL ||
+        this.editorView.getLevelOfDetail() === LevelOfDetail.LEVEL3
+      ) {
+        this.createTrainrunSectionElement(
+          // LevelOfDetail.LEVEL3
           groupLabels,
           selectedTrainrun,
           connectedTrainIds,
           TrainrunSectionText.SourceArrival,
         );
-        this.createTrainrunSectionElement( // LevelOfDetail.LEVEL3
+        this.createTrainrunSectionElement(
+          // LevelOfDetail.LEVEL3
           groupLabels,
           selectedTrainrun,
           connectedTrainIds,
           TrainrunSectionText.SourceDeparture,
         );
-        this.createTrainrunSectionElement( // LevelOfDetail.LEVEL3
+        this.createTrainrunSectionElement(
+          // LevelOfDetail.LEVEL3
           groupLabels,
           selectedTrainrun,
           connectedTrainIds,
           TrainrunSectionText.TargetArrival,
         );
-        this.createTrainrunSectionElement( // LevelOfDetail.LEVEL3
+        this.createTrainrunSectionElement(
+          // LevelOfDetail.LEVEL3
           groupLabels,
           selectedTrainrun,
           connectedTrainIds,
           TrainrunSectionText.TargetDeparture,
         );
-        this.createTrainrunSectionElement( // LevelOfDetail.LEVEL3
+        this.createTrainrunSectionElement(
+          // LevelOfDetail.LEVEL3
           groupLabels,
           selectedTrainrun,
           connectedTrainIds,
@@ -2455,46 +2528,53 @@ export class TrainrunSectionsView {
         );
       }
 
-      if (this.editorView.getLevelOfDetail() === LevelOfDetail.FULL ||
+      if (
+        this.editorView.getLevelOfDetail() === LevelOfDetail.FULL ||
         this.editorView.getLevelOfDetail() === LevelOfDetail.LEVEL3 ||
-        this.editorView.getLevelOfDetail() === LevelOfDetail.LEVEL2) {
-        this.createTrainrunSectionElement( // LevelOfDetail.LEVEL2
+        this.editorView.getLevelOfDetail() === LevelOfDetail.LEVEL2
+      ) {
+        this.createTrainrunSectionElement(
+          // LevelOfDetail.LEVEL2
           groupLabels,
           selectedTrainrun,
           connectedTrainIds,
           TrainrunSectionText.TrainrunSectionName,
-          true
+          true,
         );
 
-        this.createTrainrunsectionSemicircles( // LevelOfDetail.LEVEL2
+        this.createTrainrunsectionSemicircles(
+          // LevelOfDetail.LEVEL2
           groupLabels,
           selectedTrainrun,
           connectedTrainIds,
         );
       }
 
-      if (this.editorView.getLevelOfDetail() === LevelOfDetail.FULL ||
-        this.editorView.getLevelOfDetail() === LevelOfDetail.LEVEL3) {
-        this.createAllIntermediateStops( // LevelOfDetail.LEVEL3
+      if (
+        this.editorView.getLevelOfDetail() === LevelOfDetail.FULL ||
+        this.editorView.getLevelOfDetail() === LevelOfDetail.LEVEL3
+      ) {
+        this.createAllIntermediateStops(
+          // LevelOfDetail.LEVEL3
           groupLabels,
           selectedTrainrun,
           connectedTrainIds,
         );
       }
-
     }
   }
 
-
-  make4LayerTrainrunSectionLines(groupLines: any,
-                                 selectedTrainrun: Trainrun,
-                                 connectedTrainIds: any[],
-                                 inGroupLabels,
-                                 enableEvents: boolean) {
+  make4LayerTrainrunSectionLines(
+    groupLines: any,
+    selectedTrainrun: Trainrun,
+    connectedTrainIds: any[],
+    inGroupLabels,
+    enableEvents: boolean,
+  ) {
     this.createTrainrunSection(
       groupLines,
       StaticDomTags.EDGE_LINE_LAYER_0,
-      [LinePatternRefs.Freq30],// LinePatternRefs.Freq60], (background is required to "strech the hower area"
+      [LinePatternRefs.Freq30], // LinePatternRefs.Freq60], (background is required to "strech the hower area"
       selectedTrainrun,
       connectedTrainIds,
       enableEvents,
@@ -2643,7 +2723,7 @@ export class TrainrunSectionsView {
           this.editorView.combineTwoTrainruns(
             endNode,
             n.getPortOfTrainrunSection(trainrunSectionFrom.getId()),
-            n.getPortOfTrainrunSection(trainrunSection.getId())
+            n.getPortOfTrainrunSection(trainrunSection.getId()),
           );
           return;
         }

--- a/src/app/view/editor-main-view/data-views/transitions.view.spec.ts
+++ b/src/app/view/editor-main-view/data-views/transitions.view.spec.ts
@@ -23,9 +23,7 @@ import {NetzgrafikUnitTesting} from "../../../../integration-testing/netzgrafik.
 import {TransitionsView} from "./transitions.view";
 import {LevelOfDetailService} from "../../../services/ui/level.of.detail.service";
 import {ViewportCullService} from "../../../services/ui/viewport.cull.service";
-import {
-  PositionTransformationService
-} from "../../../services/util/position.transformation.service";
+import {PositionTransformationService} from "../../../services/util/position.transformation.service";
 
 describe("Transitions-View", () => {
   let dataService: DataService;
@@ -98,7 +96,7 @@ describe("Transitions-View", () => {
       trainrunService,
       trainrunSectionService,
       nodeService,
-      filterService
+      filterService,
     );
 
     uiInteractionService = new UiInteractionService(
@@ -131,15 +129,13 @@ describe("Transitions-View", () => {
       undoService,
     );
 
-    const levelOfDetailService = new LevelOfDetailService(
-      uiInteractionService
-    );
+    const levelOfDetailService = new LevelOfDetailService(uiInteractionService);
 
     const viewportCullService = new ViewportCullService(
       uiInteractionService,
       nodeService,
       noteService,
-      trainrunSectionService
+      trainrunSectionService,
     );
 
     const positionTransformationService = new PositionTransformationService(
@@ -147,7 +143,7 @@ describe("Transitions-View", () => {
       nodeService,
       noteService,
       uiInteractionService,
-      viewportCullService
+      viewportCullService,
     );
 
     const controller = new EditorMainViewComponent(
@@ -164,7 +160,7 @@ describe("Transitions-View", () => {
       viewportCullService,
       levelOfDetailService,
       undefined,
-      positionTransformationService
+      positionTransformationService,
     );
 
     new EditorView(
@@ -181,7 +177,7 @@ describe("Transitions-View", () => {
       viewportCullService,
       levelOfDetailService,
       undefined,
-      positionTransformationService
+      positionTransformationService,
     );
 
     controller.bindViewToServices();

--- a/src/app/view/editor-main-view/data-views/transitions.view.ts
+++ b/src/app/view/editor-main-view/data-views/transitions.view.ts
@@ -107,7 +107,9 @@ export class TransitionsView {
   ) {
     grpEnter
       .filter((d: TransitionViewObject) => {
-        return !levelFreqFilter.includes(d.transition.getTrainrun().getFrequencyLinePatternRef());
+        return !levelFreqFilter.includes(
+          d.transition.getTrainrun().getFrequencyLinePatternRef(),
+        );
       })
       .append(StaticDomTags.TRANSITION_LINE_SVG)
       .attr(
@@ -156,7 +158,9 @@ export class TransitionsView {
     selectedTrainrun: Trainrun,
     connectedTrainIds: any,
   ) {
-    if (!this.editorView.trainrunSectionPreviewLineView.getVariantIsWritable()){
+    if (
+      !this.editorView.trainrunSectionPreviewLineView.getVariantIsWritable()
+    ) {
       return;
     }
     grpEnter
@@ -188,9 +192,7 @@ export class TransitionsView {
         t.transition.getIsNonStopTransit(),
       )
       .on("mousemove", (t: TransitionViewObject, i, a) =>
-        this.onTransitionMousemove(
-          a[i],
-        ),
+        this.onTransitionMousemove(a[i]),
       )
       .on("mouseover", (t: TransitionViewObject, i, a) =>
         this.onTransitionMouseover(
@@ -249,9 +251,10 @@ export class TransitionsView {
         this.editorView.getConnectedTrainrunIds(selectedTrainrun);
     }
 
-    const transitions = inputTransitions.filter((t) =>
-      this.editorView.doCullCheckPositionsInViewport(t.getPath()) &&
-      this.filtertransitionToDisplay(t, t.getTrainrun())
+    const transitions = inputTransitions.filter(
+      (t) =>
+        this.editorView.doCullCheckPositionsInViewport(t.getPath()) &&
+        this.filtertransitionToDisplay(t, t.getTrainrun()),
     );
 
     this.createTransitions(
@@ -303,7 +306,7 @@ export class TransitionsView {
     TransitionsView.createTransitionLineLayer(
       grpEnter,
       StaticDomTags.TRANSITION_LINE_CLASS_0,
-      [LinePatternRefs.Freq30],// LinePatternRefs.Freq60], (background is required to "strech the hower area"
+      [LinePatternRefs.Freq30], // LinePatternRefs.Freq60], (background is required to "strech the hower area"
       selectedTrainrun,
       connectedTrainIds,
       this.editorView,

--- a/src/app/view/editor-main-view/editor-main-view.component.ts
+++ b/src/app/view/editor-main-view/editor-main-view.component.ts
@@ -21,7 +21,10 @@ import {UiInteractionService} from "../../services/ui/ui.interaction.service";
 import {Connection} from "../../models/connection.model";
 import {Transition} from "../../models/transition.model";
 import {FilterService} from "../../services/ui/filter.service";
-import {TrainrunCategory, TrainrunFrequency,} from "../../data-structures/business.data.structures";
+import {
+  TrainrunCategory,
+  TrainrunFrequency,
+} from "../../data-structures/business.data.structures";
 import {
   TrainrunDialogParameter,
   TrainrunDialogType,
@@ -30,15 +33,16 @@ import {TrainrunSectionText} from "../../data-structures/technical.data.structur
 import {takeUntil} from "rxjs/operators";
 import {Subject} from "rxjs";
 import {NoteService} from "../../services/data/note.service";
-import {NoteDialogParameter, NoteDialogType,} from "../dialogs/note-dialog/note-dialog.component";
+import {
+  NoteDialogParameter,
+  NoteDialogType,
+} from "../dialogs/note-dialog/note-dialog.component";
 import {AnalyticsService} from "../../services/analytics/analytics.service";
 import {Note} from "../../models/note.model";
 import {LogService} from "../../logger/log.service";
 import {UndoService} from "../../services/data/undo.service";
 import {CopyService} from "../../services/data/copy.service";
-import {
-  StreckengrafikDrawingContext
-} from "../../streckengrafik/model/util/streckengrafik.drawing.context";
+import {StreckengrafikDrawingContext} from "../../streckengrafik/model/util/streckengrafik.drawing.context";
 import {TravelTimeCreationEstimatorType} from "../themes/editor-trainrun-traveltime-creator-type";
 import {Port} from "../../models/port.model";
 import {LevelOfDetailService} from "../../services/ui/level.of.detail.service";
@@ -79,7 +83,7 @@ export class EditorMainViewComponent implements AfterViewInit, OnDestroy {
     private viewportCullService: ViewportCullService,
     private levelOfDetailService: LevelOfDetailService,
     private versionControlService: VersionControlService,
-    private positionTransformationService: PositionTransformationService
+    private positionTransformationService: PositionTransformationService,
   ) {
     this.editorView = new EditorView(
       this,
@@ -95,7 +99,7 @@ export class EditorMainViewComponent implements AfterViewInit, OnDestroy {
       viewportCullService,
       levelOfDetailService,
       versionControlService,
-      positionTransformationService
+      positionTransformationService,
     );
     this.uiInteractionService.zoomInObservable
       .pipe(takeUntil(this.destroyed))
@@ -232,7 +236,8 @@ export class EditorMainViewComponent implements AfterViewInit, OnDestroy {
         this.trainrunSectionService.createTrainrunSection(
           sourceNode.getId(),
           targetNode.getId(),
-          this.uiInteractionService.getActiveTravelTimeCreationEstimatorType() === TravelTimeCreationEstimatorType.RetrieveFromEdge
+          this.uiInteractionService.getActiveTravelTimeCreationEstimatorType() ===
+            TravelTimeCreationEstimatorType.RetrieveFromEdge,
         );
         if (!isTrainrunSelected) {
           const parameter = new TrainrunDialogParameter(
@@ -401,10 +406,11 @@ export class EditorMainViewComponent implements AfterViewInit, OnDestroy {
       this.trainrunService.splitTrainrunIntoTwoParts(t);
     });
 
-    this.editorView.bindCombineTwoTrainruns((n: Node, port1: Port, port2: Port) => {
-      this.trainrunService.combineTwoTrainruns(n, port1, port2);
-    });
-
+    this.editorView.bindCombineTwoTrainruns(
+      (n: Node, port1: Port, port2: Port) => {
+        this.trainrunService.combineTwoTrainruns(n, port1, port2);
+      },
+    );
 
     this.editorView.bindGetNodeFromConnection((c: Connection) =>
       this.nodeService.getNodeForConnection(c),
@@ -643,10 +649,8 @@ export class EditorMainViewComponent implements AfterViewInit, OnDestroy {
         this.editorView.postDisplayRendering();
       });
 
-    this.nodeService.nodes
-      .pipe(takeUntil(this.destroyed))
-      .subscribe(() => {
-        this.handleVariantChanged();
-      });
+    this.nodeService.nodes.pipe(takeUntil(this.destroyed)).subscribe(() => {
+      this.handleVariantChanged();
+    });
   }
 }

--- a/src/app/view/editor-menu/editor-menu.component.html
+++ b/src/app/view/editor-menu/editor-menu.component.html
@@ -336,18 +336,45 @@
         (click)="onOriginDestination()"
         [title]="getOriginDestinationTitle()"
       >
-        <sbb-icon _ngcontent-ng-c1568279807="" role="img" svgicon="chart-line-medium" height="25px" width="25px" aria-hidden="false" class="sbb-icon notranslate">
-          <svg xmlns="http://www.w3.org/2000/svg" width="36" height="36" fill="none" viewBox="20 -8 72 94" fit="" preserveAspectRatio="xMidYMid meet" focusable="false">
-
-          <g transform="rotate(30),scale(2.0),translate(20,-8)">
-            <path d="M21.25 15.75c0 4.377-1.308 7.222-3.342 8.982-2.047 1.772-4.91 2.518-8.158 2.518v1c3.38 0 6.516-.774 8.813-2.762 2.309-2 3.687-5.155 3.687-9.738V9.482l3.857 3.849.707-.708L22.09 7.91l-.353-.353-.353.354-4.712 4.713.707.707 3.871-3.872z" />
-          </g>
-          <g transform="scale(2.5),translate(3,10)">
-            <path width="26" height="20" d="M8 1C5.264 1 3 3.107 3 5.762v.021c.035.833.297 1.531.704 2.174l.007.01 3.886 5.811.416.621.416-.621 3.886-5.81.007-.01.006-.011c.393-.654.664-1.367.672-2.18v-.005C13 3.107 10.735 1 8 1M4.546 7.416C4.22 6.901 4.028 6.374 4 5.752 4.006 3.704 5.768 2 8 2c2.234 0 3.999 1.708 4 3.76-.006.58-.195 1.115-.523 1.661l-3.464 5.18zM6.5 6a1.5 1.5 0 1 1 3 0 1.5 1.5 0 0 1-3 0M8 3.5a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5" />
-          </g>
-          <g transform="rotate(-90),scale(2.0)translate(-22,23)">
-            <path fill="#000" fill-rule="evenodd" d="M14.5 7a5.5 5.5 0 1 0 .002 11.002A5.5 5.5 0 0 0 14.5 7M3 13h5.019a6.5 6.5 0 1 0 0-1H3zm11.5 3a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7" clip-rule="evenodd" />
-          </g>
+        <sbb-icon
+          _ngcontent-ng-c1568279807=""
+          role="img"
+          svgicon="chart-line-medium"
+          height="25px"
+          width="25px"
+          aria-hidden="false"
+          class="sbb-icon notranslate"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="36"
+            height="36"
+            fill="none"
+            viewBox="20 -8 72 94"
+            fit=""
+            preserveAspectRatio="xMidYMid meet"
+            focusable="false"
+          >
+            <g transform="rotate(30),scale(2.0),translate(20,-8)">
+              <path
+                d="M21.25 15.75c0 4.377-1.308 7.222-3.342 8.982-2.047 1.772-4.91 2.518-8.158 2.518v1c3.38 0 6.516-.774 8.813-2.762 2.309-2 3.687-5.155 3.687-9.738V9.482l3.857 3.849.707-.708L22.09 7.91l-.353-.353-.353.354-4.712 4.713.707.707 3.871-3.872z"
+              />
+            </g>
+            <g transform="scale(2.5),translate(3,10)">
+              <path
+                width="26"
+                height="20"
+                d="M8 1C5.264 1 3 3.107 3 5.762v.021c.035.833.297 1.531.704 2.174l.007.01 3.886 5.811.416.621.416-.621 3.886-5.81.007-.01.006-.011c.393-.654.664-1.367.672-2.18v-.005C13 3.107 10.735 1 8 1M4.546 7.416C4.22 6.901 4.028 6.374 4 5.752 4.006 3.704 5.768 2 8 2c2.234 0 3.999 1.708 4 3.76-.006.58-.195 1.115-.523 1.661l-3.464 5.18zM6.5 6a1.5 1.5 0 1 1 3 0 1.5 1.5 0 0 1-3 0M8 3.5a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5"
+              />
+            </g>
+            <g transform="rotate(-90),scale(2.0)translate(-22,23)">
+              <path
+                fill="#000"
+                fill-rule="evenodd"
+                d="M14.5 7a5.5 5.5 0 1 0 .002 11.002A5.5 5.5 0 0 0 14.5 7M3 13h5.019a6.5 6.5 0 1 0 0-1H3zm11.5 3a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7"
+                clip-rule="evenodd"
+              />
+            </g>
           </svg>
         </sbb-icon>
       </button>

--- a/src/app/view/editor-menu/editor-menu.component.ts
+++ b/src/app/view/editor-menu/editor-menu.component.ts
@@ -274,8 +274,14 @@ export class EditorMenuComponent implements OnInit, OnDestroy {
     const editorMode = this.uiInteractionService.getEditorMode();
 
     // Check if at least 2 nodes are selected
-    const selectedNodes = this.nodeService.getNodes().filter((n: Node) => n.selected());
-    if (this.uiInteractionService.getEditorMode() === EditorMode.MultiNodeMoving && selectedNodes.length < 2){
+    const selectedNodes = this.nodeService
+      .getNodes()
+      .filter((n: Node) => n.selected());
+    if (
+      this.uiInteractionService.getEditorMode() ===
+        EditorMode.MultiNodeMoving &&
+      selectedNodes.length < 2
+    ) {
       this._notification.open(
         $localize`:@@app.view.editor-menu.errorOriginDestination:Origin-destination matrix cannot be displayed because less than 2 nodes are selected.`,
         {
@@ -288,10 +294,14 @@ export class EditorMenuComponent implements OnInit, OnDestroy {
     }
 
     // If Node details are open and only one node is selected, unselect the node and compute od for all nodes.
-    if (this.uiInteractionService.getEditorMode() !== EditorMode.MultiNodeMoving && selectedNodes.length === 1) {
+    if (
+      this.uiInteractionService.getEditorMode() !==
+        EditorMode.MultiNodeMoving &&
+      selectedNodes.length === 1
+    ) {
       this.nodeService.unselectAllNodes();
     }
-    
+
     if (editorMode === EditorMode.OriginDestination) {
       this.nodeService.unselectAllNodes();
       this.uiInteractionService.showNetzgrafik();
@@ -314,7 +324,6 @@ export class EditorMenuComponent implements OnInit, OnDestroy {
   getOriginDestinationTitle(): string {
     if (this.isOriginDestination()) {
       return $localize`:@@app.view.editor-menu.closeOriginDestination:Close origin-destination matrix`;
-
     }
     return $localize`:@@app.view.editor-menu.displayOriginDestination:Display origin-destination matrix`;
   }

--- a/src/app/view/editor-properties-view-component/editor-properties-view.component.html
+++ b/src/app/view/editor-properties-view-component/editor-properties-view.component.html
@@ -1,9 +1,15 @@
-<h2 class="SummaryTitle">{{ 'app.view.editor-properties-view-component.settings' | translate }}</h2>
+<h2 class="SummaryTitle">
+  {{ "app.view.editor-properties-view-component.settings" | translate }}
+</h2>
 <sbb-accordion [multi]="true">
   <sbb-expansion-panel [expanded]="true">
-    <sbb-expansion-panel-header>{{ 'app.view.editor-properties-view-component.color-scheme' | translate }}</sbb-expansion-panel-header>
-    <sbb-label>{{ 'app.view.editor-properties-view-component.theme' | translate }}</sbb-label>
-    <br/>
+    <sbb-expansion-panel-header>{{
+      "app.view.editor-properties-view-component.color-scheme" | translate
+    }}</sbb-expansion-panel-header>
+    <sbb-label>{{
+      "app.view.editor-properties-view-component.theme" | translate
+    }}</sbb-label>
+    <br />
     <sbb-radio-group
       [(ngModel)]="activeColorTheme.themeRegistration"
       class="sbb-radio-group-vertical"
@@ -17,14 +23,19 @@
       </sbb-radio-button>
     </sbb-radio-group>
 
-    <br/>
+    <br />
     <ng-container *ngIf="!isActiveColorThemeDark()">
-      <sbb-label>{{ 'app.view.editor-properties-view-component.background-color' | translate }}</sbb-label>
+      <sbb-label>{{
+        "app.view.editor-properties-view-component.background-color" | translate
+      }}</sbb-label>
       <input
         id="activeBackgroundColor"
         type="color"
         sbbInput
-        [name]="'app.view.editor-properties-view-component.background-color' | translate"
+        [name]="
+          'app.view.editor-properties-view-component.background-color'
+            | translate
+        "
         style="width: 242px; min-height: 37px"
         [(ngModel)]="activeBackgroundColor"
         (change)="colorPicked($event)"
@@ -32,9 +43,12 @@
       &nbsp;
       <button
         sbb-secondary-button
-        style="vertical-align: middle;"
+        style="vertical-align: middle"
         [disabled]="isBackgroundColorWhite()"
-        [title]="'app.view.editor-properties-view-component.set-color-to-white' | translate"
+        [title]="
+          'app.view.editor-properties-view-component.set-color-to-white'
+            | translate
+        "
         (click)="setBackgroundColorToWhite()"
       >
         <svg
@@ -57,22 +71,31 @@
       <button
         sbb-secondary-button
         [disabled]="isDefaultBackgroundColorActive()"
-        style="vertical-align: middle;"
-        [title]="'app.view.editor-properties-view-component.reset-background-color-to-default' | translate"
+        style="vertical-align: middle"
+        [title]="
+          'app.view.editor-properties-view-component.reset-background-color-to-default'
+            | translate
+        "
         (click)="onResetBackgroundColor()"
       >
         <sbb-icon svgIcon="trash-small"></sbb-icon>
       </button>
     </ng-container>
     <ng-container *ngIf="isActiveColorThemeDark()">
-      <sbb-label>{{ 'app.view.editor-properties-view-component.background-color-black' | translate }}</sbb-label>
-      <br/>
+      <sbb-label>{{
+        "app.view.editor-properties-view-component.background-color-black"
+          | translate
+      }}</sbb-label>
+      <br />
       <input
         id="activeDarkBackgroundColor"
         type="color"
         sbbInput
-        [name]="'app.view.editor-properties-view-component.background-color' | translate"
-        style="width: 242px; min-height: 37px; vertical-align: middle;"
+        [name]="
+          'app.view.editor-properties-view-component.background-color'
+            | translate
+        "
+        style="width: 242px; min-height: 37px; vertical-align: middle"
         [(ngModel)]="activeDarkBackgroundColor"
         (change)="colorPicked($event)"
       />
@@ -80,31 +103,44 @@
       <button
         sbb-secondary-button
         [disabled]="isDefaultDarkBackgroundColorActive()"
-        [title]="'app.view.editor-properties-view-component.reset-background-color-to-default' | translate"
-        style="vertical-align: middle;"
+        [title]="
+          'app.view.editor-properties-view-component.reset-background-color-to-default'
+            | translate
+        "
+        style="vertical-align: middle"
         (click)="onResetDarkBackgroundColor()"
       >
         <sbb-icon svgIcon="trash-small"></sbb-icon>
       </button>
     </ng-container>
-    <br/>
+    <br />
     <ng-container *ngIf="isLocalStoredColorTheme()">
       <button
         sbb-secondary-button
         class="sbb-mt-m"
-        [title]="'app.view.editor-properties-view-component.useDefaultBrowserColorTheme' | translate"
+        [title]="
+          'app.view.editor-properties-view-component.useDefaultBrowserColorTheme'
+            | translate
+        "
         (click)="resetLocalStoredColorData()"
       >
-        {{ 'app.view.editor-properties-view-component.defaultBrowserColorTheme' | translate }}
+        {{
+          "app.view.editor-properties-view-component.defaultBrowserColorTheme"
+            | translate
+        }}
       </button>
     </ng-container>
   </sbb-expansion-panel>
 
-
   <sbb-expansion-panel [expanded]="true">
-    <sbb-expansion-panel-header>{{ 'app.view.editor-properties-view-component.editor' | translate }}</sbb-expansion-panel-header>
-    <sbb-label>{{ 'app.view.editor-properties-view-component.travel-time-presetting-default' | translate }}</sbb-label>
-    <br/>
+    <sbb-expansion-panel-header>{{
+      "app.view.editor-properties-view-component.editor" | translate
+    }}</sbb-expansion-panel-header>
+    <sbb-label>{{
+      "app.view.editor-properties-view-component.travel-time-presetting-default"
+        | translate
+    }}</sbb-label>
+    <br />
     <sbb-radio-group
       [(ngModel)]="activeTravelTimeCreationEstimatorType"
       class="sbb-radio-group-vertical"
@@ -121,9 +157,14 @@
   </sbb-expansion-panel>
 
   <sbb-expansion-panel [expanded]="true">
-    <sbb-expansion-panel-header>{{ 'app.view.editor-properties-view-component.graphicTimetable' | translate }}</sbb-expansion-panel-header>
-    <sbb-label>{{ 'app.view.editor-properties-view-component.axis-scaling-distance' | translate }}</sbb-label>
-    <br/>
+    <sbb-expansion-panel-header>{{
+      "app.view.editor-properties-view-component.graphicTimetable" | translate
+    }}</sbb-expansion-panel-header>
+    <sbb-label>{{
+      "app.view.editor-properties-view-component.axis-scaling-distance"
+        | translate
+    }}</sbb-label>
+    <br />
     <sbb-radio-group
       [(ngModel)]="activeStreckengrafikRenderingType"
       class="sbb-radio-group-vertical"
@@ -138,5 +179,4 @@
       </sbb-radio-button>
     </sbb-radio-group>
   </sbb-expansion-panel>
-
 </sbb-accordion>

--- a/src/app/view/editor-properties-view-component/editor-properties-view.component.scss
+++ b/src/app/view/editor-properties-view-component/editor-properties-view.component.scss
@@ -1,4 +1,3 @@
 @import "../../../variables";
 @import "./../../view/editor-filter-view/editor-filter-view.component.scss";
 @import "../rastering/definitions";
-

--- a/src/app/view/editor-properties-view-component/editor-properties-view.component.ts
+++ b/src/app/view/editor-properties-view-component/editor-properties-view.component.ts
@@ -4,9 +4,7 @@ import {UiInteractionService} from "../../services/ui/ui.interaction.service";
 import {SbbRadioChange} from "@sbb-esta/angular/radio-button";
 import {ThemeBase} from "../themes/theme-base";
 import {ThemeRegistration} from "../themes/theme-registration";
-import {
-  StreckengrafikRenderingType
-} from "../themes/streckengrafik-rendering-type";
+import {StreckengrafikRenderingType} from "../themes/streckengrafik-rendering-type";
 import {TravelTimeCreationEstimatorType} from "../themes/editor-trainrun-traveltime-creator-type";
 
 @Component({
@@ -62,7 +60,8 @@ export class EditorPropertiesViewComponent {
     {
       name: $localize`:@@app.view.editor-properties-view-component.timeScaledDistance:travel time scaled`,
       title: $localize`:@@app.view.editor-properties-view-component.timeScaledDistanceTooltip:The route graphic sections are displayed with travel time scaling, i.e. it is assumed that the selected train travels at a constant speed.`,
-      streckengrafikRenderingType: StreckengrafikRenderingType.TimeScaledDistance,
+      streckengrafikRenderingType:
+        StreckengrafikRenderingType.TimeScaledDistance,
     },
     {
       name: $localize`:@@app.view.editor-properties-view-component.uniformDistance:uniform`,
@@ -81,7 +80,8 @@ export class EditorPropertiesViewComponent {
     {
       name: $localize`:@@app.view.editor-properties-view-component.retrieveFromEdge:Section travel time`,
       title: $localize`:@@app.view.editor-properties-view-component.retrieveFromEdgeTooltip:Takes over the max. travel time on the same section of all trains of the same category, otherwise max. travel time of all trains, otherwise 1 min.`,
-      travelTimeCreationEstimatorType: TravelTimeCreationEstimatorType.RetrieveFromEdge,
+      travelTimeCreationEstimatorType:
+        TravelTimeCreationEstimatorType.RetrieveFromEdge,
     },
   ];
   activeTravelTimeCreationEstimatorType: TravelTimeCreationEstimatorType = null;
@@ -128,9 +128,10 @@ export class EditorPropertiesViewComponent {
     this.uiInteractionService.setActiveStreckengrafikRenderingType(event.value);
   }
 
-
   onUpdateaTravelTimeCreationEstimatorType(event: SbbRadioChange) {
-    this.uiInteractionService.setActiveTravelTimeCreationEstimatorType(event.value);
+    this.uiInteractionService.setActiveTravelTimeCreationEstimatorType(
+      event.value,
+    );
   }
 
   colorPicked(value) {

--- a/src/app/view/editor-side-view/editor-node-detail-view/editor-node-detail-view.component.html
+++ b/src/app/view/editor-side-view/editor-node-detail-view/editor-node-detail-view.component.html
@@ -5,10 +5,16 @@
 </h2>
 <sbb-accordion [multi]="true">
   <sbb-expansion-panel [expanded]="true">
-    <sbb-expansion-panel-header>{{ 'app.view.editor-side-view.editor-node-detail-view.base-data' | translate }}</sbb-expansion-panel-header>
-    <sbb-form-field [label]="'app.view.editor-side-view.editor-node-detail-view.operational-point' | translate"
-                    class="sbb-form-field-long"
-                    [class.readonly]="!versionControlService.getVariantIsWritable()"
+    <sbb-expansion-panel-header>{{
+      "app.view.editor-side-view.editor-node-detail-view.base-data" | translate
+    }}</sbb-expansion-panel-header>
+    <sbb-form-field
+      [label]="
+        'app.view.editor-side-view.editor-node-detail-view.operational-point'
+          | translate
+      "
+      class="sbb-form-field-long"
+      [class.readonly]="!versionControlService.getVariantIsWritable()"
     >
       <input
         sbbInput
@@ -16,9 +22,12 @@
         (change)="onBetriebspunktNameChanged($event)"
       />
     </sbb-form-field>
-    <sbb-form-field [label]="'app.view.editor-side-view.editor-node-detail-view.name' | translate"
-                    class="sbb-form-field-long"
-                    [class.readonly]="!versionControlService.getVariantIsWritable()"
+    <sbb-form-field
+      [label]="
+        'app.view.editor-side-view.editor-node-detail-view.name' | translate
+      "
+      class="sbb-form-field-long"
+      [class.readonly]="!versionControlService.getVariantIsWritable()"
     >
       <input
         sbbInput
@@ -26,9 +35,13 @@
         (change)="onFullNameChanged($event)"
       />
     </sbb-form-field>
-    <sbb-form-field [label]="'app.view.editor-side-view.editor-node-detail-view.connection-time' | translate"
-                    class="sbb-form-field-long"
-                    [class.readonly]="!versionControlService.getVariantIsWritable()"
+    <sbb-form-field
+      [label]="
+        'app.view.editor-side-view.editor-node-detail-view.connection-time'
+          | translate
+      "
+      class="sbb-form-field-long"
+      [class.readonly]="!versionControlService.getVariantIsWritable()"
     >
       <input
         sbbInput
@@ -41,13 +54,18 @@
   </sbb-expansion-panel>
 
   <sbb-expansion-panel [expanded]="true">
-    <sbb-expansion-panel-header>{{ 'app.view.editor-side-view.editor-node-detail-view.occupancy' | translate }}</sbb-expansion-panel-header>
+    <sbb-expansion-panel-header>{{
+      "app.view.editor-side-view.editor-node-detail-view.occupancy" | translate
+    }}</sbb-expansion-panel-header>
     <div class="sbb-mt-m">
       <sbb-knoten-auslastung-view></sbb-knoten-auslastung-view>
     </div>
-    <sbb-form-field [label]="'app.view.editor-side-view.editor-node-detail-view.capacity' | translate"
-                    class="sbb-form-field-long"
-                    [class.readonly]="!versionControlService.getVariantIsWritable()"
+    <sbb-form-field
+      [label]="
+        'app.view.editor-side-view.editor-node-detail-view.capacity' | translate
+      "
+      class="sbb-form-field-long"
+      [class.readonly]="!versionControlService.getVariantIsWritable()"
     >
       <input
         sbbInput
@@ -62,10 +80,16 @@
   </sbb-expansion-panel>
 
   <sbb-expansion-panel [expanded]="false">
-    <sbb-expansion-panel-header>{{ 'app.view.editor-side-view.editor-node-detail-view.filterable-labels' | translate }}</sbb-expansion-panel-header>
-    <sbb-form-field [label]="'app.view.editor-side-view.editor-node-detail-view.labels' | translate"
-                    class="sbb-form-field-long"
-                    [class.readonly]="!versionControlService.getVariantIsWritable()"
+    <sbb-expansion-panel-header>{{
+      "app.view.editor-side-view.editor-node-detail-view.filterable-labels"
+        | translate
+    }}</sbb-expansion-panel-header>
+    <sbb-form-field
+      [label]="
+        'app.view.editor-side-view.editor-node-detail-view.labels' | translate
+      "
+      class="sbb-form-field-long"
+      [class.readonly]="!versionControlService.getVariantIsWritable()"
     >
       <sbb-chip-list
         [value]="nodeProperties.labels"
@@ -80,7 +104,10 @@
         </sbb-chip>
         <input
           id="nodeLabelsInput"
-          [placeholder]="'app.view.editor-side-view.editor-node-detail-view.new-label-placeholder' | translate"
+          [placeholder]="
+            'app.view.editor-side-view.editor-node-detail-view.new-label-placeholder'
+              | translate
+          "
           sbbChipInput
           [sbbChipInputSeparatorKeyCodes]="separatorKeysCodes"
           (sbbChipInputTokenEnd)="add($event)"
@@ -98,17 +125,30 @@
   </sbb-expansion-panel>
 
   <sbb-expansion-panel [expanded]="false">
-    <sbb-expansion-panel-header> {{ 'app.view.editor-side-view.editor-node-detail-view.stopping-times' | translate }} </sbb-expansion-panel-header>
+    <sbb-expansion-panel-header>
+      {{
+        "app.view.editor-side-view.editor-node-detail-view.stopping-times"
+          | translate
+      }}
+    </sbb-expansion-panel-header>
 
-    <sbb-label class="sbb-mt-m">{{ 'app.view.editor-side-view.editor-node-detail-view.stopping-time-per-product' | translate }}</sbb-label>
+    <sbb-label class="sbb-mt-m">{{
+      "app.view.editor-side-view.editor-node-detail-view.stopping-time-per-product"
+        | translate
+    }}</sbb-label>
 
     <!-- TIM: this should be done with sbb table component, but I don't know how
       (or better, use flexbox for each line and make it a two column area below a certain breakpoint)-->
-    <table class="NodeDataTable"
-           [class.readonly]="!versionControlService.getVariantIsWritable()"
+    <table
+      class="NodeDataTable"
+      [class.readonly]="!versionControlService.getVariantIsWritable()"
     >
       <tr>
-        <td class="sbb-table-column-s">{{ 'app.view.editor-side-view.editor-node-detail-view.ipv' | translate }}</td>
+        <td class="sbb-table-column-s">
+          {{
+            "app.view.editor-side-view.editor-node-detail-view.ipv" | translate
+          }}
+        </td>
         <td class="sbb-table-column-m">
           <div
             *ngIf="
@@ -140,12 +180,19 @@
                 .no_halt
             "
             (change)="haltezeitIPVNoHaltChanged()"
-            >{{ 'app.view.editor-side-view.editor-node-detail-view.no-stop' | translate }}
+            >{{
+              "app.view.editor-side-view.editor-node-detail-view.no-stop"
+                | translate
+            }}
           </sbb-checkbox>
         </td>
       </tr>
       <tr>
-        <td>{{ 'app.view.editor-side-view.editor-node-detail-view.a' | translate }}</td>
+        <td>
+          {{
+            "app.view.editor-side-view.editor-node-detail-view.a" | translate
+          }}
+        </td>
         <td class="sbb-table-column-m">
           <div
             *ngIf="
@@ -176,12 +223,19 @@
               nodeProperties.nodeTrainrunCategoryHaltezeit['HaltezeitA'].no_halt
             "
             (change)="haltezeitANoHaltChanged()"
-            >{{ 'app.view.editor-side-view.editor-node-detail-view.no-stop' | translate }}
+            >{{
+              "app.view.editor-side-view.editor-node-detail-view.no-stop"
+                | translate
+            }}
           </sbb-checkbox>
         </td>
       </tr>
       <tr>
-        <td>{{ 'app.view.editor-side-view.editor-node-detail-view.b' | translate }}</td>
+        <td>
+          {{
+            "app.view.editor-side-view.editor-node-detail-view.b" | translate
+          }}
+        </td>
         <td class="sbb-table-column-m">
           <div
             *ngIf="
@@ -212,12 +266,19 @@
               nodeProperties.nodeTrainrunCategoryHaltezeit['HaltezeitB'].no_halt
             "
             (change)="haltezeitBNoHaltChanged()"
-            >{{ 'app.view.editor-side-view.editor-node-detail-view.no-stop' | translate }}
+            >{{
+              "app.view.editor-side-view.editor-node-detail-view.no-stop"
+                | translate
+            }}
           </sbb-checkbox>
         </td>
       </tr>
       <tr>
-        <td>{{ 'app.view.editor-side-view.editor-node-detail-view.c' | translate }}</td>
+        <td>
+          {{
+            "app.view.editor-side-view.editor-node-detail-view.c" | translate
+          }}
+        </td>
         <td class="sbb-table-column-m">
           <div
             *ngIf="
@@ -248,12 +309,19 @@
               nodeProperties.nodeTrainrunCategoryHaltezeit['HaltezeitC'].no_halt
             "
             (change)="haltezeitCNoHaltChanged()"
-            >{{ 'app.view.editor-side-view.editor-node-detail-view.no-stop' | translate }}
+            >{{
+              "app.view.editor-side-view.editor-node-detail-view.no-stop"
+                | translate
+            }}
           </sbb-checkbox>
         </td>
       </tr>
       <tr>
-        <td>{{ 'app.view.editor-side-view.editor-node-detail-view.d' | translate }}</td>
+        <td>
+          {{
+            "app.view.editor-side-view.editor-node-detail-view.d" | translate
+          }}
+        </td>
         <td class="sbb-table-column-m">
           <div
             *ngIf="
@@ -284,14 +352,19 @@
               nodeProperties.nodeTrainrunCategoryHaltezeit['HaltezeitD'].no_halt
             "
             (change)="haltezeitDNoHaltChanged()"
-            >{{ 'app.view.editor-side-view.editor-node-detail-view.no-stop' | translate }}
+            >{{
+              "app.view.editor-side-view.editor-node-detail-view.no-stop"
+                | translate
+            }}
           </sbb-checkbox>
         </td>
       </tr>
     </table>
   </sbb-expansion-panel>
   <sbb-expansion-panel [expanded]="false" *ngIf="!disableBackend">
-    <sbb-expansion-panel-header>{{ 'app.view.editor-side-view.editor-node-detail-view.links' | translate }}</sbb-expansion-panel-header>
+    <sbb-expansion-panel-header>{{
+      "app.view.editor-side-view.editor-node-detail-view.links" | translate
+    }}</sbb-expansion-panel-header>
     <ul>
       <li>
         <a
@@ -301,7 +374,10 @@
             nodeProperties.nodeBetriebspunktName
           }}"
         >
-          {{ 'app.view.editor-side-view.editor-node-detail-view.platform-information' | translate }}
+          {{
+            "app.view.editor-side-view.editor-node-detail-view.platform-information"
+              | translate
+          }}
         </a>
       </li>
       <li>
@@ -312,7 +388,10 @@
             nodeProperties.nodeBetriebspunktName
           }}&sort=-p_lange"
         >
-          {{ 'app.view.editor-side-view.editor-node-detail-view.platform-length' | translate }}
+          {{
+            "app.view.editor-side-view.editor-node-detail-view.platform-length"
+              | translate
+          }}
         </a>
       </li>
     </ul>
@@ -324,7 +403,10 @@
       class="sbb-mt-m sbb-ml-m"
       (click)="onDeleteNode()"
     >
-      {{ 'app.view.editor-side-view.editor-node-detail-view.delete-node' | translate }}
+      {{
+        "app.view.editor-side-view.editor-node-detail-view.delete-node"
+          | translate
+      }}
     </button>
   </ng-container>
 </sbb-accordion>

--- a/src/app/view/editor-side-view/editor-node-detail-view/editor-node-detail-view.component.ts
+++ b/src/app/view/editor-side-view/editor-node-detail-view/editor-node-detail-view.component.ts
@@ -72,7 +72,7 @@ export class EditorNodeDetailViewComponent implements OnInit, OnDestroy {
     private nodeService: NodeService,
     private labelService: LabelService,
     private labelGroupService: LabelGroupService,
-    public versionControlService : VersionControlService,
+    public versionControlService: VersionControlService,
     private cd: ChangeDetectorRef,
   ) {}
 
@@ -179,7 +179,7 @@ export class EditorNodeDetailViewComponent implements OnInit, OnDestroy {
     const node = this.nodeService.getSelectedNode();
     const confirmationDialogParamter = new ConfirmationDialogParameter(
       $localize`:@@app.view.editor-side-view.editor-node-detail-view.delete:Delete`,
-      $localize`:@@app.view.editor-side-view.editor-node-detail-view.deleteNodeDialog:Should the node ${node.getBetriebspunktName()}:operationalPointShortName: (${node.getFullName()}:operationalPointName:) be definitely deleted?`
+      $localize`:@@app.view.editor-side-view.editor-node-detail-view.deleteNodeDialog:Should the node ${node.getBetriebspunktName()}:operationalPointShortName: (${node.getFullName()}:operationalPointName:) be definitely deleted?`,
     );
     this.uiInteractionService
       .showConfirmationDiagramDialog(confirmationDialogParamter)
@@ -272,11 +272,13 @@ export class EditorNodeDetailViewComponent implements OnInit, OnDestroy {
   private checkAndSetLabels() {
     if (
       this.nodeProperties.labels.length !== this.initialNodeLabels.length ||
-      !this.nodeProperties.labels.every((label, index) => label === this.initialNodeLabels[index])
+      !this.nodeProperties.labels.every(
+        (label, index) => label === this.initialNodeLabels[index],
+      )
     ) {
       this.nodeService.changeLabels(
         this.nodeProperties.nodeId,
-        this.nodeProperties.labels
+        this.nodeProperties.labels,
       );
       this.initialNodeLabels = [...this.nodeProperties.labels];
     }

--- a/src/app/view/editor-tools-view-component/editor-tools-view.component.html
+++ b/src/app/view/editor-tools-view-component/editor-tools-view.component.html
@@ -1,50 +1,86 @@
-<h2 class="SummaryTitle">{{ 'app.view.editor-side-view.editor-tools-view-component.more-functions' | translate }}</h2>
+<h2 class="SummaryTitle">
+  {{
+    "app.view.editor-side-view.editor-tools-view-component.more-functions"
+      | translate
+  }}
+</h2>
 <sbb-accordion [multi]="true">
   <sbb-expansion-panel [expanded]="true">
-    <sbb-expansion-panel-header>{{ 'app.view.editor-side-view.editor-tools-view-component.export' | translate }}</sbb-expansion-panel-header>
+    <sbb-expansion-panel-header>{{
+      "app.view.editor-side-view.editor-tools-view-component.export" | translate
+    }}</sbb-expansion-panel-header>
     <button
       class="TrainrunDialog EditorToolButton"
       (click)="onExportContainerAsSVG()"
-      [title]="'app.view.editor-side-view.editor-tools-view-component.export-container-as-svg' | translate: {'container': getContainerName() }"
+      [title]="
+        'app.view.editor-side-view.editor-tools-view-component.export-container-as-svg'
+          | translate: {container: getContainerName()}
+      "
     >
       <sbb-icon svgIcon="picture-small"></sbb-icon>
     </button>
-    {{ 'app.view.editor-side-view.editor-tools-view-component.export-as-svg' | translate }}
+    {{
+      "app.view.editor-side-view.editor-tools-view-component.export-as-svg"
+        | translate
+    }}
     <br />
     <button
       class="TrainrunDialog EditorToolButton"
       (click)="onExportContainerAsPNG()"
-      [title]="'app.view.editor-side-view.editor-tools-view-component.export-container-as-png' | translate: {'container': getContainerName() }"
+      [title]="
+        'app.view.editor-side-view.editor-tools-view-component.export-container-as-png'
+          | translate: {container: getContainerName()}
+      "
     >
       <sbb-icon svgIcon="camera-small"></sbb-icon>
     </button>
-    {{ 'app.view.editor-side-view.editor-tools-view-component.export-as-png' | translate }}
+    {{
+      "app.view.editor-side-view.editor-tools-view-component.export-as-png"
+        | translate
+    }}
     <br />
     <button
       class="TrainrunDialog EditorToolButton"
       (click)="onPrintContainer()"
-      [title]="'app.view.editor-side-view.editor-tools-view-component.print-container' | translate: {'container': getContainerName() }"
+      [title]="
+        'app.view.editor-side-view.editor-tools-view-component.print-container'
+          | translate: {container: getContainerName()}
+      "
     >
       <sbb-icon svgIcon="printer-small"></sbb-icon>
     </button>
-    {{ 'app.view.editor-side-view.editor-tools-view-component.print' | translate }}
+    {{
+      "app.view.editor-side-view.editor-tools-view-component.print" | translate
+    }}
   </sbb-expansion-panel>
 
   <sbb-expansion-panel [expanded]="false">
-    <sbb-expansion-panel-header>{{ 'app.view.editor-side-view.editor-tools-view-component.netzgrafik' | translate }}</sbb-expansion-panel-header>
+    <sbb-expansion-panel-header>{{
+      "app.view.editor-side-view.editor-tools-view-component.netzgrafik"
+        | translate
+    }}</sbb-expansion-panel-header>
     <button
       class="TrainrunDialog EditorToolButton"
       (click)="onSave()"
-      [title]="'app.view.editor-side-view.editor-tools-view-component.export-netzgrafik' | translate"
+      [title]="
+        'app.view.editor-side-view.editor-tools-view-component.export-netzgrafik'
+          | translate
+      "
     >
       <sbb-icon svgIcon="download-small" aria-hidden="false"></sbb-icon>
     </button>
-    {{ 'app.view.editor-side-view.editor-tools-view-component.export-netzgrafik-as-json' | translate }}
+    {{
+      "app.view.editor-side-view.editor-tools-view-component.export-netzgrafik-as-json"
+        | translate
+    }}
     <ng-container *ngIf="getVariantIsWritable()">
       <br />
       <button
         (click)="onLoadButton()"
-        [title]="'app.view.editor-side-view.editor-tools-view-component.import-netzgrafik' | translate"
+        [title]="
+          'app.view.editor-side-view.editor-tools-view-component.import-netzgrafik'
+            | translate
+        "
         class="TrainrunDialog EditorToolButton"
       >
         <sbb-icon svgIcon="upload-small"></sbb-icon>
@@ -56,59 +92,115 @@
         accept=".json"
         (change)="onLoad($event)"
       />
-      {{ 'app.view.editor-side-view.editor-tools-view-component.import-netzgrafik-as-json' | translate }}
+      {{
+        "app.view.editor-side-view.editor-tools-view-component.import-netzgrafik-as-json"
+          | translate
+      }}
     </ng-container>
 
     <br />
     <button
       (click)="onExportZuglauf()"
-      [title]="'app.view.editor-side-view.editor-tools-view-component.export-trainruns' | translate"
+      [title]="
+        'app.view.editor-side-view.editor-tools-view-component.export-trainruns'
+          | translate
+      "
       class="TrainrunDialog EditorToolButton"
     >
       <sbb-icon svgIcon="download-large-data-small"></sbb-icon>
     </button>
-    {{ 'app.view.editor-side-view.editor-tools-view-component.export-trainruns-as-csv' | translate }}
-    <sbb-tooltip
-      >{{ 'app.view.editor-side-view.editor-tools-view-component.export-trainruns-as-csv-excel' | translate }}</sbb-tooltip
-    >
+    {{
+      "app.view.editor-side-view.editor-tools-view-component.export-trainruns-as-csv"
+        | translate
+    }}
+    <sbb-tooltip>{{
+      "app.view.editor-side-view.editor-tools-view-component.export-trainruns-as-csv-excel"
+        | translate
+    }}</sbb-tooltip>
     <br />
     <button
       (click)="onExportOriginDestination()"
-      [title]="'app.view.editor-side-view.editor-tools-view-component.export-origin-destination' | translate"
+      [title]="
+        'app.view.editor-side-view.editor-tools-view-component.export-origin-destination'
+          | translate
+      "
       class="TrainrunDialog EditorToolButton"
     >
-      <sbb-icon _ngcontent-ng-c1568279807="" role="img" svgicon="chart-line-medium" height="25px" width="25px" aria-hidden="false" class="sbb-icon notranslate">
-        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="16 -20 72 94" fit="" preserveAspectRatio="xMidYMid meet" focusable="false">
+      <sbb-icon
+        _ngcontent-ng-c1568279807=""
+        role="img"
+        svgicon="chart-line-medium"
+        height="25px"
+        width="25px"
+        aria-hidden="false"
+        class="sbb-icon notranslate"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="24"
+          height="24"
+          fill="none"
+          viewBox="16 -20 72 94"
+          fit=""
+          preserveAspectRatio="xMidYMid meet"
+          focusable="false"
+        >
           <g transform="rotate(30),scale(2.0),translate(20,-8)">
-            <path d="M21.25 15.75c0 4.377-1.308 7.222-3.342 8.982-2.047 1.772-4.91 2.518-8.158 2.518v1c3.38 0 6.516-.774 8.813-2.762 2.309-2 3.687-5.155 3.687-9.738V9.482l3.857 3.849.707-.708L22.09 7.91l-.353-.353-.353.354-4.712 4.713.707.707 3.871-3.872z" />
+            <path
+              d="M21.25 15.75c0 4.377-1.308 7.222-3.342 8.982-2.047 1.772-4.91 2.518-8.158 2.518v1c3.38 0 6.516-.774 8.813-2.762 2.309-2 3.687-5.155 3.687-9.738V9.482l3.857 3.849.707-.708L22.09 7.91l-.353-.353-.353.354-4.712 4.713.707.707 3.871-3.872z"
+            />
           </g>
           <g transform="scale(2.5),translate(3,10)">
-            <path width="26" height="20" d="M8 1C5.264 1 3 3.107 3 5.762v.021c.035.833.297 1.531.704 2.174l.007.01 3.886 5.811.416.621.416-.621 3.886-5.81.007-.01.006-.011c.393-.654.664-1.367.672-2.18v-.005C13 3.107 10.735 1 8 1M4.546 7.416C4.22 6.901 4.028 6.374 4 5.752 4.006 3.704 5.768 2 8 2c2.234 0 3.999 1.708 4 3.76-.006.58-.195 1.115-.523 1.661l-3.464 5.18zM6.5 6a1.5 1.5 0 1 1 3 0 1.5 1.5 0 0 1-3 0M8 3.5a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5" />
+            <path
+              width="26"
+              height="20"
+              d="M8 1C5.264 1 3 3.107 3 5.762v.021c.035.833.297 1.531.704 2.174l.007.01 3.886 5.811.416.621.416-.621 3.886-5.81.007-.01.006-.011c.393-.654.664-1.367.672-2.18v-.005C13 3.107 10.735 1 8 1M4.546 7.416C4.22 6.901 4.028 6.374 4 5.752 4.006 3.704 5.768 2 8 2c2.234 0 3.999 1.708 4 3.76-.006.58-.195 1.115-.523 1.661l-3.464 5.18zM6.5 6a1.5 1.5 0 1 1 3 0 1.5 1.5 0 0 1-3 0M8 3.5a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5"
+            />
           </g>
           <g transform="rotate(-90),scale(2.0)translate(-22,23)">
-            <path fill="#000" fill-rule="evenodd" d="M14.5 7a5.5 5.5 0 1 0 .002 11.002A5.5 5.5 0 0 0 14.5 7M3 13h5.019a6.5 6.5 0 1 0 0-1H3zm11.5 3a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7" clip-rule="evenodd" />
+            <path
+              fill="#000"
+              fill-rule="evenodd"
+              d="M14.5 7a5.5 5.5 0 1 0 .002 11.002A5.5 5.5 0 0 0 14.5 7M3 13h5.019a6.5 6.5 0 1 0 0-1H3zm11.5 3a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7"
+              clip-rule="evenodd"
+            />
           </g>
         </svg>
       </sbb-icon>
     </button>
-    {{ 'app.view.editor-side-view.editor-tools-view-component.export-origin-destination-as-csv' | translate }}
+    {{
+      "app.view.editor-side-view.editor-tools-view-component.export-origin-destination-as-csv"
+        | translate
+    }}
   </sbb-expansion-panel>
   <sbb-expansion-panel [expanded]="false">
-    <sbb-expansion-panel-header>{{ 'app.view.editor-side-view.editor-tools-view-component.base-data' | translate }}</sbb-expansion-panel-header>
+    <sbb-expansion-panel-header>{{
+      "app.view.editor-side-view.editor-tools-view-component.base-data"
+        | translate
+    }}</sbb-expansion-panel-header>
     <ng-container *ngIf="getVariantIsWritable()">
       <button
         (click)="onLoadStammdatenButton()"
-        [title]="'app.view.editor-side-view.editor-tools-view-component.import-base-data' | translate"
+        [title]="
+          'app.view.editor-side-view.editor-tools-view-component.import-base-data'
+            | translate
+        "
         class="TrainrunDialog EditorToolButton"
       >
         <sbb-icon svgIcon="document-plus-small"></sbb-icon>
       </button>
-      {{ 'app.view.editor-side-view.editor-tools-view-component.import-base-data' | translate }}
+      {{
+        "app.view.editor-side-view.editor-tools-view-component.import-base-data"
+          | translate
+      }}
       <a
         href="https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/documentation/CREATE_NODES.md#import-nodes-from-a-semicolon-seperate-value-file-csv"
         class="sbb-link link-reset"
         target="_blank"
-        >{{ 'app.view.editor-side-view.editor-tools-view-component.help-csv-data' | translate }}</a
+        >{{
+          "app.view.editor-side-view.editor-tools-view-component.help-csv-data"
+            | translate
+        }}</a
       >
       <input
         hidden
@@ -121,11 +213,17 @@
     </ng-container>
     <button
       (click)="onExportStammdaten()"
-      [title]="'app.view.editor-side-view.editor-tools-view-component.export-base-data' | translate"
+      [title]="
+        'app.view.editor-side-view.editor-tools-view-component.export-base-data'
+          | translate
+      "
       class="TrainrunDialog EditorToolButton"
     >
       <sbb-icon svgIcon="download-large-data-small"></sbb-icon>
     </button>
-    {{ 'app.view.editor-side-view.editor-tools-view-component.export-base-data' | translate }}
+    {{
+      "app.view.editor-side-view.editor-tools-view-component.export-base-data"
+        | translate
+    }}
   </sbb-expansion-panel>
 </sbb-accordion>

--- a/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
+++ b/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
@@ -66,8 +66,7 @@ export class EditorToolsViewComponent {
     private viewportCullService: ViewportCullService,
     private levelOfDetailService: LevelOfDetailService,
     private originDestinationService: OriginDestinationService,
-  ) {
-  }
+  ) {}
 
   onLoadButton() {
     this.netgrafikJsonFileInput.nativeElement.click();
@@ -115,7 +114,11 @@ export class EditorToolsViewComponent {
   onSave() {
     const data: NetzgrafikDto = this.dataService.getNetzgrafikDto();
     const blob = new Blob([JSON.stringify(data)], {type: "application/json"});
-    downloadBlob(blob, $localize`:@@app.view.editor-side-view.editor-tools-view-component.netzgrafikFile:netzgrafik` + ".json");
+    downloadBlob(
+      blob,
+      $localize`:@@app.view.editor-side-view.editor-tools-view-component.netzgrafikFile:netzgrafik` +
+        ".json",
+    );
   }
 
   onExportContainerAsSVG() {
@@ -189,19 +192,25 @@ export class EditorToolsViewComponent {
   }
 
   onExportStammdaten() {
-    const filename = $localize`:@@app.view.editor-side-view.editor-tools-view-component.baseDataFile:baseData` + ".csv";
+    const filename =
+      $localize`:@@app.view.editor-side-view.editor-tools-view-component.baseDataFile:baseData` +
+      ".csv";
     const csvData = this.convertToStammdatenCSV();
     this.onExport(filename, csvData);
   }
 
   onExportZuglauf() {
-    const filename = $localize`:@@app.view.editor-side-view.editor-tools-view-component.trainrunFile:trainrun` + ".csv";
+    const filename =
+      $localize`:@@app.view.editor-side-view.editor-tools-view-component.trainrunFile:trainrun` +
+      ".csv";
     const csvData = this.convertToZuglaufCSV();
     this.onExport(filename, csvData);
   }
 
   onExportOriginDestination() {
-    const filename = $localize`:@@app.view.editor-side-view.editor-tools-view-component.originDestinationFile:originDestination` + ".csv";
+    const filename =
+      $localize`:@@app.view.editor-side-view.editor-tools-view-component.originDestinationFile:originDestination` +
+      ".csv";
     const csvData = this.convertToOriginDestinationCSV();
     this.onExport(filename, csvData);
   }
@@ -225,7 +234,6 @@ export class EditorToolsViewComponent {
     }
     window.URL.revokeObjectURL(url);
   }
-
 
   getVariantIsWritable() {
     return this.versionControlService.getVariantIsWritable();
@@ -258,21 +266,51 @@ export class EditorToolsViewComponent {
     const comma = ",";
 
     const headers: string[] = [];
-    headers.push($localize`:@@app.view.editor-side-view.editor-tools-view-component.bp:BP`);
-    headers.push($localize`:@@app.view.editor-side-view.editor-tools-view-component.station:Station`);
-    headers.push($localize`:@@app.view.editor-side-view.editor-tools-view-component.category:category`);
-    headers.push($localize`:@@app.view.editor-side-view.editor-tools-view-component.region:Region`);
-    headers.push($localize`:@@app.view.editor-side-view.editor-tools-view-component.passengerConnectionTimeIPV:passengerConnectionTimeIPV`);
-    headers.push($localize`:@@app.view.editor-side-view.editor-tools-view-component.passengerConnectionTimeA:Passenger_connection_time_A`);
-    headers.push($localize`:@@app.view.editor-side-view.editor-tools-view-component.passengerConnectionTimeB:Passenger_connection_time_B`);
-    headers.push($localize`:@@app.view.editor-side-view.editor-tools-view-component.passengerConnectionTimeC:Passenger_connection_time_C`);
-    headers.push($localize`:@@app.view.editor-side-view.editor-tools-view-component.passengerConnectionTimeD:Passenger_connection_time_D`);
-    headers.push($localize`:@@app.view.editor-side-view.editor-tools-view-component.ZAZ:ZAZ`);
-    headers.push($localize`:@@app.view.editor-side-view.editor-tools-view-component.transferTime:Transfer_time`);
-    headers.push($localize`:@@app.view.editor-side-view.editor-tools-view-component.labels:Labels`);
-    headers.push($localize`:@@app.view.editor-side-view.editor-tools-view-component.X:X`);
-    headers.push($localize`:@@app.view.editor-side-view.editor-tools-view-component.Y:Y`);
-    headers.push($localize`:@@app.view.editor-side-view.editor-tools-view-component.create:Create`);
+    headers.push(
+      $localize`:@@app.view.editor-side-view.editor-tools-view-component.bp:BP`,
+    );
+    headers.push(
+      $localize`:@@app.view.editor-side-view.editor-tools-view-component.station:Station`,
+    );
+    headers.push(
+      $localize`:@@app.view.editor-side-view.editor-tools-view-component.category:category`,
+    );
+    headers.push(
+      $localize`:@@app.view.editor-side-view.editor-tools-view-component.region:Region`,
+    );
+    headers.push(
+      $localize`:@@app.view.editor-side-view.editor-tools-view-component.passengerConnectionTimeIPV:passengerConnectionTimeIPV`,
+    );
+    headers.push(
+      $localize`:@@app.view.editor-side-view.editor-tools-view-component.passengerConnectionTimeA:Passenger_connection_time_A`,
+    );
+    headers.push(
+      $localize`:@@app.view.editor-side-view.editor-tools-view-component.passengerConnectionTimeB:Passenger_connection_time_B`,
+    );
+    headers.push(
+      $localize`:@@app.view.editor-side-view.editor-tools-view-component.passengerConnectionTimeC:Passenger_connection_time_C`,
+    );
+    headers.push(
+      $localize`:@@app.view.editor-side-view.editor-tools-view-component.passengerConnectionTimeD:Passenger_connection_time_D`,
+    );
+    headers.push(
+      $localize`:@@app.view.editor-side-view.editor-tools-view-component.ZAZ:ZAZ`,
+    );
+    headers.push(
+      $localize`:@@app.view.editor-side-view.editor-tools-view-component.transferTime:Transfer_time`,
+    );
+    headers.push(
+      $localize`:@@app.view.editor-side-view.editor-tools-view-component.labels:Labels`,
+    );
+    headers.push(
+      $localize`:@@app.view.editor-side-view.editor-tools-view-component.X:X`,
+    );
+    headers.push(
+      $localize`:@@app.view.editor-side-view.editor-tools-view-component.Y:Y`,
+    );
+    headers.push(
+      $localize`:@@app.view.editor-side-view.editor-tools-view-component.create:Create`,
+    );
 
     const rows: string[][] = [];
     this.nodeService.getNodes().forEach((nodeElement) => {
@@ -293,38 +331,38 @@ export class EditorToolsViewComponent {
       row.push(regions.map((reg) => "" + reg).join(comma));
       row.push(
         "" +
-        (trainrunCategoryHaltezeit[HaltezeitFachCategories.IPV].no_halt
-          ? 0
-          : trainrunCategoryHaltezeit[HaltezeitFachCategories.IPV].haltezeit -
-          zaz),
+          (trainrunCategoryHaltezeit[HaltezeitFachCategories.IPV].no_halt
+            ? 0
+            : trainrunCategoryHaltezeit[HaltezeitFachCategories.IPV].haltezeit -
+              zaz),
       );
       row.push(
         "" +
-        (trainrunCategoryHaltezeit[HaltezeitFachCategories.A].no_halt
-          ? 0
-          : trainrunCategoryHaltezeit[HaltezeitFachCategories.A].haltezeit -
-          zaz),
+          (trainrunCategoryHaltezeit[HaltezeitFachCategories.A].no_halt
+            ? 0
+            : trainrunCategoryHaltezeit[HaltezeitFachCategories.A].haltezeit -
+              zaz),
       );
       row.push(
         "" +
-        (trainrunCategoryHaltezeit[HaltezeitFachCategories.B].no_halt
-          ? 0
-          : trainrunCategoryHaltezeit[HaltezeitFachCategories.B].haltezeit -
-          zaz),
+          (trainrunCategoryHaltezeit[HaltezeitFachCategories.B].no_halt
+            ? 0
+            : trainrunCategoryHaltezeit[HaltezeitFachCategories.B].haltezeit -
+              zaz),
       );
       row.push(
         "" +
-        (trainrunCategoryHaltezeit[HaltezeitFachCategories.C].no_halt
-          ? 0
-          : trainrunCategoryHaltezeit[HaltezeitFachCategories.C].haltezeit -
-          zaz),
+          (trainrunCategoryHaltezeit[HaltezeitFachCategories.C].no_halt
+            ? 0
+            : trainrunCategoryHaltezeit[HaltezeitFachCategories.C].haltezeit -
+              zaz),
       );
       row.push(
         "" +
-        (trainrunCategoryHaltezeit[HaltezeitFachCategories.D].no_halt
-          ? 0
-          : trainrunCategoryHaltezeit[HaltezeitFachCategories.D].haltezeit -
-          zaz),
+          (trainrunCategoryHaltezeit[HaltezeitFachCategories.D].no_halt
+            ? 0
+            : trainrunCategoryHaltezeit[HaltezeitFachCategories.D].haltezeit -
+              zaz),
       );
       row.push("" + zaz);
       row.push("" + nodeElement.getConnectionTime());
@@ -364,13 +402,18 @@ export class EditorToolsViewComponent {
           top: boundingBox.minCoordY - 32,
           width: boundingBox.maxCoordX - boundingBox.minCoordX + 64,
           height: boundingBox.maxCoordY - boundingBox.minCoordY + 64,
-          backgroundColor: this.uiInteractionService.getActiveTheme().backgroundColor,
+          backgroundColor:
+            this.uiInteractionService.getActiveTheme().backgroundColor,
         };
-        htmlElementToExport = document.getElementById("main-streckengrafik-container");
+        htmlElementToExport = document.getElementById(
+          "main-streckengrafik-container",
+        );
         break;
       }
       case EditorMode.OriginDestination: {
-        htmlElementToExport = document.getElementById("main-origin-destination-container");
+        htmlElementToExport = document.getElementById(
+          "main-origin-destination-container",
+        );
         if (htmlElementToExport === null) {
           return undefined;
         }
@@ -383,7 +426,8 @@ export class EditorToolsViewComponent {
           top: bbox.y - padding,
           width: bbox.width + 2 * padding,
           height: bbox.height + 2 * padding,
-          backgroundColor: this.uiInteractionService.getActiveTheme().backgroundColor,
+          backgroundColor:
+            this.uiInteractionService.getActiveTheme().backgroundColor,
         };
         break;
       }
@@ -399,7 +443,8 @@ export class EditorToolsViewComponent {
           top: 80,
           width: htmlElementToExport.offsetWidth,
           height: htmlElementToExport.offsetHeight,
-          backgroundColor: this.uiInteractionService.getActiveTheme().backgroundColor,
+          backgroundColor:
+            this.uiInteractionService.getActiveTheme().backgroundColor,
         };
         break;
       }
@@ -428,29 +473,61 @@ export class EditorToolsViewComponent {
     return {
       documentToExport: htmlElementToExport,
       exportParameter: param,
-      documentSavedStyle: oldStyle
+      documentSavedStyle: oldStyle,
     };
   }
 
   private convertToZuglaufCSV(): string {
     const comma = ",";
     const headers: string[] = [];
-    headers.push($localize`:@@app.view.editor-side-view.editor-tools-view-component.trainCategory:Train category`);
-    headers.push($localize`:@@app.view.editor-side-view.editor-tools-view-component.trainName:Train name`);
-    headers.push($localize`:@@app.view.editor-side-view.editor-tools-view-component.startStation:Start station`);
-    headers.push($localize`:@@app.view.editor-side-view.editor-tools-view-component.destinationStation:Destination station`);
-    headers.push($localize`:@@app.view.editor-side-view.editor-tools-view-component.trafficPeriod:Traffic period`);
-    headers.push($localize`:@@app.view.editor-side-view.editor-tools-view-component.frequence:Frequence`);
-    headers.push($localize`:@@app.view.editor-side-view.editor-tools-view-component.departureMinuteAtStart:Minute of departure at start node`);
-    headers.push($localize`:@@app.view.editor-side-view.editor-tools-view-component.travelTimeStartDestination:Travel time start-destination`);
-    headers.push($localize`:@@app.view.editor-side-view.editor-tools-view-component.arrivalMinuteAtDestination:Arrival minute at destination node`);
-    headers.push($localize`:@@app.view.editor-side-view.editor-tools-view-component.turnaroundTimeDestination:Turnaround time at destination station`);
-    headers.push($localize`:@@app.view.editor-side-view.editor-tools-view-component.departureMinuteDeparture:Departure minute at destination node`);
-    headers.push($localize`:@@app.view.editor-side-view.editor-tools-view-component.travelTimeDestinationStart:Travel time destination-start`);
-    headers.push($localize`:@@app.view.editor-side-view.editor-tools-view-component.arrivalMinuteAtStart:Arrival minute at start node`);
-    headers.push($localize`:@@app.view.editor-side-view.editor-tools-view-component.turnaroundTimeStart:Turnaround time at start station`);
-    headers.push($localize`:@@app.view.editor-side-view.editor-tools-view-component.turnaroundTime:Turnaround time`);
-    headers.push($localize`:@@app.view.editor-side-view.editor-tools-view-component.labels:Labels`);
+    headers.push(
+      $localize`:@@app.view.editor-side-view.editor-tools-view-component.trainCategory:Train category`,
+    );
+    headers.push(
+      $localize`:@@app.view.editor-side-view.editor-tools-view-component.trainName:Train name`,
+    );
+    headers.push(
+      $localize`:@@app.view.editor-side-view.editor-tools-view-component.startStation:Start station`,
+    );
+    headers.push(
+      $localize`:@@app.view.editor-side-view.editor-tools-view-component.destinationStation:Destination station`,
+    );
+    headers.push(
+      $localize`:@@app.view.editor-side-view.editor-tools-view-component.trafficPeriod:Traffic period`,
+    );
+    headers.push(
+      $localize`:@@app.view.editor-side-view.editor-tools-view-component.frequence:Frequence`,
+    );
+    headers.push(
+      $localize`:@@app.view.editor-side-view.editor-tools-view-component.departureMinuteAtStart:Minute of departure at start node`,
+    );
+    headers.push(
+      $localize`:@@app.view.editor-side-view.editor-tools-view-component.travelTimeStartDestination:Travel time start-destination`,
+    );
+    headers.push(
+      $localize`:@@app.view.editor-side-view.editor-tools-view-component.arrivalMinuteAtDestination:Arrival minute at destination node`,
+    );
+    headers.push(
+      $localize`:@@app.view.editor-side-view.editor-tools-view-component.turnaroundTimeDestination:Turnaround time at destination station`,
+    );
+    headers.push(
+      $localize`:@@app.view.editor-side-view.editor-tools-view-component.departureMinuteDeparture:Departure minute at destination node`,
+    );
+    headers.push(
+      $localize`:@@app.view.editor-side-view.editor-tools-view-component.travelTimeDestinationStart:Travel time destination-start`,
+    );
+    headers.push(
+      $localize`:@@app.view.editor-side-view.editor-tools-view-component.arrivalMinuteAtStart:Arrival minute at start node`,
+    );
+    headers.push(
+      $localize`:@@app.view.editor-side-view.editor-tools-view-component.turnaroundTimeStart:Turnaround time at start station`,
+    );
+    headers.push(
+      $localize`:@@app.view.editor-side-view.editor-tools-view-component.turnaroundTime:Turnaround time`,
+    );
+    headers.push(
+      $localize`:@@app.view.editor-side-view.editor-tools-view-component.labels:Labels`,
+    );
 
     const rows: string[][] = [];
     this.trainrunService
@@ -463,44 +540,66 @@ export class EditorToolsViewComponent {
         // Retrieve start -> end with:
         // start {startNode, startTrainrunSection}
         // end {iterator.current.node, iterator.current.trainrunSection}
-        const startNode = this.trainrunService.getStartNodeWithTrainrunId(trainrun.getId());
-        const startTrainrunSection = startNode.getStartTrainrunSection(trainrun.getId());
-        const iterator = this.trainrunService.getIterator(startNode, startTrainrunSection);
+        const startNode = this.trainrunService.getStartNodeWithTrainrunId(
+          trainrun.getId(),
+        );
+        const startTrainrunSection = startNode.getStartTrainrunSection(
+          trainrun.getId(),
+        );
+        const iterator = this.trainrunService.getIterator(
+          startNode,
+          startTrainrunSection,
+        );
         while (iterator.hasNext()) {
           iterator.next();
         }
 
         startBetriebspunktName = startNode.getBetriebspunktName();
         endBetriebspunktName = iterator.current().node.getBetriebspunktName();
-        const departureTimeAtStart = startTrainrunSection.getSourceNodeId() === startNode.getId() ?
-          startTrainrunSection.getSourceDepartureConsecutiveTime() :
-          startTrainrunSection.getTargetDepartureConsecutiveTime();
-        const arrivalTimeAtEnd = iterator.current().trainrunSection.getSourceNodeId() === iterator.current().node.getId() ?
-          iterator.current().trainrunSection.getSourceArrivalConsecutiveTime() :
-          iterator.current().trainrunSection.getTargetArrivalConsecutiveTime();
+        const departureTimeAtStart =
+          startTrainrunSection.getSourceNodeId() === startNode.getId()
+            ? startTrainrunSection.getSourceDepartureConsecutiveTime()
+            : startTrainrunSection.getTargetDepartureConsecutiveTime();
+        const arrivalTimeAtEnd =
+          iterator.current().trainrunSection.getSourceNodeId() ===
+          iterator.current().node.getId()
+            ? iterator
+                .current()
+                .trainrunSection.getSourceArrivalConsecutiveTime()
+            : iterator
+                .current()
+                .trainrunSection.getTargetArrivalConsecutiveTime();
         const travelTime = arrivalTimeAtEnd - departureTimeAtStart;
 
-        const startNodeDeparture = startTrainrunSection.getSourceNodeId() === startNode.getId() ?
-          startTrainrunSection.getSourceDeparture() :
-          startTrainrunSection.getTargetDeparture();
-        const endNodeArrival = iterator.current().trainrunSection.getSourceNodeId() === iterator.current().node.getId() ?
-          iterator.current().trainrunSection.getSourceArrival() :
-          iterator.current().trainrunSection.getTargetArrival();
+        const startNodeDeparture =
+          startTrainrunSection.getSourceNodeId() === startNode.getId()
+            ? startTrainrunSection.getSourceDeparture()
+            : startTrainrunSection.getTargetDeparture();
+        const endNodeArrival =
+          iterator.current().trainrunSection.getSourceNodeId() ===
+          iterator.current().node.getId()
+            ? iterator.current().trainrunSection.getSourceArrival()
+            : iterator.current().trainrunSection.getTargetArrival();
 
-        const endNodeDeparture = iterator.current().trainrunSection.getSourceNodeId() === iterator.current().node.getId() ?
-          iterator.current().trainrunSection.getSourceDeparture() :
-          iterator.current().trainrunSection.getTargetDeparture();
-        const startNodeArrival = startTrainrunSection.getSourceNodeId() === startNode.getId() ?
-          startTrainrunSection.getSourceArrival() :
-          startTrainrunSection.getTargetArrival();
+        const endNodeDeparture =
+          iterator.current().trainrunSection.getSourceNodeId() ===
+          iterator.current().node.getId()
+            ? iterator.current().trainrunSection.getSourceDeparture()
+            : iterator.current().trainrunSection.getTargetDeparture();
+        const startNodeArrival =
+          startTrainrunSection.getSourceNodeId() === startNode.getId()
+            ? startTrainrunSection.getSourceArrival()
+            : startTrainrunSection.getTargetArrival();
 
         let waitingTimeOnStartStation = startNodeDeparture - startNodeArrival;
         let waitingTimeOnEndStation = endNodeDeparture - endNodeArrival;
 
         if (trainrun.getFrequency() > 60) {
           // special case - if the freq is bigger than 60min (1h) - then just mirror
-          waitingTimeOnStartStation = 2.0 * (trainrun.getFrequency() / 2.0 - startNodeArrival);
-          waitingTimeOnEndStation = 2.0 * (trainrun.getFrequency() / 2.0 - endNodeArrival);
+          waitingTimeOnStartStation =
+            2.0 * (trainrun.getFrequency() / 2.0 - startNodeArrival);
+          waitingTimeOnEndStation =
+            2.0 * (trainrun.getFrequency() / 2.0 - endNodeArrival);
         } else {
           // find next freq (departing)
           while (waitingTimeOnStartStation < 0) {
@@ -528,7 +627,9 @@ export class EditorToolsViewComponent {
         row.push(trainrun.getTitle().trim());
         row.push(startBetriebspunktName.trim());
         row.push(endBetriebspunktName.trim());
-        row.push("Verkehrt: " + trainrun.getTrainrunTimeCategory().shortName.trim());
+        row.push(
+          "Verkehrt: " + trainrun.getTrainrunTimeCategory().shortName.trim(),
+        );
         row.push("" + trainrun.getTrainrunFrequency().shortName.trim());
         row.push("" + startNodeDeparture);
         row.push("" + travelTime);
@@ -543,13 +644,12 @@ export class EditorToolsViewComponent {
           trainrun
             .getLabelIds()
             .map((labelID) => {
-                const label = this.labelService.getLabelFromId(labelID);
-                if (label) {
-                  return label.getLabel().trim();
-                }
-                return "";
+              const label = this.labelService.getLabelFromId(labelID);
+              if (label) {
+                return label.getLabel().trim();
               }
-            )
+              return "";
+            })
             .join(comma),
         );
 
@@ -560,11 +660,21 @@ export class EditorToolsViewComponent {
 
   private convertToOriginDestinationCSV(): string {
     const headers: string[] = [];
-    headers.push($localize`:@@app.view.editor-side-view.editor-tools-view-component.origin:Origin`);
-    headers.push($localize`:@@app.view.editor-side-view.editor-tools-view-component.destination:Destination`);
-    headers.push($localize`:@@app.view.editor-side-view.editor-tools-view-component.travelTime:Travel time`);
-    headers.push($localize`:@@app.view.editor-side-view.editor-tools-view-component.transfers:Transfers`);
-    headers.push($localize`:@@app.view.editor-side-view.editor-tools-view-component.totalCost:Total cost`);
+    headers.push(
+      $localize`:@@app.view.editor-side-view.editor-tools-view-component.origin:Origin`,
+    );
+    headers.push(
+      $localize`:@@app.view.editor-side-view.editor-tools-view-component.destination:Destination`,
+    );
+    headers.push(
+      $localize`:@@app.view.editor-side-view.editor-tools-view-component.travelTime:Travel time`,
+    );
+    headers.push(
+      $localize`:@@app.view.editor-side-view.editor-tools-view-component.transfers:Transfers`,
+    );
+    headers.push(
+      $localize`:@@app.view.editor-side-view.editor-tools-view-component.totalCost:Total cost`,
+    );
 
     const matrixData = this.originDestinationService.originDestinationData();
 
@@ -588,31 +698,36 @@ export class EditorToolsViewComponent {
   }
 
   private detectNetzgrafikJSON3rdParty(netzgrafikDto: NetzgrafikDto): boolean {
-    return netzgrafikDto.nodes.find((n: NodeDto) =>
-        n.ports === undefined) !== undefined
-      ||
-      netzgrafikDto.nodes.filter((n: NodeDto) =>
-        n.ports?.length === 0).length === netzgrafikDto.nodes.length
-      ||
-      netzgrafikDto.trainrunSections.find((ts: TrainrunSectionDto) =>
-        ts.path === undefined ||
-        ts.path?.path === undefined ||
-        ts.path?.path?.length === 0
-      ) !== undefined;
+    return (
+      netzgrafikDto.nodes.find((n: NodeDto) => n.ports === undefined) !==
+        undefined ||
+      netzgrafikDto.nodes.filter((n: NodeDto) => n.ports?.length === 0)
+        .length === netzgrafikDto.nodes.length ||
+      netzgrafikDto.trainrunSections.find(
+        (ts: TrainrunSectionDto) =>
+          ts.path === undefined ||
+          ts.path?.path === undefined ||
+          ts.path?.path?.length === 0,
+      ) !== undefined
+    );
   }
 
   private processNetzgrafikJSON3rdParty(netzgrafikDto: NetzgrafikDto) {
     // --------------------------------------------------------------------------------
     // 3rd party generated JSON detected
     // --------------------------------------------------------------------------------
-    console.log("Import: Automatic Port Alignment Detection - 3rd Party Data Import.");
+    console.log(
+      "Import: Automatic Port Alignment Detection - 3rd Party Data Import.",
+    );
     const msg = $localize`:@@app.view.editor-side-view.editor-tools-view-component.import-netzgrafik-as-json-info-3rd-party:3rd party import`;
     this.logger.info(msg);
 
-
     // --------------------------------------------------------------------------------
     // (Step 1) Import only nodes
-    const netzgrafikOnlyNodeDto: NetzgrafikDto = Object.assign({}, netzgrafikDto);
+    const netzgrafikOnlyNodeDto: NetzgrafikDto = Object.assign(
+      {},
+      netzgrafikDto,
+    );
     netzgrafikOnlyNodeDto.trainruns = [];
     netzgrafikOnlyNodeDto.trainrunSections = [];
     this.dataService.loadNetzgrafikDto(netzgrafikOnlyNodeDto);
@@ -658,8 +773,7 @@ export class EditorToolsViewComponent {
 
     // import data
     if (
-      netzgrafikDto.trainrunSections.length === 0
-      ||
+      netzgrafikDto.trainrunSections.length === 0 ||
       !this.detectNetzgrafikJSON3rdParty(netzgrafikDto)
     ) {
       // -----------------------------------------------

--- a/src/app/view/error-view/error-view.component.html
+++ b/src/app/view/error-view/error-view.component.html
@@ -1,4 +1,4 @@
 <sbb-page-layout>
-  <h1>{{ 'app.view.error-view.error' | translate}}</h1>
+  <h1>{{ "app.view.error-view.error" | translate }}</h1>
   <p>{{ error | async }}</p>
 </sbb-page-layout>

--- a/src/app/view/filter-main-side-view/filter-main-side-view.component.ts
+++ b/src/app/view/filter-main-side-view/filter-main-side-view.component.ts
@@ -161,10 +161,10 @@ export class FilterMainSideViewComponent implements OnInit, OnDestroy {
         this.mainViewMode = mainViewMode;
       });
     this.uiInteractionService.originDestinationWindow
-        .pipe(takeUntil(this.destroyed))
-        .subscribe((mainViewMode: MainViewMode) => {
-          this.mainViewMode = mainViewMode;
-        });
+      .pipe(takeUntil(this.destroyed))
+      .subscribe((mainViewMode: MainViewMode) => {
+        this.mainViewMode = mainViewMode;
+      });
 
     this.dataService.triggerViewUpdate();
   }

--- a/src/app/view/knoten-auslastung-view/knoten-auslastung-view.component.ts
+++ b/src/app/view/knoten-auslastung-view/knoten-auslastung-view.component.ts
@@ -294,9 +294,9 @@ export class KnotenAuslastungViewComponent implements AfterViewInit, OnDestroy {
           "" +
           Math.round(
             (100 * d) /
-            this.resourceService
-              .getResource(selectedNode.getResourceId())
-              .getCapacity(),
+              this.resourceService
+                .getResource(selectedNode.getResourceId())
+                .getCapacity(),
           ) +
           "%",
       );

--- a/src/app/view/navigation-bar/navigation-bar.component.ts
+++ b/src/app/view/navigation-bar/navigation-bar.component.ts
@@ -23,7 +23,12 @@ export class NavigationBarComponent implements OnInit {
         {
           name: this.projectsBackendService
             .getProject(params[0].asNumber())
-            .pipe(map((project) => $localize`:@@app.view.navigation-bar.project-name:Project «${project.name}:name:»`)),
+            .pipe(
+              map(
+                (project) =>
+                  $localize`:@@app.view.navigation-bar.project-name:Project «${project.name}:name:»`,
+              ),
+            ),
           route: this.navigationService.getRouteToVariants(
             params[0].asNumber(),
           ),

--- a/src/app/view/project/project-dialog/project-dialog.component.html
+++ b/src/app/view/project/project-dialog/project-dialog.component.html
@@ -1,6 +1,10 @@
 <div sbbDialogTitle>
-  <ng-container *ngIf="isNewProject">{{ 'app.view.project.project-dialog.create-project' | translate }}</ng-container>
-  <ng-container *ngIf="!isNewProject">{{ 'app.view.project.project-dialog.edit-project' | translate }}</ng-container>
+  <ng-container *ngIf="isNewProject">{{
+    "app.view.project.project-dialog.create-project" | translate
+  }}</ng-container>
+  <ng-container *ngIf="!isNewProject">{{
+    "app.view.project.project-dialog.edit-project" | translate
+  }}</ng-container>
 </div>
 <div sbbDialogContent>
   <sbb-project-form [model]="formModel"></sbb-project-form>
@@ -12,7 +16,7 @@
     cdkFocusInitial
     (click)="onCreateClicked()"
   >
-    {{ 'app.view.project.project-dialog.create' | translate }}
+    {{ "app.view.project.project-dialog.create" | translate }}
   </button>
   <button
     *ngIf="!isNewProject"
@@ -20,7 +24,9 @@
     cdkFocusInitial
     (click)="onCreateClicked()"
   >
-    {{ 'app.view.project.project-dialog.save' | translate }}
+    {{ "app.view.project.project-dialog.save" | translate }}
   </button>
-  <button sbb-secondary-button (click)="onCancelClicked()">{{ 'app.view.project.project-dialog.cancel' | translate }}</button>
+  <button sbb-secondary-button (click)="onCancelClicked()">
+    {{ "app.view.project.project-dialog.cancel" | translate }}
+  </button>
 </div>

--- a/src/app/view/project/project-dialog/project-dialog.component.spec.ts
+++ b/src/app/view/project/project-dialog/project-dialog.component.spec.ts
@@ -11,7 +11,7 @@ describe("ProjectDialogComponent", () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [ProjectDialogComponent],
-      imports:[I18nModule],
+      imports: [I18nModule],
       providers: [
         {provide: SbbDialogRef, useValue: {}},
         {provide: SBB_DIALOG_DATA, useValue: {}},

--- a/src/app/view/project/project-dialog/project-form/project-form.component.html
+++ b/src/app/view/project/project-dialog/project-form/project-form.component.html
@@ -1,38 +1,58 @@
 <div class="content">
-  <sbb-form-field [label]="'app.view.project.project-dialog.project-form.name' | translate" class="sbb-form-field-long">
+  <sbb-form-field
+    [label]="'app.view.project.project-dialog.project-form.name' | translate"
+    class="sbb-form-field-long"
+  >
     <input
       type="text"
       sbbInput
       [formControl]="model.getControl('name')"
-      [placeholder]="'app.view.project.project-dialog.project-form.name' | translate"
+      [placeholder]="
+        'app.view.project.project-dialog.project-form.name' | translate
+      "
     />
-    <sbb-error *ngIf="model.getControl('name').errors?.required"
-      >{{ 'app.view.project.project-dialog.project-form.mandatory-field' | translate }}</sbb-error
-    >
+    <sbb-error *ngIf="model.getControl('name').errors?.required">{{
+      "app.view.project.project-dialog.project-form.mandatory-field" | translate
+    }}</sbb-error>
   </sbb-form-field>
-  <sbb-form-field [label]="'app.view.project.project-dialog.project-form.summary' | translate" class="sbb-form-field-long">
+  <sbb-form-field
+    [label]="'app.view.project.project-dialog.project-form.summary' | translate"
+    class="sbb-form-field-long"
+  >
     <input
       type="text"
       sbbInput
       [formControl]="model.getControl('summary')"
-      [placeholder]="'app.view.project.project-dialog.project-form.summary' | translate"
+      [placeholder]="
+        'app.view.project.project-dialog.project-form.summary' | translate
+      "
     />
   </sbb-form-field>
-  <sbb-form-field [label]="'app.view.project.project-dialog.project-form.description' | translate" class="sbb-form-field-long">
+  <sbb-form-field
+    [label]="
+      'app.view.project.project-dialog.project-form.description' | translate
+    "
+    class="sbb-form-field-long"
+  >
     <sbb-textarea
       [formControl]="model.getControl('description')"
       [maxlength]="500"
-      [placeholder]="'app.view.project.project-dialog.project-form.description' | translate"
+      [placeholder]="
+        'app.view.project.project-dialog.project-form.description' | translate
+      "
     ></sbb-textarea>
   </sbb-form-field>
   <ng-template #userTooltip>
     <sbb-tooltip>
-      {{ 'app.view.project.project-dialog.project-form.tooltip' | translate }}
+      {{ "app.view.project.project-dialog.project-form.tooltip" | translate }}
     </sbb-tooltip>
   </ng-template>
   <sbb-form-field class="sbb-form-field-long">
     <sbb-label>
-      {{ 'app.view.project.project-dialog.project-form.user-with-write-access' | translate }}
+      {{
+        "app.view.project.project-dialog.project-form.user-with-write-access"
+          | translate
+      }}
       <ng-container *ngTemplateOutlet="userTooltip"></ng-container>
     </sbb-label>
     <sbb-chip-list
@@ -46,19 +66,30 @@
       </sbb-chip>
       <input
         id="userWriteInput"
-        [placeholder]="'app.view.project.project-dialog.project-form.new-user-placeholder' | translate"
+        [placeholder]="
+          'app.view.project.project-dialog.project-form.new-user-placeholder'
+            | translate
+        "
         sbbChipInput
         [sbbChipInputSeparatorKeyCodes]="separatorKeysCodes"
       />
     </sbb-chip-list>
-    <sbb-error *ngIf="model.getControl('writeUsers').errors?.invalidUserIdAsEmails">
-      {{ 'app.view.project.project-dialog.project-form.invalid-values' | translate }}:
+    <sbb-error
+      *ngIf="model.getControl('writeUsers').errors?.invalidUserIdAsEmails"
+    >
+      {{
+        "app.view.project.project-dialog.project-form.invalid-values"
+          | translate
+      }}:
       {{ model.getControl("writeUsers").errors?.invalidUserIdAsEmails }}
     </sbb-error>
   </sbb-form-field>
   <sbb-form-field class="sbb-form-field-long">
     <sbb-label>
-      {{ 'app.view.project.project-dialog.project-form.user-with-read-access' | translate }}
+      {{
+        "app.view.project.project-dialog.project-form.user-with-read-access"
+          | translate
+      }}
       <ng-container *ngTemplateOutlet="userTooltip"></ng-container>
     </sbb-label>
     <sbb-chip-list
@@ -73,13 +104,21 @@
       </sbb-chip>
       <input
         id="userReadeInput"
-        [placeholder]="'app.view.project.project-dialog.project-form.new-user-placeholder' | translate"
+        [placeholder]="
+          'app.view.project.project-dialog.project-form.new-user-placeholder'
+            | translate
+        "
         sbbChipInput
         [sbbChipInputSeparatorKeyCodes]="separatorKeysCodes"
       />
     </sbb-chip-list>
-    <sbb-error *ngIf="model.getControl('readUsers').errors?.invalidUserIdAsEmails">
-      {{ 'app.view.project.project-dialog.project-form.invalid-values' | translate }}:
+    <sbb-error
+      *ngIf="model.getControl('readUsers').errors?.invalidUserIdAsEmails"
+    >
+      {{
+        "app.view.project.project-dialog.project-form.invalid-values"
+          | translate
+      }}:
       {{ model.getControl("readUsers").errors?.invalidUserIdAsEmails }}
     </sbb-error>
   </sbb-form-field>

--- a/src/app/view/project/project-dialog/project-form/project-form.component.spec.ts
+++ b/src/app/view/project/project-dialog/project-form/project-form.component.spec.ts
@@ -53,7 +53,7 @@ describe("ProjectFormComponent", () => {
       "u123456",
       "ue123456",
       "e123456",
-      "u000000"
+      "u000000",
     ];
 
     validEMailExamples.forEach((e) => {
@@ -71,7 +71,8 @@ describe("ProjectFormComponent", () => {
       "a",
       "u",
       "ue",
-      "e"];
+      "e",
+    ];
     invalidEMailExamples.forEach((e) => {
       const test = new UntypedFormControl();
       test.setValue([e]);
@@ -96,7 +97,8 @@ describe("ProjectFormComponent", () => {
       "adrian@AI.ORG",
       "adrian@ai.ORG",
       "adrian@AI.org",
-      "adrian@AI.orG"];
+      "adrian@AI.orG",
+    ];
 
     const test = new UntypedFormControl();
     test.setValue(validEMailExamples);
@@ -107,7 +109,8 @@ describe("ProjectFormComponent", () => {
     const invalidEMailExamples = [
       "u123456",
       "name.vorname.vorname2#mail.domain.ch",
-      ""];
+      "",
+    ];
     const test = new UntypedFormControl();
     test.setValue(invalidEMailExamples);
     expect(userIdsAsEmailValidator(test).invalidUserIdAsEmails.length).toBe(38);
@@ -125,7 +128,8 @@ describe("ProjectFormComponent", () => {
       "a2#b.ch",
       "1234@1234.org",
       "123a4@1234.org",
-      ""];
+      "",
+    ];
     const test = new UntypedFormControl();
     test.setValue(mixedValInvalidExamples);
     console.log(userIdsAsEmailValidator(test).invalidUserIdAsEmails);

--- a/src/app/view/project/project-dialog/project-form/project-form.component.ts
+++ b/src/app/view/project/project-dialog/project-form/project-form.component.ts
@@ -51,8 +51,9 @@ export const userIdsAsEmailValidator = (control: UntypedFormControl) => {
   const userIds: string[] = control.value;
   // email adresse validator: regex to match emails using the expression
   const invalidEmailPattern = userIds.filter((id) => {
-    const retVal =
-      id.match(/^([a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*)|(u|ue|e)\d+$/);
+    const retVal = id.match(
+      /^([a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*)|(u|ue|e)\d+$/,
+    );
     if (retVal === null) {
       return true;
     }

--- a/src/app/view/project/projects-view/projects-view.component.html
+++ b/src/app/view/project/projects-view/projects-view.component.html
@@ -1,5 +1,5 @@
 <sbb-page-layout>
-  <h1>{{ 'app.view.project.projects-view.projects' | translate }}</h1>
+  <h1>{{ "app.view.project.projects-view.projects" | translate }}</h1>
 
   <div class="actions">
     <input
@@ -7,12 +7,14 @@
       class="search"
       type="text"
       sbbInput
-      [placeholder]="'app.view.project.projects-view.search-project' | translate"
+      [placeholder]="
+        'app.view.project.projects-view.search-project' | translate
+      "
     />
     <div>
-      <sbb-checkbox [formControl]="showArchiveControl"
-        >{{ 'app.view.project.projects-view.show-archive' | translate }}</sbb-checkbox
-      >
+      <sbb-checkbox [formControl]="showArchiveControl">{{
+        "app.view.project.projects-view.show-archive" | translate
+      }}</sbb-checkbox>
     </div>
   </div>
 
@@ -24,7 +26,12 @@
     ></sbb-card>
     <sbb-card
       *ngFor="let project of projectService.filteredProjects | async"
-      [title]="project.name + (project.isArchived ? ' ' + ('app.view.project.projects-view.archived' | translate) : '')"
+      [title]="
+        project.name +
+        (project.isArchived
+          ? ' ' + ('app.view.project.projects-view.archived' | translate)
+          : '')
+      "
       [route]="['/projects', project.id]"
       [actions]="getProjectDataActions(project)"
     >

--- a/src/app/view/project/projects-view/projects-view.component.ts
+++ b/src/app/view/project/projects-view/projects-view.component.ts
@@ -10,9 +10,7 @@ import {
   ProjectDto,
   ProjectSummaryDto,
 } from "../../../api/generated";
-import {
-  ConfirmationDialogParameter
-} from "../../dialogs/confirmation-dialog/confirmation-dialog.component";
+import {ConfirmationDialogParameter} from "../../dialogs/confirmation-dialog/confirmation-dialog.component";
 import {UiInteractionService} from "../../../services/ui/ui.interaction.service";
 import {NavigationService} from "../../../services/ui/navigation.service";
 import {SlotAction} from "../../action-menu/action-menu/action-menu.component";
@@ -59,7 +57,7 @@ export class ProjectsViewComponent implements OnDestroy {
     if (event$.buttons === 1) {
       const ele = document.documentElement;
       ele.scrollTop = ele.scrollTop - event$.movementY;
-      if (event$.movementY > 2){
+      if (event$.movementY > 2) {
         event$.stopPropagation();
         event$.preventDefault();
         window.getSelection().removeAllRanges();

--- a/src/app/view/slots-view/slot/slot.component.spec.ts
+++ b/src/app/view/slots-view/slot/slot.component.spec.ts
@@ -10,7 +10,7 @@ describe("SlotComponent", () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [SlotComponent],
-      imports:[I18nModule],
+      imports: [I18nModule],
     }).compileComponents();
   });
 

--- a/src/app/view/themes/theme.spec.ts
+++ b/src/app/view/themes/theme.spec.ts
@@ -173,9 +173,13 @@ describe("Theme Tests", () => {
     const t2 = new ThemeDefaultUxDark("red");
     const t3 = new ThemeDefaultUxDark("yellow", "blue");
     expect(t1.backgroundColor).toBe("var(--sbb-header-lean-background-color)");
-    expect(t1.backgroundStreckengraphikColor).toBe("var(--sbb-header-lean-background-color)");
+    expect(t1.backgroundStreckengraphikColor).toBe(
+      "var(--sbb-header-lean-background-color)",
+    );
     expect(t2.backgroundColor).toBe("red");
-    expect(t2.backgroundStreckengraphikColor).toBe("var(--sbb-header-lean-background-color)");
+    expect(t2.backgroundStreckengraphikColor).toBe(
+      "var(--sbb-header-lean-background-color)",
+    );
     expect(t3.backgroundColor).toBe("yellow");
     expect(t3.backgroundStreckengraphikColor).toBe("blue");
   });
@@ -197,9 +201,13 @@ describe("Theme Tests", () => {
     const t2 = new ThemeFachDark("red");
     const t3 = new ThemeFachDark("yellow", "blue");
     expect(t1.backgroundColor).toBe("var(--sbb-header-lean-background-color)");
-    expect(t1.backgroundStreckengraphikColor).toBe("var(--sbb-header-lean-background-color)");
+    expect(t1.backgroundStreckengraphikColor).toBe(
+      "var(--sbb-header-lean-background-color)",
+    );
     expect(t2.backgroundColor).toBe("red");
-    expect(t2.backgroundStreckengraphikColor).toBe("var(--sbb-header-lean-background-color)");
+    expect(t2.backgroundStreckengraphikColor).toBe(
+      "var(--sbb-header-lean-background-color)",
+    );
     expect(t3.backgroundColor).toBe("yellow");
     expect(t3.backgroundStreckengraphikColor).toBe("blue");
   });
@@ -233,9 +241,13 @@ describe("Theme Tests", () => {
     const t2 = new ThemeGrayDark("red");
     const t3 = new ThemeGrayDark("yellow", "blue");
     expect(t1.backgroundColor).toBe("var(--sbb-header-lean-background-color)");
-    expect(t1.backgroundStreckengraphikColor).toBe("var(--sbb-header-lean-background-color)");
+    expect(t1.backgroundStreckengraphikColor).toBe(
+      "var(--sbb-header-lean-background-color)",
+    );
     expect(t2.backgroundColor).toBe("red");
-    expect(t2.backgroundStreckengraphikColor).toBe("var(--sbb-header-lean-background-color)");
+    expect(t2.backgroundStreckengraphikColor).toBe(
+      "var(--sbb-header-lean-background-color)",
+    );
     expect(t3.backgroundColor).toBe("yellow");
     expect(t3.backgroundStreckengraphikColor).toBe("blue");
   });

--- a/src/app/view/util/generalViewFunctions.ts
+++ b/src/app/view/util/generalViewFunctions.ts
@@ -81,7 +81,10 @@ export class GeneralViewFunctions {
     }
   }
 
-  static getStartForwardAndBackwardNode(endNode1: Node, endNode2: Node): {
+  static getStartForwardAndBackwardNode(
+    endNode1: Node,
+    endNode2: Node,
+  ): {
     startForwardNode: Node;
     startBackwardNode: Node;
   } {
@@ -91,13 +94,11 @@ export class GeneralViewFunctions {
     );
 
     const startBackwardNode =
-      endNode1.getId() === startForwardNode.getId()
-        ? endNode2
-        : endNode1;
+      endNode1.getId() === startForwardNode.getId() ? endNode2 : endNode1;
 
     return {
       startForwardNode: startForwardNode,
-      startBackwardNode: startBackwardNode
+      startBackwardNode: startBackwardNode,
     };
   }
 

--- a/src/app/view/util/svg.mouse.controller.spec.ts
+++ b/src/app/view/util/svg.mouse.controller.spec.ts
@@ -1,4 +1,7 @@
-import {SVGMouseController, SVGMouseControllerObserver,} from "./svg.mouse.controller";
+import {
+  SVGMouseController,
+  SVGMouseControllerObserver,
+} from "./svg.mouse.controller";
 import {Vec2D} from "../../utils/vec2D";
 import {ViewboxProperties} from "../../services/ui/ui.interaction.service";
 
@@ -7,26 +10,19 @@ class DummySVGMouseControllerObserver implements SVGMouseControllerObserver {
     return true;
   }
 
-  onGraphContainerMouseup(mousePosition: Vec2D, onPaning: boolean) {
-  }
+  onGraphContainerMouseup(mousePosition: Vec2D, onPaning: boolean) {}
 
-  zoomFactorChanged(newZoomFactor: number) {
-  }
+  zoomFactorChanged(newZoomFactor: number) {}
 
-  onViewboxChanged(viewboxProperties: ViewboxProperties) {
-  }
+  onViewboxChanged(viewboxProperties: ViewboxProperties) {}
 
-  onStartMultiSelect() {
-  }
+  onStartMultiSelect() {}
 
-  updateMultiSelect(topLeft: Vec2D, bottomRight: Vec2D) {
-  }
+  updateMultiSelect(topLeft: Vec2D, bottomRight: Vec2D) {}
 
-  onEndMultiSelect() {
-  }
+  onEndMultiSelect() {}
 
-  onScaleNetzgrafik(factor: number, scaleCenter: Vec2D) {
-  }
+  onScaleNetzgrafik(factor: number, scaleCenter: Vec2D) {}
 }
 
 describe("general view functions", () => {

--- a/src/app/view/util/svg.mouse.controller.ts
+++ b/src/app/view/util/svg.mouse.controller.ts
@@ -39,9 +39,8 @@ export class SVGMouseController {
   constructor(
     private svgName: string,
     private svgMouseControllerObserver: SVGMouseControllerObserver,
-    private undoService : UndoService
-  ) {
-  }
+    private undoService: UndoService,
+  ) {}
 
   init(viewboxProperties: ViewboxProperties) {
     this.viewboxProperties = viewboxProperties;
@@ -104,7 +103,6 @@ export class SVGMouseController {
       this.viewboxProperties.zoomFactor,
     );
   }
-
 
   scaleIn(scaleCenter: Vec2D) {
     this.svgMouseControllerObserver.onScaleNetzgrafik(1.125, scaleCenter);
@@ -399,9 +397,9 @@ export class SVGMouseController {
   private updateZoomCenter(zoomCenter: Vec2D) {
     const oldZoomCenter = new Vec2D(
       this.viewboxProperties.panZoomLeft +
-      zoomCenter.getX() * this.viewboxProperties.panZoomWidth,
+        zoomCenter.getX() * this.viewboxProperties.panZoomWidth,
       this.viewboxProperties.panZoomTop +
-      zoomCenter.getY() * this.viewboxProperties.panZoomHeight,
+        zoomCenter.getY() * this.viewboxProperties.panZoomHeight,
     );
 
     const zoomFactor = 100.0 / this.viewboxProperties.zoomFactor;
@@ -420,9 +418,9 @@ export class SVGMouseController {
 
     const newZoomCenter = new Vec2D(
       this.viewboxProperties.panZoomLeft +
-      zoomCenter.getX() * this.viewboxProperties.panZoomWidth,
+        zoomCenter.getX() * this.viewboxProperties.panZoomWidth,
       this.viewboxProperties.panZoomTop +
-      zoomCenter.getY() * this.viewboxProperties.panZoomHeight,
+        zoomCenter.getY() * this.viewboxProperties.panZoomHeight,
     );
 
     this.viewboxProperties.panZoomLeft -=
@@ -464,9 +462,9 @@ export class SVGMouseController {
     );
   }
 
-  private temporaryDisableUndoServicePushCurrentVersion(){
+  private temporaryDisableUndoServicePushCurrentVersion() {
     // temporary disable undoService push current version
-    if (this.undoService !== undefined){
+    if (this.undoService !== undefined) {
       this.undoService.setIgnoreNextPushCurrentVersionCall();
     }
   }

--- a/src/app/view/variant/variant-dialog/variant-dialog.component.html
+++ b/src/app/view/variant/variant-dialog/variant-dialog.component.html
@@ -1,13 +1,19 @@
 <div sbbDialogTitle>
-  <ng-container *ngIf="isNewVariant">{{ 'app.view.variant.variant-dialog.create-variant' | translate }}</ng-container>
-  <ng-container *ngIf="!isNewVariant">{{ 'app.view.variant.variant-dialog.edit-variant' | translate }}</ng-container>
+  <ng-container *ngIf="isNewVariant">{{
+    "app.view.variant.variant-dialog.create-variant" | translate
+  }}</ng-container>
+  <ng-container *ngIf="!isNewVariant">{{
+    "app.view.variant.variant-dialog.edit-variant" | translate
+  }}</ng-container>
 </div>
 <div sbbDialogContent>
   <sbb-variant-form [model]="formModel"></sbb-variant-form>
 </div>
 <div sbbDialogActions>
   <button sbb-button cdkFocusInitial (click)="onCreateClicked()">
-    {{ 'app.view.variant.variant-dialog.save' | translate }}
+    {{ "app.view.variant.variant-dialog.save" | translate }}
   </button>
-  <button sbb-secondary-button (click)="onCancelClicked()">{{ 'app.view.variant.variant-dialog.cancel' | translate }}</button>
+  <button sbb-secondary-button (click)="onCancelClicked()">
+    {{ "app.view.variant.variant-dialog.cancel" | translate }}
+  </button>
 </div>

--- a/src/app/view/variant/variant-dialog/variant-dialog.component.spec.ts
+++ b/src/app/view/variant/variant-dialog/variant-dialog.component.spec.ts
@@ -10,7 +10,7 @@ describe("VariantDialogComponent", () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [VariantDialogComponent],
-      imports:[I18nModule],
+      imports: [I18nModule],
       providers: [
         {provide: SbbDialogRef, useValue: {}},
         {provide: SBB_DIALOG_DATA, useValue: {}},

--- a/src/app/view/variant/variant-dialog/variant-form/variant-form.component.html
+++ b/src/app/view/variant/variant-dialog/variant-form/variant-form.component.html
@@ -1,13 +1,18 @@
 <div class="content">
-  <sbb-form-field [label]="'app.view.variant.variant-dialog.variant-form.name' | translate" class="sbb-form-field-long">
+  <sbb-form-field
+    [label]="'app.view.variant.variant-dialog.variant-form.name' | translate"
+    class="sbb-form-field-long"
+  >
     <input
       type="text"
       sbbInput
       [formControl]="model.getControl('name')"
-      [placeholder]="'app.view.variant.variant-dialog.variant-form.name' | translate"
+      [placeholder]="
+        'app.view.variant.variant-dialog.variant-form.name' | translate
+      "
     />
-    <sbb-error *ngIf="model.getControl('name').errors?.required"
-      >{{ 'app.view.variant.variant-dialog.variant-form.mandatory-field' | translate }}</sbb-error
-    >
+    <sbb-error *ngIf="model.getControl('name').errors?.required">{{
+      "app.view.variant.variant-dialog.variant-form.mandatory-field" | translate
+    }}</sbb-error>
   </sbb-form-field>
 </div>

--- a/src/app/view/variant/variant-dialog/variant-form/variant-form.component.spec.ts
+++ b/src/app/view/variant/variant-dialog/variant-form/variant-form.component.spec.ts
@@ -12,7 +12,7 @@ describe("VariantFormComponent", () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports:[I18nModule],
+      imports: [I18nModule],
       declarations: [VariantFormComponent],
     }).compileComponents();
   });

--- a/src/app/view/variant/variant-view/variant-history/preview-button/preview-button.component.spec.ts
+++ b/src/app/view/variant/variant-view/variant-history/preview-button/preview-button.component.spec.ts
@@ -10,7 +10,7 @@ describe("PreviewButtonComponent", () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [PreviewButtonComponent],
-      imports:[I18nModule],
+      imports: [I18nModule],
     }).compileComponents();
   });
 

--- a/src/app/view/variant/variant-view/variant-history/publish-entry/publish-entry.component.html
+++ b/src/app/view/variant/variant-view/variant-history/publish-entry/publish-entry.component.html
@@ -8,16 +8,27 @@
     <input
       type="text"
       sbbInput
-      [placeholder]="'app.view.variant.variant-view.variant-history.publish-entry.comment' | translate"
+      [placeholder]="
+        'app.view.variant.variant-view.variant-history.publish-entry.comment'
+          | translate
+      "
       [formControl]="comment"
     />
     <button
       sbb-button
       (click)="onPublishClicked()"
       [disabled]="publishDisabled"
-      [title]="this.publishDisabled ? ('app.view.variant.variant-view.variant-history.publish-entry.local-changes' | translate) : ''"
+      [title]="
+        this.publishDisabled
+          ? ('app.view.variant.variant-view.variant-history.publish-entry.local-changes'
+            | translate)
+          : ''
+      "
     >
-      {{ 'app.view.variant.variant-view.variant-history.publish-entry.publish' | translate }}
+      {{
+        "app.view.variant.variant-view.variant-history.publish-entry.publish"
+          | translate
+      }}
     </button>
   </div>
 </sbb-history-entry>

--- a/src/app/view/variant/variant-view/variant-history/version-entry-layout/version-entry-layout.component.html
+++ b/src/app/view/variant/variant-view/variant-history/version-entry-layout/version-entry-layout.component.html
@@ -8,10 +8,12 @@
     <div class="info-field title-field" *ngIf="getTitle(); let title">
       {{ title }}
     </div>
-    <div class="info-field title-field user-id"
-         *ngIf="getUserId(); let userId"
-         [attr.title]="getUserId()"
-          (click)="copyUserId()">
+    <div
+      class="info-field title-field user-id"
+      *ngIf="getUserId(); let userId"
+      [attr.title]="getUserId()"
+      (click)="copyUserId()"
+    >
       {{ userId }}
     </div>
     <div class="info-field date-field">
@@ -24,7 +26,7 @@
       *ngIf="commentField && commentField !== ''"
       (click)="copyComment()"
     >
-      <br>
+      <br />
       «{{ commentField }}»
     </div>
   </div>

--- a/src/app/view/variant/variant-view/variant-history/version-entry-layout/version-entry-layout.component.scss
+++ b/src/app/view/variant/variant-view/variant-history/version-entry-layout/version-entry-layout.component.scss
@@ -72,7 +72,6 @@
   }
 }
 
-
 .user-id {
   width: 140px;
   overflow: hidden;

--- a/src/app/view/variant/variant-view/variant-history/version-entry-layout/version-entry-layout.component.ts
+++ b/src/app/view/variant/variant-view/variant-history/version-entry-layout/version-entry-layout.component.ts
@@ -14,8 +14,7 @@ export class VersionEntryLayoutComponent {
   @Input() dateField: Date;
   @Input() commentField?: string;
 
-  constructor(private readonly logService: LogService) {
-  }
+  constructor(private readonly logService: LogService) {}
 
   isInConflictState(): boolean {
     return this.state === "conflict";
@@ -68,6 +67,5 @@ export class VersionEntryLayoutComponent {
 }
 
 export class UserId {
-  constructor(readonly value: string) {
-  }
+  constructor(readonly value: string) {}
 }

--- a/src/app/view/variant/variant-view/variant-view.component.html
+++ b/src/app/view/variant/variant-view/variant-view.component.html
@@ -1,7 +1,7 @@
 <h2 class="title" style="margin-right: -9px">
   {{ (versionControlService.variant$ | async)?.latestVersion?.name }}
   <ng-container *ngIf="versionControlService.variant.isArchived">
-    {{ 'app.view.variant.variant-view.archived' | translate }}
+    {{ "app.view.variant.variant-view.archived" | translate }}
   </ng-container>
   <div style="float: right">
     <button [sbbContextmenuTriggerFor]="menu"></button>
@@ -14,17 +14,19 @@
         *ngIf="versionControlService.variant.isWritable"
       >
         <sbb-icon svgIcon="pen-small"></sbb-icon>
-        {{ 'app.view.variant.variant-view.edit-variant' | translate }}
+        {{ "app.view.variant.variant-view.edit-variant" | translate }}
       </button>
       <button
         sbb-menu-item
         mode="icon"
         (click)="onDeleteVariant()"
-        [title]="'app.view.variant.variant-view.delete-variant.title' | translate"
+        [title]="
+          'app.view.variant.variant-view.delete-variant.title' | translate
+        "
         *ngIf="versionControlService.variant.isDeletable"
       >
         <sbb-icon svgIcon="trash-small"></sbb-icon>
-        {{ 'app.view.variant.variant-view.delete-variant.title' | translate }}
+        {{ "app.view.variant.variant-view.delete-variant.title" | translate }}
       </button>
     </sbb-menu>
   </div>
@@ -32,7 +34,9 @@
 
 <sbb-accordion [multi]="true">
   <sbb-expansion-panel [expanded]="true">
-    <sbb-expansion-panel-header>{{ 'app.view.variant.variant-view.versions' | translate }}</sbb-expansion-panel-header>
+    <sbb-expansion-panel-header>{{
+      "app.view.variant.variant-view.versions" | translate
+    }}</sbb-expansion-panel-header>
     <sbb-variant-history
       *ngIf="versionControlService.variant$ | async as variant"
       [variant]="variant"

--- a/src/app/view/variant/variants-view/variants-view.component.html
+++ b/src/app/view/variant/variants-view/variants-view.component.html
@@ -1,8 +1,10 @@
 <sbb-page-layout *ngIf="projectSubject.asObservable() | async as proj">
   <div class="header">
     <h1>
-      {{ proj.name + ' '}}
-      <ng-container *ngIf="proj.isArchived">{{ 'app.view.variant.variants-view.archived' | translate }}</ng-container>
+      {{ proj.name + " " }}
+      <ng-container *ngIf="proj.isArchived">{{
+        "app.view.variant.variants-view.archived" | translate
+      }}</ng-container>
     </h1>
   </div>
 
@@ -14,13 +16,15 @@
           class="search"
           type="text"
           sbbInput
-          [placeholder]="'app.view.variant.variants-view.search-variants' | translate"
+          [placeholder]="
+            'app.view.variant.variants-view.search-variants' | translate
+          "
         />
       </div>
       <div class="archive">
-        <sbb-checkbox [formControl]="showArchiveControl"
-          >{{ 'app.view.variant.variants-view.show-archive' | translate }}</sbb-checkbox
-        >
+        <sbb-checkbox [formControl]="showArchiveControl">{{
+          "app.view.variant.variants-view.show-archive" | translate
+        }}</sbb-checkbox>
       </div>
       <sbb-card-grid>
         <sbb-card
@@ -44,7 +48,10 @@
         </sbb-card>
       </sbb-card-grid>
     </sbb-slot>
-    <sbb-slot [title]="'app.view.variant.variants-view.project-description' | translate" [actions]="projectDataActions">
+    <sbb-slot
+      [title]="'app.view.variant.variants-view.project-description' | translate"
+      [actions]="projectDataActions"
+    >
       <div class="project-data">
         <div style="height: 32px"></div>
         <div style="font-weight: bold; vertical-align: bottom; height: 32px">

--- a/src/app/view/variant/variants-view/variants-view.component.ts
+++ b/src/app/view/variant/variants-view/variants-view.component.ts
@@ -157,7 +157,7 @@ export class VariantsViewComponent implements OnDestroy {
     if (event$.buttons === 1) {
       const ele = document.documentElement;
       ele.scrollTop = ele.scrollTop - event$.movementY;
-      if (event$.movementY > 2){
+      if (event$.movementY > 2) {
         event$.stopPropagation();
         event$.preventDefault();
         window.getSelection().removeAllRanges();
@@ -308,7 +308,9 @@ export class VariantsViewComponent implements OnDestroy {
   }
 
   getTitleCurrentVersion(variant: VariantSummaryDto): string {
-    const archivedSuffix = variant.isArchived ? " " + $localize`:@@app.view.variant.variants-view.archived:(archived)` : "";
+    const archivedSuffix = variant.isArchived
+      ? " " + $localize`:@@app.view.variant.variants-view.archived:(archived)`
+      : "";
 
     if (variant.latestSnapshotVersion) {
       return variant.latestSnapshotVersion.name + "*" + archivedSuffix;
@@ -318,7 +320,9 @@ export class VariantsViewComponent implements OnDestroy {
       return variant.latestReleaseVersion.name + archivedSuffix;
     }
 
-    throw new Error($localize`:@@app.view.variant.variants-view.error-unexpected-data:Unexpected data: No snapshot and no released version.`);
+    throw new Error(
+      $localize`:@@app.view.variant.variants-view.error-unexpected-data:Unexpected data: No snapshot and no released version.`,
+    );
   }
 
   getChangedAtCurrentVersion(variant: VariantSummaryDto): Date {
@@ -330,7 +334,9 @@ export class VariantsViewComponent implements OnDestroy {
       return new Date(variant.latestReleaseVersion.createdAt);
     }
 
-    throw new Error($localize`:@@app.view.variant.variants-view.error-unexpected-data:Unexpected data: No snapshot and no released version.`);
+    throw new Error(
+      $localize`:@@app.view.variant.variants-view.error-unexpected-data:Unexpected data: No snapshot and no released version.`,
+    );
   }
 
   private updateProject(project: ProjectDto): void {

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -270,7 +270,7 @@
           "filterableLabels": "Filterable Labels",
           "trainrun-filter-tab": {
             "labels": "Labels",
-            "newLabels" : "New label...",
+            "newLabels": "New label...",
             "trainrunDuplicate": "Duplicate trainrun",
             "trainrunDelete": "Delete trainrun",
             "delete": "Delete",

--- a/src/integration-testing/netzgrafik.unit.test.reconnec.trainrunsectionst.ts
+++ b/src/integration-testing/netzgrafik.unit.test.reconnec.trainrunsectionst.ts
@@ -699,7 +699,7 @@ export class NetzgrafikUnitTestingReconnectTrainrunSection {
         analyticsSettings: {
           originDestinationSettings: {
             connectionPenalty: 5,
-          }
+          },
         },
         trainrunCategories: [
           {

--- a/src/integration-testing/netzgrafik.unit.testing.transition.ts
+++ b/src/integration-testing/netzgrafik.unit.testing.transition.ts
@@ -1129,7 +1129,7 @@ export class NetzgrafikUnitTestingTransition {
         analyticsSettings: {
           originDestinationSettings: {
             connectionPenalty: 5,
-          }
+          },
         },
         trainrunCategories: [
           {

--- a/src/integration-testing/netzgrafik.unit.testing.ts
+++ b/src/integration-testing/netzgrafik.unit.testing.ts
@@ -823,7 +823,7 @@ export class NetzgrafikUnitTesting {
         analyticsSettings: {
           originDestinationSettings: {
             connectionPenalty: 5,
-          }
+          },
         },
         trainrunCategories: [
           {

--- a/tsconfig.app.es5.json
+++ b/tsconfig.app.es5.json
@@ -1,5 +1,4 @@
 {
   "extends": "./tsconfig.app.json",
-  "compilerOptions": {
-  }
+  "compilerOptions": {}
 }

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -4,11 +4,6 @@
     "outDir": "./out-tsc/app",
     "types": []
   },
-  "files": [
-    "src/main.ts",
-    "src/polyfills.ts"
-  ],
-  "include": [
-    "src/**/*.d.ts"
-  ]
+  "files": ["src/main.ts", "src/polyfills.ts"],
+  "include": ["src/**/*.d.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,13 +11,8 @@
     "moduleResolution": "node",
     "importHelpers": true,
     "target": "ES2022",
-    "typeRoots": [
-      "node_modules/@types"
-    ],
-    "lib": [
-      "es2018",
-      "dom"
-    ],
+    "typeRoots": ["node_modules/@types"],
+    "lib": ["es2018", "dom"],
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
     "useDefineForClassFields": false

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -2,17 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/spec",
-    "types": [
-      "jasmine",
-      "node"
-    ]
+    "types": ["jasmine", "node"]
   },
-  "files": [
-    "src/test.ts",
-    "src/polyfills.ts"
-  ],
-  "include": [
-    "src/**/*.spec.ts",
-    "src/**/*.d.ts"
-  ]
+  "files": ["src/test.ts", "src/polyfills.ts"],
+  "include": ["src/**/*.spec.ts", "src/**/*.d.ts"]
 }


### PR DESCRIPTION
# Description

Introducing Prettier for code formatting.

The changes include:
- Addition of Prettier to ensure consistent code formatting. -> configuration file `.prettierrc` needs to be checked for formatting rules.
- New `npm` scripts:
  - `format`: To format the code according to Prettier rules.
  - `format:check`: To check that the code is correctly formatted.
- CI integration as new job in `continuous-integration.yml` file to check code formatting.
- All files have been reformatted to comply with the new formatting rules defined by Prettier.

These changes aim to improve code consistency and automate formatting checks in our CI pipeline.

# Issues

Many files needed formatting.

# Checklist

* [x] This PR contains a description of the changes I'm making
* [x] I've read the [Contribution Guidelines](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/CONTRIBUTING.md)
* [x] I documented any high-level concepts I'm introducing in `documentation/`
* [x] CI is currently green and this is ready for review