### PR TITLE
Improve rendering performance by switching SVG rendering of O/D matrix to Canvas

### DIFF
--- a/src/app/models/filterSettings.model.ts
+++ b/src/app/models/filterSettings.model.ts
@@ -123,9 +123,9 @@ export class FilterSetting {
   }
 
   copy(): FilterSetting {
-    const newFilterSettting = new FilterSetting(Object.assign({}, this.getDto()));
-    newFilterSettting.id = FilterSetting.incrementId();
-    return newFilterSettting;
+    const newFilterSetting = new FilterSetting(Object.assign({}, this.getDto()));
+    newFilterSetting.id = FilterSetting.incrementId();
+    return newFilterSetting;
   }
 
   areFilteringAttributesEqual(fs: FilterSetting): boolean {

--- a/src/app/services/analytics/origin-destination/components/origin-destination.component.html
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.component.html
@@ -1,11 +1,20 @@
 <div class="matrix-wrapper">
   <button
     type="button"
-    class="ODResetButton"
+    class="ODLeftPanelButton ODResetButton"
     [title]="'app.origin-destination.buttons.reset' | translate"
     (click)="onResetButton()"
   >
     <sbb-icon svgIcon="kom:arrow-circle-reset-small"></sbb-icon>
+  </button>
+
+  <button
+    type="button"
+    [class]="'ODLeftPanelButton ODCrossHighlightingButton ' + getCrossHighlightingTag()"
+    [title]="'app.origin-destination.buttons.crossHighlighting' | translate"
+    (click)="toggleCrossHighlighting()"
+  >
+    <sbb-icon svgIcon="highlighter-small"></sbb-icon>
   </button>
 
   <div id="main-origin-destination-container-root"></div>

--- a/src/app/services/analytics/origin-destination/components/origin-destination.component.html
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.component.html
@@ -1,7 +1,17 @@
 <div class="matrix-wrapper">
+
+  <button
+    type="button"
+    class="ODResetButton"
+    [title]="'app.origin-destination.reset' | translate"
+    (click)="onResetButton()"
+  >
+    <sbb-icon svgIcon="kom:arrow-circle-reset-small"></sbb-icon>
+  </button>
+
   <div id="main-origin-destination-container-root"></div>
 
-  <div class="palette-buttons">
+  <div class="palette-buttons" style="transform: translateX(-32px);">
     <div
       class="palette-option red"
       [class.active]="colorSetName === 'red'"
@@ -30,6 +40,7 @@
     <div class="color-by-selector">
       <label>
         <input
+          class="ODRadioButton"
           type="radio"
           name="colorBy"
           value="totalCost"
@@ -40,6 +51,7 @@
       </label>
       <label>
         <input
+          class="ODRadioButton"
           type="radio"
           name="colorBy"
           value="travelTime"
@@ -50,6 +62,7 @@
       </label>
       <label>
         <input
+          class="ODRadioButton"
           type="radio"
           name="colorBy"
           value="transfers"
@@ -72,27 +85,20 @@
       flex-wrap: nowrap;
     "
   >
-    <button
-      type="button"
-      class="SimpleButton"
-      [title]="'app.streckengrafik.components.reset' | translate"
-      (click)="onResetButton()"
-    >
-      <sbb-icon svgIcon="kom:arrow-circle-reset-small"></sbb-icon>
-    </button>
+
 
     <sbb-radio-group
       class="sbb-checkbox-group-horizontal"
       [(ngModel)]="displayBy"
-      style="display: flex; flex-direction: row; gap: 0.5rem; transform: translate(32px, -1px)"
+      style="display: flex; flex-direction: row; gap: 0.5rem; transform: translateX(-16px)"
     >
-      <sbb-radio-button value="totalCost" (change)="onChangeDisplayBy('totalCost')">
+      <sbb-radio-button class="ODRadioButton" value="totalCost" (change)="onChangeDisplayBy('totalCost')">
         {{ "app.origin-destination.display-by-selector.total-cost" | translate }}
       </sbb-radio-button>
-      <sbb-radio-button value="travelTime" (change)="onChangeDisplayBy('travelTime')">
+      <sbb-radio-button class="ODRadioButton" value="travelTime" (change)="onChangeDisplayBy('travelTime')">
         {{ "app.origin-destination.display-by-selector.travel-time" | translate }}
       </sbb-radio-button>
-      <sbb-radio-button value="transfers" (change)="onChangeDisplayBy('transfers')">
+      <sbb-radio-button class="ODRadioButton" value="transfers" (change)="onChangeDisplayBy('transfers')">
         {{ "app.origin-destination.display-by-selector.transfers" | translate }}
       </sbb-radio-button>
     </sbb-radio-group>

--- a/src/app/services/analytics/origin-destination/components/origin-destination.component.html
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.component.html
@@ -1,7 +1,25 @@
 <div class="matrix-wrapper">
+  <button
+    type="button"
+    class="ODLeftPanelButton ODResetButton"
+    [title]="'app.origin-destination.buttons.reset' | translate"
+    (click)="onResetButton()"
+  >
+    <sbb-icon svgIcon="kom:arrow-circle-reset-small"></sbb-icon>
+  </button>
+
+  <button
+    type="button"
+    [class]="'ODLeftPanelButton ODCrossHighlightingButton ' + getCrossHighlightingTag()"
+    [title]="'app.origin-destination.buttons.crossHighlighting' | translate"
+    (click)="toggleCrossHighlighting()"
+  >
+    <sbb-icon svgIcon="highlighter-small"></sbb-icon>
+  </button>
+
   <div id="main-origin-destination-container-root"></div>
 
-  <div class="palette-buttons">
+  <div class="palette-buttons" style="transform: translateX(-64px)">
     <div
       class="palette-option red"
       [class.active]="colorSetName === 'red'"
@@ -28,48 +46,75 @@
     ></div>
 
     <div class="color-by-selector">
-      <label>
-        <input
-          type="radio"
-          name="colorBy"
+      <sbb-radio-group
+        class="sbb-checkbox-group-horizontal"
+        [(ngModel)]="colorBy"
+        style="display: flex; flex-direction: row; gap: 0.5rem; transform: translate(-18px, 92px)"
+      >
+        <sbb-radio-button
+          class="ODRadioButton"
           value="totalCost"
-          [checked]="colorBy === 'totalCost'"
           (change)="onChangeColorBy('totalCost')"
-        />
-        {{ "app.origin-destination.color-by-selector.total-cost" | translate }}
-      </label>
-      <label>
-        <input
-          type="radio"
-          name="colorBy"
+        >
+          {{ "app.origin-destination.color-by-selector.total-cost" | translate }}
+        </sbb-radio-button>
+
+        <sbb-radio-button
+          class="ODRadioButton"
           value="travelTime"
-          [checked]="colorBy === 'travelTime'"
           (change)="onChangeColorBy('travelTime')"
-        />
-        {{ "app.origin-destination.color-by-selector.travel-time" | translate }}
-      </label>
-      <label>
-        <input
-          type="radio"
-          name="colorBy"
+        >
+          {{ "app.origin-destination.color-by-selector.travel-time" | translate }}
+        </sbb-radio-button>
+
+        <sbb-radio-button
+          class="ODRadioButton"
           value="transfers"
-          [checked]="colorBy === 'transfers'"
           (change)="onChangeColorBy('transfers')"
-        />
-        {{ "app.origin-destination.color-by-selector.transfers" | translate }}
-      </label>
+        >
+          {{ "app.origin-destination.color-by-selector.transfers" | translate }}
+        </sbb-radio-button>
+      </sbb-radio-group>
     </div>
   </div>
 
-  <sbb-radio-group class="sbb-checkbox-group-horizontal" [(ngModel)]="displayBy">
-    <sbb-radio-button value="totalCost" (change)="onChangeDisplayBy('totalCost')">
-      {{ "app.origin-destination.display-by-selector.total-cost" | translate }}
-    </sbb-radio-button>
-    <sbb-radio-button value="travelTime" (change)="onChangeDisplayBy('travelTime')">
-      {{ "app.origin-destination.display-by-selector.travel-time" | translate }}
-    </sbb-radio-button>
-    <sbb-radio-button value="transfers" (change)="onChangeDisplayBy('transfers')">
-      {{ "app.origin-destination.display-by-selector.transfers" | translate }}
-    </sbb-radio-button>
-  </sbb-radio-group>
+  <div
+    class="noprint"
+    style="
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      width: 100%;
+      height: 57px;
+      flex-wrap: nowrap;
+    "
+  >
+    <sbb-radio-group
+      class="sbb-checkbox-group-horizontal"
+      [(ngModel)]="displayBy"
+      style="display: flex; flex-direction: row; gap: 0.5rem; transform: translateX(-16px)"
+    >
+      <sbb-radio-button
+        class="ODRadioButton"
+        value="totalCost"
+        (change)="onChangeDisplayBy('totalCost')"
+      >
+        {{ "app.origin-destination.display-by-selector.total-cost" | translate }}
+      </sbb-radio-button>
+      <sbb-radio-button
+        class="ODRadioButton"
+        value="travelTime"
+        (change)="onChangeDisplayBy('travelTime')"
+      >
+        {{ "app.origin-destination.display-by-selector.travel-time" | translate }}
+      </sbb-radio-button>
+      <sbb-radio-button
+        class="ODRadioButton"
+        value="transfers"
+        (change)="onChangeDisplayBy('transfers')"
+      >
+        {{ "app.origin-destination.display-by-selector.transfers" | translate }}
+      </sbb-radio-button>
+    </sbb-radio-group>
+  </div>
 </div>

--- a/src/app/services/analytics/origin-destination/components/origin-destination.component.html
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.component.html
@@ -19,7 +19,7 @@
 
   <div id="main-origin-destination-container-root"></div>
 
-  <div class="palette-buttons" style="transform: translateX(-32px)">
+  <div class="palette-buttons" style="transform: translateX(-64px)">
     <div
       class="palette-option red"
       [class.active]="colorSetName === 'red'"

--- a/src/app/services/analytics/origin-destination/components/origin-destination.component.html
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.component.html
@@ -61,15 +61,40 @@
     </div>
   </div>
 
-  <sbb-radio-group class="sbb-checkbox-group-horizontal" [(ngModel)]="displayBy">
-    <sbb-radio-button value="totalCost" (change)="onChangeDisplayBy('totalCost')">
-      {{ "app.origin-destination.display-by-selector.total-cost" | translate }}
-    </sbb-radio-button>
-    <sbb-radio-button value="travelTime" (change)="onChangeDisplayBy('travelTime')">
-      {{ "app.origin-destination.display-by-selector.travel-time" | translate }}
-    </sbb-radio-button>
-    <sbb-radio-button value="transfers" (change)="onChangeDisplayBy('transfers')">
-      {{ "app.origin-destination.display-by-selector.transfers" | translate }}
-    </sbb-radio-button>
-  </sbb-radio-group>
+  <div
+    class="noprint"
+    style="
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      width: 100%;
+      height: 57px;
+      flex-wrap: nowrap;
+    "
+  >
+    <button
+      type="button"
+      class="SimpleButton"
+      [title]="'app.streckengrafik.components.reset' | translate"
+      (click)="onResetButton()"
+    >
+      <sbb-icon svgIcon="kom:arrow-circle-reset-small"></sbb-icon>
+    </button>
+
+    <sbb-radio-group
+      class="sbb-checkbox-group-horizontal"
+      [(ngModel)]="displayBy"
+      style="display: flex; flex-direction: row; gap: 0.5rem; transform: translate(32px, -1px)"
+    >
+      <sbb-radio-button value="totalCost" (change)="onChangeDisplayBy('totalCost')">
+        {{ "app.origin-destination.display-by-selector.total-cost" | translate }}
+      </sbb-radio-button>
+      <sbb-radio-button value="travelTime" (change)="onChangeDisplayBy('travelTime')">
+        {{ "app.origin-destination.display-by-selector.travel-time" | translate }}
+      </sbb-radio-button>
+      <sbb-radio-button value="transfers" (change)="onChangeDisplayBy('transfers')">
+        {{ "app.origin-destination.display-by-selector.transfers" | translate }}
+      </sbb-radio-button>
+    </sbb-radio-group>
+  </div>
 </div>

--- a/src/app/services/analytics/origin-destination/components/origin-destination.component.html
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.component.html
@@ -1,9 +1,8 @@
 <div class="matrix-wrapper">
-
   <button
     type="button"
     class="ODResetButton"
-    [title]="'app.origin-destination.reset' | translate"
+    [title]="'app.origin-destination.buttons.reset' | translate"
     (click)="onResetButton()"
   >
     <sbb-icon svgIcon="kom:arrow-circle-reset-small"></sbb-icon>
@@ -11,7 +10,7 @@
 
   <div id="main-origin-destination-container-root"></div>
 
-  <div class="palette-buttons" style="transform: translateX(-32px);">
+  <div class="palette-buttons" style="transform: translateX(-32px)">
     <div
       class="palette-option red"
       [class.active]="colorSetName === 'red'"
@@ -38,39 +37,35 @@
     ></div>
 
     <div class="color-by-selector">
-      <label>
-        <input
+      <sbb-radio-group
+        class="sbb-checkbox-group-horizontal"
+        [(ngModel)]="colorBy"
+        style="display: flex; flex-direction: row; gap: 0.5rem; transform: translate(-18px, 92px)"
+      >
+        <sbb-radio-button
           class="ODRadioButton"
-          type="radio"
-          name="colorBy"
           value="totalCost"
-          [checked]="colorBy === 'totalCost'"
           (change)="onChangeColorBy('totalCost')"
-        />
-        {{ "app.origin-destination.color-by-selector.total-cost" | translate }}
-      </label>
-      <label>
-        <input
+        >
+          {{ "app.origin-destination.color-by-selector.total-cost" | translate }}
+        </sbb-radio-button>
+
+        <sbb-radio-button
           class="ODRadioButton"
-          type="radio"
-          name="colorBy"
           value="travelTime"
-          [checked]="colorBy === 'travelTime'"
           (change)="onChangeColorBy('travelTime')"
-        />
-        {{ "app.origin-destination.color-by-selector.travel-time" | translate }}
-      </label>
-      <label>
-        <input
+        >
+          {{ "app.origin-destination.color-by-selector.travel-time" | translate }}
+        </sbb-radio-button>
+
+        <sbb-radio-button
           class="ODRadioButton"
-          type="radio"
-          name="colorBy"
           value="transfers"
-          [checked]="colorBy === 'transfers'"
           (change)="onChangeColorBy('transfers')"
-        />
-        {{ "app.origin-destination.color-by-selector.transfers" | translate }}
-      </label>
+        >
+          {{ "app.origin-destination.color-by-selector.transfers" | translate }}
+        </sbb-radio-button>
+      </sbb-radio-group>
     </div>
   </div>
 
@@ -85,20 +80,30 @@
       flex-wrap: nowrap;
     "
   >
-
-
     <sbb-radio-group
       class="sbb-checkbox-group-horizontal"
       [(ngModel)]="displayBy"
       style="display: flex; flex-direction: row; gap: 0.5rem; transform: translateX(-16px)"
     >
-      <sbb-radio-button class="ODRadioButton" value="totalCost" (change)="onChangeDisplayBy('totalCost')">
+      <sbb-radio-button
+        class="ODRadioButton"
+        value="totalCost"
+        (change)="onChangeDisplayBy('totalCost')"
+      >
         {{ "app.origin-destination.display-by-selector.total-cost" | translate }}
       </sbb-radio-button>
-      <sbb-radio-button class="ODRadioButton" value="travelTime" (change)="onChangeDisplayBy('travelTime')">
+      <sbb-radio-button
+        class="ODRadioButton"
+        value="travelTime"
+        (change)="onChangeDisplayBy('travelTime')"
+      >
         {{ "app.origin-destination.display-by-selector.travel-time" | translate }}
       </sbb-radio-button>
-      <sbb-radio-button class="ODRadioButton" value="transfers" (change)="onChangeDisplayBy('transfers')">
+      <sbb-radio-button
+        class="ODRadioButton"
+        value="transfers"
+        (change)="onChangeDisplayBy('transfers')"
+      >
         {{ "app.origin-destination.display-by-selector.transfers" | translate }}
       </sbb-radio-button>
     </sbb-radio-group>

--- a/src/app/services/analytics/origin-destination/components/origin-destination.component.scss
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.component.scss
@@ -115,7 +115,7 @@
   }
 }
 
-button.ODResetButton {
+button.ODLeftPanelButton {
   min-width: 30px;
   max-width: 30px;
   min-height: 28px;
@@ -132,14 +132,34 @@ button.ODResetButton {
   position: absolute;
 }
 
-button.ODResetButton:hover {
+button.ODLeftPanelButton:hover {
   background: var(--COLOR_BACKGROUND);
   font-weight: bold;
-  transform: translate(-35px, -4px) scale(1.25);
+  transform: translate(-35px, -4px) scale(1);
 }
 
-button.ODResetButton:active {
+button.ODLeftPanelButton:active {
   background: var(--COLOR_BACKGROUND);
+}
+
+button.ODResetButton {
+  transform: translate(-35px, -4px) scale(1);
+}
+
+button.ODResetButton:hover {
+  transform: translate(-35px, -4px) scale(1);
+}
+
+button.ODCrossHighlightingButton {
+  transform: translate(-35px, 32px) scale(1);
+}
+
+button.ODCrossHighlightingButton:hover {
+  transform: translate(-35px, 32px) scale(1.25);
+}
+
+button.ODCrossHighlightingButton.isCrossHighlighting {
+  color: #eb0000;
 }
 
 .ODRadioButton:hover {

--- a/src/app/services/analytics/origin-destination/components/origin-destination.component.scss
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.component.scss
@@ -7,9 +7,12 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    width: calc(100% - 188px);
-    height: calc(100% - 74px);
+    width: calc(100% - 160px);
+    height: calc(100% - 61px);
     box-sizing: border-box;
+    overflow: hidden;
+    border: var(--COLOR_Default) solid 1px;
+    background: var(--NODE_DOCKABLE);
   }
 
   ::ng-deep svg.main-origin-destination-container {
@@ -31,6 +34,7 @@
     line-height: 1.5;
     text-align: left;
     text-align: start;
+    background: var(--NODE_DOCKABLE);
   }
   .palette-buttons {
     position: absolute;
@@ -81,7 +85,6 @@
   .color-by-selector {
     position: absolute;
     top: 24px;
-    right: 0px;
     padding: 12px 0px;
     border-radius: 2px;
     font-size: calc(var(--sbb-font-size) * 0.8);
@@ -103,7 +106,7 @@
 
   .sbb-checkbox-group-horizontal {
     position: absolute;
-    bottom: 44px;
+    bottom: 14px;
     left: 12px;
     padding: 8px 8px;
     border-radius: 4px;

--- a/src/app/services/analytics/origin-destination/components/origin-destination.component.scss
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.component.scss
@@ -1,15 +1,21 @@
+@import "./../../../../view/rastering/definitions";
+
 .matrix-wrapper {
   position: relative;
   width: 100%;
-  height: 100%;
+  height: 98%;
+  margin: 8px 0px 0px 64px;
 
   #main-origin-destination-container-root {
     display: flex;
     justify-content: center;
     align-items: center;
-    width: calc(100% - 188px);
-    height: calc(100% - 74px);
+    width: calc(100% - 240px);
+    height: calc(100% - 61px);
     box-sizing: border-box;
+    overflow: hidden;
+    border: var(--COLOR_Default) solid 1px;
+    background: var(--NODE_DOCKABLE);
   }
 
   ::ng-deep svg.main-origin-destination-container {
@@ -31,6 +37,7 @@
     line-height: 1.5;
     text-align: left;
     text-align: start;
+    background: var(--NODE_DOCKABLE);
   }
   .palette-buttons {
     position: absolute;
@@ -81,10 +88,9 @@
   .color-by-selector {
     position: absolute;
     top: 24px;
-    right: 0px;
     padding: 12px 0px;
     border-radius: 2px;
-    font-size: calc(var(--sbb-font-size) * 0.8);
+    font-size: var(--sbb-font-size);
     display: flex;
     flex-direction: column;
     gap: 1px;
@@ -103,10 +109,73 @@
 
   .sbb-checkbox-group-horizontal {
     position: absolute;
-    bottom: 44px;
+    bottom: 14px;
     left: 12px;
     padding: 8px 8px;
     border-radius: 4px;
     column-gap: 8px;
   }
+}
+
+button.ODLeftPanelButton {
+  min-width: 30px;
+  max-width: 30px;
+  min-height: 28px;
+  max-height: 28px;
+  background: var(--COLOR_BACKGROUND);
+  border: none;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0;
+  margin: 0;
+  color: var(--NODE_TEXT_FOCUS);
+  transform: translate(-35px, -4px) scale(1);
+  position: absolute;
+}
+
+button.ODLeftPanelButton:hover {
+  background: var(--COLOR_BACKGROUND);
+  font-weight: bold;
+  transform: translate(-35px, -4px) scale(1);
+}
+
+button.ODLeftPanelButton:active {
+  background: var(--COLOR_BACKGROUND);
+}
+
+button.ODResetButton {
+  transform: translate(-45px, 2px) scale(1);
+}
+
+button.ODResetButton:hover {
+  transform: translate(-45px, 2px) scale(1.25);
+}
+
+button.ODResetButton:active {
+  background-color: $COLOR_MUTED_SILVER;
+}
+
+button.ODCrossHighlightingButton {
+  transform: translate(-45px, 48px) scale(1);
+}
+
+button.ODCrossHighlightingButton:hover {
+  transform: translate(-45px, 48px) scale(1.25);
+}
+
+button.ODCrossHighlightingButton:active {
+  background-color: $COLOR_MUTED_SILVER;
+}
+
+button.ODCrossHighlightingButton.isCrossHighlighting {
+  color: #eb0000;
+}
+
+.ODRadioButton:hover {
+  font-weight: bold;
+}
+
+.sbb-selection-checked {
+  font-weight: bold !important;
 }

--- a/src/app/services/analytics/origin-destination/components/origin-destination.component.scss
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.component.scss
@@ -1,7 +1,7 @@
 .matrix-wrapper {
   position: relative;
   width: 100%;
-  height: 100%;
+  height: 98%;
   margin: 8px 0px 0px 8px;
 
   #main-origin-destination-container-root {
@@ -88,7 +88,7 @@
     top: 24px;
     padding: 12px 0px;
     border-radius: 2px;
-    font-size: calc(var(--sbb-font-size) * 0.8);
+    font-size: var(--sbb-font-size);
     display: flex;
     flex-direction: column;
     gap: 1px;
@@ -113,4 +113,50 @@
     border-radius: 4px;
     column-gap: 8px;
   }
+}
+
+button.SimpleButton {
+  min-width: 30px;
+  max-width: 30px;
+  min-height: 28px;
+  max-height: 28px;
+  background: var(--COLOR_BACKGROUND);
+  border: none;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0;
+  margin: 0;
+  color: var(--NODE_TEXT_FOCUS);
+}
+
+button.SimpleButton.TogglePathNode {
+  min-width: 16px;
+  min-height: 16px;
+  max-width: 16px;
+  max-height: 16px;
+  left: 2px;
+  top: 5px;
+  background: none;
+  transform: scale(0.8) translate(-6px, 6px);
+}
+
+button.SimpleButton.ZoomEqual {
+  font-weight: bold;
+}
+
+button.SimpleButton:hover {
+  background: var(--COLOR_BACKGROUND);
+  font-weight: bold;
+  transform: scale(1.25);
+}
+
+button.SimpleButton.TogglePathNode:hover {
+  background: none;
+  font-weight: bold;
+  transform: scale(1) translate(-6px, 3px);
+}
+
+button.SimpleButton:active {
+  background: var(--COLOR_BACKGROUND);
 }

--- a/src/app/services/analytics/origin-destination/components/origin-destination.component.scss
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.component.scss
@@ -2,6 +2,7 @@
   position: relative;
   width: 100%;
   height: 100%;
+  margin: 8px 0px 0px 8px;
 
   #main-origin-destination-container-root {
     display: flex;

--- a/src/app/services/analytics/origin-destination/components/origin-destination.component.scss
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.component.scss
@@ -1,8 +1,10 @@
+@import "./../../../../view/rastering/definitions";
+
 .matrix-wrapper {
   position: relative;
   width: 100%;
   height: 98%;
-  margin: 8px 0px 0px 42px;
+  margin: 8px 0px 0px 64px;
 
   #main-origin-destination-container-root {
     display: flex;
@@ -143,19 +145,27 @@ button.ODLeftPanelButton:active {
 }
 
 button.ODResetButton {
-  transform: translate(-35px, -4px) scale(1);
+  transform: translate(-45px, 2px) scale(1);
 }
 
 button.ODResetButton:hover {
-  transform: translate(-35px, -4px) scale(1);
+  transform: translate(-45px, 2px) scale(1.25);
+}
+
+button.ODResetButton:active {
+  background-color: $COLOR_MUTED_SILVER;
 }
 
 button.ODCrossHighlightingButton {
-  transform: translate(-35px, 32px) scale(1);
+  transform: translate(-45px, 48px) scale(1);
 }
 
 button.ODCrossHighlightingButton:hover {
-  transform: translate(-35px, 32px) scale(1.25);
+  transform: translate(-45px, 48px) scale(1.25);
+}
+
+button.ODCrossHighlightingButton:active {
+  background-color: $COLOR_MUTED_SILVER;
 }
 
 button.ODCrossHighlightingButton.isCrossHighlighting {

--- a/src/app/services/analytics/origin-destination/components/origin-destination.component.scss
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.component.scss
@@ -8,7 +8,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    width: calc(100% - 200px);
+    width: calc(100% - 240px);
     height: calc(100% - 61px);
     box-sizing: border-box;
     overflow: hidden;

--- a/src/app/services/analytics/origin-destination/components/origin-destination.component.scss
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.component.scss
@@ -128,7 +128,7 @@ button.ODResetButton {
   padding: 0;
   margin: 0;
   color: var(--NODE_TEXT_FOCUS);
-  transform: translate(-35px, -4px) scale(1.0);
+  transform: translate(-35px, -4px) scale(1);
   position: absolute;
 }
 
@@ -144,5 +144,8 @@ button.ODResetButton:active {
 
 .ODRadioButton:hover {
   font-weight: bold;
-  transform: scale(1.05);
+}
+
+.sbb-selection-checked {
+  font-weight: bold !important;
 }

--- a/src/app/services/analytics/origin-destination/components/origin-destination.component.scss
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.component.scss
@@ -2,13 +2,13 @@
   position: relative;
   width: 100%;
   height: 98%;
-  margin: 8px 0px 0px 8px;
+  margin: 8px 0px 0px 42px;
 
   #main-origin-destination-container-root {
     display: flex;
     justify-content: center;
     align-items: center;
-    width: calc(100% - 160px);
+    width: calc(100% - 200px);
     height: calc(100% - 61px);
     box-sizing: border-box;
     overflow: hidden;
@@ -115,7 +115,7 @@
   }
 }
 
-button.SimpleButton {
+button.ODResetButton {
   min-width: 30px;
   max-width: 30px;
   min-height: 28px;
@@ -128,35 +128,21 @@ button.SimpleButton {
   padding: 0;
   margin: 0;
   color: var(--NODE_TEXT_FOCUS);
+  transform: translate(-35px, -4px) scale(1.0);
+  position: absolute;
 }
 
-button.SimpleButton.TogglePathNode {
-  min-width: 16px;
-  min-height: 16px;
-  max-width: 16px;
-  max-height: 16px;
-  left: 2px;
-  top: 5px;
-  background: none;
-  transform: scale(0.8) translate(-6px, 6px);
-}
-
-button.SimpleButton.ZoomEqual {
-  font-weight: bold;
-}
-
-button.SimpleButton:hover {
+button.ODResetButton:hover {
   background: var(--COLOR_BACKGROUND);
   font-weight: bold;
-  transform: scale(1.25);
+  transform: translate(-35px, -4px) scale(1.25);
 }
 
-button.SimpleButton.TogglePathNode:hover {
-  background: none;
-  font-weight: bold;
-  transform: scale(1) translate(-6px, 3px);
-}
-
-button.SimpleButton:active {
+button.ODResetButton:active {
   background: var(--COLOR_BACKGROUND);
+}
+
+.ODRadioButton:hover {
+  font-weight: bold;
+  transform: scale(1.05);
 }

--- a/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
@@ -117,21 +117,21 @@ export class OriginDestinationComponent implements OnInit, OnDestroy {
     // create diagonal entries for all involved node ids
     const idSet = new Set<number>();
     for (const od of this.matrixData) {
-      idSet.add(od.originID);
-      idSet.add(od.destinationID);
+      idSet.add(od.originId);
+      idSet.add(od.destinationId);
     }
 
     for (const nodeId of Array.from(idSet)) {
       const exists = this.matrixData.some(
-        (d) => d.originID === nodeId && d.destinationID === nodeId,
+        (d) => d.originId === nodeId && d.destinationId === nodeId,
       );
       if (!exists) {
         const node = this.nodeService.getNodeFromId(nodeId);
         this.matrixData.push({
           origin: node.getBetriebspunktName(),
           destination: node.getBetriebspunktName(),
-          originID: nodeId,
-          destinationID: nodeId,
+          originId: nodeId,
+          destinationId: nodeId,
           totalCost: undefined,
           travelTime: undefined,
           transfers: undefined,
@@ -332,8 +332,8 @@ export class OriginDestinationComponent implements OnInit, OnDestroy {
 
     for (let i = 0, len = this.matrixData.length; i < len; i++) {
       const d = this.matrixData[i];
-      const ox = nameIndex.get(d.originID);
-      const oy = nameIndex.get(d.destinationID);
+      const ox = nameIndex.get(d.originId);
+      const oy = nameIndex.get(d.destinationId);
       if (ox === undefined || oy === undefined) continue;
 
       const x = ox * this.cellSize + this.offsetX;
@@ -390,8 +390,8 @@ export class OriginDestinationComponent implements OnInit, OnDestroy {
 
     for (let i = 0, len = this.matrixData.length; i < len; i++) {
       const d = this.matrixData[i];
-      const ox = nameIndex.get(d.originID);
-      const oy = nameIndex.get(d.destinationID);
+      const ox = nameIndex.get(d.originId);
+      const oy = nameIndex.get(d.destinationId);
       if (ox === undefined || oy === undefined) continue;
       const cx = ox * this.cellSize + this.offsetX + this.cellSize / 2;
       const cy = oy * this.cellSize + this.offsetY + this.cellSize / 2;

--- a/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
@@ -9,6 +9,7 @@ import {
 import {UiInteractionService, ViewboxProperties} from "src/app/services/ui/ui.interaction.service";
 import {Vec2D} from "src/app/utils/vec2D";
 import {UndoService} from "src/app/services/data/undo.service";
+import {ThemeBase} from "../../../../view/themes/theme-base";
 
 type FieldName = "totalCost" | "travelTime" | "transfers";
 type ColorSetName = "red" | "blue" | "orange" | "gray";
@@ -92,6 +93,9 @@ export class OriginDestinationComponent implements OnInit, OnDestroy {
     this.uiInteractionService.zoomResetObservable
       .pipe(takeUntil(this.destroyed$))
       .subscribe((zoomCenter: Vec2D) => this.controller?.zoomReset(zoomCenter));
+    this.uiInteractionService.themeChangedObservable
+      .pipe(takeUntil(this.destroyed$))
+      .subscribe(() => this.drawCanvasMatrix());
   }
 
   ngOnDestroy(): void {
@@ -121,7 +125,6 @@ export class OriginDestinationComponent implements OnInit, OnDestroy {
       .attr("class", "tooltip")
       .style("opacity", 0)
       .style("position", "absolute")
-      .style("background-color", "white")
       .style("border", "solid")
       .style("border-width", "1px")
       .style("border-radius", "4px")
@@ -226,7 +229,7 @@ export class OriginDestinationComponent implements OnInit, OnDestroy {
     }
 
     // Y axis labels (left)
-    ctx.fillStyle = "#000";
+    ctx.fillStyle = this.uiInteractionService.getActiveTheme().isDark ? "white" : "black";
     ctx.font = `${Math.max(10, Math.floor(this.cellSize * 0.25 * this.zoomFactor))}px SBBWeb Roman`;
     ctx.textAlign = "right";
     ctx.textBaseline = "middle";
@@ -279,8 +282,8 @@ export class OriginDestinationComponent implements OnInit, OnDestroy {
 
       this.tooltip
         .style("opacity", 1)
-        .style("left", `${e.pageX + 10}px`)
-        .style("top", `${e.pageY + 10}px`)
+        .style("left", `${e.clientX - 10 * zf}px`)
+        .style("top", `${e.clientY - 10 * zf}px`)
         .html(
           `${nodeNameMap.get(d.origin)} (<b>${d.origin}</b>) &#x2192; ${nodeNameMap.get(
             d.destination,

--- a/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
@@ -253,8 +253,6 @@ export class OriginDestinationComponent implements OnInit, OnDestroy {
   private handleCanvasMouseMove(e: MouseEvent): void {
     if (!this.canvas || !this.tooltip) return;
 
-
-
     const rect = this.canvas.getBoundingClientRect();
     const zf = this.zoomFactor;
     const xIndex = Math.floor((e.clientX / zf - rect.left / zf - this.offsetX) / this.cellSize);

--- a/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
@@ -18,6 +18,8 @@ type ColorSetName = "red" | "blue" | "orange" | "gray";
 
 /**
  * Component to display the origin-destination matrix.
+ * Initialization (DOM scaffold, axes, controller) is separated
+ * from updates (cell content, colors, text).
  * It also provides options to change the color scale and display field.
  * The component is initialized with data from the OriginDestinationService.
  */
@@ -38,9 +40,9 @@ export class OriginDestinationComponent implements OnInit, OnDestroy {
   ) {}
 
   private matrixData: OriginDestination[] = [];
+  private nodeNames: {shortName: string; fullName: string}[] = [];
 
   private colorScale: d3.ScaleLinear<string, string>;
-
   private controller: SVGMouseController;
 
   // Field used for the color scale.
@@ -52,32 +54,56 @@ export class OriginDestinationComponent implements OnInit, OnDestroy {
 
   private cellSize: number = 30;
 
-  private extractNumericODValues(odList: OriginDestination[], field: FieldName): number[] {
-    return odList.filter((od) => od["found"]).map((od) => od[field]);
+  // avoid multiple dom access / creating (share)
+  private tooltip: d3.Selection<HTMLDivElement, unknown, HTMLElement, any>;
+
+  // cached selections for updates
+  private svg: d3.Selection<SVGSVGElement, unknown, HTMLElement, any>;
+  private graphContentGroup: d3.Selection<SVGGElement, unknown, HTMLElement, any>;
+  private xScale: d3.ScaleBand<string>;
+  private yScale: d3.ScaleBand<string>;
+
+  private extractNumericODValues(odList: OriginDestination[], field: FieldName): any {
+    // This call avoids out-of-memory issue for very big netzgrafik.
+    let minValue = undefined;
+    let maxValue = undefined;
+    odList
+      .filter((od) => od["found"])
+      .map((od) => {
+        const v = od[field];
+        if (minValue !== undefined) {
+          if (v < minValue) {
+            minValue = v;
+          } else {
+            if (v > maxValue) {
+              maxValue = v;
+            }
+          }
+        } else {
+          minValue = v;
+          maxValue = minValue;
+        }
+      });
+    if (minValue === undefined) {
+      return {
+        minValue: 0,
+        maxValue: 1,
+      };
+    }
+    return {
+      minValue: minValue,
+      maxValue: maxValue,
+    };
   }
 
-  private renderView() {
-    const nodes = this.originDestinationService.getODOutputNodes();
-    const nodeNames = nodes.map((node) => ({
-      shortName: node.getBetriebspunktName(),
-      fullName: node.getFullName(),
-    }));
-
-    this.rendermatrixOD(nodeNames);
-
-    this.controller = new SVGMouseController(
-      "main-origin-destination-container",
-      this.createSvgMouseControllerObserver(),
-      this.undoService,
-    );
-    this.controller.init(this.createInitialViewboxProperties(nodeNames.length));
-  }
-
-  // Compute the matrix (expensive) and render the default view.
   ngOnInit(): void {
+    // create tooltip (only once)
+    this.createTooltip();
+
+    // compute matrix data (expensive) once
     this.matrixData = this.originDestinationService.originDestinationData();
 
-    // Add some data so we can mouseover the diagonal cells.
+    // Add diagonal entries so we can mouseover diagonal cells
     const origins = this.matrixData.map((d) => d.origin);
     const destinations = this.matrixData.map((d) => d.destination);
     const uniqueOriginsDestinations = [...new Set([...origins, ...destinations])];
@@ -90,8 +116,21 @@ export class OriginDestinationComponent implements OnInit, OnDestroy {
       found: false,
     }));
     this.matrixData = [...this.matrixData, ...diagonalData];
-    this.renderView();
 
+    // compute nodes and nodeNames once
+    const nodes = this.originDestinationService.getODOutputNodes();
+    this.nodeNames = nodes.map((node) => ({
+      shortName: node.getBetriebspunktName(),
+      fullName: node.getFullName(),
+    }));
+
+    // initialize DOM scaffold, axes and controller (only once)
+    this.initView();
+
+    // initial population of cells (and color scale)
+    this.updateView();
+
+    // wire zoom observables
     this.uiInteractionService.zoomInObservable
       .pipe(takeUntil(this.destroyed$))
       .subscribe((zoomCenter: Vec2D) => this.controller.zoomIn(zoomCenter));
@@ -105,13 +144,42 @@ export class OriginDestinationComponent implements OnInit, OnDestroy {
       .subscribe((zoomCenter: Vec2D) => this.controller.zoomReset(zoomCenter));
   }
 
-  // Render the matrix with the given node names.
-  rendermatrixOD(nodeNames: {shortName: string; fullName: string}[]) {
-    const width = this.cellSize * nodeNames.length;
-    const height = this.cellSize * nodeNames.length;
+  private createTooltip(): void {
+    // Ensure we don't create multiple tooltips
+    const root = d3.select("#main-origin-destination-container-root");
+    const existing = root.select<HTMLDivElement>(".tooltip");
+    if (!existing.empty()) {
+      this.tooltip = existing as any;
+      return;
+    }
 
-    // append the svg object to the body of the page
-    const svg = d3
+    this.tooltip = root
+      .append("div")
+      .attr("class", "tooltip")
+      .style("opacity", 0)
+      .style("position", "absolute")
+      .style("background-color", "white")
+      .style("border", "solid")
+      .style("border-width", "2px")
+      .style("border-radius", "5px")
+      .style("padding", "5px")
+      .style("user-select", "none")
+      .style("pointer-events", "none");
+  }
+
+  /**
+   * initView
+   * - creates svg, axes, scales, container group and mouse-controller
+   * - does NOT create cells content (that is done by updateView)
+   */
+  private initView(): void {
+    const width = this.cellSize * this.nodeNames.length;
+    const height = this.cellSize * this.nodeNames.length;
+
+    // remove existing svg if any (defensive)
+    d3.select("#main-origin-destination-container").remove();
+
+    this.svg = d3
       .select("#main-origin-destination-container-root")
       .append("svg")
       .classed("main-origin-destination-container", true)
@@ -126,23 +194,24 @@ export class OriginDestinationComponent implements OnInit, OnDestroy {
     const offsetX = Math.max(0, (containerWidth - width) / 2);
     const offsetY = Math.max(0, (containerHeight - height) / 2);
 
-    const graphContentGroup = svg
+    this.graphContentGroup = this.svg
       .append("g")
       .attr("id", "zoom-group")
       .attr("transform", `translate(${offsetX}, ${offsetY})`);
 
     // Build X scales and axis:
-    const x = d3
+    this.xScale = d3
       .scaleBand()
       .range([0, width])
-      .domain(nodeNames.map((n) => n.shortName))
+      .domain(this.nodeNames.map((n) => n.shortName))
       .padding(0.05);
 
-    graphContentGroup
+    this.graphContentGroup
       .append("g")
+      .attr("id", "od-x-axis")
       .style("pointer-events", "none")
       .attr("transform", "translate(0, -20)")
-      .call(d3.axisBottom(x).tickSize(0))
+      .call(d3.axisBottom(this.xScale).tickSize(0))
       .style("user-select", "none")
       .call((g) =>
         g
@@ -158,47 +227,60 @@ export class OriginDestinationComponent implements OnInit, OnDestroy {
       .remove();
 
     // Build Y scales and axis:
-    const y = d3
+    this.yScale = d3
       .scaleBand()
       .range([height, 0])
-      .domain(nodeNames.map((n) => n.shortName).reverse())
+      .domain(this.nodeNames.map((n) => n.shortName).reverse())
       .padding(0.05);
-    graphContentGroup
+
+    this.graphContentGroup
       .append("g")
+      .attr("id", "od-y-axis")
       .style("pointer-events", "none")
-      .call(d3.axisLeft(y).tickSize(0))
+      .call(d3.axisLeft(this.yScale).tickSize(0))
       .style("user-select", "none")
       .call((g) => g.selectAll("text").attr("data-destination-label", (d: string) => d))
       .select(".domain")
       .remove();
 
+    // create mouse controller (only once)
+    this.controller = new SVGMouseController(
+      "main-origin-destination-container",
+      this.createSvgMouseControllerObserver(),
+      this.undoService,
+    );
+    this.controller.init(this.createInitialViewboxProperties(this.nodeNames.length));
+  }
+
+  /**
+   * updateView
+   * - recomputes color scale based on current matrixData and colorBy
+   * - creates/updates cells (enter/update/exit) and texts
+   * - keeps axes and controller intact
+   */
+  private updateView(): void {
+    if (!this.graphContentGroup) {
+      return;
+    }
+
+    // compute color scale
     const numericValues = this.extractNumericODValues(this.matrixData, this.colorBy);
-    const maxValue = numericValues.length ? Math.max(...numericValues) : 1;
-    const minValue = numericValues.length ? Math.min(...numericValues) : 0;
-    this.colorScale = this.getColorScale(minValue, maxValue);
+    this.colorScale = this.getColorScale(numericValues.minValue, numericValues.maxValue);
 
-    // create a tooltip
-    const tooltip = d3
-      .select("#main-origin-destination-container-root")
-      .append("div")
-      .style("opacity", 0)
-      .attr("class", "tooltip")
-      .style("background-color", "white")
-      .style("border", "solid")
-      .style("border-width", "2px")
-      .style("border-radius", "5px")
-      .style("padding", "5px")
-      .style("user-select", "none")
-      .style("pointer-events", "none");
+    // Prepare nodeNameMap and tooltip
+    const nodeNameMap = new Map(this.nodeNames.map((n) => [n.shortName, n.fullName]));
+    const tooltip = this.tooltip;
 
-    // Three function that change the tooltip when user hover / move / leave a cell
+    const totalCostTranslation = $localize`:@@app.origin-destination.tooltip.total-cost:Total cost`;
+    const transfersTranslation = $localize`:@@app.origin-destination.tooltip.transfers:Transfers`;
+    const travelTimeTranslation = $localize`:@@app.origin-destination.tooltip.travel-time:Travel time`;
+
+    // mouse handlers reference closure values
     const mouseover = function (d: OriginDestination) {
       if (d.found) {
         tooltip.style("opacity", 1);
         d3.select(this).style("stroke", "black").style("stroke-width", "2px").style("opacity", 1);
       }
-
-      // Highlight axis labels in bold when hovering over a cell
       d3.selectAll(`[data-origin-label="${d.origin}"]`)
         .style("font-weight", "bold")
         .style("font-size", "12px");
@@ -206,12 +288,6 @@ export class OriginDestinationComponent implements OnInit, OnDestroy {
         .style("font-weight", "bold")
         .style("font-size", "12px");
     };
-
-    const totalCostTranslation = $localize`:@@app.origin-destination.tooltip.total-cost:Total cost`;
-    const transfersTranslation = $localize`:@@app.origin-destination.tooltip.transfers:Transfers`;
-    const travelTimeTranslation = $localize`:@@app.origin-destination.tooltip.travel-time:Travel time`;
-
-    const nodeNameMap = new Map(nodeNames.map((n) => [n.shortName, n.fullName]));
 
     const mousemove = function (d: OriginDestination) {
       let details = "";
@@ -224,20 +300,21 @@ export class OriginDestinationComponent implements OnInit, OnDestroy {
       tooltip
         .html(
           `${nodeNameMap.get(d.origin)} (<b>${d.origin}</b>) &#x2192;
-          ${nodeNameMap.get(d.destination)} (<b>${d.destination}</b>)
-          ${details}`,
+        ${nodeNameMap.get(d.destination)} (<b>${d.destination}</b>)
+        ${details}`,
         )
-        .style("left", `${d3.event.offsetX + 64}px`)
-        .style("top", `${d3.event.offsetY + 64 < 0 ? 0 : d3.event.offsetY + 64}px`);
+        .style("left", `${(d3.event as any).offsetX + 64}px`)
+        .style(
+          "top",
+          `${(d3.event as any).offsetY + 64 < 0 ? 0 : (d3.event as any).offsetY + 64}px`,
+        );
     };
 
-    const mouseleave = function (_d) {
+    const mouseleave = function (_d: OriginDestination) {
       tooltip.style("opacity", 0);
       d3.select(this)
         .style("stroke", "none")
         .style("opacity", (d: OriginDestination) => (d.origin === d.destination ? 0 : 0.8));
-
-      // Remove boldness from the axis labels
       d3.selectAll(`[data-origin-label="${_d.origin}"]`)
         .style("font-weight", null)
         .style("font-size", null);
@@ -246,53 +323,79 @@ export class OriginDestinationComponent implements OnInit, OnDestroy {
         .style("font-size", null);
     };
 
-    // add the squares
-    graphContentGroup
-      .selectAll()
-      .data(this.matrixData)
-      .enter()
-      .append("rect")
-      .attr("x", (d: OriginDestination) => {
-        return x(d.origin);
-      })
-      .attr("y", function (d: OriginDestination) {
-        return y(d.destination);
-      })
+    // Build a color cache for performance
+    const colorCache = new Map<string, string>();
+    this.matrixData.forEach((d) => {
+      const key = `${d.origin}-${d.destination}`;
+      const value = this.getCellValue(d, this.colorBy);
+      colorCache.set(key, value === undefined ? "#76767633" : this.colorScale(value));
+    });
+
+    // DATA JOIN for cells (group elements)
+    const cells = this.graphContentGroup
+      .selectAll<SVGGElement, OriginDestination>("g.cell")
+      .data(this.matrixData, (d: any) => `${d.origin}-${d.destination}`);
+
+    // EXIT
+    cells.exit().remove();
+
+    // ENTER
+    const enterCells = cells.enter().append("g").classed("cell", true);
+    //.attr(
+    //  "transform",
+    //  (d) => `translate(${this.xScale(d.origin)}, ${this.yScale(d.destination)})`,
+    //);
+
+    const rectCellsGroup = enterCells.append("rect");
+    rectCellsGroup
       .attr("rx", 4)
       .attr("ry", 4)
-      .attr("width", x.bandwidth())
-      .attr("height", y.bandwidth())
-
-      .style("fill", (d: OriginDestination) => this.getCellColor(d))
-
-      .style("stroke-width", 4)
-      .style("stroke", "none")
-      .style("opacity", (d: OriginDestination) => (d.origin === d.destination ? 0 : 0.8))
+      .attr("x", (d) => this.xScale(d.origin))
+      .attr("y", (d) => this.yScale(d.destination))
+      .attr("width", this.xScale.bandwidth())
+      .attr("height", this.yScale.bandwidth())
       .style("pointer-events", "auto")
-
       .on("mouseover", mouseover)
       .on("mousemove", mousemove)
       .on("mouseleave", mouseleave);
 
-    graphContentGroup
-      .selectAll()
-      .data(this.matrixData)
-      .enter()
-      .append("text")
-      .style("pointer-events", "none")
-      .attr("x", (d: OriginDestination) => {
-        return x(d.origin) + x.bandwidth() / 2;
-      })
-      .attr("y", function (d: OriginDestination) {
-        return y(d.destination) + y.bandwidth() / 2;
-      })
-      .text((d: OriginDestination) => this.getCellText(d))
+    const textCellGroup = enterCells.append("text");
+    textCellGroup
+      .attr("x", this.xScale.bandwidth() / 2)
+      .attr("y", this.yScale.bandwidth() / 2)
       .style("text-anchor", "middle")
       .style("alignment-baseline", "middle")
       .style("font-size", "10px")
       .style("pointer-events", "none")
       .style("user-select", "none")
       .style("fill", "white");
+
+    // UPDATE (both existing and newly entered)
+    const merged = enterCells.merge(cells as any);
+
+    //merged.attr(
+    //  "transform",
+    //  (d) => `translate(${this.xScale(d.origin)}, ${this.yScale(d.destination)})`,
+    //);
+
+    // Directly select rects and set fill from cache/scale
+    merged
+      .select("rect")
+      .style("fill", (d: OriginDestination) => {
+        const key = `${d.origin}-${d.destination}`;
+        return colorCache.get(key) ?? "#76767633";
+      })
+      .style("stroke-width", 4)
+      .style("stroke", "none")
+      .style("opacity", (d: OriginDestination) => (d.origin === d.destination ? 0 : 0.8));
+
+    // Update texts
+
+    merged
+      .select("text")
+      .attr("x", (d) => this.xScale(d.origin) + this.xScale.bandwidth() / 2)
+      .attr("y", (d) => this.yScale(d.destination) + this.yScale.bandwidth() / 2)
+      .text((d: OriginDestination) => this.getCellText(d));
   }
 
   private createSvgMouseControllerObserver(): SVGMouseControllerObserver {
@@ -353,6 +456,9 @@ export class OriginDestinationComponent implements OnInit, OnDestroy {
   ngOnDestroy(): void {
     this.destroyed$.next();
     this.destroyed$.complete();
+    // optional cleanup
+    d3.select("#main-origin-destination-container").remove();
+    this.tooltip?.remove();
   }
 
   // Return the color scale based on the selected color set.
@@ -394,25 +500,21 @@ export class OriginDestinationComponent implements OnInit, OnDestroy {
     }
   }
 
-  // Update color set and re-render the view.
+  // Update palette and refresh cells without full re-init.
   onChangePalette(name: ColorSetName) {
     this.colorSetName = name;
-    d3.select("#main-origin-destination-container").remove();
-    this.renderView();
+    this.updateView();
   }
 
-  // Update color field and re-render the view.
+  // Update color field and refresh cells without full re-init.
   onChangeColorBy(field: FieldName) {
     this.colorBy = field;
-    d3.select("#main-origin-destination-container").remove();
-    this.renderView();
+    this.updateView();
   }
 
-  // Update display field and re-render the view.
+  // Update display field and refresh cells without full re-init.
   onChangeDisplayBy(field: FieldName) {
-    // TODO: why is that needed?
     this.displayBy = field;
-    d3.select("#main-origin-destination-container").remove();
-    this.renderView();
+    this.updateView();
   }
 }

--- a/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
@@ -492,6 +492,14 @@ export class OriginDestinationComponent implements OnInit, OnDestroy {
     this.drawCanvasMatrix();
   }
 
+  onResetButton() {
+    this.initViewbox();
+    this.colorBy = "totalCost";
+    this.displayBy = "totalCost";
+    this.colorSetName = "red";
+    this.drawCanvasMatrix();
+  }
+
   private createSvgMouseControllerObserver(): SVGMouseControllerObserver {
     return {
       onEarlyReturnFromMousemove: () => false,

--- a/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
@@ -252,9 +252,13 @@ export class OriginDestinationComponent implements OnInit, OnDestroy {
 
   private handleCanvasMouseMove(e: MouseEvent): void {
     if (!this.canvas || !this.tooltip) return;
+
+
+
     const rect = this.canvas.getBoundingClientRect();
-    const xIndex = Math.floor((e.clientX - rect.left - this.offsetX) / this.cellSize);
-    const yIndex = Math.floor((e.clientY - rect.top - this.offsetY) / this.cellSize);
+    const zf = this.zoomFactor;
+    const xIndex = Math.floor((e.clientX / zf - rect.left / zf - this.offsetX) / this.cellSize);
+    const yIndex = Math.floor((e.clientY / zf - rect.top / zf - this.offsetY) / this.cellSize);
 
     const origin = this.nodeNames[xIndex]?.shortName;
     const destination = this.nodeNames[yIndex]?.shortName;

--- a/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
@@ -239,7 +239,7 @@ export class OriginDestinationComponent implements OnInit, OnDestroy {
       ctx.fillStyle = "white";
       ctx.textAlign = "center";
       ctx.textBaseline = "middle";
-      ctx.font = `${Math.max(8, Math.floor(this.cellSize * 0.35 * Math.min(1.5,Math.sqrt(this.zoomFactor))))}px SBBWeb Roman`;
+      ctx.font = `${Math.max(8, Math.floor(this.cellSize * 0.35 * Math.min(1.5, Math.sqrt(this.zoomFactor))))}px SBBWeb Roman`;
 
       for (let i = 0, len = this.matrixData.length; i < len; i++) {
         const d = this.matrixData[i];
@@ -285,8 +285,12 @@ export class OriginDestinationComponent implements OnInit, OnDestroy {
     const zf = this.zoomFactor;
 
     // logical indices (same logic you already use)
-    const xIndex = Math.floor((e.clientX - rect.left) / zf / this.cellSize - this.offsetX / this.cellSize);
-    const yIndex = Math.floor((e.clientY - rect.top) / zf / this.cellSize - this.offsetY / this.cellSize);
+    const xIndex = Math.floor(
+      (e.clientX - rect.left) / zf / this.cellSize - this.offsetX / this.cellSize,
+    );
+    const yIndex = Math.floor(
+      (e.clientY - rect.top) / zf / this.cellSize - this.offsetY / this.cellSize,
+    );
 
     const origin = this.nodeNames[xIndex]?.shortName;
     const destination = this.nodeNames[yIndex]?.shortName;
@@ -317,8 +321,8 @@ export class OriginDestinationComponent implements OnInit, OnDestroy {
     let tooltipTop: number;
     if (offsetParent) {
       const parentRect = offsetParent.getBoundingClientRect();
-      tooltipLeft = e.clientX - parentRect.left + (this.cellSize * 0.75) * zf;
-      tooltipTop = e.clientY - parentRect.top + (this.cellSize * 0.75) * zf;
+      tooltipLeft = e.clientX - parentRect.left + this.cellSize * 0.75 * zf;
+      tooltipTop = e.clientY - parentRect.top + this.cellSize * 0.75 * zf;
     } else {
       tooltipLeft = e.pageX;
       tooltipTop = e.pageY;
@@ -340,8 +344,8 @@ export class OriginDestinationComponent implements OnInit, OnDestroy {
 
     // ---------- Highlight: compute the hovered cell rectangle in screen (parent) coords ----------
     // Logical cell top-left in canvas-local coordinates
-    const cellLogicalX = (this.offsetX + xIndex * this.cellSize);
-    const cellLogicalY = (this.offsetY + yIndex * this.cellSize);
+    const cellLogicalX = this.offsetX + xIndex * this.cellSize;
+    const cellLogicalY = this.offsetY + yIndex * this.cellSize;
 
     // Convert to pixel coordinates on screen (canvas pixels after zoom) and then to offsetParent space
     const cellScreenX = rect.left + cellLogicalX * zf;
@@ -384,7 +388,6 @@ export class OriginDestinationComponent implements OnInit, OnDestroy {
     this.highlight.style.width = `${Math.round(cellScreenW)}px`;
     this.highlight.style.height = `${Math.round(cellScreenH)}px`;
   }
-
 
   private extractNumericODValues(odList: OriginDestination[], field: FieldName): any {
     let minValue: number | undefined = undefined;

--- a/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
@@ -183,6 +183,26 @@ export class OriginDestinationComponent implements OnInit, OnDestroy {
     this.controller.init(this.createInitialViewboxProperties(this.nodeNames.length));
   }
 
+  private makeCell(
+    ctx: CanvasRenderingContext2D,
+    x: number,
+    y: number,
+    w: number,
+    h: number,
+    r: number,
+    color: string,
+  ) {
+    ctx.beginPath();
+    ctx.moveTo(x + r, y);
+    ctx.arcTo(x + w, y, x + w, y + h, r);
+    ctx.arcTo(x + w, y + h, x, y + h, r);
+    ctx.arcTo(x, y + h, x, y, r);
+    ctx.arcTo(x, y, x + w, y, r);
+    ctx.closePath();
+    ctx.fillStyle = color;
+    ctx.fill();
+  }
+
   private drawCanvasMatrix(): void {
     if (!this.ctx || !this.canvas) return;
 
@@ -205,8 +225,7 @@ export class OriginDestinationComponent implements OnInit, OnDestroy {
       const value = this.getCellValue(d, this.colorBy);
       const color = value === undefined ? "#76767633" : colorScale(value);
 
-      ctx.fillStyle = color;
-      ctx.fillRect(x + 1, y + 1, this.cellSize - 2, this.cellSize - 2);
+      this.makeCell(ctx, x + 1, y + 1, this.cellSize - 2, this.cellSize - 2, 2, color);
     }
 
     // optional cell text
@@ -214,7 +233,7 @@ export class OriginDestinationComponent implements OnInit, OnDestroy {
       ctx.fillStyle = "white";
       ctx.textAlign = "center";
       ctx.textBaseline = "middle";
-      ctx.font = `${Math.max(8, Math.floor(this.cellSize * 0.15 * this.zoomFactor))}px SBBWeb Roman`;
+      ctx.font = `${Math.max(8, Math.floor(this.cellSize * 0.25 * Math.sqrt(this.zoomFactor)))}px SBBWeb Roman`;
 
       for (let i = 0, len = this.matrixData.length; i < len; i++) {
         const d = this.matrixData[i];

--- a/src/app/services/analytics/origin-destination/components/origin-destination.service.ts
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.service.ts
@@ -15,6 +15,9 @@ export type OriginDestination = {
   // Names.
   origin: string;
   destination: string;
+  // Node ID
+  originID: number;
+  destinationID: number;
   // Travel time in minutes.
   travelTime: number | undefined;
   // Number of transfers.
@@ -101,6 +104,8 @@ export class OriginDestinationService {
           rows.push({
             origin: origin.getBetriebspunktName(),
             destination: destination.getBetriebspunktName(),
+            originID: origin.getId(),
+            destinationID: destination.getId(),
             found: false,
           });
           return;
@@ -109,6 +114,8 @@ export class OriginDestinationService {
         const row = {
           origin: origin.getBetriebspunktName(),
           destination: destination.getBetriebspunktName(),
+          originID: origin.getId(),
+          destinationID: destination.getId(),
           travelTime: totalCost - connections * connectionPenalty,
           transfers: connections,
           totalCost: totalCost,

--- a/src/app/services/analytics/origin-destination/components/origin-destination.service.ts
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.service.ts
@@ -81,21 +81,16 @@ export class OriginDestinationService {
     // In theory we could parallelize the pathfindings, but the overhead might be too big.
     const res = new Map<string, [number, number]>();
     odNodes.forEach((origin, idx) => {
-      if (idx % 80 === 0) {
-        console.log("computeShortestPaths", idx, odNodes.length);
-        computeShortestPaths(origin.getId(), neighbors, vertices, tsSuccessor).forEach(
-          (value, key) => {
-            res.set([origin.getId(), key].join(","), value);
-          },
-        );
-      }
+      computeShortestPaths(origin.getId(), neighbors, vertices, tsSuccessor).forEach(
+        (value, key) => {
+          res.set([origin.getId(), key].join(","), value);
+        },
+      );
     });
 
     const rows = [];
     odNodes.sort((a, b) => a.getBetriebspunktName().localeCompare(b.getBetriebspunktName()));
     odNodes.forEach((origin, idx) => {
-      console.log("compute o/d pairs", idx, odNodes.length);
-
       odNodes.forEach((destination) => {
         if (origin.getId() === destination.getId()) {
           return;

--- a/src/app/services/analytics/origin-destination/components/origin-destination.service.ts
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.service.ts
@@ -15,6 +15,9 @@ export type OriginDestination = {
   // Names.
   origin: string;
   destination: string;
+  // Node ID
+  originId: number;
+  destinationId: number;
   // Travel time in minutes.
   travelTime: number | undefined;
   // Number of transfers.
@@ -101,6 +104,8 @@ export class OriginDestinationService {
           rows.push({
             origin: origin.getBetriebspunktName(),
             destination: destination.getBetriebspunktName(),
+            originId: origin.getId(),
+            destinationId: destination.getId(),
             found: false,
           });
           return;
@@ -109,6 +114,8 @@ export class OriginDestinationService {
         const row = {
           origin: origin.getBetriebspunktName(),
           destination: destination.getBetriebspunktName(),
+          originId: origin.getId(),
+          destinationId: destination.getId(),
           travelTime: totalCost - connections * connectionPenalty,
           transfers: connections,
           totalCost: totalCost,

--- a/src/app/services/analytics/origin-destination/components/origin-destination.service.ts
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.service.ts
@@ -80,17 +80,22 @@ export class OriginDestinationService {
     const vertices = topoSort(neighbors);
     // In theory we could parallelize the pathfindings, but the overhead might be too big.
     const res = new Map<string, [number, number]>();
-    odNodes.forEach((origin) => {
-      computeShortestPaths(origin.getId(), neighbors, vertices, tsSuccessor).forEach(
-        (value, key) => {
-          res.set([origin.getId(), key].join(","), value);
-        },
-      );
+    odNodes.forEach((origin, idx) => {
+      if (idx % 80 === 0) {
+        console.log("computeShortestPaths", idx, odNodes.length);
+        computeShortestPaths(origin.getId(), neighbors, vertices, tsSuccessor).forEach(
+          (value, key) => {
+            res.set([origin.getId(), key].join(","), value);
+          },
+        );
+      }
     });
 
     const rows = [];
     odNodes.sort((a, b) => a.getBetriebspunktName().localeCompare(b.getBetriebspunktName()));
-    odNodes.forEach((origin) => {
+    odNodes.forEach((origin, idx) => {
+      console.log("compute o/d pairs", idx, odNodes.length);
+
       odNodes.forEach((destination) => {
         if (origin.getId() === destination.getId()) {
           return;

--- a/src/app/services/analytics/origin-destination/components/origin-destination.service.ts
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.service.ts
@@ -80,7 +80,7 @@ export class OriginDestinationService {
     const vertices = topoSort(neighbors);
     // In theory we could parallelize the pathfindings, but the overhead might be too big.
     const res = new Map<string, [number, number]>();
-    odNodes.forEach((origin, idx) => {
+    odNodes.forEach((origin) => {
       computeShortestPaths(origin.getId(), neighbors, vertices, tsSuccessor).forEach(
         (value, key) => {
           res.set([origin.getId(), key].join(","), value);
@@ -90,7 +90,7 @@ export class OriginDestinationService {
 
     const rows = [];
     odNodes.sort((a, b) => a.getBetriebspunktName().localeCompare(b.getBetriebspunktName()));
-    odNodes.forEach((origin, idx) => {
+    odNodes.forEach((origin) => {
       odNodes.forEach((destination) => {
         if (origin.getId() === destination.getId()) {
           return;

--- a/src/app/services/analytics/origin-destination/components/origin-destination.service.ts
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.service.ts
@@ -16,8 +16,8 @@ export type OriginDestination = {
   origin: string;
   destination: string;
   // Node ID
-  originID: number;
-  destinationID: number;
+  originId: number;
+  destinationId: number;
   // Travel time in minutes.
   travelTime: number | undefined;
   // Number of transfers.
@@ -104,8 +104,8 @@ export class OriginDestinationService {
           rows.push({
             origin: origin.getBetriebspunktName(),
             destination: destination.getBetriebspunktName(),
-            originID: origin.getId(),
-            destinationID: destination.getId(),
+            originId: origin.getId(),
+            destinationId: destination.getId(),
             found: false,
           });
           return;
@@ -114,8 +114,8 @@ export class OriginDestinationService {
         const row = {
           origin: origin.getBetriebspunktName(),
           destination: destination.getBetriebspunktName(),
-          originID: origin.getId(),
-          destinationID: destination.getId(),
+          originId: origin.getId(),
+          destinationId: destination.getId(),
           travelTime: totalCost - connections * connectionPenalty,
           transfers: connections,
           totalCost: totalCost,

--- a/src/app/services/data/is-trainrun-section.service.ts
+++ b/src/app/services/data/is-trainrun-section.service.ts
@@ -9,7 +9,7 @@ import {TrainrunService} from "./trainrun.service";
 export class IsTrainrunSelectedService implements OnDestroy {
   // Description of observable data service: https://coryrylan.com/blog/angular-observable-data-services
   trainrunIdSelectedSubject = new BehaviorSubject<number>(undefined);
-  readonly trainrunIdSelecteds$ = this.trainrunIdSelectedSubject.asObservable();
+  readonly trainrunIdSelected$ = this.trainrunIdSelectedSubject.asObservable();
 
   trainrunIdSelectedByClickSubject = new BehaviorSubject<number>(undefined);
   readonly trainrunIdSelectedByClick$ = this.trainrunIdSelectedByClickSubject.asObservable();
@@ -34,8 +34,8 @@ export class IsTrainrunSelectedService implements OnDestroy {
     this.destroyed$.complete();
   }
 
-  getTrainrunIdSelecteds(): Observable<number> {
-    return this.trainrunIdSelecteds$;
+  getTrainrunIdSelected(): Observable<number> {
+    return this.trainrunIdSelected$;
   }
 
   setTrainrunIdSelectedByClick(trainrunIdSelected: number) {

--- a/src/app/services/data/is-trainrun-selected.service.spec.ts
+++ b/src/app/services/data/is-trainrun-selected.service.spec.ts
@@ -89,7 +89,7 @@ describe("IsTrainrunSelectedService", () => {
   it("IsTrainrunSelectedService - 002", () => {
     const itss = new IsTrainrunSelectedService(trainrunService);
     let nbrCalls = 0;
-    itss.getTrainrunIdSelecteds().subscribe((trainrunIdSelected: number) => {
+    itss.getTrainrunIdSelected().subscribe((trainrunIdSelected: number) => {
       if (nbrCalls === 0) {
         expect(trainrunIdSelected).toBe(undefined);
       } else {
@@ -103,7 +103,7 @@ describe("IsTrainrunSelectedService", () => {
   it("IsTrainrunSelectedService - 003", () => {
     const itss = new IsTrainrunSelectedService(trainrunService);
     let nbrCalls = 0;
-    itss.getTrainrunIdSelecteds().subscribe((trainrunIdSelected: number) => {
+    itss.getTrainrunIdSelected().subscribe((trainrunIdSelected: number) => {
       if (nbrCalls === 0) {
         expect(trainrunIdSelected).toBe(undefined);
       } else {

--- a/src/app/services/ui/ui.interaction.service.ts
+++ b/src/app/services/ui/ui.interaction.service.ts
@@ -88,6 +88,9 @@ export class UiInteractionService implements OnDestroy {
   zoomFactorSubject = new Subject<number>();
   readonly zoomFactorObservable = this.zoomFactorSubject.asObservable();
 
+  themeChanged = new Subject<ThemeBase>();
+  readonly themeChangedObservable = this.themeChanged.asObservable();
+
   setEditorModeSubject = new Subject<number>();
   readonly setEditorModeObservable = this.setEditorModeSubject.asObservable();
 
@@ -432,6 +435,7 @@ export class UiInteractionService implements OnDestroy {
       this.saveUserSettingToLocalStorage();
     }
     this.updateLightDark();
+    this.themeChanged.next(this.activeTheme);
   }
 
   updateLightDark() {

--- a/src/app/view/column-layout/column-layout.component.scss
+++ b/src/app/view/column-layout/column-layout.component.scss
@@ -68,7 +68,7 @@ $close-size: $close-padding * 2 + $defaultIconSize;
     background: var(--sbb-color-background);
     fill: $colorBlack20;
     padding: $close-padding;
-    margin-left: -(calc($close-size/2));
+    margin-left: calc(-#{$close-size} / 2);
     width: $close-size;
     height: $close-size;
 
@@ -131,7 +131,7 @@ $close-size: $close-padding * 2 + $defaultIconSize;
     z-index: 3;
     fill: $colorBlack20;
     padding: $close-padding;
-    margin-right: -(calc($close-size/2));
+    margin-right: calc(-#{$close-size} / 2);
     width: $close-size;
     height: $close-size;
 

--- a/src/app/view/column-layout/column-layout.component.ts
+++ b/src/app/view/column-layout/column-layout.component.ts
@@ -10,7 +10,7 @@ import {
 import {environment} from "../../../environments/environment";
 
 /**
- * Different layout modes. Generally the layout contains (up to) 3 columns that are distributed over a 4 columen layout:
+ * Different layout modes. Generally the layout contains (up to) 3 columns that are distributed over a 4 columns layout:
  * - filter (f)
  * - main (m)
  * - aside (a)

--- a/src/app/view/dialogs/filterable-labels-dialog/filterable-label-dialog.component.ts
+++ b/src/app/view/dialogs/filterable-labels-dialog/filterable-label-dialog.component.ts
@@ -73,9 +73,9 @@ export class FilterableLabelDialogComponent implements OnDestroy {
   onTransferClicked(): void {
     const dialogTitle = $localize`:@@app.view.dialogs.filterable-labels-dialog.filterable-label-dialog-component.transfer.title:Transfer`;
     const dialogContent = $localize`:@@app.view.dialogs.filterable-labels-dialog.filterable-label-dialog-component.transfer.content:Should the label ${this.originalLabel}:label: be applied on all visible ${dialogTitle}:element:?`;
-    const confirmationDialogParamter = new ConfirmationDialogParameter(dialogTitle, dialogContent);
+    const confirmationDialogParameter = new ConfirmationDialogParameter(dialogTitle, dialogContent);
     this.uiInteractionService
-      .showConfirmationDiagramDialog(confirmationDialogParamter)
+      .showConfirmationDiagramDialog(confirmationDialogParameter)
       .subscribe((confirmed: boolean) => {
         if (confirmed) {
           this.transferLabelCallback(this.originalLabel);
@@ -87,9 +87,9 @@ export class FilterableLabelDialogComponent implements OnDestroy {
   onDeleteClicked(): void {
     const dialogTitle = $localize`:@@app.view.dialogs.filterable-labels-dialog.filterable-label-dialog-component.delete.title:Delete`;
     const dialogContent = $localize`:@@app.view.dialogs.filterable-labels-dialog.filterable-label-dialog-component.delete.content:Should the label ${this.originalLabel}:label: be definitely delete on all visible ${dialogTitle}:element:?`;
-    const confirmationDialogParamter = new ConfirmationDialogParameter(dialogTitle, dialogContent);
+    const confirmationDialogParameter = new ConfirmationDialogParameter(dialogTitle, dialogContent);
     this.uiInteractionService
-      .showConfirmationDiagramDialog(confirmationDialogParamter)
+      .showConfirmationDiagramDialog(confirmationDialogParameter)
       .subscribe((confirmed: boolean) => {
         if (confirmed) {
           this.deleteLabelCallback(this.originalLabel);

--- a/src/app/view/dialogs/note-dialog/htmlEditor/html-editor.component.ts
+++ b/src/app/view/dialogs/note-dialog/htmlEditor/html-editor.component.ts
@@ -151,7 +151,7 @@ export class HtmlEditorComponent implements OnInit, OnDestroy {
   getColorStyle(color: HtmlEditorColor): string {
     if (color === undefined) {
       if (this.textBasedActiveColor.length > 0) {
-        return "opactiy: 1.0";
+        return "opacity: 1.0";
       }
       return "opacity: 0.25";
     }

--- a/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-filter-tab/trainrun-filter-tab.component.ts
+++ b/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-filter-tab/trainrun-filter-tab.component.ts
@@ -103,9 +103,9 @@ export class TrainrunFilterTabComponent implements OnInit, OnDestroy {
   onDeleteTrainrun() {
     const dialogTitle = $localize`:@@app.view.dialogs.trainrun-and-section-dialog.trainrun-tab.delete:Delete`;
     const dialogContent = $localize`:@@app.view.dialogs.trainrun-and-section-dialog.trainrun-tab.deleteConfirmationQuestion:Should the entire train route be definitively deleted?`;
-    const confirmationDialogParamter = new ConfirmationDialogParameter(dialogTitle, dialogContent);
+    const confirmationDialogParameter = new ConfirmationDialogParameter(dialogTitle, dialogContent);
     this.uiInteractionService
-      .showConfirmationDiagramDialog(confirmationDialogParamter)
+      .showConfirmationDiagramDialog(confirmationDialogParameter)
       .subscribe((confirmed: boolean) => {
         if (confirmed) {
           this.trainrunSectionService.deleteAllTrainrunSectionsOfTrainrun(

--- a/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-roundtrip-tab/trainrun-roundtrip-tab.component.ts
+++ b/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-roundtrip-tab/trainrun-roundtrip-tab.component.ts
@@ -91,9 +91,9 @@ export class TrainrunRoundtripTabComponent implements OnInit, OnDestroy {
   onDeleteTrainrun() {
     const dialogTitle = $localize`:@@app.view.dialogs.trainrun-and-section-dialog.trainrun-tab.delete:Delete`;
     const dialogContent = $localize`:@@app.view.dialogs.trainrun-and-section-dialog.trainrun-tab.deleteConfirmationQuestion:Should the entire train route be definitively deleted?`;
-    const confirmationDialogParamter = new ConfirmationDialogParameter(dialogTitle, dialogContent);
+    const confirmationDialogParameter = new ConfirmationDialogParameter(dialogTitle, dialogContent);
     this.uiInteractionService
-      .showConfirmationDiagramDialog(confirmationDialogParamter)
+      .showConfirmationDiagramDialog(confirmationDialogParameter)
       .subscribe((confirmed: boolean) => {
         if (confirmed) {
           this.trainrunSectionService.deleteAllTrainrunSectionsOfTrainrun(

--- a/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-tab/trainrun-tab.component.ts
+++ b/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-tab/trainrun-tab.component.ts
@@ -158,9 +158,9 @@ export class TrainrunTabComponent implements OnDestroy {
   onDeleteTrainrun() {
     const dialogTitle = $localize`:@@app.view.dialogs.trainrun-and-section-dialog.trainrun-tab.delete:Delete`;
     const dialogContent = $localize`:@@app.view.dialogs.trainrun-and-section-dialog.trainrun-tab.deleteConfirmationQuestion:Should the entire train route be definitively deleted?`;
-    const confirmationDialogParamter = new ConfirmationDialogParameter(dialogTitle, dialogContent);
+    const confirmationDialogParameter = new ConfirmationDialogParameter(dialogTitle, dialogContent);
     this.uiInteractionService
-      .showConfirmationDiagramDialog(confirmationDialogParamter)
+      .showConfirmationDiagramDialog(confirmationDialogParameter)
       .subscribe((confirmed: boolean) => {
         if (confirmed) {
           this.trainrunSectionService.deleteAllTrainrunSectionsOfTrainrun(

--- a/src/app/view/dialogs/trainrun-and-section-dialog/trainrunsection-tab/trainrun-section-tab.component.html
+++ b/src/app/view/dialogs/trainrun-and-section-dialog/trainrunsection-tab/trainrun-section-tab.component.html
@@ -322,7 +322,7 @@
               </sbb-icon>
             </div>
           </div>
-          <div class="NodeLefttLock">
+          <div class="NodeLeftLock">
             <div *ngIf="trainrunSectionTimesService.getLockStructure().leftLock === false">
               <sbb-icon
                 svgIcon="lock-open-medium"

--- a/src/app/view/dialogs/trainrun-and-section-dialog/trainrunsection-tab/trainrun-section-tab.component.scss
+++ b/src/app/view/dialogs/trainrun-and-section-dialog/trainrunsection-tab/trainrun-section-tab.component.scss
@@ -145,7 +145,7 @@ input.NumberOfStopsInputElement.IsActive {
   grid-row: 1;
 }
 
-::ng-deep .NodeLefttLock {
+::ng-deep .NodeLeftLock {
   grid-column: 2/3;
   grid-row: 2;
   background: var(--sbb-header-lean-background-color);

--- a/src/app/view/editor-edit-tools-view-component/editor-edit-tools-view.component.html
+++ b/src/app/view/editor-edit-tools-view-component/editor-edit-tools-view.component.html
@@ -105,7 +105,7 @@
     </sbb-expansion-panel-header>
     <br />
     <button
-      (click)="onLoadNetzgrafikToInsertCopieButton()"
+      (click)="onLoadNetzgrafikToInsertCopyButton()"
       [title]="
         'app.view.editor-edit-tools-view-component.add-netzgrafik-as-copy-tooltip' | translate
       "

--- a/src/app/view/editor-edit-tools-view-component/editor-edit-tools-view.component.ts
+++ b/src/app/view/editor-edit-tools-view-component/editor-edit-tools-view.component.ts
@@ -80,12 +80,12 @@ export class EditorEditToolsViewComponent implements OnDestroy {
   }
 
   onClearAllFiltered() {
-    const confirmationDialogParamter = new ConfirmationDialogParameter(
+    const confirmationDialogParameter = new ConfirmationDialogParameter(
       $localize`:@@app.view.editor-edit-tools-view-component.delete:Delete`,
       $localize`:@@app.view.editor-edit-tools-view-component.on-clear-delete-all-non-visible-elements:Should all non-visible elements be permanently deleted from the netzgrafik?`,
     );
     this.uiInteractionService
-      .showConfirmationDiagramDialog(confirmationDialogParamter)
+      .showConfirmationDiagramDialog(confirmationDialogParameter)
       .subscribe((confirmed: boolean) => {
         if (confirmed) {
           this.trainrunSectionService.deleteAllNonVisibleTrainrunSections();
@@ -96,12 +96,12 @@ export class EditorEditToolsViewComponent implements OnDestroy {
   }
 
   onClear() {
-    const confirmationDialogParamter = new ConfirmationDialogParameter(
+    const confirmationDialogParameter = new ConfirmationDialogParameter(
       $localize`:@@app.view.editor-edit-tools-view-component.delete:Delete`,
       $localize`:@@app.view.editor-edit-tools-view-component.on-clear-delete-all-visible-elements:Should all visible elements be permanently deleted from the netzgrafik?`,
     );
     this.uiInteractionService
-      .showConfirmationDiagramDialog(confirmationDialogParamter)
+      .showConfirmationDiagramDialog(confirmationDialogParameter)
       .subscribe((confirmed: boolean) => {
         if (confirmed) {
           this.trainrunSectionService.deleteAllVisibleTrainrunSections();
@@ -112,12 +112,12 @@ export class EditorEditToolsViewComponent implements OnDestroy {
   }
 
   onClearAllTrainruns() {
-    const confirmationDialogParamter = new ConfirmationDialogParameter(
+    const confirmationDialogParameter = new ConfirmationDialogParameter(
       $localize`:@@app.view.editor-edit-tools-view-component.delete:Delete`,
       $localize`:@@app.view.editor-edit-tools-view-component.on-clear-delete-all-visible-trainruns:Should all visible trainruns be permanently deleted from the netzgrafik?`,
     );
     this.uiInteractionService
-      .showConfirmationDiagramDialog(confirmationDialogParamter)
+      .showConfirmationDiagramDialog(confirmationDialogParameter)
       .subscribe((confirmed: boolean) => {
         if (confirmed) {
           this.trainrunSectionService.deleteAllVisibleTrainrunSections();
@@ -126,12 +126,12 @@ export class EditorEditToolsViewComponent implements OnDestroy {
   }
 
   onClearAllNotes() {
-    const confirmationDialogParamter = new ConfirmationDialogParameter(
+    const confirmationDialogParameter = new ConfirmationDialogParameter(
       $localize`:@@app.view.editor-edit-tools-view-component.delete:Delete`,
       $localize`:@@app.view.editor-edit-tools-view-component.on-clear-delete-all-visible-notes:Should all visible notes be permanently deleted from the netzgrafik?`,
     );
     this.uiInteractionService
-      .showConfirmationDiagramDialog(confirmationDialogParamter)
+      .showConfirmationDiagramDialog(confirmationDialogParameter)
       .subscribe((confirmed: boolean) => {
         if (confirmed) {
           this.noteService.deleteAllVisibleNotes();
@@ -139,7 +139,7 @@ export class EditorEditToolsViewComponent implements OnDestroy {
       });
   }
 
-  onLoadNetzgrafikToInsertCopieButton() {
+  onLoadNetzgrafikToInsertCopyButton() {
     this.netzgrafikMergeAsACopyFileInput.nativeElement.click();
   }
 

--- a/src/app/view/editor-filter-view/editor-filter-view.component.scss
+++ b/src/app/view/editor-filter-view/editor-filter-view.component.scss
@@ -70,7 +70,7 @@
   }
 }
 
-::ng-deep button.FilterSettting {
+::ng-deep button.FilterSetting {
   margin-right: $buttonHeight;
   min-width: 20%;
   min-height: 43px;
@@ -97,7 +97,7 @@
   }
 }
 
-::ng-deep .FilterSettting:active {
+::ng-deep .FilterSetting:active {
 }
 
 .sbb-filtersetting-chip-group {
@@ -109,6 +109,6 @@
   flex: 1 1 160px;
 }
 
-::ng-deep .FilterSettting.function:active {
+::ng-deep .FilterSetting.function:active {
   color: red;
 }

--- a/src/app/view/editor-filter-view/editor-filter-view.component.ts
+++ b/src/app/view/editor-filter-view/editor-filter-view.component.ts
@@ -129,16 +129,16 @@ export class EditorFilterViewComponent implements OnInit, OnDestroy {
 
   getFilterSettingClassname(filterSetting: FilterSetting, isFunctionButton = false): string {
     if (isFunctionButton) {
-      return "FilterSettting function";
+      return "FilterSetting function";
     }
     if (this.checkIsFilterSettingActive(filterSetting)) {
-      return "FilterSettting selected";
+      return "FilterSetting selected";
     }
-    return "FilterSettting";
+    return "FilterSetting";
   }
 
   getFilterSettingAddButtonClassname(): string {
-    return "FilterSettting add_button";
+    return "FilterSetting add_button";
   }
 
   getFilterSettingTooltip(filterSetting: FilterSetting): string {

--- a/src/app/view/editor-main-view/data-views/connections.view.ts
+++ b/src/app/view/editor-main-view/data-views/connections.view.ts
@@ -367,14 +367,14 @@ export class ConnectionsView {
       const obj = d3.select(domObj);
       obj.attr("cx", obj.attr("org_x"));
       obj.attr("cy", obj.attr("org_y"));
-      this.setUnderlayingTrainrunAsSelected(connection, domObj, node);
+      this.setUnderlyingTrainrunAsSelected(connection, domObj, node);
       return;
     }
     this.editorView.removeConnectionFromNode(connection, node);
-    this.setUnderlayingTrainrunAsSelected(connection, domObj, node);
+    this.setUnderlyingTrainrunAsSelected(connection, domObj, node);
   }
 
-  private setUnderlayingTrainrunAsSelected(connection: Connection, domObj: any, node: Node) {
+  private setUnderlyingTrainrunAsSelected(connection: Connection, domObj: any, node: Node) {
     const trainrunID = d3.select(domObj).attr(StaticDomTags.CONNECTION_TRAINRUN_ID);
     const trainrunPort1 = ConnectionsView.getTrainrunSectionPort1(connection, node).getTrainrun();
     const trainrunPort2 = ConnectionsView.getTrainrunSectionPort2(connection, node).getTrainrun();

--- a/src/app/view/editor-main-view/data-views/editor.view.ts
+++ b/src/app/view/editor-main-view/data-views/editor.view.ts
@@ -508,7 +508,7 @@ export class EditorView implements SVGMouseControllerObserver {
       return;
     }
     this.isMultiSelectOn = false;
-    this.multiSelectRenderer.undisplayBox();
+    this.multiSelectRenderer.hideBox();
 
     if (
       this.nodeService.getSelectedNode() === null &&
@@ -519,11 +519,11 @@ export class EditorView implements SVGMouseControllerObserver {
     }
   }
 
-  onGraphContainerMouseup(mousePosition: Vec2D, onPaning: boolean) {
+  onGraphContainerMouseup(mousePosition: Vec2D, onPanning: boolean) {
     if (this.isMultiSelectOn) {
       return;
     }
-    if (!this.trainrunSectionPreviewLineView.isDragging() && !onPaning) {
+    if (!this.trainrunSectionPreviewLineView.isDragging() && !onPanning) {
       if (
         d3.event.button === 0 &&
         this.editorMode === EditorMode.TopologyEditing &&

--- a/src/app/view/editor-main-view/data-views/multiSelectRenderer.ts
+++ b/src/app/view/editor-main-view/data-views/multiSelectRenderer.ts
@@ -30,7 +30,7 @@ export class MultiSelectRenderer {
       .attr("height", bottomRight.getY() - topLeft.getY());
   }
 
-  undisplayBox() {
+  hideBox() {
     if (!this.isBoxDrawing) {
       return;
     }

--- a/src/app/view/editor-main-view/data-views/nodes.view.ts
+++ b/src/app/view/editor-main-view/data-views/nodes.view.ts
@@ -487,7 +487,7 @@ export class NodesView {
     const added = groupEnter.append(StaticDomTags.NODE_LABELAREA_TEXT_SVG);
     added
       .attr("class", StaticDomTags.NODE_LABELAREA_TEXT_CLASS)
-      .attr("data-test", StaticDomTags.NODE_LABELAREA_TEXT_CLASS)
+      .attr("data-testid", StaticDomTags.NODE_LABELAREA_TEXT_CLASS)
       .attr(StaticDomTags.NODE_ID, (n: NodeViewObject) => n.node.getId())
       .attr("x", NODE_TEXT_LEFT_SPACING)
       .attr("y", (n: NodeViewObject) => n.node.getNodeHeight() - TEXT_SIZE / 2)
@@ -546,12 +546,12 @@ export class NodesView {
     this.unhoverNodeDockable(node, domObj);
   }
 
-  hoverPinsAsConnectionDropable(node: Node) {
-    this.highlightPinsAsConnectionDropable(node, true);
+  hoverPinsAsConnectionDroppable(node: Node) {
+    this.highlightPinsAsConnectionDroppable(node, true);
   }
 
-  unhoverPinsAsConnectionDropable(node: Node) {
-    this.highlightPinsAsConnectionDropable(node, false);
+  unhoverPinsAsConnectionDroppable(node: Node) {
+    this.highlightPinsAsConnectionDroppable(node, false);
   }
 
   onNodeMouseover(node: Node, domObj: any) {
@@ -559,7 +559,7 @@ export class NodesView {
   }
 
   onNodeMousemove(node: Node, domObj: any) {
-    this.hoverPinsAsConnectionDropable(node);
+    this.hoverPinsAsConnectionDroppable(node);
   }
 
   onNodeLabelAreaMouseover(node: Node, domObj: any) {
@@ -685,7 +685,7 @@ export class NodesView {
       .filter((n: NodeViewObject) => n.node.getId() === node.getId())
       .classed(StaticDomTags.TAG_HOVER, true);
 
-    this.hoverPinsAsConnectionDropable(node);
+    this.hoverPinsAsConnectionDroppable(node);
   }
 
   unhoverNode(node: Node, domObj: any) {
@@ -702,7 +702,7 @@ export class NodesView {
       .filter((n: NodeViewObject) => n.node.getId() === node.getId())
       .classed(StaticDomTags.TAG_MUTED, false);
 
-    this.unhoverPinsAsConnectionDropable(node);
+    this.unhoverPinsAsConnectionDroppable(node);
   }
 
   hoverNodeDockable(node: Node, domObj: any) {
@@ -869,7 +869,7 @@ export class NodesView {
     this.dragPreviousMousePosition = currentMousePosition;
   }
 
-  private highlightPinsAsConnectionDropable(node: Node, hover: boolean) {
+  private highlightPinsAsConnectionDroppable(node: Node, hover: boolean) {
     if (this.editorView.trainrunSectionPreviewLineView.getMode() !== PreviewLineMode.NotDragging) {
       const dragTransitionInfo: DragTransitionInfo =
         this.editorView.trainrunSectionPreviewLineView.getDragTransitionInfo();

--- a/src/app/view/editor-main-view/data-views/static.dom.tags.ts
+++ b/src/app/view/editor-main-view/data-views/static.dom.tags.ts
@@ -249,7 +249,7 @@ export class StaticDomTags {
   static CONNECTION_LINE_CLASS_1 = StaticDomTags.LINE_LAYER + "_1";
   static CONNECTION_LINE_CLASS_2 = StaticDomTags.LINE_LAYER + "_2";
   static CONNECTION_LINE_CLASS_3 = StaticDomTags.LINE_LAYER + "_3";
-  static CONNECTION_TAG_ONGOING_GDRAGGING = "connection_ongoing_dragging";
+  static CONNECTION_TAG_ONGOING_DRAGGING = "connection_ongoing_dragging";
 
   static CONNECTION_LINE_PIN_SVG = "circle";
   static CONNECTION_LINE_PIN_CLASS = "connection_line_pin";

--- a/src/app/view/editor-main-view/data-views/trainrunsection.previewline.view.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunsection.previewline.view.ts
@@ -183,7 +183,7 @@ export class TrainrunSectionPreviewLineView {
 
   updatePreviewLine() {
     if (this.dragIntermediateStopInfo !== null) {
-      this.undisplayConnectionPreviewLine();
+      this.hideConnectionPreviewLine();
       this.displayTrainrunSectionPreviewLine();
       D3Utils.updateIntermediateStopOrTransitionPreviewLine(
         this.dragIntermediateStopInfo.trainrunSection.getPath()[0],
@@ -193,7 +193,7 @@ export class TrainrunSectionPreviewLineView {
     }
 
     if (this.dragTransitionInfo !== null) {
-      this.undisplayConnectionPreviewLine();
+      this.hideConnectionPreviewLine();
       this.displayTrainrunSectionPreviewLine();
       if (this.dragTransitionInfo.insideNode) {
         const startPos = this.dragTransitionInfo.transition.getPath()[0];
@@ -234,14 +234,14 @@ export class TrainrunSectionPreviewLineView {
     }
 
     if (this.startConnectionPos !== null) {
-      this.undisplayTrainrunSectionPreviewLine();
+      this.hideTrainrunSectionPreviewLine();
       this.displayConnectionPreviewLine();
       D3Utils.updateConnectionPreviewLine(this.startConnectionPos, this.canCombineTwoTrainruns());
       return true;
     }
 
     if (this.startPos !== null) {
-      this.undisplayConnectionPreviewLine();
+      this.hideConnectionPreviewLine();
       this.displayTrainrunSectionPreviewLine();
       D3Utils.updateTrainrunSectionPreviewLine(this.startPos);
       return true;
@@ -251,8 +251,8 @@ export class TrainrunSectionPreviewLineView {
 
   stopPreviewLine() {
     this.filterService.resetTemporaryEmptyAndNonStopFilteringSwitchedOff();
-    this.undisplayTrainrunSectionPreviewLine();
-    this.undisplayConnectionPreviewLine();
+    this.hideTrainrunSectionPreviewLine();
+    this.hideConnectionPreviewLine();
     if (this.dragIntermediateStopInfo !== null) {
       D3Utils.removeGrayout(this.dragIntermediateStopInfo.trainrunSection);
       d3.select(this.dragIntermediateStopInfo.domRef).classed(StaticDomTags.TAG_HOVER, false);
@@ -288,7 +288,7 @@ export class TrainrunSectionPreviewLineView {
       .attr("class", StaticDomTags.PREVIEW_LINE_CLASS);
   }
 
-  private undisplayTrainrunSectionPreviewLine() {
+  private hideTrainrunSectionPreviewLine() {
     if (!this.drawingTrainrunSectionObjectCreated) {
       return;
     }
@@ -309,7 +309,7 @@ export class TrainrunSectionPreviewLineView {
       .attr("class", StaticDomTags.PREVIEW_CONNECTION_LINE_CLASS);
   }
 
-  private undisplayConnectionPreviewLine() {
+  private hideConnectionPreviewLine() {
     if (!this.drawingConnectionObjectCreated) {
       return;
     }

--- a/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
@@ -1380,6 +1380,7 @@ export class TrainrunSectionsView {
           connectedTrainIds,
         ),
       )
+      .attr("data-testid", StaticDomTags.EDGE_LINE_TEXT_CLASS)
       .attr(StaticDomTags.EDGE_ID, (d: TrainrunSectionViewObject) => d.trainrunSection.getId())
       .attr(StaticDomTags.EDGE_LINE_LINE_ID, (d: TrainrunSectionViewObject) =>
         d.trainrunSection.getTrainrunId(),
@@ -1558,7 +1559,6 @@ export class TrainrunSectionsView {
           TrainrunSectionText.TrainrunSectionNumberOfStops,
         ),
       )
-      .attr("data-testid", StaticDomTags.EDGE_LINE_TEXT_CLASS)
       .text(numberOfStops)
       .classed(StaticDomTags.TAG_MUTED, () =>
         TrainrunSectionsView.isMuted(trainrunSection, selectedTrainrun, connectedTrainIds),
@@ -1923,7 +1923,7 @@ export class TrainrunSectionsView {
     this.editorView.trainrunSectionPreviewLineView.updatePreviewLineCombineTrainruns(hasTrans);
 
     d3.selectAll(StaticDomTags.CONNECTION_LINE_PIN_DOM_REF).classed(
-      StaticDomTags.CONNECTION_TAG_ONGOING_GDRAGGING,
+      StaticDomTags.CONNECTION_TAG_ONGOING_DRAGGING,
       true,
     );
   }
@@ -1938,7 +1938,7 @@ export class TrainrunSectionsView {
 
   onTrainrunSectionMouseupPin(trainrunSection: TrainrunSection, atSource: boolean) {
     d3.selectAll(StaticDomTags.CONNECTION_LINE_PIN_DOM_REF).classed(
-      StaticDomTags.CONNECTION_TAG_ONGOING_GDRAGGING,
+      StaticDomTags.CONNECTION_TAG_ONGOING_DRAGGING,
       false,
     );
     this.createNewTrainrunSectionAfterPinDropped(
@@ -2051,9 +2051,9 @@ export class TrainrunSectionsView {
       );
       transformedPath = transformedPath.reverse();
 
-      const transtionObject: Transition = srcNode.getTransition(ts.getId());
-      if (transtionObject !== undefined) {
-        const tPath = Object.assign([], transtionObject.getPath());
+      const transitionObject: Transition = srcNode.getTransition(ts.getId());
+      if (transitionObject !== undefined) {
+        const tPath = Object.assign([], transitionObject.getPath());
         const n0 = Vec2D.norm(Vec2D.sub(element, tPath[0]));
         const n1 = Vec2D.norm(Vec2D.sub(element, tPath[3]));
         if (n0 <= n1) {
@@ -2092,9 +2092,9 @@ export class TrainrunSectionsView {
         transformedPath,
       );
 
-      const transtionObject: Transition = trgNode.getTransition(ts.getId());
-      if (transtionObject !== undefined) {
-        const tPath = Object.assign([], transtionObject.getPath());
+      const transitionObject: Transition = trgNode.getTransition(ts.getId());
+      if (transitionObject !== undefined) {
+        const tPath = Object.assign([], transitionObject.getPath());
         const n0 = Vec2D.norm(Vec2D.sub(element, tPath[0]));
         const n1 = Vec2D.norm(Vec2D.sub(element, tPath[3]));
         if (n0 <= n1) {
@@ -2154,8 +2154,8 @@ export class TrainrunSectionsView {
       return true;
     }
     const filterSourceNode = this.editorView.checkFilterNode(trainrunSection.getSourceNode());
-    const filterTragetNode = this.editorView.checkFilterNode(trainrunSection.getTargetNode());
-    return filterSourceNode && filterTragetNode;
+    const filterTargetNode = this.editorView.checkFilterNode(trainrunSection.getTargetNode());
+    return filterSourceNode && filterTargetNode;
   }
 
   private oneNodeHiddenTrainrunSectionsRendering(
@@ -2442,7 +2442,7 @@ export class TrainrunSectionsView {
     this.createTrainrunSection(
       groupLines,
       StaticDomTags.EDGE_LINE_LAYER_0,
-      [LinePatternRefs.Freq30], // LinePatternRefs.Freq60], (background is required to "strech the hower area"
+      [LinePatternRefs.Freq30], // LinePatternRefs.Freq60], (background is required to "stretch the lower area"
       selectedTrainrun,
       connectedTrainIds,
       enableEvents,

--- a/src/app/view/editor-main-view/data-views/transitions.view.ts
+++ b/src/app/view/editor-main-view/data-views/transitions.view.ts
@@ -167,7 +167,7 @@ export class TransitionsView {
     this.transitionsGroup = transitionsGroup.append(StaticDomTags.GROUP_SVG);
     this.transitionsGroup.attr("class", "transitions");
     this.selectedTransitionsGroup = transitionsGroup.append(StaticDomTags.GROUP_SVG);
-    this.selectedTransitionsGroup.attr("class", "selectedTansitions");
+    this.selectedTransitionsGroup.attr("class", "selectedTransitions");
   }
 
   filtertransitionToDisplay(transition: Transition, trainrun: Trainrun) {
@@ -235,7 +235,7 @@ export class TransitionsView {
     TransitionsView.createTransitionLineLayer(
       grpEnter,
       StaticDomTags.TRANSITION_LINE_CLASS_0,
-      [LinePatternRefs.Freq30], // LinePatternRefs.Freq60], (background is required to "strech the hower area"
+      [LinePatternRefs.Freq30], // LinePatternRefs.Freq60], (background is required to "stretch the lower area"
       selectedTrainrun,
       connectedTrainIds,
       this.editorView,

--- a/src/app/view/editor-main-view/editor-main-view.component.html
+++ b/src/app/view/editor-main-view/editor-main-view.component.html
@@ -1,7 +1,7 @@
 <svg
   class="graphContainer associations"
   id="graphContainer"
-  data-test="graph-container"
+  data-testid="graph-container"
   width="100%"
   height="100%"
   #graphContainer

--- a/src/app/view/editor-menu/editor-menu.component.ts
+++ b/src/app/view/editor-menu/editor-menu.component.ts
@@ -75,7 +75,7 @@ export class EditorMenuComponent implements OnInit, OnDestroy {
       });
 
     this.isTrainrunSelectedService
-      .getTrainrunIdSelecteds()
+      .getTrainrunIdSelected()
       .pipe(takeUntil(this.destroyed))
       .subscribe((trainrunIdSelected) => {
         this.trainrunIdSelected = trainrunIdSelected;

--- a/src/app/view/editor-properties-view-component/editor-properties-view.component.html
+++ b/src/app/view/editor-properties-view-component/editor-properties-view.component.html
@@ -128,7 +128,7 @@
         *ngFor="let option of travelTimeCreationEstimatorTypeOptions"
         [value]="option.travelTimeCreationEstimatorType"
         [title]="option.title"
-        (change)="onUpdateaTravelTimeCreationEstimatorType($event)"
+        (change)="onUpdateTravelTimeCreationEstimatorType($event)"
       >
         {{ option.name }}
       </sbb-radio-button>

--- a/src/app/view/editor-properties-view-component/editor-properties-view.component.ts
+++ b/src/app/view/editor-properties-view-component/editor-properties-view.component.ts
@@ -121,7 +121,7 @@ export class EditorPropertiesViewComponent {
     this.uiInteractionService.setActiveStreckengrafikRenderingType(event.value);
   }
 
-  onUpdateaTravelTimeCreationEstimatorType(event: SbbRadioChange) {
+  onUpdateTravelTimeCreationEstimatorType(event: SbbRadioChange) {
     this.uiInteractionService.setActiveTravelTimeCreationEstimatorType(event.value);
   }
 

--- a/src/app/view/editor-side-view/editor-node-detail-view/editor-node-detail-view.component.ts
+++ b/src/app/view/editor-side-view/editor-node-detail-view/editor-node-detail-view.component.ts
@@ -24,7 +24,7 @@ interface NodeProperties {
   nodeBetriebspunktFullName: string;
   nodeConnectionTime: number;
   nodeTrainrunCategoryHaltezeit: TrainrunCategoryHaltezeit;
-  nodeResouceId: number;
+  nodeResourceId: number;
   nodeCapacity: number;
   labels: string[];
 }
@@ -44,7 +44,7 @@ export class EditorNodeDetailViewComponent implements OnInit, OnDestroy {
     nodeBetriebspunktFullName: "",
     nodeConnectionTime: 0,
     nodeTrainrunCategoryHaltezeit: Node.getDefaultHaltezeit(),
-    nodeResouceId: null,
+    nodeResourceId: null,
     nodeCapacity: 2,
     labels: [],
   };
@@ -148,28 +148,28 @@ export class EditorNodeDetailViewComponent implements OnInit, OnDestroy {
   onCapacityChanged() {
     if (this.nodeProperties.nodeCapacity > 0) {
       this.resourceService.changeCapacity(
-        this.nodeProperties.nodeResouceId,
+        this.nodeProperties.nodeResourceId,
         this.nodeProperties.nodeCapacity,
       );
     } else {
-      this.resourceService.changeCapacity(this.nodeProperties.nodeResouceId, 1);
+      this.resourceService.changeCapacity(this.nodeProperties.nodeResourceId, 1);
     }
   }
 
   loadCapacityValue() {
     this.nodeProperties.nodeCapacity = this.resourceService
-      .getResource(this.nodeProperties.nodeResouceId)
+      .getResource(this.nodeProperties.nodeResourceId)
       .getCapacity();
   }
 
   onDeleteNode() {
     const node = this.nodeService.getSelectedNode();
-    const confirmationDialogParamter = new ConfirmationDialogParameter(
+    const confirmationDialogParameter = new ConfirmationDialogParameter(
       $localize`:@@app.view.editor-side-view.editor-node-detail-view.delete:Delete`,
       $localize`:@@app.view.editor-side-view.editor-node-detail-view.deleteNodeDialog:Should the node ${node.getBetriebspunktName()}:operationalPointShortName: (${node.getFullName()}:operationalPointName:) be definitely deleted?`,
     );
     this.uiInteractionService
-      .showConfirmationDiagramDialog(confirmationDialogParamter)
+      .showConfirmationDiagramDialog(confirmationDialogParameter)
       .subscribe((confirmed: boolean) => {
         if (confirmed) {
           this.nodeService.deleteNode(node.getId());
@@ -244,7 +244,7 @@ export class EditorNodeDetailViewComponent implements OnInit, OnDestroy {
         nodeBetriebspunktFullName: selectedNode.getFullName(),
         nodeConnectionTime: selectedNode.getConnectionTime(),
         nodeTrainrunCategoryHaltezeit: selectedNode.getTrainrunCategoryHaltezeit(),
-        nodeResouceId: resource.getId(),
+        nodeResourceId: resource.getId(),
         nodeCapacity: resource.getCapacity(),
         labels: this.labelService.getTextLabelsFromIds(selectedNode.getLabelIds()),
       };

--- a/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
+++ b/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
@@ -439,7 +439,7 @@ export class EditorToolsViewComponent {
     };
   }
 
-  private exportOriginDestinationCanvasToPNG(filename: string, quality = 1.0) {
+  private exportOriginDestinationCanvasToPNG(filename: string) {
     const sel = d3.select("#main-origin-destination-canvas");
     const canvas = sel.node(); // <- real HTMLCanvasElement or null
 
@@ -464,7 +464,7 @@ export class EditorToolsViewComponent {
     a.remove();
   }
 
-  private exportOriginDestinationCanvasToSVG(filename: string, quality = 1.0) {
+  private exportOriginDestinationCanvasToSVG(filename: string) {
     const sel = d3.select("#main-origin-destination-canvas");
     const canvas = sel.node(); // <- real HTMLCanvasElement or null
 
@@ -476,7 +476,7 @@ export class EditorToolsViewComponent {
     }
 
     if (canvas === null) {
-      return undefined;
+      return;
     }
     const buildSvgFromCanvas = (canvas) => {
       const width = canvas.width;

--- a/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
+++ b/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
@@ -27,6 +27,7 @@ import {TrainrunSectionValidator} from "../../services/util/trainrunsection.vali
 import {OriginDestinationService} from "src/app/services/analytics/origin-destination/components/origin-destination.service";
 import {EditorMode} from "../editor-menu/editor-mode";
 import {NODE_TEXT_AREA_HEIGHT, RASTERING_BASIC_GRID_SIZE} from "../rastering/definitions";
+import * as d3 from "d3";
 
 interface ContainertoExportData {
   documentToExport: HTMLElement;
@@ -131,6 +132,15 @@ export class EditorToolsViewComponent {
     this.levelOfDetailService.disableLevelOfDetailRendering();
     this.viewportCullService.onViewportChangeUpdateRendering(false);
 
+    // Handle special case origin destination matrix (canvas)
+    const editorMode = this.uiInteractionService.getEditorMode();
+    if (editorMode === EditorMode.OriginDestination) {
+      this.exportOriginDestinationCanvasToSVG(this.getFilenameToExport() + ".svg");
+      this.levelOfDetailService.enableLevelOfDetailRendering();
+      return;
+    }
+
+    // Handle all other cases (svg)
     const containerInfo = this.getContainerToExport();
     this.prepareStyleForExport(containerInfo);
 
@@ -157,6 +167,15 @@ export class EditorToolsViewComponent {
     this.levelOfDetailService.disableLevelOfDetailRendering();
     this.viewportCullService.onViewportChangeUpdateRendering(false);
 
+    // Handle special case origin destination matrix (canvas)
+    const editorMode = this.uiInteractionService.getEditorMode();
+    if (editorMode === EditorMode.OriginDestination) {
+      this.exportOriginDestinationCanvasToPNG(this.getFilenameToExport() + ".png");
+      this.levelOfDetailService.enableLevelOfDetailRendering();
+      return;
+    }
+
+    // Handle all other cases (svg)
     const containerInfo = this.getContainerToExport();
     this.prepareStyleForExport(containerInfo);
 
@@ -420,41 +439,79 @@ export class EditorToolsViewComponent {
     };
   }
 
-  private getOriginDestinationContainerToExport(): ContainertoExportData {
-    const htmlElementToExport = document.getElementById("main-origin-destination-container");
-    if (htmlElementToExport === null) {
-      return undefined;
+  private exportOriginDestinationCanvasToPNG(filename: string) {
+    const sel = d3.select("#main-origin-destination-canvas");
+    const canvas = sel.node(); // <- real HTMLCanvasElement or null
+
+    if (!canvas) {
+      console.error("Canvas nicht gefunden:", sel);
+    } else {
+      const ctx = canvas.getContext("2d");
+      console.log("Canvas found, size:", canvas.width, canvas.height, ctx);
     }
-    const bbox = (htmlElementToExport as unknown as SVGGElement).getBBox();
-    const padding = 10;
-    const param = {
-      encoderOptions: 1.0,
-      scale: 1.0,
-      left: bbox.x - padding,
-      top: bbox.y - padding,
-      width: bbox.width + 2 * padding,
-      height: bbox.height + 2 * padding,
-      backgroundColor: this.uiInteractionService.getActiveTheme().backgroundColor,
+
+    if (canvas === null) {
+      return;
+    }
+
+    // quality only used for image/jpeg
+    const dataUrl = canvas.toDataURL("image/png");
+    const a = document.createElement("a");
+    a.href = dataUrl;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+  }
+
+  private exportOriginDestinationCanvasToSVG(filename: string) {
+    const sel = d3.select("#main-origin-destination-canvas");
+    const canvas = sel.node(); // <- real HTMLCanvasElement or null
+
+    if (!canvas) {
+      console.error("Canvas nicht gefunden:", sel);
+    } else {
+      const ctx = canvas.getContext("2d");
+      console.log("Canvas found, size:", canvas.width, canvas.height, ctx);
+    }
+
+    if (canvas === null) {
+      return;
+    }
+    const buildSvgFromCanvas = (canvas) => {
+      const width = canvas.width;
+      const height = canvas.height;
+      // canvas Data-URL (PNG)
+      const dataUrl = canvas.toDataURL("image/png");
+
+      // Erzeuge SVG string mit eingebettetem Bild
+      const svg = `<svg id="main-origin-destination-canvas" xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
+        <image href="${dataUrl}" x="0" y="0" width="${width}" height="${height}" preserveAspectRatio="none"/>
+        </svg>`;
+
+      return svg;
     };
 
-    const essentialProps = [
-      "fill",
-      "stroke",
-      "stroke-width",
-      "stroke-dasharray",
-      "font-family",
-      "font-size",
-      "font-weight",
-      "opacity",
-      "text-anchor",
-      "dominant-baseline",
-    ];
+    const svgString = buildSvgFromCanvas(canvas);
 
-    return {
-      documentToExport: htmlElementToExport,
-      exportParameter: param,
-      essentialProps: essentialProps,
-    };
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(svgString, "image/svg+xml");
+    const svgEl = doc.documentElement;
+
+    if (!svgEl.getAttribute("width")) svgEl.setAttribute("width", canvas.width);
+    if (!svgEl.getAttribute("height")) svgEl.setAttribute("height", canvas.height);
+
+    const blob = new Blob([new XMLSerializer().serializeToString(svgEl)], {
+      type: "image/svg+xml;charset=utf-8",
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    setTimeout(() => URL.revokeObjectURL(url), 2000);
   }
 
   private getNetzgrafikEditingContainerToExport(): ContainertoExportData {
@@ -520,7 +577,7 @@ export class EditorToolsViewComponent {
       case EditorMode.StreckengrafikEditing:
         return this.getStreckengrafikEditingContainerToExport();
       case EditorMode.OriginDestination:
-        return this.getOriginDestinationContainerToExport();
+        return undefined;
       default:
         return this.getNetzgrafikEditingContainerToExport();
     }

--- a/src/app/view/project/project-dialog/project-form/project-form.component.ts
+++ b/src/app/view/project/project-dialog/project-form/project-form.component.ts
@@ -49,7 +49,7 @@ export const userIdsAsEmailValidator = (control: UntypedFormControl) => {
     return null;
   }
   const userIds: string[] = control.value;
-  // email adresse validator: regex to match emails using the expression
+  // email address validator: regex to match emails using the expression
   const invalidEmailPattern = userIds.filter((id) => {
     const retVal = id.match(
       /^([a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*)|(u|ue|e)\d+$/,

--- a/src/app/view/util/origin-destination-graph.ts
+++ b/src/app/view/util/origin-destination-graph.ts
@@ -164,7 +164,6 @@ export const computeShortestPaths = (
   const dist = new Map<Vertex, [number, number]>();
   let started = false;
   vertices.forEach((vertex) => {
-    const key = vertex;
     // First, look for our start node.
     if (!started) {
       if (from === vertex.nodeId && vertex.isDeparture === true && vertex.time === undefined) {
@@ -190,11 +189,6 @@ export const computeShortestPaths = (
     // The shortest path from the start node to this vertex is a shortest path from the start node to a neighbor
     // plus the weight of the edge connecting the neighbor to this vertex.
     neighs.forEach(([neighbor, weight]) => {
-      const alt = dist.get(vertex)[0] + weight;
-      if (dist.get(neighbor) === undefined || alt < dist.get(neighbor)[0]) {
-      const alt = dist.get(key)[0] + weight;
-      const neighborKey = neighbor;
-      if (dist.get(neighborKey) === undefined || alt < dist.get(neighborKey)[0]) {
       const alt = dist.get(vertex)[0] + weight;
       if (dist.get(neighbor) === undefined || alt < dist.get(neighbor)[0]) {
         let connection = 0;
@@ -262,7 +256,7 @@ const buildSectionEdgesFromIterator = (
     let tsId = ts.getId();
     const trainrunId = reverseIterator
       ? // Minus 1 so we don't conflate 0 with -0.
-        -ts.getTrainrunId() - 1
+      -ts.getTrainrunId() - 1
       : ts.getTrainrunId();
 
     const reverseSection = tsIterator.current().node.getId() !== ts.getTargetNodeId();

--- a/src/app/view/util/origin-destination-graph.ts
+++ b/src/app/view/util/origin-destination-graph.ts
@@ -121,6 +121,7 @@ export const buildEdges = (
 
 // Given edges, return the neighbors (with weights) for each vertex, if any (outgoing adjacency list).
 export const computeNeighbors = (edges: Edge[]): Map<Vertex, [Vertex, number][]> => {
+  // Note: we can use vertices as keys, as long as they are unique.
   const neighbors = new Map<Vertex, [Vertex, number][]>();
   edges.forEach((edge) => {
     const v1 = edge.v1;
@@ -189,6 +190,8 @@ export const computeShortestPaths = (
     // The shortest path from the start node to this vertex is a shortest path from the start node to a neighbor
     // plus the weight of the edge connecting the neighbor to this vertex.
     neighs.forEach(([neighbor, weight]) => {
+      const alt = dist.get(vertex)[0] + weight;
+      if (dist.get(neighbor) === undefined || alt < dist.get(neighbor)[0]) {
       const alt = dist.get(key)[0] + weight;
       const neighborKey = neighbor;
       if (dist.get(neighborKey) === undefined || alt < dist.get(neighborKey)[0]) {

--- a/src/app/view/util/origin-destination-graph.ts
+++ b/src/app/view/util/origin-destination-graph.ts
@@ -120,10 +120,10 @@ export const buildEdges = (
 };
 
 // Given edges, return the neighbors (with weights) for each vertex, if any (outgoing adjacency list).
-export const computeNeighbors = (edges: Edge[]): Map<string, [Vertex, number][]> => {
-  const neighbors = new Map<string, [Vertex, number][]>();
+export const computeNeighbors = (edges: Edge[]): Map<Vertex, [Vertex, number][]> => {
+  const neighbors = new Map<Vertex, [Vertex, number][]>();
   edges.forEach((edge) => {
-    const v1 = JSON.stringify(edge.v1);
+    const v1 = edge.v1;
     const v1Neighbors = neighbors.get(v1);
     if (v1Neighbors === undefined) {
       neighbors.set(v1, [[edge.v2, edge.weight]]);
@@ -136,12 +136,12 @@ export const computeNeighbors = (edges: Edge[]): Map<string, [Vertex, number][]>
 
 // Given a graph (adjacency list), return the vertices in topological order.
 // Note: sorting vertices by time would be enough for our use case.
-export const topoSort = (graph: Map<string, [Vertex, number][]>): Vertex[] => {
+export const topoSort = (graph: Map<Vertex, [Vertex, number][]>): Vertex[] => {
   const res = [];
-  const visited = new Set<string>();
+  const visited = new Set<Vertex>();
   for (const node of graph.keys()) {
     if (!visited.has(node)) {
-      depthFirstSearch(graph, JSON.parse(node) as Vertex, visited, res);
+      depthFirstSearch(graph, node, visited, res);
     }
   }
   return res.reverse();
@@ -151,7 +151,7 @@ export const topoSort = (graph: Map<string, [Vertex, number][]>): Vertex[] => {
 // from a given node to other nodes.
 export const computeShortestPaths = (
   from: number,
-  neighbors: Map<string, [Vertex, number][]>,
+  neighbors: Map<Vertex, [Vertex, number][]>,
   vertices: Vertex[],
   tsSuccessor: Map<number, number>,
 ): Map<number, [number, number]> => {
@@ -160,10 +160,10 @@ export const computeShortestPaths = (
     tsPredecessor.set(v, k);
   });
   const res = new Map<number, [number, number]>();
-  const dist = new Map<string, [number, number]>();
+  const dist = new Map<Vertex, [number, number]>();
   let started = false;
   vertices.forEach((vertex) => {
-    const key = JSON.stringify(vertex);
+    const key = vertex;
     // First, look for our start node.
     if (!started) {
       if (from === vertex.nodeId && vertex.isDeparture === true && vertex.time === undefined) {
@@ -190,7 +190,7 @@ export const computeShortestPaths = (
     // plus the weight of the edge connecting the neighbor to this vertex.
     neighs.forEach(([neighbor, weight]) => {
       const alt = dist.get(key)[0] + weight;
-      const neighborKey = JSON.stringify(neighbor);
+      const neighborKey = neighbor;
       if (dist.get(neighborKey) === undefined || alt < dist.get(neighborKey)[0]) {
         let connection = 0;
         let successor = tsSuccessor;
@@ -407,17 +407,17 @@ const buildConnectionEdges = (
 };
 
 const depthFirstSearch = (
-  graph: Map<string, [Vertex, number][]>,
+  graph: Map<Vertex, [Vertex, number][]>,
   root: Vertex,
-  visited: Set<string>,
+  visited: Set<Vertex>,
   res: Vertex[],
 ): void => {
-  const key = JSON.stringify(root);
+  const key = root;
   visited.add(key);
   const neighbors = graph.get(key);
   if (neighbors !== undefined) {
     neighbors.forEach(([neighbor, weight]) => {
-      if (!visited.has(JSON.stringify(neighbor))) {
+      if (!visited.has(neighbor)) {
         depthFirstSearch(graph, neighbor, visited, res);
       }
     });

--- a/src/app/view/util/origin-destination-graph.ts
+++ b/src/app/view/util/origin-destination-graph.ts
@@ -121,7 +121,6 @@ export const buildEdges = (
 
 // Given edges, return the neighbors (with weights) for each vertex, if any (outgoing adjacency list).
 export const computeNeighbors = (edges: Edge[]): Map<Vertex, [Vertex, number][]> => {
-  // Note: we can use vertices as keys, as long as they are unique.
   const neighbors = new Map<Vertex, [Vertex, number][]>();
   edges.forEach((edge) => {
     const v1 = edge.v1;
@@ -164,6 +163,7 @@ export const computeShortestPaths = (
   const dist = new Map<Vertex, [number, number]>();
   let started = false;
   vertices.forEach((vertex) => {
+    const key = vertex;
     // First, look for our start node.
     if (!started) {
       if (from === vertex.nodeId && vertex.isDeparture === true && vertex.time === undefined) {
@@ -189,6 +189,9 @@ export const computeShortestPaths = (
     // The shortest path from the start node to this vertex is a shortest path from the start node to a neighbor
     // plus the weight of the edge connecting the neighbor to this vertex.
     neighs.forEach(([neighbor, weight]) => {
+      const alt = dist.get(key)[0] + weight;
+      const neighborKey = neighbor;
+      if (dist.get(neighborKey) === undefined || alt < dist.get(neighborKey)[0]) {
       const alt = dist.get(vertex)[0] + weight;
       if (dist.get(neighbor) === undefined || alt < dist.get(neighbor)[0]) {
         let connection = 0;

--- a/src/app/view/util/origin-destination-graph.ts
+++ b/src/app/view/util/origin-destination-graph.ts
@@ -256,7 +256,7 @@ const buildSectionEdgesFromIterator = (
     let tsId = ts.getId();
     const trainrunId = reverseIterator
       ? // Minus 1 so we don't conflate 0 with -0.
-        -ts.getTrainrunId() - 1
+      -ts.getTrainrunId() - 1
       : ts.getTrainrunId();
 
     const reverseSection = tsIterator.current().node.getId() !== ts.getTargetNodeId();

--- a/src/app/view/util/origin-destination-graph.ts
+++ b/src/app/view/util/origin-destination-graph.ts
@@ -121,6 +121,7 @@ export const buildEdges = (
 
 // Given edges, return the neighbors (with weights) for each vertex, if any (outgoing adjacency list).
 export const computeNeighbors = (edges: Edge[]): Map<Vertex, [Vertex, number][]> => {
+  // Note: we can use vertices as keys, as long as they are unique.
   const neighbors = new Map<Vertex, [Vertex, number][]>();
   edges.forEach((edge) => {
     const v1 = edge.v1;
@@ -163,12 +164,11 @@ export const computeShortestPaths = (
   const dist = new Map<Vertex, [number, number]>();
   let started = false;
   vertices.forEach((vertex) => {
-    const key = vertex;
     // First, look for our start node.
     if (!started) {
       if (from === vertex.nodeId && vertex.isDeparture === true && vertex.time === undefined) {
         started = true;
-        dist.set(key, [0, 0]);
+        dist.set(vertex, [0, 0]);
       } else {
         return;
       }
@@ -177,21 +177,20 @@ export const computeShortestPaths = (
     if (
       vertex.isDeparture === false &&
       vertex.time === undefined &&
-      dist.get(key) !== undefined &&
+      dist.get(vertex) !== undefined &&
       vertex.nodeId !== from
     ) {
-      res.set(vertex.nodeId, dist.get(key));
+      res.set(vertex.nodeId, dist.get(vertex));
     }
-    const neighs = neighbors.get(key);
-    if (neighs === undefined || dist.get(key) === undefined) {
+    const neighs = neighbors.get(vertex);
+    if (neighs === undefined || dist.get(vertex) === undefined) {
       return;
     }
     // The shortest path from the start node to this vertex is a shortest path from the start node to a neighbor
     // plus the weight of the edge connecting the neighbor to this vertex.
     neighs.forEach(([neighbor, weight]) => {
-      const alt = dist.get(key)[0] + weight;
-      const neighborKey = neighbor;
-      if (dist.get(neighborKey) === undefined || alt < dist.get(neighborKey)[0]) {
+      const alt = dist.get(vertex)[0] + weight;
+      if (dist.get(neighbor) === undefined || alt < dist.get(neighbor)[0]) {
         let connection = 0;
         let successor = tsSuccessor;
         if (vertex.trainrunId < 0) {
@@ -206,7 +205,7 @@ export const computeShortestPaths = (
         ) {
           connection = 1;
         }
-        dist.set(neighborKey, [alt, dist.get(key)[1] + connection]);
+        dist.set(neighbor, [alt, dist.get(vertex)[1] + connection]);
       }
     });
   });

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -142,6 +142,10 @@
         "travel-time": "Reisezeit",
         "transfers": "Umstiege"
       },
+      "buttons": {
+        "reset": "Zurücksetzen",
+        "crossHighlighting": "Zeilen/Spalten hervorheben"
+      },
       "palette-buttons": {
         "red": "Rote Palette",
         "blue": "Blaue Palette",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -143,7 +143,8 @@
         "transfers": "Umstiege"
       },
       "buttons": {
-        "reset": "Zurücksetzen"
+        "reset": "Zurücksetzen",
+        "crossHighlighting": "Zeilen/Spalten hervorheben"
       },
       "palette-buttons": {
         "red": "Rote Palette",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -142,6 +142,9 @@
         "travel-time": "Reisezeit",
         "transfers": "Umstiege"
       },
+      "buttons": {
+        "reset": "Zurücksetzen"
+      },
       "palette-buttons": {
         "red": "Rote Palette",
         "blue": "Blaue Palette",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -142,6 +142,9 @@
         "travel-time": "Travel time",
         "transfers": "Transfers"
       },
+      "buttons": {
+        "reset": "Reset"
+      },
       "palette-buttons": {
         "red": "Red palette",
         "blue": "Blue palette",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -143,7 +143,8 @@
         "transfers": "Transfers"
       },
       "buttons": {
-        "reset": "Reset"
+        "reset": "Reset",
+        "crossHighlighting": "Highlight rows/columns"
       },
       "palette-buttons": {
         "red": "Red palette",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -142,6 +142,10 @@
         "travel-time": "Travel time",
         "transfers": "Transfers"
       },
+      "buttons": {
+        "reset": "Reset",
+        "crossHighlighting": "Highlight rows/columns"
+      },
       "palette-buttons": {
         "red": "Red palette",
         "blue": "Blue palette",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -142,7 +142,8 @@
         "transfers": "Changements"
       },
       "buttons": {
-        "reset": "Réinitialiser"
+        "reset": "Réinitialiser",
+        "crossHighlighting": "Mettre en surbrillance les lignes/colonnes"
       },
       "palette-buttons": {
         "red": "Palette rouge",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -141,6 +141,9 @@
         "travel-time": "Temps de parcours",
         "transfers": "Changements"
       },
+      "buttons": {
+        "reset": "Réinitialiser"
+      },
       "palette-buttons": {
         "red": "Palette rouge",
         "blue": "Palette bleue",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -141,6 +141,10 @@
         "travel-time": "Temps de parcours",
         "transfers": "Changements"
       },
+      "buttons": {
+        "reset": "Réinitialiser",
+        "crossHighlighting": "Mettre en surbrillance les lignes/colonnes"
+      },
       "palette-buttons": {
         "red": "Palette rouge",
         "blue": "Palette bleue",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -141,6 +141,9 @@
         "travel-time": "Travel time",
         "transfers": "Transfers"
       },
+      "buttons": {
+        "reset": "Reset"
+      },
       "palette-buttons": {
         "red": "Red palette",
         "blue": "Blue palette",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -142,7 +142,8 @@
         "transfers": "Transfers"
       },
       "buttons": {
-        "reset": "Reset"
+        "reset": "Reset",
+        "crossHighlighting": "Highlight rows/columns"
       },
       "palette-buttons": {
         "red": "Red palette",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -141,6 +141,10 @@
         "travel-time": "Travel time",
         "transfers": "Transfers"
       },
+      "buttons": {
+        "reset": "Reset",
+        "crossHighlighting": "Highlight rows/columns"
+      },
       "palette-buttons": {
         "red": "Red palette",
         "blue": "Blue palette",

--- a/src/integration-testing/origin.destination.csv.test.spec.ts
+++ b/src/integration-testing/origin.destination.csv.test.spec.ts
@@ -290,12 +290,12 @@ describe("Origin Destination CSV Test", () => {
 
     // v4 has no outgoing edges.
     expect(neighbors).toHaveSize(3);
-    expect(neighbors.get(JSON.stringify(v1))).toHaveSize(1);
-    expect(neighbors.get(JSON.stringify(v1))).toContain([v2, 0]);
-    expect(neighbors.get(JSON.stringify(v2))).toHaveSize(1);
-    expect(neighbors.get(JSON.stringify(v2))).toContain([v3, 15]);
-    expect(neighbors.get(JSON.stringify(v3))).toHaveSize(1);
-    expect(neighbors.get(JSON.stringify(v3))).toContain([v4, 0]);
+    expect(neighbors.get(v1)).toHaveSize(1);
+    expect(neighbors.get(v1)).toContain([v2, 0]);
+    expect(neighbors.get(v2)).toHaveSize(1);
+    expect(neighbors.get(v2)).toContain([v3, 15]);
+    expect(neighbors.get(v3)).toHaveSize(1);
+    expect(neighbors.get(v3)).toContain([v4, 0]);
 
     const topoVertices = topoSort(neighbors);
 
@@ -348,15 +348,15 @@ describe("Origin Destination CSV Test", () => {
 
     const neighbors = computeNeighbors(edges);
     expect(neighbors).toHaveSize(9);
-    expect(neighbors.get(JSON.stringify(v1))).toHaveSize(1);
-    expect(neighbors.get(JSON.stringify(v2))).toHaveSize(1);
-    expect(neighbors.get(JSON.stringify(v3))).toHaveSize(2);
-    expect(neighbors.get(JSON.stringify(v4))).toHaveSize(1);
-    expect(neighbors.get(JSON.stringify(v5))).toHaveSize(1);
-    expect(neighbors.get(JSON.stringify(v7))).toHaveSize(1);
-    expect(neighbors.get(JSON.stringify(v8))).toHaveSize(1);
-    expect(neighbors.get(JSON.stringify(v9))).toHaveSize(2);
-    expect(neighbors.get(JSON.stringify(v11))).toHaveSize(1);
+    expect(neighbors.get(v1)).toHaveSize(1);
+    expect(neighbors.get(v2)).toHaveSize(1);
+    expect(neighbors.get(v3)).toHaveSize(2);
+    expect(neighbors.get(v4)).toHaveSize(1);
+    expect(neighbors.get(v5)).toHaveSize(1);
+    expect(neighbors.get(v7)).toHaveSize(1);
+    expect(neighbors.get(v8)).toHaveSize(1);
+    expect(neighbors.get(v9)).toHaveSize(2);
+    expect(neighbors.get(v11)).toHaveSize(1);
 
     const topoVertices = topoSort(neighbors);
     expect(topoVertices).toHaveSize(11);


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->

# Description

Rendering of the origin/destination matrix was a major performance bottleneck. To address this, the SVG-based rendering of the O/D matrix has been replaced with a Canvas-based implementation.

<img width="1915" height="1011" alt="image" src="https://github.com/user-attachments/assets/ff6f0108-3ffc-40dc-8b10-51a22bf2d48a" />
Final Version.

## To discuss - but it looks very promising 
Please compare the rendering outcome: Pixel graphics (new) vs Vector graphics (old). If we like to have high quality support (vector graphic / svg) we might have to implement an automatic switch from (old) to new if the matrix gets to big. 

**I strongly recommend using canvas** -> just using this canvas based rendering for such matrix based rendering otherwise we will run into big issue with the performance. I am aware that it's not so cool having pixel graphics but is looks quite good. And as well it make againt the interactive tool more complex du of having svg ( d3.js) and canvas in one product. But for interactive real - time application the life is hard:)


## What changed
- Replaced SVG rendering of the O/D matrix with a Canvas renderer.
- Result: rendering is now fast and responsive, especially for large matrices.

## Known issues / TODOs

- [x] Export to PNG/SVG currently does not work. Export functionality needs to be restored for the new Canvas renderer. <img width="765" height="87" alt="image" src="https://github.com/user-attachments/assets/baa556b9-158d-499e-93b4-ec4b07c79392" />  Issue fixed - png can directly exported - svg must be simulated with an image layer but it works.

- [x] Small visual issue: some "button" elements render without a background. It appears the rendering area for those elements is too large, causing their backgrounds not to be drawn correctly. 

| Before |  After |
| --- | --- | 
|  <img width="956" height="505" alt="image" src="https://github.com/user-attachments/assets/39215fc9-e175-4e9b-ab88-e14d5b740c1f" /> |   <img width="956" height="505" alt="image" src="https://github.com/user-attachments/assets/932d6d90-9d48-4d7f-95e0-f3cf9eed9b14" /> |

<!-- Describe the changes your PR introduces here. -->
 

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

- [x] This PR contains a description of the changes I'm making
- [x] I've read the [Contribution Guidelines](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/CONTRIBUTING.md)
- [ ] I've added tests for changes or features I've introduced
- [ ] I documented any high-level concepts I'm introducing in `documentation/`
- [x] CI is currently green and this is ready for review

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation.
-->
