### PR TITLE
Fix: A problem "introduced" while "last" refactoring: Moving windows no longer works smoothly.

### DIFF
--- a/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-and-section-dialog.component.scss
+++ b/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-and-section-dialog.component.scss
@@ -101,23 +101,30 @@
   cursor: move;
 
   .dialog-drag-handle-icon {
-    transform: translate(-12px, 242px);
+    transform: translate(-12px, 230px);
     pointer-events: none;
     opacity: 0.25;
   }
+}
 
-  &:active .dialog-drag-handle-icon {
-    color: #eb0000;
-    opacity: 0.5;
+.dialog-drag-and-close-handle-area:hover {
+  .dialog-drag-handle-icon {
+    transform: translate(-12px, 230px);
+    pointer-events: none;
   }
 }
 
-::ng-deep
-  .trainrun-dialog-container:active
-  ~ .dialog-drag-and-close-handle-area
+.dialog-drag-and-close-handle-area:active {
+  border: 116px solid rgba(0, 0, 0, 0);
+
   .dialog-drag-handle-icon {
-  color: #eb0000;
-  opacity: 0.5;
+    transform: translate(-112px, 130px);
+    pointer-events: none;
+  }
+
+  .dialog-close-button-icon {
+    transform: translate(-114px, -160px);
+  }
 }
 
 .sbb-tab-group {


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->

# Description

There was an issue introduced during refactoring. The problem occurs when the user drags too quickly from left to right: the mouse suddenly leaves the dialog window and loses the drag content. This causes the dragging to get stuck and results in poor UX.

This is the reason behind the rather complex border logic. Increasing or changing the border requires recalculating the icon’s position. It’s not particularly nice, but it works quite smoothly.


### Before 
[chrome-capture-2025-11-25.webm](https://github.com/user-attachments/assets/2423909c-3fc5-425a-a453-0f06758bd4c1)

### After 
[chrome-capture-2025-11-25 (1).webm](https://github.com/user-attachments/assets/9a559cdd-e5ee-4857-88f6-4dcf10ef9809)



#### Technical insights (debug visualization)
By extending the hover area, mouse events are correctly collected (handled).

[chrome-capture-2025-11-25 (2).webm](https://github.com/user-attachments/assets/46f80fd5-d28c-4e36-a640-b89a6702c73b)



<!-- Describe the changes your PR introduces here. -->

# Issues

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

- [x] This PR contains a description of the changes I'm making
- [x] I've read the [Contribution Guidelines](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/CONTRIBUTING.md)
- [ ] I've added tests for changes or features I've introduced
- [ ] I documented any high-level concepts I'm introducing in `documentation/`
- [x] CI is currently green and this is ready for review

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation.
-->
