### PR TITLE
refactor: drop dead logic for target → source trainrun sections 

### DIFF
--- a/src/app/services/data/trainrunsection.service.ts
+++ b/src/app/services/data/trainrunsection.service.ts
@@ -385,7 +385,7 @@ export class TrainrunSectionService implements OnDestroy {
     this.trainrunSectionsUpdated();
   }
 
-  propagteTimeSourceToTarget(
+  propagateTimeSourceToTarget(
     previousPair: TrainrunSectionNodePair,
     pair: TrainrunSectionNodePair,
     arrivalDepartureTimes: DepartureAndArrivalTimes,
@@ -482,7 +482,7 @@ export class TrainrunSectionService implements OnDestroy {
         TrainrunSectionService.TIME_PRECISION,
       );
 
-      this.propagteTimeSourceToTarget(previousPair, pair, arrivalDepartureTimes, isNonStop);
+      this.propagateTimeSourceToTarget(previousPair, pair, arrivalDepartureTimes, isNonStop);
       TrainrunSectionValidator.validateOneSection(pair.trainrunSection);
 
       if (


### PR DESCRIPTION
Preliminary work for https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/pull/589

Since commit https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/commit/308028674b747f849c418ca6c316fa6af83836d1 ("refactor: ensure consistent source → target
trainrunSections chain"), all trainrun sections are guaranteed to
always be ordred source-to-target. This chunk of code handled the
reverse case, and is now dead code.

Also fix a typo.