### PR TITLE
one-way: replace ⋮ by ⟷ for one-way components

### DIFF
--- a/src/app/perlenkette/perlenkette.component.html
+++ b/src/app/perlenkette/perlenkette.component.html
@@ -52,9 +52,9 @@
                 style="transform: translateY(-2px)"
                 >{{ perlenketteTrainrun.pathItems.at(0).getPerlenketteNode().fullName }}</span
               >
-              @if (getArrowDirectionForOneWayTrainrun() !== null) {
+              @if (trainrunService.getSbbArrowForTrainrunDirection() !== null) {
                 <sbb-icon
-                  [svgIcon]="getArrowDirectionForOneWayTrainrun()"
+                  [svgIcon]="trainrunService.getSbbArrowForTrainrunDirection()"
                   aria-hidden="false"
                   height="13px"
                   width="13px"
@@ -77,9 +77,9 @@
               <span class="station" (click)="scrollFirst($event)">{{
                 perlenketteTrainrun.pathItems.at(0).getPerlenketteNode().fullName
               }}</span>
-              @if (getArrowDirectionForOneWayTrainrun() !== null) {
+              @if (trainrunService.getSbbArrowForTrainrunDirection() !== null) {
                 <sbb-icon
-                  [svgIcon]="getArrowDirectionForOneWayTrainrun()"
+                  [svgIcon]="trainrunService.getSbbArrowForTrainrunDirection()"
                   aria-hidden="false"
                   height="13px"
                   width="13px"
@@ -114,10 +114,13 @@
             </sbb-toggle-icon>
           </sbb-toggle-option>
           <sbb-toggle-option
-            label="⟷"
+            label=""
             subtitle=""
             [value]="ShowTrainrunEditTab.sbb_trainrun_roundtrip_tab"
           >
+            <sbb-toggle-icon>
+              <sbb-icon [svgIcon]="trainrunService.getSbbArrowForTrainrunDirection()"></sbb-icon>
+            </sbb-toggle-icon>
           </sbb-toggle-option>
         </sbb-toggle>
       </div>

--- a/src/app/perlenkette/perlenkette.component.ts
+++ b/src/app/perlenkette/perlenkette.component.ts
@@ -58,8 +58,6 @@ export class PerlenketteComponent implements AfterContentChecked, OnDestroy {
 
   private showAllLockStates = false;
 
-  private trainrunSectionHelper: TrainrunsectionHelper;
-
   public showTrainrunEditTab: ShowTrainrunEditTab = ShowTrainrunEditTab.sbb_trainrun_tab;
 
   sbbToogleValue = ShowTrainrunEditTab.sbb_trainrun_tab;
@@ -71,11 +69,10 @@ export class PerlenketteComponent implements AfterContentChecked, OnDestroy {
     private readonly nodeService: NodeService,
     private versionControlService: VersionControlService,
     private changeDetectorRef: ChangeDetectorRef,
-    private trainrunService: TrainrunService,
+    public trainrunService: TrainrunService,
     private trainrunSectionService: TrainrunSectionService,
   ) {
     this.selectedPerlenketteConnection = undefined;
-    this.trainrunSectionHelper = new TrainrunsectionHelper(this.trainrunService);
 
     this.loadPerlenketteService
       .getPerlenketteData()
@@ -442,20 +439,6 @@ export class PerlenketteComponent implements AfterContentChecked, OnDestroy {
     this.svgPoint.setY(
       Math.max(-this.contentHeight / 4, Math.min(this.renderedElementsHeight - 48, y)),
     );
-  }
-
-  getArrowDirectionForOneWayTrainrun(): string {
-    if (!this.perlenketteTrainrun || this.perlenketteTrainrun.direction === Direction.ROUND_TRIP) {
-      return "minus-medium";
-    }
-    const isTargetRightOrBottom = TrainrunsectionHelper.isTargetRightOrBottom(
-      this.trainrunSectionService.getSelectedTrainrunSection(),
-    );
-    if (isTargetRightOrBottom) {
-      return "arrow-right-medium";
-    } else {
-      return "arrow-left-medium";
-    }
   }
 
   protected readonly ShowTrainrunEditTab = ShowTrainrunEditTab;

--- a/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-and-section-dialog.component.html
+++ b/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-and-section-dialog.component.html
@@ -25,25 +25,16 @@
           ></sbb-trainrun-tab>
         </sbb-tab>
         <sbb-tab id="trainrun-section-tab">
-          @if (getArrowDirectionForOneWayTrainrun() !== null) {
-            <ng-template sbb-tab-label>
-              <span style="transform: translateY(-2px)" class="onewayTrip">{{
-                nextStopLeftNodeName
-              }}</span>
-              <sbb-icon
-                style="transform: translateY(-2px)"
-                [svgIcon]="getArrowDirectionForOneWayTrainrun()"
-                aria-hidden="false"
-                height="13px"
-                width="13px"
-              ></sbb-icon>
-              <span style="transform: translateY(-2px)">{{ nextStopRightNodeName }}</span>
-            </ng-template>
-          } @else {
-            <ng-template sbb-tab-label>
-              <span>{{ nextStopLeftNodeName + " — " + nextStopRightNodeName }}</span>
-            </ng-template>
-          }
+          <ng-template sbb-tab-label
+            >{{ nextStopLeftNodeName }}
+            <sbb-icon
+              [svgIcon]="trainrunService.getSbbArrowForTrainrunSectionDirection()"
+              aria-hidden="false"
+              height="13px"
+              width="13px"
+            ></sbb-icon
+            >{{ nextStopRightNodeName }}
+          </ng-template>
           <sbb-trainrunsection-tab [trainrunDialogParameter]="data"></sbb-trainrunsection-tab>
         </sbb-tab>
         <sbb-tab
@@ -52,7 +43,15 @@
         >
           <sbb-trainrun-filter-tab (trainrunDeleted)="closeDialog()"></sbb-trainrun-filter-tab>
         </sbb-tab>
-        <sbb-tab label="⟷" id="trainrun-roundTrip-tab">
+        <sbb-tab id="trainrun-roundTrip-tab">
+          <ng-template sbb-tab-label>
+            <sbb-icon
+              [svgIcon]="trainrunService.getSbbArrowForTrainrunDirection()"
+              aria-hidden="false"
+              height="13px"
+              width="13px"
+            ></sbb-icon>
+          </ng-template>
           <sbb-trainrun-roundtrip-tab
             (trainrunDeleted)="closeDialog()"
           ></sbb-trainrun-roundtrip-tab>

--- a/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-and-section-dialog.component.ts
+++ b/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-and-section-dialog.component.ts
@@ -81,7 +81,7 @@ export class TrainrunAndSectionDialogComponent implements OnDestroy {
   constructor(
     public dialog: SbbDialog,
     private uiInteractionService: UiInteractionService,
-    private trainrunService: TrainrunService,
+    public trainrunService: TrainrunService,
     private trainrunSectionService: TrainrunSectionService,
     private dataService: DataService,
   ) {
@@ -219,19 +219,5 @@ export class TrainrunAndSectionDialogComponent implements OnDestroy {
       right: dialogPos.right + "px",
       top: dialogPos.top + "px",
     };
-  }
-
-  getArrowDirectionForOneWayTrainrun(): string {
-    if (!this.selectedTrainrun || this.selectedTrainrun.isRoundTrip()) {
-      return "minus-medium";
-    }
-    const isTargetRightOrBottom = TrainrunsectionHelper.isTargetRightOrBottom(
-      this.trainrunSectionService.getSelectedTrainrunSection(),
-    );
-    if (isTargetRightOrBottom) {
-      return "arrow-right-medium";
-    } else {
-      return "arrow-left-medium";
-    }
   }
 }

--- a/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-tab/trainrun-tab.component.scss
+++ b/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-tab/trainrun-tab.component.scss
@@ -7,10 +7,7 @@
 
 ::ng-deep div.sbb-tab-label {
   background: var(--sbb-header-lean-background-color);
-}
-::ng-deep div.sbb-tab-label:has(span.onewayTrip) {
-  padding: 0 15px;
-  height: 36px;
+  max-height: 36px;
 }
 
 ::ng-deep .sbb-trainrun-chip-group {


### PR DESCRIPTION

<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->

# Description

The ⋮ character is not obvious for me for refering to one-ways. This has more to deal with succession of something, like nodes or stops from the trainrun's path.

Before:
<img width="1270" height="550" alt="image" src="https://github.com/user-attachments/assets/7e64840d-02ad-4dfe-8024-0288de59bd4e" />

After:

https://github.com/user-attachments/assets/f1a1f936-a835-423b-94ae-e1a774c588e8


# Issues

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

- [x] This PR contains a description of the changes I'm making
- [x] I've read the [Contribution Guidelines](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/CONTRIBUTING.md)
- [ ] I've added tests for changes or features I've introduced
- [ ] I documented any high-level concepts I'm introducing in `documentation/`
- [x] CI is currently green and this is ready for review

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation.
-->
