### PR TITLE
Improve rendering performance by switching SVG rendering of O/D matrix to Canvas

### DIFF
--- a/src/app/services/analytics/origin-destination/components/origin-destination.component.html
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.component.html
@@ -1,7 +1,25 @@
 <div class="matrix-wrapper">
+  <button
+    type="button"
+    class="ODLeftPanelButton ODResetButton"
+    [title]="'app.origin-destination.buttons.reset' | translate"
+    (click)="onResetButton()"
+  >
+    <sbb-icon svgIcon="kom:arrow-circle-reset-small"></sbb-icon>
+  </button>
+
+  <button
+    type="button"
+    [class]="'ODLeftPanelButton ODCrossHighlightingButton ' + getCrossHighlightingTag()"
+    [title]="'app.origin-destination.buttons.crossHighlighting' | translate"
+    (click)="toggleCrossHighlighting()"
+  >
+    <sbb-icon svgIcon="highlighter-small"></sbb-icon>
+  </button>
+
   <div id="main-origin-destination-container-root"></div>
 
-  <div class="palette-buttons">
+  <div class="palette-buttons" style="transform: translateX(-64px)">
     <div
       class="palette-option red"
       [class.active]="colorSetName === 'red'"
@@ -28,48 +46,75 @@
     ></div>
 
     <div class="color-by-selector">
-      <label>
-        <input
-          type="radio"
-          name="colorBy"
+      <sbb-radio-group
+        class="sbb-checkbox-group-horizontal"
+        [(ngModel)]="colorBy"
+        style="display: flex; flex-direction: row; gap: 0.5rem; transform: translate(-18px, 92px)"
+      >
+        <sbb-radio-button
+          class="ODRadioButton"
           value="totalCost"
-          [checked]="colorBy === 'totalCost'"
           (change)="onChangeColorBy('totalCost')"
-        />
-        {{ "app.origin-destination.color-by-selector.total-cost" | translate }}
-      </label>
-      <label>
-        <input
-          type="radio"
-          name="colorBy"
+        >
+          {{ "app.origin-destination.color-by-selector.total-cost" | translate }}
+        </sbb-radio-button>
+
+        <sbb-radio-button
+          class="ODRadioButton"
           value="travelTime"
-          [checked]="colorBy === 'travelTime'"
           (change)="onChangeColorBy('travelTime')"
-        />
-        {{ "app.origin-destination.color-by-selector.travel-time" | translate }}
-      </label>
-      <label>
-        <input
-          type="radio"
-          name="colorBy"
+        >
+          {{ "app.origin-destination.color-by-selector.travel-time" | translate }}
+        </sbb-radio-button>
+
+        <sbb-radio-button
+          class="ODRadioButton"
           value="transfers"
-          [checked]="colorBy === 'transfers'"
           (change)="onChangeColorBy('transfers')"
-        />
-        {{ "app.origin-destination.color-by-selector.transfers" | translate }}
-      </label>
+        >
+          {{ "app.origin-destination.color-by-selector.transfers" | translate }}
+        </sbb-radio-button>
+      </sbb-radio-group>
     </div>
   </div>
 
-  <sbb-radio-group class="sbb-checkbox-group-horizontal" [(ngModel)]="displayBy">
-    <sbb-radio-button value="totalCost" (change)="onChangeDisplayBy('totalCost')">
-      {{ "app.origin-destination.display-by-selector.total-cost" | translate }}
-    </sbb-radio-button>
-    <sbb-radio-button value="travelTime" (change)="onChangeDisplayBy('travelTime')">
-      {{ "app.origin-destination.display-by-selector.travel-time" | translate }}
-    </sbb-radio-button>
-    <sbb-radio-button value="transfers" (change)="onChangeDisplayBy('transfers')">
-      {{ "app.origin-destination.display-by-selector.transfers" | translate }}
-    </sbb-radio-button>
-  </sbb-radio-group>
+  <div
+    class="noprint"
+    style="
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      width: 100%;
+      height: 57px;
+      flex-wrap: nowrap;
+    "
+  >
+    <sbb-radio-group
+      class="sbb-checkbox-group-horizontal"
+      [(ngModel)]="displayBy"
+      style="display: flex; flex-direction: row; gap: 0.5rem; transform: translateX(-16px)"
+    >
+      <sbb-radio-button
+        class="ODRadioButton"
+        value="totalCost"
+        (change)="onChangeDisplayBy('totalCost')"
+      >
+        {{ "app.origin-destination.display-by-selector.total-cost" | translate }}
+      </sbb-radio-button>
+      <sbb-radio-button
+        class="ODRadioButton"
+        value="travelTime"
+        (change)="onChangeDisplayBy('travelTime')"
+      >
+        {{ "app.origin-destination.display-by-selector.travel-time" | translate }}
+      </sbb-radio-button>
+      <sbb-radio-button
+        class="ODRadioButton"
+        value="transfers"
+        (change)="onChangeDisplayBy('transfers')"
+      >
+        {{ "app.origin-destination.display-by-selector.transfers" | translate }}
+      </sbb-radio-button>
+    </sbb-radio-group>
+  </div>
 </div>

--- a/src/app/services/analytics/origin-destination/components/origin-destination.component.html
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.component.html
@@ -17,7 +17,9 @@
     <sbb-icon svgIcon="highlighter-small"></sbb-icon>
   </button>
 
-  <div id="main-origin-destination-container-root"></div>
+  <div id="main-origin-destination-container-root">
+    <div id="tooltip" class="tooltip"></div>
+  </div>
 
   <div class="palette-buttons">
     <div

--- a/src/app/services/analytics/origin-destination/components/origin-destination.component.html
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.component.html
@@ -19,7 +19,7 @@
 
   <div id="main-origin-destination-container-root"></div>
 
-  <div class="palette-buttons" style="transform: translateX(-64px)">
+  <div class="palette-buttons">
     <div
       class="palette-option red"
       [class.active]="colorSetName === 'red'"
@@ -46,7 +46,7 @@
     ></div>
 
     <div class="color-by-selector">
-      <sbb-radio-group class="sbb-checkbox-group-horizontal" [(ngModel)]="colorBy">
+      <sbb-radio-group class="sbb-checkbox-group-vertikal" [(ngModel)]="colorBy">
         <sbb-radio-button
           class="ODRadioButton"
           value="totalCost"
@@ -74,22 +74,8 @@
     </div>
   </div>
 
-  <div
-    class="noprint"
-    style="
-      display: flex;
-      align-items: center;
-      gap: 1rem;
-      width: 100%;
-      height: 57px;
-      flex-wrap: nowrap;
-    "
-  >
-    <sbb-radio-group
-      class="sbb-checkbox-group-horizontal"
-      [(ngModel)]="displayBy"
-      style="display: flex; flex-direction: row; gap: 0.5rem; transform: translateX(-16px)"
-    >
+  <div class="ValueButtons noprint">
+    <sbb-radio-group class="sbb-checkbox-group-horizontal" [(ngModel)]="displayBy">
       <sbb-radio-button
         class="ODRadioButton"
         value="totalCost"

--- a/src/app/services/analytics/origin-destination/components/origin-destination.component.html
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.component.html
@@ -46,11 +46,7 @@
     ></div>
 
     <div class="color-by-selector">
-      <sbb-radio-group
-        class="sbb-checkbox-group-horizontal"
-        [(ngModel)]="colorBy"
-        style="display: flex; flex-direction: row; gap: 0.5rem; transform: translate(-18px, 92px)"
-      >
+      <sbb-radio-group class="sbb-checkbox-group-horizontal" [(ngModel)]="colorBy">
         <sbb-radio-button
           class="ODRadioButton"
           value="totalCost"

--- a/src/app/services/analytics/origin-destination/components/origin-destination.component.scss
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.component.scss
@@ -1,15 +1,21 @@
+@import "./../../../../view/rastering/definitions";
+
 .matrix-wrapper {
   position: relative;
   width: 100%;
-  height: 100%;
+  height: 98%;
+  margin: 8px 0px 0px 64px;
 
   #main-origin-destination-container-root {
     display: flex;
     justify-content: center;
     align-items: center;
-    width: calc(100% - 188px);
-    height: calc(100% - 74px);
+    width: calc(100% - 240px);
+    height: calc(100% - 61px);
     box-sizing: border-box;
+    overflow: hidden;
+    border: var(--COLOR_Default) solid 1px;
+    background: var(--NODE_DOCKABLE);
   }
 
   ::ng-deep svg.main-origin-destination-container {
@@ -31,6 +37,7 @@
     line-height: 1.5;
     text-align: left;
     text-align: start;
+    background: var(--NODE_DOCKABLE);
   }
   .palette-buttons {
     position: absolute;
@@ -81,10 +88,9 @@
   .color-by-selector {
     position: absolute;
     top: 24px;
-    right: 0px;
     padding: 12px 0px;
     border-radius: 2px;
-    font-size: calc(var(--sbb-font-size) * 0.8);
+    font-size: var(--sbb-font-size);
     display: flex;
     flex-direction: column;
     gap: 1px;
@@ -103,10 +109,73 @@
 
   .sbb-checkbox-group-horizontal {
     position: absolute;
-    bottom: 44px;
+    bottom: 14px;
     left: 12px;
     padding: 8px 8px;
     border-radius: 4px;
     column-gap: 8px;
   }
+}
+
+button.ODLeftPanelButton {
+  min-width: 30px;
+  max-width: 30px;
+  min-height: 28px;
+  max-height: 28px;
+  background: var(--COLOR_BACKGROUND);
+  border: none;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0;
+  margin: 0;
+  color: var(--NODE_TEXT_FOCUS);
+  transform: translate(-35px, -4px) scale(1);
+  position: absolute;
+}
+
+button.ODLeftPanelButton:hover {
+  background: var(--COLOR_BACKGROUND);
+  font-weight: bold;
+  transform: translate(-35px, -4px) scale(1);
+}
+
+button.ODLeftPanelButton:active {
+  background: var(--COLOR_BACKGROUND);
+}
+
+button.ODResetButton {
+  transform: translate(-45px, 2px) scale(1);
+}
+
+button.ODResetButton:hover {
+  transform: translate(-45px, 2px) scale(1.25);
+}
+
+button.ODResetButton:active {
+  background-color: $COLOR_MUTED_SILVER;
+}
+
+button.ODCrossHighlightingButton {
+  transform: translate(-45px, 48px) scale(1);
+}
+
+button.ODCrossHighlightingButton:hover {
+  transform: translate(-45px, 48px) scale(1.25);
+}
+
+button.ODCrossHighlightingButton:active {
+  background-color: $COLOR_MUTED_SILVER;
+}
+
+button.ODCrossHighlightingButton.isCrossHighlighting {
+  color: #eb0000;
+}
+
+.ODRadioButton:hover {
+  font-weight: bold;
+}
+
+.sbb-selection-checked {
+  font-weight: bold !important;
 }

--- a/src/app/services/analytics/origin-destination/components/origin-destination.component.scss
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.component.scss
@@ -18,15 +18,6 @@
     background: var(--NODE_DOCKABLE);
   }
 
-  ::ng-deep svg.main-origin-destination-container {
-    transform: translateX(16px);
-    display: block;
-    max-width: 100%;
-    height: calc(100% - 10px);
-    background: var(--NODE_DOCKABLE);
-    border: solid 1px var(--COLOR_Default);
-  }
-
   ::ng-deep .tooltip {
     position: absolute;
     z-index: 1070;
@@ -35,10 +26,10 @@
     font-style: normal;
     font-weight: 400;
     line-height: 1.5;
-    text-align: left;
     text-align: start;
     background: var(--NODE_DOCKABLE);
   }
+
   .palette-buttons {
     position: absolute;
     top: 16px;
@@ -85,6 +76,7 @@
       background: #c60018;
     }
   }
+
   .color-by-selector {
     position: absolute;
     top: 24px;

--- a/src/app/services/analytics/origin-destination/components/origin-destination.component.scss
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.component.scss
@@ -28,6 +28,12 @@
     line-height: 1.5;
     text-align: start;
     background: var(--NODE_DOCKABLE);
+    opacity: 0;
+    border: solid 1px;
+    border-radius: 4px;
+    padding: 6px;
+    user-select: none;
+    pointer-events: none;
   }
 
   .palette-buttons {
@@ -170,4 +176,11 @@ button.ODCrossHighlightingButton.isCrossHighlighting {
 
 .sbb-selection-checked {
   font-weight: bold !important;
+}
+
+.sbb-checkbox-group-horizontal {
+  display: flex;
+  flex-direction: row;
+  gap: 0.5rem;
+  transform: translate(-18px, 110px);
 }

--- a/src/app/services/analytics/origin-destination/components/origin-destination.component.scss
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.component.scss
@@ -43,6 +43,7 @@
     display: flex;
     gap: 10px;
     z-index: 10;
+    transform: translateX(-64px);
 
     .palette-option {
       width: 24px;
@@ -92,6 +93,7 @@
     display: flex;
     flex-direction: column;
     gap: 1px;
+    transform: translateY(8px);
 
     label {
       display: flex;
@@ -103,15 +105,6 @@
     input[type="radio"] {
       cursor: pointer;
     }
-  }
-
-  .sbb-checkbox-group-horizontal {
-    position: absolute;
-    bottom: 14px;
-    left: 12px;
-    padding: 8px 8px;
-    border-radius: 4px;
-    column-gap: 8px;
   }
 }
 
@@ -182,5 +175,24 @@ button.ODCrossHighlightingButton.isCrossHighlighting {
   display: flex;
   flex-direction: row;
   gap: 0.5rem;
-  transform: translate(-18px, 110px);
+  position: absolute;
+  bottom: 14px;
+  left: 12px;
+  padding: 8px 8px;
+  border-radius: 4px;
+  column-gap: 8px;
+  transform: translateX(-16px);
+}
+
+.ValueButtons {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  width: 100%;
+  height: 57px;
+  flex-wrap: nowrap;
+}
+
+.main-origin-destination-container {
+  position: relative;
 }

--- a/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
@@ -15,15 +15,6 @@ import {NodeService} from "../../../data/node.service";
 type FieldName = "totalCost" | "travelTime" | "transfers";
 type ColorSetName = "red" | "blue" | "orange" | "gray";
 
-/**
- * OriginDestinationComponent
- *
- * - Refactored into small, focused methods.
- * - Improved naming and consistent typing.
- * - Tooltip and highlight use offsetParent coordinates for correct positioning.
- * - Data is loaded only once during initialization.
- * - Initial render is executed exactly once at the end of ngOnInit.
- */
 @Component({
   selector: "sbb-origin-destination",
   templateUrl: "./origin-destination.component.html",

--- a/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
@@ -149,16 +149,7 @@ export class OriginDestinationComponent implements OnInit, OnDestroy {
   }
 
   private createTooltipIfNeeded(): void {
-    const root = d3.select("#main-origin-destination-container-root");
-    if (root.empty()) return;
-
-    const existing = root.select(".tooltip");
-    if (!existing.empty()) {
-      this.tooltip = existing as any;
-      return;
-    }
-
-    this.tooltip = root.append("div");
+    this.tooltip = d3.select("#tooltip");
   }
 
   private createHighlightIfNeeded(): void {

--- a/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
@@ -162,16 +162,7 @@ export class OriginDestinationComponent implements OnInit, OnDestroy {
       return;
     }
 
-    this.tooltip = root
-      .append("div")
-      .attr("class", "tooltip")
-      .style("opacity", 0)
-      .style("position", "absolute")
-      .style("border", "solid 1px")
-      .style("border-radius", "4px")
-      .style("padding", "6px")
-      .style("user-select", "none")
-      .style("pointer-events", "none");
+    this.tooltip = root.append("div");
   }
 
   private createHighlightIfNeeded(): void {

--- a/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
@@ -113,10 +113,15 @@ export class OriginDestinationComponent implements OnInit, OnDestroy {
     }
 
     for (const nodeId of Array.from(idSet)) {
+      // Ensures only missing diagonal elements are added
       const exists = this.matrixData.some(
         (d) => d.originId === nodeId && d.destinationId === nodeId,
       );
       if (!exists) {
+        // only add the diagonal element if it not exists
+        // it helps prevent future issues—such as if the calculation of
+        // this.originDestinationService.originDestinationData()
+        // changes and diagonal elements end up being sent as well.
         const node = this.nodeService.getNodeFromId(nodeId);
         this.matrixData.push({
           origin: node.getBetriebspunktName(),

--- a/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
@@ -94,10 +94,6 @@ export class OriginDestinationComponent implements OnInit, OnDestroy {
     this.cleanupDom();
   }
 
-  // -------------------------
-  // Initialization helpers
-  // -------------------------
-
   private initViewbox(): void {
     this.controller = new SVGMouseController(
       "main-origin-destination-container-root",
@@ -210,7 +206,6 @@ export class OriginDestinationComponent implements OnInit, OnDestroy {
     const containerNode = root
       .append("div")
       .attr("id", "main-origin-destination-container")
-      .style("position", "relative")
       .node() as HTMLElement;
 
     // canvas element

--- a/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
@@ -200,7 +200,9 @@ export class OriginDestinationComponent implements OnInit, OnDestroy {
     this.offsetY = this.offsetYOrg;
 
     const width = Math.round(2 * this.offsetX + this.cellSize * Math.max(1, this.nodeNames.length));
-    const height = Math.round(2 * this.offsetY + this.cellSize * Math.max(1, this.nodeNames.length));
+    const height = Math.round(
+      2 * this.offsetY + this.cellSize * Math.max(1, this.nodeNames.length),
+    );
 
     // remove previous nodes
     d3.select("#main-origin-destination-canvas").remove();
@@ -264,12 +266,10 @@ export class OriginDestinationComponent implements OnInit, OnDestroy {
       });
 
     // filter changes should only redraw using existing data (data is loaded only once)
-    this.filterService.filter
-      .pipe(takeUntil(this.destroyed$))
-      .subscribe(() => {
-        if (!this.ctx || !this.canvas) return;
-        this.loadMatrixData();
-        this.drawCanvasMatrix();
+    this.filterService.filter.pipe(takeUntil(this.destroyed$)).subscribe(() => {
+      if (!this.ctx || !this.canvas) return;
+      this.loadMatrixData();
+      this.drawCanvasMatrix();
     });
   }
 

--- a/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
@@ -264,8 +264,12 @@ export class OriginDestinationComponent implements OnInit, OnDestroy {
       });
 
     // filter changes should only redraw using existing data (data is loaded only once)
-    this.filterService.filter.pipe(takeUntil(this.destroyed$)).subscribe(() => {
-      this.drawCanvasMatrix();
+    this.filterService.filter
+      .pipe(takeUntil(this.destroyed$))
+      .subscribe(() => {
+        if (!this.ctx || !this.canvas) return;
+        this.loadMatrixData();
+        this.drawCanvasMatrix();
     });
   }
 

--- a/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
@@ -261,7 +261,7 @@ export class OriginDestinationComponent implements OnInit, OnDestroy {
         this.drawCanvasMatrix();
       });
 
-    // filter changes should only redraw using existing data (data is loaded only once)
+    // filter changes should only reload and redraw
     this.filterService.filter.pipe(takeUntil(this.destroyed$)).subscribe(() => {
       if (!this.ctx || !this.canvas) return;
       this.loadMatrixData();

--- a/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
@@ -64,7 +64,7 @@ export class OriginDestinationComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     // create tooltip and highlight first so offsetParent is available
-    this.createTooltipIfNeeded();
+    this.getTooltipHtmlElementRef();
     this.createHighlightIfNeeded();
 
     // subscribe to observables (subscriptions do not reload data, only redraw)
@@ -148,7 +148,7 @@ export class OriginDestinationComponent implements OnInit, OnDestroy {
     }));
   }
 
-  private createTooltipIfNeeded(): void {
+  private getTooltipHtmlElementRef(): void {
     this.tooltip = d3.select("#tooltip");
   }
 

--- a/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
@@ -199,8 +199,8 @@ export class OriginDestinationComponent implements OnInit, OnDestroy {
     this.offsetX = this.offsetXOrg;
     this.offsetY = this.offsetYOrg;
 
-    const width = Math.round(this.offsetX + this.cellSize * Math.max(1, this.nodeNames.length));
-    const height = Math.round(this.offsetY + this.cellSize * Math.max(1, this.nodeNames.length));
+    const width = Math.round(2 * this.offsetX + this.cellSize * Math.max(1, this.nodeNames.length));
+    const height = Math.round(2 * this.offsetY + this.cellSize * Math.max(1, this.nodeNames.length));
 
     // remove previous nodes
     d3.select("#main-origin-destination-canvas").remove();
@@ -438,7 +438,7 @@ export class OriginDestinationComponent implements OnInit, OnDestroy {
       const x = this.offsetX + i * this.cellSize + this.cellSize / 2;
       this.ctx.save();
       this.ctx.translate(x, this.offsetY - 12);
-      this.ctx.rotate(-Math.PI / 2);
+      this.ctx.rotate(-Math.PI / 4);
       if (highlightIndex !== i) {
         const alpha = highlightIndex === undefined ? 1.0 : 0.75;
         this.ctx.fillStyle = `rgba(${colorRGB},${alpha})`;

--- a/src/app/services/analytics/origin-destination/components/origin-destination.service.ts
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.service.ts
@@ -15,6 +15,9 @@ export type OriginDestination = {
   // Names.
   origin: string;
   destination: string;
+  // Node ID
+  originId: number;
+  destinationId: number;
   // Travel time in minutes.
   travelTime: number | undefined;
   // Number of transfers.
@@ -101,6 +104,8 @@ export class OriginDestinationService {
           rows.push({
             origin: origin.getBetriebspunktName(),
             destination: destination.getBetriebspunktName(),
+            originId: origin.getId(),
+            destinationId: destination.getId(),
             found: false,
           });
           return;
@@ -109,6 +114,8 @@ export class OriginDestinationService {
         const row = {
           origin: origin.getBetriebspunktName(),
           destination: destination.getBetriebspunktName(),
+          originId: origin.getId(),
+          destinationId: destination.getId(),
           travelTime: totalCost - connections * connectionPenalty,
           transfers: connections,
           totalCost: totalCost,

--- a/src/app/services/ui/ui.interaction.service.ts
+++ b/src/app/services/ui/ui.interaction.service.ts
@@ -88,6 +88,9 @@ export class UiInteractionService implements OnDestroy {
   zoomFactorSubject = new Subject<number>();
   readonly zoomFactorObservable = this.zoomFactorSubject.asObservable();
 
+  themeChanged = new Subject<ThemeBase>();
+  readonly themeChangedObservable = this.themeChanged.asObservable();
+
   setEditorModeSubject = new Subject<number>();
   readonly setEditorModeObservable = this.setEditorModeSubject.asObservable();
 
@@ -432,6 +435,7 @@ export class UiInteractionService implements OnDestroy {
       this.saveUserSettingToLocalStorage();
     }
     this.updateLightDark();
+    this.themeChanged.next(this.activeTheme);
   }
 
   updateLightDark() {

--- a/src/app/view/editor-filter-view/filterable-label-filter/filterable-label-filter.component.ts
+++ b/src/app/view/editor-filter-view/filterable-label-filter/filterable-label-filter.component.ts
@@ -41,8 +41,6 @@ export class FilterableLabelFilterComponent implements OnInit, OnDestroy {
         this.translateComponentLabelRef(),
       );
     });
-
-    this.filterService.filterChanged();
   }
 
   ngOnDestroy(): void {

--- a/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
+++ b/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
@@ -499,7 +499,7 @@ export class EditorToolsViewComponent {
       // canvas Data-URL (PNG)
       const dataUrl = canvas.toDataURL("image/png");
 
-      // Erzeuge SVG string mit eingebettetem Bild
+      // create SVG string where to embed the image
       const svg = `<svg id="main-origin-destination-canvas" xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
         <image href="${dataUrl}" x="0" y="0" width="${width}" height="${height}" preserveAspectRatio="none"/>
         </svg>`;

--- a/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
+++ b/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
@@ -197,7 +197,7 @@ export class EditorToolsViewComponent {
   handleOriginDestinationCanvasToPNG() {
     this.levelOfDetailService.disableLevelOfDetailRendering();
     this.viewportCullService.onViewportChangeUpdateRendering(false);
-    this.exportOriginDestinationCanvasToPNG(this.getFilenameToExport() + ".svg");
+    this.exportOriginDestinationCanvasToPNG(this.getFilenameToExport() + ".png");
     this.levelOfDetailService.enableLevelOfDetailRendering();
   }
 

--- a/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
+++ b/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
@@ -462,6 +462,7 @@ export class EditorToolsViewComponent {
     document.body.appendChild(a);
     a.click();
     a.remove();
+    setTimeout(() => URL.revokeObjectURL(url), 2000);
   }
 
   private exportOriginDestinationCanvasToSVG(filename: string) {

--- a/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
+++ b/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
@@ -127,27 +127,34 @@ export class EditorToolsViewComponent {
   }
 
   onExportContainerAsSVG() {
+    const editorMode = this.uiInteractionService.getEditorMode();
+    switch (editorMode) {
+      case EditorMode.NetzgrafikEditing:
+        this.handleExportContainerAsSVG(this.getNetzgrafikEditingContainerToExport());
+        return;
+      case EditorMode.StreckengrafikEditing:
+        this.handleExportContainerAsSVG(this.getStreckengrafikEditingContainerToExport());
+        return;
+      case EditorMode.OriginDestination:
+        this.handleOriginDestinationCanvasToSVG();
+        return;
+      default:
+        this.handleExportContainerAsSVG(this.getNetzgrafikEditingContainerToExport());
+    }
+  }
+
+  handleOriginDestinationCanvasToSVG() {
+    this.levelOfDetailService.disableLevelOfDetailRendering();
+    this.viewportCullService.onViewportChangeUpdateRendering(false);
+    this.exportOriginDestinationCanvasToSVG(this.getFilenameToExport() + ".svg");
+    this.levelOfDetailService.enableLevelOfDetailRendering();
+  }
+
+  handleExportContainerAsSVG(containerInfo: ContainertoExportData) {
     // option 2: save svg as svg
     // https://www.npmjs.com/package/save-svg-as-png
     this.levelOfDetailService.disableLevelOfDetailRendering();
     this.viewportCullService.onViewportChangeUpdateRendering(false);
-
-    const editorMode = this.uiInteractionService.getEditorMode();
-    let containerInfo = undefined;
-    switch (editorMode) {
-      case EditorMode.NetzgrafikEditing:
-        containerInfo = this.getNetzgrafikEditingContainerToExport();
-        break;
-      case EditorMode.StreckengrafikEditing:
-        containerInfo = this.getStreckengrafikEditingContainerToExport();
-        break;
-      case EditorMode.OriginDestination:
-        this.exportOriginDestinationCanvasToSVG(this.getFilenameToExport() + ".svg");
-        this.levelOfDetailService.enableLevelOfDetailRendering();
-        return;
-      default:
-        containerInfo = this.getNetzgrafikEditingContainerToExport();
-    }
 
     // Handle all other cases (svg)
     this.prepareStyleForExport(containerInfo);
@@ -170,27 +177,35 @@ export class EditorToolsViewComponent {
   }
 
   onExportContainerAsPNG() {
-    // option 1: save svg as png
-    // https://www.npmjs.com/package/save-svg-as-png
-    this.levelOfDetailService.disableLevelOfDetailRendering();
-    this.viewportCullService.onViewportChangeUpdateRendering(false);
-
     const editorMode = this.uiInteractionService.getEditorMode();
     let containerInfo = undefined;
     switch (editorMode) {
       case EditorMode.NetzgrafikEditing:
-        containerInfo = this.getNetzgrafikEditingContainerToExport();
-        break;
+        this.handleExportContainerAsPNG(this.getNetzgrafikEditingContainerToExport());
+        return;
       case EditorMode.StreckengrafikEditing:
-        containerInfo = this.getStreckengrafikEditingContainerToExport();
-        break;
+        this.handleExportContainerAsPNG(this.getStreckengrafikEditingContainerToExport());
+        return;
       case EditorMode.OriginDestination:
-        this.exportOriginDestinationCanvasToPNG(this.getFilenameToExport() + ".svg");
-        this.levelOfDetailService.enableLevelOfDetailRendering();
+        this.handleOriginDestinationCanvasToPNG();
         return;
       default:
-        containerInfo = this.getNetzgrafikEditingContainerToExport();
+        this.handleExportContainerAsPNG(this.getNetzgrafikEditingContainerToExport());
     }
+  }
+
+  handleOriginDestinationCanvasToPNG() {
+    this.levelOfDetailService.disableLevelOfDetailRendering();
+    this.viewportCullService.onViewportChangeUpdateRendering(false);
+    this.exportOriginDestinationCanvasToPNG(this.getFilenameToExport() + ".svg");
+    this.levelOfDetailService.enableLevelOfDetailRendering();
+  }
+
+  handleExportContainerAsPNG(containerInfo: ContainertoExportData) {
+    // option 1: save svg as png
+    // https://www.npmjs.com/package/save-svg-as-png
+    this.levelOfDetailService.disableLevelOfDetailRendering();
+    this.viewportCullService.onViewportChangeUpdateRendering(false);
 
     // Handle all other cases (svg)
     this.prepareStyleForExport(containerInfo);

--- a/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
+++ b/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
@@ -445,13 +445,6 @@ export class EditorToolsViewComponent {
 
     if (!canvas) {
       console.error("Canvas nicht gefunden:", sel);
-    } else {
-      const ctx = canvas.getContext("2d");
-      console.log("Canvas found, size:", canvas.width, canvas.height, ctx);
-    }
-
-    if (canvas === null) {
-      return;
     }
 
     // quality only used for image/jpeg
@@ -459,10 +452,9 @@ export class EditorToolsViewComponent {
     const a = document.createElement("a");
     a.href = dataUrl;
     a.download = filename;
-    document.body.appendChild(a);
     a.click();
     a.remove();
-    setTimeout(() => URL.revokeObjectURL(url), 2000);
+    setTimeout(() => URL.revokeObjectURL(dataUrl), 2000);
   }
 
   private exportOriginDestinationCanvasToSVG(filename: string) {
@@ -471,14 +463,8 @@ export class EditorToolsViewComponent {
 
     if (!canvas) {
       console.error("Canvas nicht gefunden:", sel);
-    } else {
-      const ctx = canvas.getContext("2d");
-      console.log("Canvas found, size:", canvas.width, canvas.height, ctx);
     }
 
-    if (canvas === null) {
-      return;
-    }
     const buildSvgFromCanvas = (canvas) => {
       const width = canvas.width;
       const height = canvas.height;
@@ -509,7 +495,6 @@ export class EditorToolsViewComponent {
     const a = document.createElement("a");
     a.href = url;
     a.download = filename;
-    document.body.appendChild(a);
     a.click();
     a.remove();
     setTimeout(() => URL.revokeObjectURL(url), 2000);

--- a/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
+++ b/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
@@ -178,7 +178,6 @@ export class EditorToolsViewComponent {
 
   onExportContainerAsPNG() {
     const editorMode = this.uiInteractionService.getEditorMode();
-    let containerInfo = undefined;
     switch (editorMode) {
       case EditorMode.NetzgrafikEditing:
         this.handleExportContainerAsPNG(this.getNetzgrafikEditingContainerToExport());

--- a/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
+++ b/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
@@ -151,7 +151,6 @@ export class EditorToolsViewComponent {
   }
 
   handleExportContainerAsSVG(containerInfo: ContainertoExportData) {
-    // option 2: save svg as svg
     // https://www.npmjs.com/package/save-svg-as-png
     this.levelOfDetailService.disableLevelOfDetailRendering();
     this.viewportCullService.onViewportChangeUpdateRendering(false);
@@ -201,7 +200,6 @@ export class EditorToolsViewComponent {
   }
 
   handleExportContainerAsPNG(containerInfo: ContainertoExportData) {
-    // option 1: save svg as png
     // https://www.npmjs.com/package/save-svg-as-png
     this.levelOfDetailService.disableLevelOfDetailRendering();
     this.viewportCullService.onViewportChangeUpdateRendering(false);

--- a/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
+++ b/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
@@ -27,6 +27,7 @@ import {TrainrunSectionValidator} from "../../services/util/trainrunsection.vali
 import {OriginDestinationService} from "src/app/services/analytics/origin-destination/components/origin-destination.service";
 import {EditorMode} from "../editor-menu/editor-mode";
 import {NODE_TEXT_AREA_HEIGHT, RASTERING_BASIC_GRID_SIZE} from "../rastering/definitions";
+import * as d3 from "d3";
 
 interface ContainertoExportData {
   documentToExport: HTMLElement;
@@ -131,6 +132,15 @@ export class EditorToolsViewComponent {
     this.levelOfDetailService.disableLevelOfDetailRendering();
     this.viewportCullService.onViewportChangeUpdateRendering(false);
 
+    // Handle special case origin destination matrix (canvas)
+    const editorMode = this.uiInteractionService.getEditorMode();
+    if (editorMode === EditorMode.OriginDestination) {
+      this.exportOriginDestinationCanvasToSVG(this.getFilenameToExport() + ".svg");
+      this.levelOfDetailService.enableLevelOfDetailRendering();
+      return;
+    }
+
+    // Handle all other cases (svg)
     const containerInfo = this.getContainerToExport();
     this.prepareStyleForExport(containerInfo);
 
@@ -157,6 +167,15 @@ export class EditorToolsViewComponent {
     this.levelOfDetailService.disableLevelOfDetailRendering();
     this.viewportCullService.onViewportChangeUpdateRendering(false);
 
+    // Handle special case origin destination matrix (canvas)
+    const editorMode = this.uiInteractionService.getEditorMode();
+    if (editorMode === EditorMode.OriginDestination) {
+      this.exportOriginDestinationCanvasToPNG(this.getFilenameToExport() + ".png");
+      this.levelOfDetailService.enableLevelOfDetailRendering();
+      return;
+    }
+
+    // Handle all other cases (svg)
     const containerInfo = this.getContainerToExport();
     this.prepareStyleForExport(containerInfo);
 
@@ -420,41 +439,79 @@ export class EditorToolsViewComponent {
     };
   }
 
-  private getOriginDestinationContainerToExport(): ContainertoExportData {
-    const htmlElementToExport = document.getElementById("main-origin-destination-container");
-    if (htmlElementToExport === null) {
-      return undefined;
+  private exportOriginDestinationCanvasToPNG(filename: string) {
+    const sel = d3.select("#main-origin-destination-canvas");
+    const canvas = sel.node(); // <- real HTMLCanvasElement or null
+
+    if (!canvas) {
+      console.error("Canvas nicht gefunden:", sel);
+    } else {
+      const ctx = canvas.getContext("2d");
+      console.log("Canvas found, size:", canvas.width, canvas.height, ctx);
     }
-    const bbox = (htmlElementToExport as unknown as SVGGElement).getBBox();
-    const padding = 10;
-    const param = {
-      encoderOptions: 1.0,
-      scale: 1.0,
-      left: bbox.x - padding,
-      top: bbox.y - padding,
-      width: bbox.width + 2 * padding,
-      height: bbox.height + 2 * padding,
-      backgroundColor: this.uiInteractionService.getActiveTheme().backgroundColor,
+
+    if (canvas === null) {
+      return;
+    }
+
+    // quality only used for image/jpeg
+    const dataUrl = canvas.toDataURL("image/png");
+    const a = document.createElement("a");
+    a.href = dataUrl;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+  }
+
+  private exportOriginDestinationCanvasToSVG(filename: string) {
+    const sel = d3.select("#main-origin-destination-canvas");
+    const canvas = sel.node(); // <- real HTMLCanvasElement or null
+
+    if (!canvas) {
+      console.error("Canvas nicht gefunden:", sel);
+    } else {
+      const ctx = canvas.getContext("2d");
+      console.log("Canvas found, size:", canvas.width, canvas.height, ctx);
+    }
+
+    if (canvas === null) {
+      return;
+    }
+    const buildSvgFromCanvas = (canvas) => {
+      const width = canvas.width;
+      const height = canvas.height;
+      // canvas Data-URL (PNG)
+      const dataUrl = canvas.toDataURL("image/png");
+
+      // Erzeuge SVG string mit eingebettetem Bild
+      const svg = `<svg id="main-origin-destination-canvas" xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
+        <image href="${dataUrl}" x="0" y="0" width="${width}" height="${height}" preserveAspectRatio="none"/>
+        </svg>`;
+
+      return svg;
     };
 
-    const essentialProps = [
-      "fill",
-      "stroke",
-      "stroke-width",
-      "stroke-dasharray",
-      "font-family",
-      "font-size",
-      "font-weight",
-      "opacity",
-      "text-anchor",
-      "dominant-baseline",
-    ];
+    const svgString = buildSvgFromCanvas(canvas);
 
-    return {
-      documentToExport: htmlElementToExport,
-      exportParameter: param,
-      essentialProps: essentialProps,
-    };
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(svgString, "image/svg+xml");
+    const svgEl = doc.documentElement;
+
+    if (!svgEl.getAttribute("width")) svgEl.setAttribute("width", canvas.width);
+    if (!svgEl.getAttribute("height")) svgEl.setAttribute("height", canvas.height);
+
+    const blob = new Blob([new XMLSerializer().serializeToString(svgEl)], {
+      type: "image/svg+xml;charset=utf-8",
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    setTimeout(() => URL.revokeObjectURL(url), 2000);
   }
 
   private getNetzgrafikEditingContainerToExport(): ContainertoExportData {
@@ -520,7 +577,7 @@ export class EditorToolsViewComponent {
       case EditorMode.StreckengrafikEditing:
         return this.getStreckengrafikEditingContainerToExport();
       case EditorMode.OriginDestination:
-        return this.getOriginDestinationContainerToExport();
+        return undefined;
       default:
         return this.getNetzgrafikEditingContainerToExport();
     }

--- a/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
+++ b/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
@@ -132,16 +132,24 @@ export class EditorToolsViewComponent {
     this.levelOfDetailService.disableLevelOfDetailRendering();
     this.viewportCullService.onViewportChangeUpdateRendering(false);
 
-    // Handle special case origin destination matrix (canvas)
     const editorMode = this.uiInteractionService.getEditorMode();
-    if (editorMode === EditorMode.OriginDestination) {
-      this.exportOriginDestinationCanvasToSVG(this.getFilenameToExport() + ".svg");
-      this.levelOfDetailService.enableLevelOfDetailRendering();
-      return;
+    let containerInfo = undefined;
+    switch (editorMode) {
+      case EditorMode.NetzgrafikEditing:
+        containerInfo = this.getNetzgrafikEditingContainerToExport();
+        break;
+      case EditorMode.StreckengrafikEditing:
+        containerInfo = this.getStreckengrafikEditingContainerToExport();
+        break;
+      case EditorMode.OriginDestination:
+        this.exportOriginDestinationCanvasToSVG(this.getFilenameToExport() + ".svg");
+        this.levelOfDetailService.enableLevelOfDetailRendering();
+        return;
+      default:
+        containerInfo = this.getNetzgrafikEditingContainerToExport();
     }
 
     // Handle all other cases (svg)
-    const containerInfo = this.getContainerToExport();
     this.prepareStyleForExport(containerInfo);
 
     // SVG scaling does not affect resolution since SVGs are rendered as vector graphics.
@@ -167,16 +175,24 @@ export class EditorToolsViewComponent {
     this.levelOfDetailService.disableLevelOfDetailRendering();
     this.viewportCullService.onViewportChangeUpdateRendering(false);
 
-    // Handle special case origin destination matrix (canvas)
     const editorMode = this.uiInteractionService.getEditorMode();
-    if (editorMode === EditorMode.OriginDestination) {
-      this.exportOriginDestinationCanvasToPNG(this.getFilenameToExport() + ".png");
-      this.levelOfDetailService.enableLevelOfDetailRendering();
-      return;
+    let containerInfo = undefined;
+    switch (editorMode) {
+      case EditorMode.NetzgrafikEditing:
+        containerInfo = this.getNetzgrafikEditingContainerToExport();
+        break;
+      case EditorMode.StreckengrafikEditing:
+        containerInfo = this.getStreckengrafikEditingContainerToExport();
+        break;
+      case EditorMode.OriginDestination:
+        this.exportOriginDestinationCanvasToPNG(this.getFilenameToExport() + ".svg");
+        this.levelOfDetailService.enableLevelOfDetailRendering();
+        return;
+      default:
+        containerInfo = this.getNetzgrafikEditingContainerToExport();
     }
 
     // Handle all other cases (svg)
-    const containerInfo = this.getContainerToExport();
     this.prepareStyleForExport(containerInfo);
 
     svg.saveSvgAsPng(
@@ -444,7 +460,7 @@ export class EditorToolsViewComponent {
     const canvas = sel.node(); // <- real HTMLCanvasElement or null
 
     if (!canvas) {
-      console.error("Canvas nicht gefunden:", sel);
+      console.error("Canvas not found:", sel);
     }
 
     // quality only used for image/jpeg
@@ -462,7 +478,7 @@ export class EditorToolsViewComponent {
     const canvas = sel.node(); // <- real HTMLCanvasElement or null
 
     if (!canvas) {
-      console.error("Canvas nicht gefunden:", sel);
+      console.error("Canvas not found:", sel);
     }
 
     const buildSvgFromCanvas = (canvas) => {
@@ -555,18 +571,6 @@ export class EditorToolsViewComponent {
         .join(" ");
       el.setAttribute("style", inlineStyle);
     });
-  }
-
-  private getContainerToExport(): ContainertoExportData {
-    const editorMode = this.uiInteractionService.getEditorMode();
-    switch (editorMode) {
-      case EditorMode.StreckengrafikEditing:
-        return this.getStreckengrafikEditingContainerToExport();
-      case EditorMode.OriginDestination:
-        return undefined;
-      default:
-        return this.getNetzgrafikEditingContainerToExport();
-    }
   }
 
   private convertToZuglaufCSV(): string {

--- a/src/app/view/util/origin-destination-graph.ts
+++ b/src/app/view/util/origin-destination-graph.ts
@@ -256,7 +256,7 @@ const buildSectionEdgesFromIterator = (
     let tsId = ts.getId();
     const trainrunId = reverseIterator
       ? // Minus 1 so we don't conflate 0 with -0.
-      -ts.getTrainrunId() - 1
+        -ts.getTrainrunId() - 1
       : ts.getTrainrunId();
 
     const reverseSection = tsIterator.current().node.getId() !== ts.getTargetNodeId();

--- a/src/app/view/util/origin-destination-graph.ts
+++ b/src/app/view/util/origin-destination-graph.ts
@@ -256,7 +256,7 @@ const buildSectionEdgesFromIterator = (
     let tsId = ts.getId();
     const trainrunId = reverseIterator
       ? // Minus 1 so we don't conflate 0 with -0.
-        -ts.getTrainrunId() - 1
+      -ts.getTrainrunId() - 1
       : ts.getTrainrunId();
 
     const reverseSection = tsIterator.current().node.getId() !== ts.getTargetNodeId();

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -142,6 +142,10 @@
         "travel-time": "Reisezeit",
         "transfers": "Umstiege"
       },
+      "buttons": {
+        "reset": "Zurücksetzen",
+        "crossHighlighting": "Zeilen/Spalten hervorheben"
+      },
       "palette-buttons": {
         "red": "Rote Palette",
         "blue": "Blaue Palette",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -142,6 +142,10 @@
         "travel-time": "Travel time",
         "transfers": "Transfers"
       },
+      "buttons": {
+        "reset": "Reset",
+        "crossHighlighting": "Highlight rows/columns"
+      },
       "palette-buttons": {
         "red": "Red palette",
         "blue": "Blue palette",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -141,6 +141,10 @@
         "travel-time": "Temps de parcours",
         "transfers": "Changements"
       },
+      "buttons": {
+        "reset": "Réinitialiser",
+        "crossHighlighting": "Mettre en surbrillance les lignes/colonnes"
+      },
       "palette-buttons": {
         "red": "Palette rouge",
         "blue": "Palette bleue",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -141,6 +141,10 @@
         "travel-time": "Travel time",
         "transfers": "Transfers"
       },
+      "buttons": {
+        "reset": "Reset",
+        "crossHighlighting": "Highlight rows/columns"
+      },
       "palette-buttons": {
         "red": "Red palette",
         "blue": "Blue palette",


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->

# Description

Rendering of the origin/destination matrix was a major performance bottleneck. To address this, the SVG-based rendering of the O/D matrix has been replaced with a Canvas-based implementation.

<img width="1916" height="1010" alt="image" src="https://github.com/user-attachments/assets/4b171671-8f60-4794-91a7-09d49a952fe3" />
Final Version.

## To discuss - but it looks very promising 
Please compare the rendering outcome: Pixel graphics (new) vs Vector graphics (old). If we like to have high quality support (vector graphic / svg) we might have to implement an automatic switch from (old) to new if the matrix gets to big. 

**I strongly recommend using canvas** -> just using this canvas based rendering for such matrix based rendering otherwise we will run into big issue with the performance. I am aware that it's not so cool having pixel graphics but is looks quite good. And as well it make againt the interactive tool more complex du of having svg ( d3.js) and canvas in one product. But for interactive real - time application the life is hard:)


## What changed
- Replaced SVG rendering of the O/D matrix with a Canvas renderer.
- Result: rendering is now fast and responsive, especially for large matrices.

## Known issues / TODOs

- [x] Export to PNG/SVG currently does not work. Export functionality needs to be restored for the new Canvas renderer. <img width="765" height="87" alt="image" src="https://github.com/user-attachments/assets/baa556b9-158d-499e-93b4-ec4b07c79392" />  Issue fixed - png can directly exported - svg must be simulated with an image layer but it works.

- [x] Small visual issue: some "button" elements render without a background. It appears the rendering area for those elements is too large, causing their backgrounds not to be drawn correctly. 

| Before |  After |
| --- | --- | 
|  <img width="956" height="505" alt="image" src="https://github.com/user-attachments/assets/39215fc9-e175-4e9b-ab88-e14d5b740c1f" /> |   <img width="956" height="505" alt="image" src="https://github.com/user-attachments/assets/932d6d90-9d48-4d7f-95e0-f3cf9eed9b14" /> |

<!-- Describe the changes your PR introduces here. -->
 

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

- [x] This PR contains a description of the changes I'm making
- [x] I've read the [Contribution Guidelines](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/CONTRIBUTING.md)
- [ ] I've added tests for changes or features I've introduced
- [ ] I documented any high-level concepts I'm introducing in `documentation/`
- [x] CI is currently green and this is ready for review

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation.
-->

## Fixed known issue 
Issue with ambiguous node names fixed:

| test json (case 1)  |  test json (case 2) | 
| --- | --- | 
| [netzgrafik (1).json](https://github.com/user-attachments/files/23054975/netzgrafik.1.json) | [netzgrafik (2).json](https://github.com/user-attachments/files/23061875/netzgrafik.2.json) |
| <img width="217" height="102" alt="image" src="https://github.com/user-attachments/assets/ab10f032-964a-44e4-a832-842c4207d2df" /> | <img width="200" height="100" alt="image" src="https://github.com/user-attachments/assets/9a14eebb-84c6-4298-bcdf-111f34e6e3fc" /> |
| <img width="131" height="146" alt="image" src="https://github.com/user-attachments/assets/6e1d72bf-5735-4756-a87c-98b095fd2d34" /> | <img width="100" height="100" alt="image" src="https://github.com/user-attachments/assets/e6fced32-b563-4f50-b63a-44180f143fbf" /> |



# Final result
[chrome-capture-2025-10-22.webm](https://github.com/user-attachments/assets/6afb5fd7-0f16-4029-aafb-495c1defa61d)
