### PR TITLE
chore: add dependabot configuration file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 5
+    groups:
+      angular:
+        patterns:
+          - "@angular/*"
+          - "@angular-devkit/*"
+          - "@angular-eslint/*"
+      typescript-eslint:
+        patterns:
+          - "@typescript-eslint/*"
+          - "typescript-eslint"
+      patch:
+        update-types:
+          - "patch"
+    commit-message:
+      prefix: "chore(deps):"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
Up until now, dependabot only opened pull requests for security issues. This configuration file will make it so dependabot performs regular upgrades too.