### PR TITLE
trainrun: fix trainrun deletion when perlenkette is opened

### DIFF
--- a/src/app/services/data/trainrunsection.service.ts
+++ b/src/app/services/data/trainrunsection.service.ts
@@ -191,7 +191,7 @@ export class TrainrunSectionService implements OnDestroy {
 
   setTrainrunSectionAsSelected(trainrunSectionId: number) {
     this.trainrunSectionsStore.trainrunSections.forEach((tr) => tr.unselect());
-    this.getTrainrunSectionFromId(trainrunSectionId).select();
+    this.getTrainrunSectionFromId(trainrunSectionId)?.select();
   }
 
   getSelectedTrainrunSection(): TrainrunSection {


### PR DESCRIPTION
# Description

When Perlenkette was opened and user deletes a trainrun, the trainrun selection tries to still give something to the perlenkette component, to display something in it. This fix prevents an error in the logs

Before fix:
https://github.com/user-attachments/assets/2d0ea4f3-3ceb-415f-93e9-c699b1fe7277

After fix: no error

# Issues

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

- [ ] This PR contains a description of the changes I'm making
- [ ] I've read the [Contribution Guidelines](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/CONTRIBUTING.md)
- [ ] I've added tests for changes or features I've introduced
- [ ] I documented any high-level concepts I'm introducing in `documentation/`
- [ ] CI is currently green and this is ready for review

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation.
-->
