### PR TITLE
fix: Lock symbol (svg) background rendering issue pearls view

### DIFF
--- a/src/app/perlenkette/perlenkette-section/perlenkette-section.component.html
+++ b/src/app/perlenkette/perlenkette-section/perlenkette-section.component.html
@@ -92,7 +92,7 @@
           y="1"
           width="12"
           height="22"
-          style="cursor: pointer; fill: var(--sbb-color-background)"
+          class="lock-icon-background"
           (click)="switchSectionViewToggleLock($event, 'leftDepartureTime')"
         ></rect>
         <path
@@ -118,7 +118,7 @@
           y="1"
           width="12"
           height="22"
-          style="cursor: pointer; fill: var(--sbb-color-background)"
+          class="lock-icon-background"
           (click)="switchSectionViewToggleLock($event, 'travelTime')"
         ></rect>
         <path
@@ -136,7 +136,7 @@
           y="1"
           width="12"
           height="22"
-          style="cursor: pointer; fill: var(--sbb-color-background)"
+          class="lock-icon-background"
           (click)="switchSectionViewToggleLock($event, 'rightDepartureTime')"
         ></rect>
         <path

--- a/src/app/perlenkette/perlenkette-section/perlenkette-section.component.scss
+++ b/src/app/perlenkette/perlenkette-section/perlenkette-section.component.scss
@@ -201,3 +201,8 @@ button.FunctionButton.Rotation90.disabled {
   pointer-events: none;
   opacity: 0;
 }
+
+.lock-icon-background {
+  cursor: pointer;
+  fill: var(--sbb-color-background);
+}


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->

# Description

This is just a very small fix. The background color was not set for the side-panel (pearls view) which cause a rendering issue. The rendering issue was only seen on screens with bad contrast adjustments.

<!-- Describe the changes your PR introduces here. -->

# Issues

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

- [x] This PR contains a description of the changes I'm making
- [x] I've read the [Contribution Guidelines](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/CONTRIBUTING.md)
- [ ] I've added tests for changes or features I've introduced
- [ ] I documented any high-level concepts I'm introducing in `documentation/`
- [x] CI is currently green and this is ready for review

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation.
-->
