### PR TITLE
import: set node position before calling replaceIntermediateStopWithNode()

### DIFF
--- a/src/app/services/data/data.service.ts
+++ b/src/app/services/data/data.service.ts
@@ -112,20 +112,28 @@ export class DataService implements OnDestroy {
     for (const trainrunSection of netzgrafikDto.trainrunSections) {
       let currentSection = trainrunSection;
       for (let i = 0; i < trainrunSection.numberOfStops; i++) {
-        const newNode = this.nodeService.addEmptyNode();
+        const oldTrainrunSection = this.trainrunSectionService.getTrainrunSectionFromId(
+          currentSection.id,
+        );
+        const sourceNode = oldTrainrunSection.getSourceNode();
+        const targetNode = oldTrainrunSection.getTargetNode();
+        const interpolatedPosition = new Vec2D(
+          sourceNode.getPositionX() + (targetNode.getPositionX() - sourceNode.getPositionX()) * 0.5,
+          sourceNode.getPositionY() + (targetNode.getPositionY() - sourceNode.getPositionY()) * 0.5,
+        );
+
+        const newNode = this.nodeService.addEmptyNode(
+          interpolatedPosition.getX(),
+          interpolatedPosition.getY(),
+        );
+
         const {existingTrainRunSection, newTrainRunSection} =
           this.trainrunSectionService.replaceIntermediateStopWithNode(
             currentSection.id,
             0,
             newNode.getId(),
           );
-        const sourceNode = existingTrainRunSection.getSourceNode();
-        const targetNode = newTrainRunSection.getTargetNode();
-        const interpolatedPosition = new Vec2D(
-          sourceNode.getPositionX() + (targetNode.getPositionX() - sourceNode.getPositionX()) * 0.5,
-          sourceNode.getPositionY() + (targetNode.getPositionY() - sourceNode.getPositionY()) * 0.5,
-        );
-        newNode.setPosition(interpolatedPosition.getX(), interpolatedPosition.getY());
+
         currentSection = newTrainRunSection.getDto();
       }
     }

--- a/src/app/services/data/node.service.ts
+++ b/src/app/services/data/node.service.ts
@@ -254,8 +254,9 @@ export class NodeService implements OnDestroy {
     return node;
   }
 
-  addEmptyNode(): Node {
+  addEmptyNode(positionX: number, positionY: number): Node {
     const node: Node = new Node();
+    node.setPosition(positionX, positionY);
     node.setIsCollapsed(true);
     const resource: Resource = this.resourceService.createAndGetResource();
     node.setResourceId(resource.getId());


### PR DESCRIPTION
replaceIntermediateStopWithNode() recomputes a bunch of transition position stuff. At import time, tt was working with incorrect node positions, routing everything to the (0, 0) position. This causes transition positions to be mis-rendered.

Instead, set the node position at initialization, before calling replaceIntermediateStopWithNode(). That way the function can work with the final node position. As a bonus, the "new node" event is fired with the correct node position.

Fixes: 435f1c66b8ed ("import: handle importing old files with numberOfStops")