### PR TITLE
Fix Tip display for Collapsed Node

### DIFF
--- a/src/app/models/trainrunsection.model.ts
+++ b/src/app/models/trainrunsection.model.ts
@@ -551,6 +551,14 @@ export class TrainrunSection {
     return this.targetNodeId;
   }
 
+  areBothNodesCollapsed(): boolean {
+    return this.sourceNode.getIsCollapsed() && this.targetNode.getIsCollapsed();
+  }
+
+  areBothNodesExpanded(): boolean {
+    return !this.sourceNode.getIsCollapsed() && !this.targetNode.getIsCollapsed();
+  }
+
   getTrainrun(): Trainrun {
     return this.trainrun;
   }

--- a/src/app/view/editor-main-view/data-views/data.view.spec.ts
+++ b/src/app/view/editor-main-view/data-views/data.view.spec.ts
@@ -217,7 +217,7 @@ describe("Editor-DataView", () => {
     const ts = trainrunSectionService.getTrainrunSectionFromId(3);
     const cvo1 = new TrainrunSectionViewObject(editorView, [ts]);
     expect(cvo1.key).toBe(
-      "#3@1234_false_false_0_39_49_1_21_39_0_0_141_39_0_180_0_S_20_7/24_4_1_0_S_20_7/24_20_0_round_trip_false_true_false_false_false_false_false_false_false_true_true_true_false_false_true_true_true_0_false_2_true_true_true_1_false_true_true_0_false_true_true(130,80)(194,80)(254,80)(318,80)",
+      "#3@1234_false_false_0_39_49_1_21_39_0_0_141_39_0_180_0_false_false_S_20_7/24_4_1_0_S_20_7/24_20_0_round_trip_false_true_false_false_false_false_false_false_false_true_true_true_false_false_true_true_true_0_false_2_true_true_true_1_false_true_true_0_false_true_true(130,80)(194,80)(254,80)(318,80)",
     );
   });
 

--- a/src/app/view/editor-main-view/data-views/editor.view.ts
+++ b/src/app/view/editor-main-view/data-views/editor.view.ts
@@ -522,7 +522,7 @@ export class EditorView implements SVGMouseControllerObserver {
         const maxY = Math.max(p[1].getY(), p[2].getY());
         const center = Vec2D.scale(Vec2D.add(p[1], p[2]), 0.5);
 
-        if (this.filterService.filterTrainrun(ts.getTrainrun())) {
+        if (this.filterService.filterTrainrun(ts.getTrainrun()) && ts.areBothNodesExpanded()) {
           if (
             topLeft.getX() < center.getX() &&
             center.getX() < bottomRight.getX() &&

--- a/src/app/view/editor-main-view/data-views/trainrunSectionViewObject.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunSectionViewObject.ts
@@ -93,6 +93,24 @@ export class TrainrunSectionViewObject {
     return atSource ? this.getPositionAtSourceNode() : this.getPositionAtTargetNode();
   }
 
+  // A "Tip" is the state of a trainrun section's end (source or target). This state is represented
+  // as a cropped line on the end's side and a node's name displayed next to it. A trainrun section's
+  // end is a Tip when the node on its side is collapsed or filtered.
+  // Note: in this function, we deal only with collapsed node, because the filtering system is a mess.
+  isTip(atSource: boolean): boolean {
+    if (atSource) {
+      return (
+        !this.firstSection.getSourceNode().getIsCollapsed() &&
+        this.lastSection.getTargetNode().getIsCollapsed()
+      );
+    } else {
+      return (
+        this.firstSection.getSourceNode().getIsCollapsed() &&
+        !this.lastSection.getTargetNode().getIsCollapsed()
+      );
+    }
+  }
+
   private generateKey(editorView: EditorView, trainrunSections: TrainrunSection[]): string {
     const selectedTrainrun = editorView.getSelectedTrainrun();
     let connectedTrainIds = [];
@@ -175,6 +193,10 @@ export class TrainrunSectionViewObject {
       this.firstSection.getSourceArrivalConsecutiveTime() +
       "_" +
       this.firstSection.getNumberOfStops() +
+      "_" +
+      this.firstSection.getSourceNode().getIsCollapsed() +
+      "_" +
+      this.lastSection.getTargetNode().getIsCollapsed() +
       "_" +
       this.getTrainrun().getTrainrunCategory().shortName +
       "_" +


### PR DESCRIPTION
Should wait for:
- https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/pull/730 to be merged
- https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/pull/816 to be merged

Only the last commit is relevant for this PR.

<img width="1151" height="630" alt="image" src="https://github.com/user-attachments/assets/20e9185b-b925-4d47-9a28-1e0451c1b6cb" />


<img width="1248" height="606" alt="image" src="https://github.com/user-attachments/assets/fb6b2ed0-bacd-4f19-99a9-4746171a71d5" />
