### PR TITLE
fix: address XSS vulnerability with note text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "angular-oauth2-oidc": "^15.0.1",
         "angular-server-side-configuration": "^18.2.0",
         "d3": "^5.16.0",
+        "dompurify": "^3.3.3",
         "extract-i18n": "^1.0.0",
         "ngx-editor": "^15.0.1",
         "papaparse": "^5.3.2",
@@ -5973,6 +5974,13 @@
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
       "dev": true
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/wrap-ansi": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
@@ -9416,6 +9424,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "angular-oauth2-oidc": "^15.0.1",
     "angular-server-side-configuration": "^18.2.0",
     "d3": "^5.16.0",
+    "dompurify": "^3.3.3",
     "extract-i18n": "^1.0.0",
     "ngx-editor": "^15.0.1",
     "papaparse": "^5.3.2",

--- a/src/app/models/note.model.ts
+++ b/src/app/models/note.model.ts
@@ -1,5 +1,20 @@
+import DOMPurify from "dompurify";
 import {FreeFloatingTextDto} from "../data-structures/business.data.structures";
 import {DataMigration} from "../utils/data-migration";
+
+// TODO: drop once we upgrade to a newer TypeScript which ships Sanitizer types
+declare global {
+  class Sanitizer {
+    allowAttribute(name: string);
+    removeUnsafe();
+  }
+  interface HTMLElement {
+    setHTML(unsafeHTML: string, options?: {sanitizer: Sanitizer});
+  }
+  interface Window {
+    Sanitizer?: typeof Sanitizer;
+  }
+}
 
 export class Note {
   public static DEFAULT_NOTE_WIDTH = 192;
@@ -162,5 +177,23 @@ export class Note {
       textColor: this.textColor,
       labelIds: this.labelIds,
     };
+  }
+
+  getSanitizedText() {
+    if (window.Sanitizer) {
+      const sanitizer = new Sanitizer();
+      sanitizer.allowAttribute("style");
+      sanitizer.allowAttribute("target");
+      sanitizer.removeUnsafe();
+
+      const elt = document.createElement("div");
+      elt.setHTML(this.getText(), {sanitizer});
+      return elt.innerHTML;
+    } else {
+      // TODO: drop this fallback once Sanitizer support is widespread across
+      // browsers:
+      // https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API
+      return DOMPurify.sanitize(this.getText(), {ADD_ATTR: ["target"]});
+    }
   }
 }

--- a/src/app/view/editor-main-view/data-views/notes.view.ts
+++ b/src/app/view/editor-main-view/data-views/notes.view.ts
@@ -78,7 +78,7 @@ export class NotesView {
   static extractTextBasedWidth(n: Note): number {
     let maxLen = 0;
     const div = document.createElement("div");
-    div.innerHTML = n.getText().split("<br>").join("<br>\n").split("<p>").join("<p>\n");
+    div.innerHTML = n.getSanitizedText().split("<br>").join("<br>\n").split("<p>").join("<p>\n");
     div.textContent.split("\n", 9999).forEach((v) => {
       maxLen = Math.max(maxLen, v.length);
     });
@@ -306,7 +306,7 @@ export class NotesView {
       .attr(StaticDomTags.NOTE_ID, (n: NoteViewObject) => n.note.getId())
       .attr("x", NOTE_TEXT_LEFT_SPACING)
       .attr("y", 3 * TEXT_SIZE)
-      .html((n: NoteViewObject) => NotesView.convertText(n.note.getText()))
+      .html((n: NoteViewObject) => NotesView.convertText(n.note.getSanitizedText()))
       .on("mousedown", (n: NoteViewObject) => this.onNoteMousedown(n.note))
       .on("mouseout", (n: NoteViewObject) => this.onNoteMouseout(n.note, null))
       .on("mouseover", (n: NoteViewObject, i, a) => this.onNoteMouseover(n.note, a[i]));

--- a/src/app/view/editor-main-view/editor-main-view.component.ts
+++ b/src/app/view/editor-main-view/editor-main-view.component.ts
@@ -149,7 +149,7 @@ export class EditorMainViewComponent implements AfterViewInit, OnDestroy {
     parameter.noteFormComponentModel = {
       id: note.getId(),
       noteTitle: note.getTitle(),
-      noteText: note.getText(),
+      noteText: note.getSanitizedText(),
       noteHeight: note.getHeight(),
       noteWidth: note.getWidth(),
       notePositionX: note.getPositionX(),


### PR DESCRIPTION
Notes can contain HTML in their body text. The HTML was directly piped into the DOM in 3 spots, resulting in an XSS vulnerability. The XSS vulnerability can be used to e.g. perform authenticated API calls on behalf of another user by making a privileged user open a shared variant by sending them a link.

Here are the 3 spots where the note text is used:

- In the notes view, when displaying the body text in the editor main view's SVG with d3. The d3 html() method is used.
- In the notes view, when computing the size of the body text. The innerHTML field is set.
- In the note edit dialog, when passing the text to ngx-editor. ngx-editor doesn't perform any sanitization on its own.

Fix all of these by sanitizing unsafe HTML strings before using them. A new Note.getSanitizedText() method is introduced for this purpose.

Unfortunately we cannot leverage Angular's DomSanitizer.sanitize() method, because it's not flexible enough for us: it disallows style attributes, which are used for text color. There is no way to customize this behavior.

Instead, use the standard [HTML Sanitizer API][1] if available. Safari doesn't yet implement it, so keep a DOMPurify-based fallback in place ([Webkit ticket](https://bugs.webkit.org/show_bug.cgi?id=303808)). We'll be able to drop this fallback when all browsers have the standard API available.

Here is a PoC for the XSS vulnerability: 
[networkGraphic(16).json](https://github.com/user-attachments/files/24254633/networkGraphic.16.json)

[1]: https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API
