### PR TITLE
Fix typos introduced in collapsed nodes cleanups

### DIFF
--- a/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
@@ -1559,7 +1559,7 @@ export class TrainrunSectionsView {
       })
       .classed(StaticDomTags.TAG_HIDDEN, (d: TrainrunSectionViewObject) => {
         const trainrunSection = d.trainrunSections.at(atTarget ? -1 : 0)!;
-        return this.getHiddenTagForTime(d.trainrunSections[0], textElement);
+        return this.getHiddenTagForTime(trainrunSection, textElement);
       })
       .classed(StaticDomTags.TAG_EVENT_DISABLED, !enableEvents)
       .text((d: TrainrunSectionViewObject) =>


### PR DESCRIPTION
Fixes two typos introduced in https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/pull/605