### PR TITLE
scale-netzgrafik: fix touchpad gesture with ctrl event listener

### DIFF
--- a/documentation/AdvancedEditingShortcuts.md
+++ b/documentation/AdvancedEditingShortcuts.md
@@ -30,7 +30,7 @@ easier to manage and edit complex network structures.
 ---
 
 ### Scale Netzgrafik 
-When you press `Ctrl` and use the `mouse wheel`, the netzgrafik gets scaled. This feature can be used when the nodes are spatially too close together. 
+When you press `Ctrl` and use the `mouse wheel` (or `Ctrl` and pinch-to-zoom touchpad gesture), the netzgrafik gets scaled. This feature can be used when the nodes are spatially too close together. 
 
 When you have selected multiple nodes with `right mouse button pressed and move`, then only the multi-selected nodes get scaled around their center of mass.
  

--- a/src/app/view/editor-main-view/data-views/editor.view.ts
+++ b/src/app/view/editor-main-view/data-views/editor.view.ts
@@ -165,6 +165,10 @@ export class EditorView implements SVGMouseControllerObserver {
     );
   }
 
+  destroyView() {
+    this.svgMouseController.destroy();
+  }
+
   bindAddNode(callback) {
     this.addNode = callback;
   }

--- a/src/app/view/editor-main-view/editor-main-view.component.ts
+++ b/src/app/view/editor-main-view/editor-main-view.component.ts
@@ -148,6 +148,7 @@ export class EditorMainViewComponent implements AfterViewInit, OnDestroy {
   ngOnDestroy(): void {
     this.destroyed.next();
     this.destroyed.complete();
+    this.editorView.destroyView();
   }
 
   moveNetzgrafikEditorViewFocalPoint(center: Vec2D) {

--- a/src/app/view/util/svg.mouse.controller.ts
+++ b/src/app/view/util/svg.mouse.controller.ts
@@ -35,19 +35,22 @@ export class SVGMouseController {
   private viewboxIsFixed = false;
 
   private lastMouseEventTimeStamp: number = undefined;
-  private static ctrlKeyPressed = false;
+  private ctrlKeyPressed = false;
 
   constructor(
     private svgName: string,
     private svgMouseControllerObserver: SVGMouseControllerObserver,
     private undoService: UndoService,
-  ) {}
+  ) {
+    this.ctrlKeyDownListener = this.ctrlKeyDownListener.bind(this);
+    this.ctrlKeyUpListener = this.ctrlKeyUpListener.bind(this);
+  }
 
   private ctrlKeyDownListener(e: KeyboardEvent) {
-    if (e.key === "Control") SVGMouseController.ctrlKeyPressed = true;
+    if (e.key === "Control") this.ctrlKeyPressed = true;
   }
   private ctrlKeyUpListener(e: KeyboardEvent) {
-    if (e.key === "Control") SVGMouseController.ctrlKeyPressed = false;
+    if (e.key === "Control") this.ctrlKeyPressed = false;
   }
 
   init(viewboxProperties: ViewboxProperties) {
@@ -351,7 +354,7 @@ export class SVGMouseController {
 
     // We can't use d3.event.ctrlKey because it'll be set to true during
     // pinch-to-zoom touchpad gestures. Use keydown/keyup event listeners instead.
-    if (!SVGMouseController.ctrlKeyPressed) {
+    if (!this.ctrlKeyPressed) {
       // mouse wheel
       if (d3.event.deltaY > 0) {
         this.zoomOut(zoomCenter);

--- a/src/app/view/util/svg.mouse.controller.ts
+++ b/src/app/view/util/svg.mouse.controller.ts
@@ -35,12 +35,21 @@ export class SVGMouseController {
   private viewboxIsFixed = false;
 
   private lastMouseEventTimeStamp: number = undefined;
+  private static ctrlKeyPressed = false;
 
   constructor(
     private svgName: string,
     private svgMouseControllerObserver: SVGMouseControllerObserver,
     private undoService : UndoService
   ) {
+    // Listens to ctrl key events to differentiate
+    // between pinch-to-zoom touchpad gesture and ctrl + mousewheel
+    window.addEventListener("keydown", (e) => {
+      if (e.key === "Control") SVGMouseController.ctrlKeyPressed = true;
+    });
+    window.addEventListener("keyup", (e) => {
+      if (e.key === "Control") SVGMouseController.ctrlKeyPressed = false;
+    });
   }
 
   init(viewboxProperties: ViewboxProperties) {
@@ -332,7 +341,8 @@ export class SVGMouseController {
       d3.event.offsetY / this.viewboxProperties.origHeight,
     );
 
-    if (!d3.event.ctrlKey) {
+  // to differentiate pinch-to-zoom touchpad gesture and ctrl + mousewheel
+  if (!SVGMouseController.ctrlKeyPressed) {
       // mouse wheel
       if (d3.event.deltaY > 0) {
         this.zoomOut(zoomCenter);


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->
# Description

Closes https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/464

The above issue is a known issue : https://stackoverflow.com/questions/5527601/normalizing-mousewheel-speed-across-browsers

# Issues

`d3.event.ctrlKey` is not detect when track pad is used. The solution is to get this event through an event listener.

# Checklist

* [x] This PR contains a description of the changes I'm making
* [ x I've read the [Contribution Guidelines](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/CONTRIBUTING.md)
* [ ] I've added tests for changes or features I've introduced
* [ ] I documented any high-level concepts I'm introducing in `documentation/`
* [x] CI is currently green and this is ready for review

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation.
-->
