### PR TITLE
Fix ngx editor dependencies versions conflict

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13692,9 +13692,10 @@
       }
     },
     "node_modules/prosemirror-model": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.19.0.tgz",
-      "integrity": "sha512-/CvFGJnwc41EJSfDkQLly1cAJJJmBpZwwUJtwZPTjY2RqZJfM8HVbCreOY/jti8wTRbVyjagcylyGoeJH/g/3w==",
+      "version": "1.25.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
+      "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
+      "license": "MIT",
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -13725,14 +13726,6 @@
       "integrity": "sha512-5UXkr1LIRx3jmpXXNKDhv8OyAOeLTGuXNwdVfg8x27uASna/wQkr9p6fD3eupGOi4PLJfbezxTyi/7fSJypXHg==",
       "dependencies": {
         "prosemirror-model": "^1.21.0"
-      }
-    },
-    "node_modules/prosemirror-transform/node_modules/prosemirror-model": {
-      "version": "1.25.3",
-      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.3.tgz",
-      "integrity": "sha512-dY2HdaNXlARknJbrManZ1WyUtos+AP97AmvqdOQtWtrrC5g4mohVX5DTi9rXNFSk09eczLq9GuNTtq3EfMeMGA==",
-      "dependencies": {
-        "orderedmap": "^2.0.0"
       }
     },
     "node_modules/prosemirror-view": {

--- a/package.json
+++ b/package.json
@@ -93,5 +93,8 @@
     "prettier": "^3.6.2",
     "ts-node": "~10.9.2",
     "typescript": "^5.4.5"
+  },
+  "overrides": {
+    "prosemirror-model": "1.25.4"
   }
 }


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->

# Description

synch versions of prosemirror-model in dependencies of ngx-editor so that we prevent loading two different versions at the same time

<!-- Describe the changes your PR introduces here. -->

# Issues

This fixes double import problem on

#599  
#600 
#710 

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

- [x] This PR contains a description of the changes I'm making
- [x] I've read the [Contribution Guidelines](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/CONTRIBUTING.md)
- [ ] I've added tests for changes or features I've introduced
- [ ] I documented any high-level concepts I'm introducing in `documentation/`
- [x] CI is currently green and this is ready for review

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation.
-->
