### PR TITLE
chore: add explicit devtools-protocol optional dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
         "typescript": "~5.2.2"
       },
       "optionalDependencies": {
+        "devtools-protocol": "*",
         "puppeteer": "^22.13.1"
       }
     },
@@ -8248,8 +8249,7 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1561482.tgz",
       "integrity": "sha512-nSXIMgdQxupOkVN94VPoE01UWJVXPOJ/IkEDQOlDbx3tmGzlKgVd3b54AT1cy8XIb4TQPcYac1nxYntEhiFKAQ==",
       "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/di": {
       "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "zone.js": "~0.14.10"
   },
   "optionalDependencies": {
-    "puppeteer": "^22.13.1"
+    "puppeteer": "^22.13.1",
+    "devtools-protocol": "*"
   },
   "devDependencies": {
     "@angular-devkit/architect": "^0.1700.10",


### PR DESCRIPTION
The devtools-protocol is dropped by dependabot for some reason. It's a peer dependency of chromium-bidi and a hard dependency of puppeteer (which is an optional dep of NGE).

This makes `npm clean-install` fail:

    npm error `npm ci` can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync. Please update your lock file with `npm install` before continuing.
    npm error
    npm error Missing: devtools-protocol@0.0.1561482 from lock file
    npm error Missing: devtools-protocol@0.0.1312386 from lock file
    npm error Missing: devtools-protocol@0.0.1312386 from lock file

Work around this issue by explicitly listing devtools-protocol in our optional dependencies.

Closes: https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/issues/716