### PR TITLE
create dot for collapsed node in trainrunSectionViewObject

### DIFF
--- a/src/app/view/editor-main-view/data-views/trainrunSectionViewObject.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunSectionViewObject.ts
@@ -43,6 +43,14 @@ export class TrainrunSectionViewObject {
     return this.trainrunSections[0].getTrainrun();
   }
 
+  getNumberOfStops(): number {
+    // Count non-stop collapsed source nodes
+    // Note: in this context, all intermediate sections are collapsed
+    return this.trainrunSections
+      .slice(1) // skip first section
+      .filter((section) => section.getSourceNode().isNonStop(section)).length;
+  }
+
   getTravelTime(): number {
     if (this.trainrunSections.length === 1) {
       return this.trainrunSections[0].getTravelTime();

--- a/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
@@ -1627,7 +1627,7 @@ export class TrainrunSectionsView {
     selectedTrainrun: Trainrun,
     connectedTrainIds: any,
   ) {
-    const numberOfStops = viewObject.trainrunSections.length - 1;
+    const numberOfStops = viewObject.getNumberOfStops();
     const path = viewObject.getPath();
     let startPosition = path[1];
     let lineOrientationVector = Vec2D.sub(path[2], startPosition);


### PR DESCRIPTION
Create a visual Dot for each collapsed node in a trainrun sections chain (`trainrunSectionViewObject`)

Code picked from [mrd/demo-intermediate-collapsed-dots](https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/tree/mrd/demo-intermediate-collapsed-dots)

Might conflict a bit with https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/pull/661