### PR TITLE
i18n: fix warning and restrict i18n loading

### DIFF
--- a/src/app/core/i18n/i18n.service.ts
+++ b/src/app/core/i18n/i18n.service.ts
@@ -46,7 +46,10 @@ export class I18nService {
   }
 
   async loadTranslations() {
-    const languageTranslationsModule = await import(`src/assets/i18n/${this.language}.json`);
+    const languageTranslationsModule = await import(
+      /* webpackInclude: /(en|de|fr)\.json$/ */
+      `src/assets/i18n/${this.language}.json`
+    );
 
     this.translations = this.flattenTranslations(languageTranslationsModule.default);
     loadTranslations(this.translations);


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->

# Description

<img width="1157" height="745" alt="image" src="https://github.com/user-attachments/assets/28b21146-aa98-43f4-a9bd-6a0dcd667163" />

For a weird reason, i18n tries to dynamically import italian language even tho it is not supported by NGE. Added a webpackInclude comment restricts the import and fixes the warning.

# Issues

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

- [x] This PR contains a description of the changes I'm making
- [x] I've read the [Contribution Guidelines](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/CONTRIBUTING.md)
- [ ] I've added tests for changes or features I've introduced
- [ ] I documented any high-level concepts I'm introducing in `documentation/`
- [x] CI is currently green and this is ready for review

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation.
-->
