### PR TITLE
format: fix CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,9 @@
 
 ## [2.10.1](https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/compare/netzgrafik-frontend-v2.10.0...netzgrafik-frontend-v2.10.1) (2025-12-05)
 
-
 ### Bug Fixes
 
-* Mouse cursor issue fixed ([#662](https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/issues/662)) ([4ca8377](https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/commit/4ca8377c0ece96e377572031da39cc92d213b24e))
+- Mouse cursor issue fixed ([#662](https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/issues/662)) ([4ca8377](https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/commit/4ca8377c0ece96e377572031da39cc92d213b24e))
 
 ## [2.10.0](https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/compare/netzgrafik-frontend-v2.9.29...netzgrafik-frontend-v2.10.0) (2025-11-27)
 


### PR DESCRIPTION
Surprisingly, the CI checks things that cannot be detected using `npm run format`

The CI uses:
```yml
jobs:
  format:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: actions/setup-node@v4
        with:
          node-version-file: ".nvmrc"
          cache: "npm"
      - run: npm clean-install
      - name: Check code formatting
        run: npx prettier --check .

```

Whereas we use manually `npm run ...`
```yml
    "format": "prettier --write .",
    "format:check": "prettier --check .",
```

Do you have any clue on what we should do to have a coherent local check and prevent CI failures? @emersion 