### PR TITLE
Fix: One way train run arrows are drawn outside of lines when moving node

### DIFF
--- a/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
@@ -1058,7 +1058,6 @@ export class TrainrunSectionsView {
         .filter((d: TrainrunSectionViewObject) => !d.trainrunSection.getTrainrun().isRoundTrip())
         .append(StaticDomTags.EDGE_LINE_ARROW_SVG)
         .attr("d", "M-4,-5L2,0L-4,5Z")
-        })
         .attr("transform", (d: TrainrunSectionViewObject) =>
           this.translateAndRotateArrow(d.trainrunSection, arrowType),
         )


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->

# Description

I made two changes. **The 1st one fixes the issue,** the second one is a very small change but has an impact to the rendering overall performance. It's shows how we can enable/disable objects for rendering based on a switch .... 

- When dragging a node, the train route section is displayed very abstractly—just as a line. As soon as the node is dragged (finished drag), the full detail rendering is  (re-)applied. This ensures high drag performance and prevents elements that have not yet been fully updated (recalculated) from being displayed incorrectly. This means that not everything always needs to be fully updated when dragging, which further improves performance.

- Add filter to groupLinesEnter: render arrows only for non-round trips

<!-- Describe the changes your PR introduces here. -->

# Issues

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

- [x] This PR contains a description of the changes I'm making
- [x] I've read the [Contribution Guidelines](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/CONTRIBUTING.md)
- [ ] I've added tests for changes or features I've introduced
- [ ] I documented any high-level concepts I'm introducing in `documentation/`
- [x] CI is currently green and this is ready for review

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation.
-->
