### PR TITLE
Fix: Clicking in the background in the Pearl view triggers stop editing

### DIFF
--- a/src/app/perlenkette/perlenkette.component.ts
+++ b/src/app/perlenkette/perlenkette.component.ts
@@ -335,8 +335,8 @@ export class PerlenketteComponent implements AfterContentChecked, OnDestroy {
     return this.contentHeight * window.devicePixelRatio - 40;
   }
 
-  disableSectionView() { 
-    this.signalIsBeingEdited(undefined); 
+  disableSectionView() {
+    this.signalIsBeingEdited(undefined);
   }
 
   scrollFirst(event: MouseEvent) {


### PR DESCRIPTION

<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->

# Description

Fix: We have to send this.signalIsBeingEdited(undefined) to reliably exit pearls view - edit mode, regardless of getVariantIsWritable() or not.

<!-- Describe the changes your PR introduces here. -->

# Issues

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

- [x] This PR contains a description of the changes I'm making
- [x] I've read the [Contribution Guidelines](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/CONTRIBUTING.md)
- [ ] I've added tests for changes or features I've introduced
- [ ] I documented any high-level concepts I'm introducing in `documentation/`
- [x] CI is currently green and this is ready for review

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation.
-->
