### PR TITLE
fix: use getDto() in NGE events instead of models

### DIFF
--- a/src/app/models/operation.model.ts
+++ b/src/app/models/operation.model.ts
@@ -2,6 +2,12 @@ import {Node} from "./node.model";
 import {Trainrun} from "./trainrun.model";
 import {Label} from "./label.model";
 import {Note} from "./note.model";
+import {
+  FreeFloatingTextDto,
+  LabelDto,
+  NodeDto,
+  TrainrunDto,
+} from "../data-structures/business.data.structures";
 
 enum OperationType {
   create = "create",
@@ -27,38 +33,38 @@ abstract class Operation {
 }
 
 class TrainrunOperation extends Operation {
-  readonly trainrun: Trainrun;
+  readonly trainrun: TrainrunDto;
 
   constructor(operationType: OperationType, trainrun: Trainrun) {
     super(operationType, OperationObjectType.trainrun);
-    this.trainrun = trainrun;
+    this.trainrun = trainrun.getDto();
   }
 }
 
 class NodeOperation extends Operation {
-  readonly node: Node;
+  readonly node: NodeDto;
 
   constructor(operationType: OperationType, node: Node) {
     super(operationType, OperationObjectType.node);
-    this.node = node;
+    this.node = node.getDto();
   }
 }
 
 class LabelOperation extends Operation {
-  readonly label: Label;
+  readonly label: LabelDto;
 
   constructor(operationType: OperationType, label: Label) {
     super(operationType, OperationObjectType.label);
-    this.label = label;
+    this.label = label.getDto();
   }
 }
 
 class NoteOperation extends Operation {
-  readonly note: Note;
+  readonly note: FreeFloatingTextDto;
 
   constructor(operationType: OperationType, note: Note) {
     super(operationType, OperationObjectType.note);
-    this.note = note;
+    this.note = note.getDto();
   }
 }
 


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->

# Description

Objects passed in NGEEvent fields are mutable models that can be modified by NGE after the event is emitted but before OSRD handlers process them. This causes race conditions and data inconsistencies, especially when events are processed asynchronously.
A solution for this could be to call `getDto()` in operation constructors to pass immutable DTOs instead of mutable models

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

- [x] This PR contains a description of the changes I'm making
- [x] I've read the [Contribution Guidelines](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/CONTRIBUTING.md)
- [x] CI is currently green and this is ready for review

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation.
-->
