### PR TITLE
one-way: make arrow direction smaller

### DIFF
--- a/src/app/perlenkette/perlenkette-section/perlenkette-section.component.html
+++ b/src/app/perlenkette/perlenkette-section/perlenkette-section.component.html
@@ -13,15 +13,15 @@
       <path
         *ngIf="!isRoundTrip()"
         [class]="getEdgeLineArrowClass()"
-        d="M0,4L0,6L8,6L8,10L14,5L8,0L8,4Z"
-        [attr.transform]="getArrowTranslateAndRotate(35)"
+        d="M-4,-5L2,0L-4,5Z"
+        [attr.transform]="getArrowTranslateAndRotate(45)"
         [attr.hidden]="isDirectionArrowHidden() ? '' : null"
       ></path>
       <path
         *ngIf="!isRoundTrip()"
         [class]="getEdgeLineArrowClass()"
-        d="M0,4L0,6L8,6L8,10L14,5L8,0L8,4Z"
-        [attr.transform]="getArrowTranslateAndRotate(130)"
+        d="M-4,-5L2,0L-4,5Z"
+        [attr.transform]="getArrowTranslateAndRotate(145)"
         [attr.hidden]="isDirectionArrowHidden() ? '' : null"
       ></path>
     </g>
@@ -229,15 +229,15 @@
           <path
             *ngIf="!isRoundTrip()"
             [class]="getEdgeLineArrowClass()"
-            d="M0,4L0,6L8,6L8,10L14,5L8,0L8,4Z"
-            [attr.transform]="getArrowTranslateAndRotate(35)"
+            d="M-4,-5L2,0L-4,5Z"
+            [attr.transform]="getArrowTranslateAndRotate(45)"
             [attr.hidden]="isDirectionArrowHidden() ? '' : null"
           ></path>
           <path
             *ngIf="!isRoundTrip()"
             [class]="getEdgeLineArrowClass()"
-            d="M0,4L0,6L8,6L8,10L14,5L8,0L8,4Z"
-            [attr.transform]="getArrowTranslateAndRotate(130)"
+            d="M-4,-5L2,0L-4,5Z"
+            [attr.transform]="getArrowTranslateAndRotate(145)"
             [attr.hidden]="isDirectionArrowHidden() ? '' : null"
           ></path>
         </g>
@@ -577,15 +577,15 @@
           <path
             *ngIf="!isRoundTrip()"
             [class]="getEdgeLineArrowClass()"
-            d="M0,4L0,6L8,6L8,10L14,5L8,0L8,4Z"
-            [attr.transform]="getArrowTranslateAndRotate(35)"
+            d="M-4,-5L2,0L-4,5Z"
+            [attr.transform]="getArrowTranslateAndRotate(45)"
             [attr.hidden]="isDirectionArrowHidden() ? '' : null"
           ></path>
           <path
             *ngIf="!isRoundTrip()"
             [class]="getEdgeLineArrowClass()"
-            d="M0,4L0,6L8,6L8,10L14,5L8,0L8,4Z"
-            [attr.transform]="getArrowTranslateAndRotate(130)"
+            d="M-4,-5L2,0L-4,5Z"
+            [attr.transform]="getArrowTranslateAndRotate(145)"
             [attr.hidden]="isDirectionArrowHidden() ? '' : null"
           ></path>
         </g>

--- a/src/app/perlenkette/perlenkette-section/perlenkette-section.component.ts
+++ b/src/app/perlenkette/perlenkette-section/perlenkette-section.component.ts
@@ -189,9 +189,9 @@ export class PerlenketteSectionComponent implements OnInit, AfterContentInit, On
 
   getArrowTranslateAndRotate(y: number) {
     if (this.isRightSideDisplayed() && !this.isLeftSideDisplayed()) {
-      return `translate(142, ${y}) rotate(90)`;
+      return `translate(137, ${y}) rotate(90)`;
     } else if (!this.isRightSideDisplayed() && this.isLeftSideDisplayed()) {
-      return `translate(132, ${y + 15}) rotate(-90)`;
+      return `translate(137, ${y + 15}) rotate(-90)`;
     }
     return "";
   }

--- a/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
@@ -1057,7 +1057,7 @@ export class TrainrunSectionsView {
       groupLinesEnter
         .append(StaticDomTags.EDGE_LINE_ARROW_SVG)
         .attr("d", (d: TrainrunSectionViewObject) => {
-          return d.trainrunSection.getTrainrun().isRoundTrip() ? "" : "M-5,-7L3,0L-5,7Z";
+          return d.trainrunSection.getTrainrun().isRoundTrip() ? "" : "M-4,-5L2,0L-4,5Z";
         })
         .attr("transform", (d: TrainrunSectionViewObject) =>
           this.translateAndRotateArrow(d.trainrunSection, arrowType),


### PR DESCRIPTION
# Description

Makes direction arrow smaller

Before:
<img width="1700" height="865" alt="image" src="https://github.com/user-attachments/assets/3ec81999-9cfc-4907-ae2a-d8b868875f60" />

After:
<img width="1655" height="754" alt="image" src="https://github.com/user-attachments/assets/6a9a34a3-20c0-402b-8582-431c42662ffa" />

# Issues

The arrows were too big and overwelming in a big scenario

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

- [x] This PR contains a description of the changes I'm making
- [x] I've read the [Contribution Guidelines](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/CONTRIBUTING.md)
- [x] CI is currently green and this is ready for review

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation.
-->
