### PR TITLE
chore: git ignore .vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,11 +24,7 @@ speed-measure-plugin*.json
 *.sublime-workspace
 
 # IDE - VSCode
-.vscode/*
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
+.vscode
 .history/*
 
 # misc


### PR DESCRIPTION
Some parts of .vscode were not git ignored. However, none of these were actually committed. Additionally, such a folder tends to vary wildly between different developers, and should probably not be committed.
