### PR TITLE
Prevent spurious update event on note creation

### DIFF
--- a/src/app/services/data/note.service.ts
+++ b/src/app/services/data/note.service.ts
@@ -246,6 +246,7 @@ export class NoteService {
 
   moveNoteToFront(noteId: number, enforceUpdate = true) {
     const note = this.getNoteFromId(noteId);
+    if (this.notesStore.notes.at(-1) === note) return;
     this.notesStore.notes = this.notesStore.notes.filter((n: Note) => n.getId() !== noteId);
     this.notesStore.notes.push(note);
     if (enforceUpdate) {


### PR DESCRIPTION
When a note is created, moveNoteToFront() is called. This triggers an "update" event even when the note is already at the top of the stack.

Make it so moveNoteToFront() is a no-op when the note is already at the top.
