### PR TITLE
issue-template: add a new template for feature refinement

### DIFF
--- a/.github/ISSUE_TEMPLATE/3-refinement.md
+++ b/.github/ISSUE_TEMPLATE/3-refinement.md
@@ -1,0 +1,45 @@
+---
+name: Feature Ticket (refinement)
+about: Refinement about a future feature
+title: ""
+labels: ""
+assignees: ""
+---
+
+# Description
+
+<!-- Please give a brief description of the feature -->
+
+# Mock-ups
+
+<!-- Give a link to the mock-up or some screenshots -->
+
+# Acceptance Criteria
+
+<!-- A clear and exhaustive list of criteria / details that must be fulfilled -->
+
+- [ ] Criteria 1
+- [ ] Criteria 2
+- [ ] ...
+
+# Implementation Plan
+
+<!-- A clear and exhaustive list of steps to achieve this feature -->
+
+- Step 1
+- Step 2
+- ...
+
+# Tests
+
+# Definition of Ready
+
+- **PO/UX-UI**
+  - [ ] Mock-ups are complete and validated
+  - [ ] ACs are clear and have been reviewed by another refiner
+
+- **Technical**
+  - [ ] Implementation plan has been written and validated by another maintainer
+
+- **General**
+  - [ ] Validated by Adrian


### PR DESCRIPTION
# Description

Trying a new format for refining new features. Not sure this is the way it should be done

# Issues

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

- [ ] This PR contains a description of the changes I'm making
- [ ] I've read the [Contribution Guidelines](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/CONTRIBUTING.md)
- [ ] I've added tests for changes or features I've introduced
- [ ] I documented any high-level concepts I'm introducing in `documentation/`
- [ ] CI is currently green and this is ready for review

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation.
-->
