### PR TITLE
Fix: Graphical Timetable (Streckengrafik) – Section Track Estimator Not Working for Train with direction changes

### DIFF
--- a/src/app/streckengrafik/services/sg-6-track.service.ts
+++ b/src/app/streckengrafik/services/sg-6-track.service.ts
@@ -128,31 +128,12 @@ export class Sg6TrackService implements OnDestroy {
   private getSectionKey(ps: SgTrainrunSection, separateForwardBackwardTracks: boolean) {
     let node1 = ps.arrivalPathNode === undefined ? undefined : ps.arrivalPathNode.nodeId;
     let node2 = ps.departurePathNode === undefined ? undefined : ps.departurePathNode.nodeId;
-    let key1 =
-      (ps.arrivalPathNode === undefined
-        ? "undefined_" + separateForwardBackwardTracks
-        : ps.arrivalPathNode.nodeShortName) +
-      "_" +
-      node1 +
-      "_" +
-      ps.index;
-    let key2 =
-      (ps.departurePathNode === undefined
-        ? "undefined_" + separateForwardBackwardTracks
-        : ps.departurePathNode.nodeShortName) +
-      "_" +
-      node2 +
-      "_" +
-      ps.index;
     if (node1 > node2) {
       const tmp = node1;
       node1 = node2;
       node2 = tmp;
-      const keyTmp = key1;
-      key1 = key2;
-      key2 = keyTmp;
     }
-    const sectionKey = key1 + "#" + key2;
+    const sectionKey = "@" + ps.index;
     return {key: sectionKey, node1: node1, node2: node2};
   }
 


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->

# Description

This PR fixes missing track estimations in the graphical timetable for train run GX (A-B-C-D-E-D-C-F). The minimum number of tracks is now correctly displayed for sections C→D, D→E, E→D, and D→C. The issue occurred in all template paths involving trains arriving at and departing from terminal stations (Sackbahnhöfe).

# Issues

[<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.
-->](https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/issues/567)

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

- [x] This PR contains a description of the changes I'm making
- [x] I've read the [Contribution Guidelines](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/CONTRIBUTING.md)
- [ ] I've added tests for changes or features I've introduced
- [ ] I documented any high-level concepts I'm introducing in `documentation/`
- [x] CI is currently green and this is ready for review

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation.
-->
