### PR TITLE
chore: don't format CHANGELOG.md with Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+CHANGELOG.md


### PR DESCRIPTION
CHANGELOG.md is automatically generated by release-please-action. The generated file doesn't exactly conform to the Prettier style. Add it to .prettierignore to avoid breaking CI on each new release.
