### PR TITLE
chore: fix reconnect test

### DIFF
--- a/src/integration-testing/reconnect.trainrunsections.test.spec.ts
+++ b/src/integration-testing/reconnect.trainrunsections.test.spec.ts
@@ -66,10 +66,10 @@ describe("Reconnect TrainrunSection Test", () => {
     dataService.loadNetzgrafikDto(
       NetzgrafikUnitTestingReconnectTrainrunSection.getUnitTestReconnectTrainrunSectionNetzgrafik(),
     );
-    const trainrunSectionOfInterest1 = trainrunSectionService.getTrainrunSectionFromId(6);
+    const trainrunSectionOfInterest1 = trainrunSectionService.getTrainrunSectionFromId(1);
 
     trainrunSectionService.reconnectTrainrunSection(
-      12,
+      1,
       7,
       trainrunSectionOfInterest1.getId(),
       trainrunSectionOfInterest1.getTargetNodeId(),
@@ -80,12 +80,12 @@ describe("Reconnect TrainrunSection Test", () => {
       trainrunSectionOfInterest1.getSourceNode(),
       trainrunSectionOfInterest1,
     );
-    expect(endNode1.getId()).toBe(11);
+    expect(endNode1.getId()).toBe(8);
 
-    const trainrunSectionOfInterest2 = trainrunSectionService.getTrainrunSectionFromId(7);
+    const trainrunSectionOfInterest2 = trainrunSectionService.getTrainrunSectionFromId(2);
     trainrunSectionService.reconnectTrainrunSection(
-      12,
-      11,
+      1,
+      8,
       trainrunSectionOfInterest2.getId(),
       trainrunSectionOfInterest2.getTargetNodeId(),
       trainrunSectionOfInterest2.getSourceNodeId(),
@@ -95,12 +95,12 @@ describe("Reconnect TrainrunSection Test", () => {
       trainrunSectionOfInterest2.getSourceNode(),
       trainrunSectionOfInterest2,
     );
-    expect(endNode2.getId()).toBe(11);
+    expect(endNode2.getId()).toBe(1);
 
-    const trainrunSectionOfInterest4 = trainrunSectionService.getTrainrunSectionFromId(8);
+    const trainrunSectionOfInterest4 = trainrunSectionService.getTrainrunSectionFromId(4);
     trainrunSectionService.reconnectTrainrunSection(
-      11,
-      14,
+      1,
+      8,
       trainrunSectionOfInterest4.getId(),
       trainrunSectionOfInterest4.getTargetNodeId(),
       trainrunSectionOfInterest4.getSourceNodeId(),
@@ -110,26 +110,26 @@ describe("Reconnect TrainrunSection Test", () => {
       trainrunSectionOfInterest4.getSourceNode(),
       trainrunSectionOfInterest4,
     );
-    expect(endNode4.getId()).toBe(14);
+    expect(endNode4.getId()).toBe(7);
 
     trainrunSectionService.reconnectTrainrunSection(
       7,
-      12,
+      1,
       trainrunSectionOfInterest1.getId(),
       trainrunSectionOfInterest1.getTargetNodeId(),
       trainrunSectionOfInterest1.getSourceNodeId(),
     );
 
-    const nLTH = nodeService.getNodeFromId(11);
+    const nLTH = nodeService.getNodeFromId(8);
     expect(nLTH.getTransitions().length).toBe(1);
 
     const nRTR = nodeService.getNodeFromId(7);
     expect(nRTR.getTransitions().length).toBe(0);
 
-    const nBN = nodeService.getNodeFromId(14);
+    const nBN = nodeService.getNodeFromId(0);
     expect(nBN.getTransitions().length).toBe(0);
 
-    const nOL = nodeService.getNodeFromId(12);
+    const nOL = nodeService.getNodeFromId(1);
     expect(nOL.getTransitions().length).toBe(1);
   });
 });

--- a/src/integration-testing/test-data/testReconnectTrainrunSectionNetzgrafik.json
+++ b/src/integration-testing/test-data/testReconnectTrainrunSectionNetzgrafik.json
@@ -1,268 +1,49 @@
 {
   "nodes": [
     {
-      "id": 11,
-      "betriebspunktName": "C",
-      "fullName": "Neuer Knoten",
-      "positionX": 1536,
-      "positionY": 864,
+      "id": 0,
+      "betriebspunktName": "BN",
+      "fullName": "Bern",
+      "positionX": -192,
+      "positionY": 32,
       "ports": [
-        {"id": 14, "trainrunSectionId": 7, "positionIndex": 0, "positionAlignment": 2},
-        {"id": 20, "trainrunSectionId": 10, "positionIndex": 1, "positionAlignment": 2},
-        {"id": 15, "trainrunSectionId": 8, "positionIndex": 2, "positionAlignment": 2},
-        {"id": 21, "trainrunSectionId": 11, "positionIndex": 3, "positionAlignment": 2}
+        {"id": 4, "trainrunSectionId": 2, "positionIndex": 0, "positionAlignment": 3},
+        {"id": 5, "trainrunSectionId": 3, "positionIndex": 1, "positionAlignment": 3}
       ],
-      "transitions": [{"id": 4, "port1Id": 20, "port2Id": 21, "isNonStopTransit": true}],
+      "transitions": [{"id": 1, "port1Id": 4, "port2Id": 5, "isNonStopTransit": false}],
       "connections": [],
-      "resourceId": 12,
-      "perronkanten": 5,
-      "connectionTime": 3,
+      "resourceId": 1,
+      "perronkanten": 10,
+      "connectionTime": 5,
       "trainrunCategoryHaltezeiten": {
-        "HaltezeitIPV": {"haltezeit": 3, "no_halt": false},
+        "HaltezeitIPV": {"haltezeit": 2, "no_halt": false},
         "HaltezeitA": {"haltezeit": 2, "no_halt": false},
         "HaltezeitB": {"haltezeit": 2, "no_halt": false},
-        "HaltezeitC": {"haltezeit": 1, "no_halt": false},
+        "HaltezeitC": {"haltezeit": 1.5, "no_halt": false},
         "HaltezeitD": {"haltezeit": 1, "no_halt": false},
         "HaltezeitUncategorized": {"haltezeit": 0, "no_halt": true}
       },
-      "symmetryAxis": null,
-      "warnings": null,
-      "labelIds": []
-    },
-    {
-      "id": 12,
-      "betriebspunktName": "A",
-      "fullName": "Neuer Knoten",
-      "positionX": 1120,
-      "positionY": 672,
-      "ports": [
-        {"id": 17, "trainrunSectionId": 9, "positionIndex": 0, "positionAlignment": 1},
-        {"id": 12, "trainrunSectionId": 6, "positionIndex": 0, "positionAlignment": 2},
-        {"id": 13, "trainrunSectionId": 7, "positionIndex": 0, "positionAlignment": 3},
-        {"id": 19, "trainrunSectionId": 10, "positionIndex": 1, "positionAlignment": 3}
-      ],
-      "transitions": [{"id": 3, "port1Id": 12, "port2Id": 13, "isNonStopTransit": false}],
-      "connections": [],
-      "resourceId": 13,
-      "perronkanten": 5,
-      "connectionTime": 8,
-      "trainrunCategoryHaltezeiten": {
-        "HaltezeitIPV": {"haltezeit": 3, "no_halt": false},
-        "HaltezeitA": {"haltezeit": 2, "no_halt": false},
-        "HaltezeitB": {"haltezeit": 2, "no_halt": false},
-        "HaltezeitC": {"haltezeit": 1, "no_halt": false},
-        "HaltezeitD": {"haltezeit": 1, "no_halt": false},
-        "HaltezeitUncategorized": {"haltezeit": 0, "no_halt": true}
-      },
-      "symmetryAxis": null,
-      "warnings": null,
-      "labelIds": []
-    },
-    {
-      "id": 13,
-      "betriebspunktName": "D",
-      "fullName": "Neuer Knoten",
-      "positionX": 1088,
-      "positionY": 1088,
-      "ports": [
-        {"id": 18, "trainrunSectionId": 9, "positionIndex": 0, "positionAlignment": 0},
-        {"id": 22, "trainrunSectionId": 11, "positionIndex": 0, "positionAlignment": 3}
-      ],
-      "transitions": [],
-      "connections": [],
-      "resourceId": 14,
-      "perronkanten": 5,
-      "connectionTime": 3,
-      "trainrunCategoryHaltezeiten": {
-        "HaltezeitIPV": {"haltezeit": 3, "no_halt": false},
-        "HaltezeitA": {"haltezeit": 2, "no_halt": false},
-        "HaltezeitB": {"haltezeit": 2, "no_halt": false},
-        "HaltezeitC": {"haltezeit": 1, "no_halt": false},
-        "HaltezeitD": {"haltezeit": 1, "no_halt": false},
-        "HaltezeitUncategorized": {"haltezeit": 0, "no_halt": true}
-      },
-      "symmetryAxis": null,
-      "warnings": null,
-      "labelIds": []
-    },
-    {
-      "id": 14,
-      "betriebspunktName": "B",
-      "fullName": "Neuer Knoten",
-      "positionX": 800,
-      "positionY": 864,
-      "ports": [
-        {"id": 11, "trainrunSectionId": 6, "positionIndex": 0, "positionAlignment": 3},
-        {"id": 16, "trainrunSectionId": 8, "positionIndex": 1, "positionAlignment": 3}
-      ],
-      "transitions": [],
-      "connections": [],
-      "resourceId": 15,
-      "perronkanten": 5,
-      "connectionTime": 3,
-      "trainrunCategoryHaltezeiten": {
-        "HaltezeitIPV": {"haltezeit": 3, "no_halt": false},
-        "HaltezeitA": {"haltezeit": 2, "no_halt": false},
-        "HaltezeitB": {"haltezeit": 2, "no_halt": false},
-        "HaltezeitC": {"haltezeit": 1, "no_halt": false},
-        "HaltezeitD": {"haltezeit": 1, "no_halt": false},
-        "HaltezeitUncategorized": {"haltezeit": 0, "no_halt": true}
-      },
-      "symmetryAxis": null,
-      "warnings": null,
-      "labelIds": []
-    },
-    {
-      "id": 15,
-      "betriebspunktName": "E",
-      "fullName": "New node",
-      "positionX": 1472,
-      "positionY": 1248,
-      "ports": [{"id": 24, "trainrunSectionId": 12, "positionIndex": 0, "positionAlignment": 3}],
-      "transitions": [],
-      "connections": [],
-      "resourceId": 16,
-      "perronkanten": 5,
-      "connectionTime": 3,
-      "trainrunCategoryHaltezeiten": {
-        "HaltezeitIPV": {"haltezeit": 3, "no_halt": false},
-        "HaltezeitA": {"haltezeit": 2, "no_halt": false},
-        "HaltezeitB": {"haltezeit": 2, "no_halt": false},
-        "HaltezeitC": {"haltezeit": 1, "no_halt": false},
-        "HaltezeitD": {"haltezeit": 1, "no_halt": false},
-        "HaltezeitUncategorized": {"haltezeit": 0, "no_halt": true}
-      },
-      "symmetryAxis": null,
-      "warnings": null,
-      "labelIds": []
-    },
-    {
-      "id": 16,
-      "betriebspunktName": "F",
-      "fullName": "New node",
-      "positionX": 1696,
-      "positionY": 1248,
-      "ports": [
-        {"id": 23, "trainrunSectionId": 12, "positionIndex": 0, "positionAlignment": 2},
-        {"id": 25, "trainrunSectionId": 13, "positionIndex": 0, "positionAlignment": 3}
-      ],
-      "transitions": [{"id": 5, "port1Id": 23, "port2Id": 25, "isNonStopTransit": false}],
-      "connections": [],
-      "resourceId": 17,
-      "perronkanten": 5,
-      "connectionTime": 3,
-      "trainrunCategoryHaltezeiten": {
-        "HaltezeitIPV": {"haltezeit": 3, "no_halt": false},
-        "HaltezeitA": {"haltezeit": 2, "no_halt": false},
-        "HaltezeitB": {"haltezeit": 2, "no_halt": false},
-        "HaltezeitC": {"haltezeit": 1, "no_halt": false},
-        "HaltezeitD": {"haltezeit": 1, "no_halt": false},
-        "HaltezeitUncategorized": {"haltezeit": 0, "no_halt": true}
-      },
-      "symmetryAxis": null,
-      "warnings": null,
-      "labelIds": []
-    },
-    {
-      "id": 17,
-      "betriebspunktName": "G",
-      "fullName": "New node",
-      "positionX": 1920,
-      "positionY": 1248,
-      "ports": [{"id": 26, "trainrunSectionId": 13, "positionIndex": 0, "positionAlignment": 2}],
-      "transitions": [],
-      "connections": [],
-      "resourceId": 18,
-      "perronkanten": 5,
-      "connectionTime": 3,
-      "trainrunCategoryHaltezeiten": {
-        "HaltezeitIPV": {"haltezeit": 3, "no_halt": false},
-        "HaltezeitA": {"haltezeit": 2, "no_halt": false},
-        "HaltezeitB": {"haltezeit": 2, "no_halt": false},
-        "HaltezeitC": {"haltezeit": 1, "no_halt": false},
-        "HaltezeitD": {"haltezeit": 1, "no_halt": false},
-        "HaltezeitUncategorized": {"haltezeit": 0, "no_halt": true}
-      },
-      "symmetryAxis": null,
+      "symmetryAxis": 0,
       "warnings": null,
       "labelIds": []
     },
     {
       "id": 1,
-      "betriebspunktName": "I",
-      "fullName": "I",
+      "betriebspunktName": "OL",
+      "fullName": "Olten",
       "positionX": 832,
       "positionY": 32,
-      "ports": [
-        {"id": 11, "trainrunSectionId": 15, "positionIndex": 0, "positionAlignment": 1},
-        {"id": 14, "trainrunSectionId": 16, "positionIndex": 1, "positionAlignment": 1},
-        {"id": 10, "trainrunSectionId": 14, "positionIndex": 0, "positionAlignment": 2},
-        {"id": 15, "trainrunSectionId": 17, "positionIndex": 0, "positionAlignment": 3}
-      ],
-      "transitions": [
-        {"id": 4, "port1Id": 11, "port2Id": 10, "isNonStopTransit": false},
-        {"id": 6, "port1Id": 14, "port2Id": 15, "isNonStopTransit": false}
-      ],
+      "ports": [{"id": 8, "trainrunSectionId": 4, "positionIndex": 1, "positionAlignment": 2}],
+      "transitions": [],
       "connections": [],
       "resourceId": 2,
       "perronkanten": 10,
       "connectionTime": 5,
       "trainrunCategoryHaltezeiten": {
-        "HaltezeitIPV": {"haltezeit": 3, "no_halt": false},
+        "HaltezeitIPV": {"haltezeit": 2, "no_halt": false},
         "HaltezeitA": {"haltezeit": 2, "no_halt": false},
         "HaltezeitB": {"haltezeit": 2, "no_halt": false},
-        "HaltezeitC": {"haltezeit": 1, "no_halt": false},
-        "HaltezeitD": {"haltezeit": 1, "no_halt": false},
-        "HaltezeitUncategorized": {"haltezeit": 0, "no_halt": true}
-      },
-      "symmetryAxis": null,
-      "warnings": null,
-      "labelIds": []
-    },
-    {
-      "id": 2,
-      "betriebspunktName": "K",
-      "fullName": "K",
-      "positionX": 1632,
-      "positionY": 32,
-      "ports": [{"id": 16, "trainrunSectionId": 17, "positionIndex": 0, "positionAlignment": 2}],
-      "transitions": [],
-      "connections": [],
-      "resourceId": 3,
-      "perronkanten": 10,
-      "connectionTime": 5,
-      "trainrunCategoryHaltezeiten": {
-        "HaltezeitIPV": {"haltezeit": 3, "no_halt": false},
-        "HaltezeitA": {"haltezeit": 2, "no_halt": false},
-        "HaltezeitB": {"haltezeit": 2, "no_halt": false},
-        "HaltezeitC": {"haltezeit": 1, "no_halt": false},
-        "HaltezeitD": {"haltezeit": 1, "no_halt": false},
-        "HaltezeitUncategorized": {"haltezeit": 0, "no_halt": true}
-      },
-      "symmetryAxis": null,
-      "warnings": null,
-      "labelIds": []
-    },
-    {
-      "id": 4,
-      "betriebspunktName": "J",
-      "fullName": "J",
-      "positionX": 832,
-      "positionY": 448,
-      "ports": [
-        {"id": 12, "trainrunSectionId": 15, "positionIndex": 0, "positionAlignment": 0},
-        {"id": 13, "trainrunSectionId": 16, "positionIndex": 1, "positionAlignment": 0}
-      ],
-      "transitions": [{"id": 5, "port1Id": 12, "port2Id": 13, "isNonStopTransit": false}],
-      "connections": [],
-      "resourceId": 5,
-      "perronkanten": 5,
-      "connectionTime": 3,
-      "trainrunCategoryHaltezeiten": {
-        "HaltezeitIPV": {"haltezeit": 3, "no_halt": false},
-        "HaltezeitA": {"haltezeit": 2, "no_halt": false},
-        "HaltezeitB": {"haltezeit": 2, "no_halt": false},
-        "HaltezeitC": {"haltezeit": 1, "no_halt": false},
+        "HaltezeitC": {"haltezeit": 1.5, "no_halt": false},
         "HaltezeitD": {"haltezeit": 1, "no_halt": false},
         "HaltezeitUncategorized": {"haltezeit": 0, "no_halt": true}
       },
@@ -272,21 +53,50 @@
     },
     {
       "id": 7,
-      "betriebspunktName": "H",
-      "fullName": "H",
+      "betriebspunktName": "RTR",
+      "fullName": "Rothrist",
       "positionX": 320,
       "positionY": 32,
-      "ports": [{"id": 9, "trainrunSectionId": 14, "positionIndex": 0, "positionAlignment": 3}],
+      "ports": [{"id": 11, "trainrunSectionId": 1, "positionIndex": 0, "positionAlignment": 1}],
       "transitions": [],
       "connections": [],
       "resourceId": 8,
       "perronkanten": 5,
       "connectionTime": 5,
       "trainrunCategoryHaltezeiten": {
-        "HaltezeitIPV": {"haltezeit": 3, "no_halt": false},
+        "HaltezeitIPV": {"haltezeit": 2, "no_halt": false},
         "HaltezeitA": {"haltezeit": 2, "no_halt": false},
         "HaltezeitB": {"haltezeit": 2, "no_halt": false},
-        "HaltezeitC": {"haltezeit": 1, "no_halt": false},
+        "HaltezeitC": {"haltezeit": 1.5, "no_halt": false},
+        "HaltezeitD": {"haltezeit": 1, "no_halt": false},
+        "HaltezeitUncategorized": {"haltezeit": 0, "no_halt": true}
+      },
+      "symmetryAxis": null,
+      "warnings": null,
+      "labelIds": []
+    },
+    {
+      "id": 8,
+      "betriebspunktName": "LTH",
+      "fullName": "Langenthal",
+      "positionX": 320,
+      "positionY": 192,
+      "ports": [
+        {"id": 3, "trainrunSectionId": 2, "positionIndex": 0, "positionAlignment": 2},
+        {"id": 6, "trainrunSectionId": 3, "positionIndex": 1, "positionAlignment": 2},
+        {"id": 9, "trainrunSectionId": 1, "positionIndex": 0, "positionAlignment": 0},
+        {"id": 10, "trainrunSectionId": 4, "positionIndex": 0, "positionAlignment": 3}
+      ],
+      "transitions": [{"id": 3, "port1Id": 3, "port2Id": 9, "isNonStopTransit": false}],
+      "connections": [],
+      "resourceId": 9,
+      "perronkanten": 5,
+      "connectionTime": 5,
+      "trainrunCategoryHaltezeiten": {
+        "HaltezeitIPV": {"haltezeit": 2, "no_halt": false},
+        "HaltezeitA": {"haltezeit": 2, "no_halt": false},
+        "HaltezeitB": {"haltezeit": 2, "no_halt": false},
+        "HaltezeitC": {"haltezeit": 1.5, "no_halt": false},
         "HaltezeitD": {"haltezeit": 1, "no_halt": false},
         "HaltezeitUncategorized": {"haltezeit": 0, "no_halt": true}
       },
@@ -297,142 +107,14 @@
   ],
   "trainrunSections": [
     {
-      "id": 6,
-      "sourceNodeId": 14,
+      "id": 1,
+      "sourceNodeId": 7,
       "sourcePortId": 11,
-      "targetNodeId": 12,
-      "targetPortId": 12,
+      "targetNodeId": 8,
+      "targetPortId": 9,
       "travelTime": {
-        "time": 2,
-        "consecutiveTime": 1,
-        "lock": true,
-        "warning": null,
-        "timeFormatter": null
-      },
-      "sourceDeparture": {
-        "time": 0,
-        "consecutiveTime": 0,
-        "lock": false,
-        "warning": null,
-        "timeFormatter": null
-      },
-      "sourceArrival": {
-        "time": 0,
-        "consecutiveTime": 60,
-        "lock": false,
-        "warning": null,
-        "timeFormatter": null
-      },
-      "targetDeparture": {
-        "time": 58,
-        "consecutiveTime": 58,
-        "lock": false,
-        "warning": null,
-        "timeFormatter": null
-      },
-      "targetArrival": {
-        "time": 2,
-        "consecutiveTime": 2,
-        "lock": false,
-        "warning": null,
-        "timeFormatter": null
-      },
-      "numberOfStops": 0,
-      "trainrunId": 4,
-      "resourceId": 0,
-      "specificTrainrunSectionFrequencyId": null,
-      "path": {
-        "path": [
-          {"x": 898, "y": 880},
-          {"x": 962, "y": 880},
-          {"x": 1054, "y": 688},
-          {"x": 1118, "y": 688}
-        ],
-        "textPositions": {
-          "0": {"x": 916, "y": 892},
-          "1": {"x": 944, "y": 868},
-          "2": {"x": 1100, "y": 676},
-          "3": {"x": 1072, "y": 700},
-          "4": {"x": 1008, "y": 772},
-          "5": {"x": 1008, "y": 772},
-          "6": {"x": 1008, "y": 796}
-        }
-      },
-      "warnings": null
-    },
-    {
-      "id": 7,
-      "sourceNodeId": 12,
-      "sourcePortId": 13,
-      "targetNodeId": 11,
-      "targetPortId": 14,
-      "travelTime": {
-        "time": 4,
-        "consecutiveTime": 1,
-        "lock": true,
-        "warning": null,
-        "timeFormatter": null
-      },
-      "sourceDeparture": {
-        "time": 3,
-        "consecutiveTime": 3,
-        "lock": false,
-        "warning": null,
-        "timeFormatter": null
-      },
-      "sourceArrival": {
-        "time": 57,
-        "consecutiveTime": 57,
-        "lock": false,
-        "warning": null,
-        "timeFormatter": null
-      },
-      "targetDeparture": {
-        "time": 53,
-        "consecutiveTime": 53,
-        "lock": false,
-        "warning": null,
-        "timeFormatter": null
-      },
-      "targetArrival": {
-        "time": 7,
-        "consecutiveTime": 7,
-        "lock": false,
-        "warning": null,
-        "timeFormatter": null
-      },
-      "numberOfStops": 0,
-      "trainrunId": 4,
-      "resourceId": 0,
-      "specificTrainrunSectionFrequencyId": null,
-      "path": {
-        "path": [
-          {"x": 1218, "y": 688},
-          {"x": 1282, "y": 688},
-          {"x": 1470, "y": 880},
-          {"x": 1534, "y": 880}
-        ],
-        "textPositions": {
-          "0": {"x": 1236, "y": 700},
-          "1": {"x": 1264, "y": 676},
-          "2": {"x": 1516, "y": 868},
-          "3": {"x": 1488, "y": 892},
-          "4": {"x": 1376, "y": 772},
-          "5": {"x": 1376, "y": 772},
-          "6": {"x": 1376, "y": 796}
-        }
-      },
-      "warnings": null
-    },
-    {
-      "id": 8,
-      "sourceNodeId": 11,
-      "sourcePortId": 15,
-      "targetNodeId": 14,
-      "targetPortId": 16,
-      "travelTime": {
-        "time": 6,
-        "consecutiveTime": 1,
+        "time": 10,
+        "consecutiveTime": 10,
         "lock": true,
         "warning": null,
         "timeFormatter": null
@@ -447,70 +129,6 @@
       "sourceArrival": {
         "time": 0,
         "consecutiveTime": 60,
-        "lock": false,
-        "warning": null,
-        "timeFormatter": null
-      },
-      "targetDeparture": {
-        "time": 54,
-        "consecutiveTime": 54,
-        "lock": false,
-        "warning": null,
-        "timeFormatter": null
-      },
-      "targetArrival": {
-        "time": 6,
-        "consecutiveTime": 66,
-        "lock": false,
-        "warning": null,
-        "timeFormatter": null
-      },
-      "numberOfStops": 0,
-      "trainrunId": 5,
-      "resourceId": 0,
-      "specificTrainrunSectionFrequencyId": null,
-      "path": {
-        "path": [
-          {"x": 1534, "y": 944},
-          {"x": 1470, "y": 944},
-          {"x": 962, "y": 912},
-          {"x": 898, "y": 912}
-        ],
-        "textPositions": {
-          "0": {"x": 1516, "y": 932},
-          "1": {"x": 1488, "y": 956},
-          "2": {"x": 916, "y": 924},
-          "3": {"x": 944, "y": 900},
-          "4": {"x": 1216, "y": 916},
-          "5": {"x": 1216, "y": 916},
-          "6": {"x": 1216, "y": 940}
-        }
-      },
-      "warnings": null
-    },
-    {
-      "id": 9,
-      "sourceNodeId": 12,
-      "sourcePortId": 17,
-      "targetNodeId": 13,
-      "targetPortId": 18,
-      "travelTime": {
-        "time": 2,
-        "consecutiveTime": 1,
-        "lock": true,
-        "warning": null,
-        "timeFormatter": null
-      },
-      "sourceDeparture": {
-        "time": 8,
-        "consecutiveTime": 8,
-        "lock": false,
-        "warning": null,
-        "timeFormatter": null
-      },
-      "sourceArrival": {
-        "time": 52,
-        "consecutiveTime": 52,
         "lock": false,
         "warning": null,
         "timeFormatter": null
@@ -524,50 +142,50 @@
       },
       "targetArrival": {
         "time": 10,
+        "consecutiveTime": 70,
+        "lock": false,
+        "warning": null,
+        "timeFormatter": null
+      },
+      "numberOfStops": 0,
+      "trainrunId": 1,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 336, "y": 98},
+          {"x": 336, "y": 162},
+          {"x": 336, "y": 126},
+          {"x": 336, "y": 190}
+        ],
+        "textPositions": {
+          "0": {"x": 324, "y": 116},
+          "1": {"x": 348, "y": 144},
+          "2": {"x": 348, "y": 172},
+          "3": {"x": 324, "y": 144},
+          "4": {"x": 324, "y": 144},
+          "5": {"x": 324, "y": 144},
+          "6": {"x": 348, "y": 144}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 2,
+      "sourceNodeId": 8,
+      "sourcePortId": 3,
+      "targetNodeId": 0,
+      "targetPortId": 4,
+      "travelTime": {
+        "time": 10,
         "consecutiveTime": 10,
-        "lock": false,
-        "warning": null,
-        "timeFormatter": null
-      },
-      "numberOfStops": 0,
-      "trainrunId": 6,
-      "resourceId": 0,
-      "specificTrainrunSectionFrequencyId": null,
-      "path": {
-        "path": [
-          {"x": 1136, "y": 766},
-          {"x": 1136, "y": 830},
-          {"x": 1104, "y": 1022},
-          {"x": 1104, "y": 1086}
-        ],
-        "textPositions": {
-          "0": {"x": 1124, "y": 784},
-          "1": {"x": 1148, "y": 812},
-          "2": {"x": 1116, "y": 1068},
-          "3": {"x": 1092, "y": 1040},
-          "4": {"x": 1108, "y": 926},
-          "5": {"x": 1108, "y": 926},
-          "6": {"x": 1132, "y": 926}
-        }
-      },
-      "warnings": null
-    },
-    {
-      "id": 10,
-      "sourceNodeId": 12,
-      "sourcePortId": 19,
-      "targetNodeId": 11,
-      "targetPortId": 20,
-      "travelTime": {
-        "time": 5,
-        "consecutiveTime": 1,
         "lock": true,
         "warning": null,
         "timeFormatter": null
       },
       "sourceDeparture": {
         "time": 0,
-        "consecutiveTime": 0,
+        "consecutiveTime": 60,
         "lock": false,
         "warning": null,
         "timeFormatter": null
@@ -575,461 +193,13 @@
       "sourceArrival": {
         "time": 0,
         "consecutiveTime": 60,
-        "lock": false,
-        "warning": null,
-        "timeFormatter": null
-      },
-      "targetDeparture": {
-        "time": 55,
-        "consecutiveTime": 55,
-        "lock": false,
-        "warning": null,
-        "timeFormatter": null
-      },
-      "targetArrival": {
-        "time": 5,
-        "consecutiveTime": 5,
-        "lock": false,
-        "warning": null,
-        "timeFormatter": null
-      },
-      "numberOfStops": 0,
-      "trainrunId": 7,
-      "resourceId": 0,
-      "specificTrainrunSectionFrequencyId": null,
-      "path": {
-        "path": [
-          {"x": 1218, "y": 720},
-          {"x": 1282, "y": 720},
-          {"x": 1470, "y": 912},
-          {"x": 1534, "y": 912}
-        ],
-        "textPositions": {
-          "0": {"x": 1236, "y": 732},
-          "1": {"x": 1264, "y": 708},
-          "2": {"x": 1516, "y": 900},
-          "3": {"x": 1488, "y": 924},
-          "4": {"x": 1376, "y": 804},
-          "5": {"x": 1376, "y": 804},
-          "6": {"x": 1376, "y": 828}
-        }
-      },
-      "warnings": null
-    },
-    {
-      "id": 11,
-      "sourceNodeId": 11,
-      "sourcePortId": 21,
-      "targetNodeId": 13,
-      "targetPortId": 22,
-      "travelTime": {
-        "time": 4,
-        "consecutiveTime": 1,
-        "lock": true,
-        "warning": null,
-        "timeFormatter": null
-      },
-      "sourceDeparture": {
-        "time": 5,
-        "consecutiveTime": 5,
-        "lock": false,
-        "warning": null,
-        "timeFormatter": null
-      },
-      "sourceArrival": {
-        "time": 55,
-        "consecutiveTime": 55,
-        "lock": false,
-        "warning": null,
-        "timeFormatter": null
-      },
-      "targetDeparture": {
-        "time": 51,
-        "consecutiveTime": 51,
-        "lock": false,
-        "warning": null,
-        "timeFormatter": null
-      },
-      "targetArrival": {
-        "time": 9,
-        "consecutiveTime": 9,
-        "lock": false,
-        "warning": null,
-        "timeFormatter": null
-      },
-      "numberOfStops": 0,
-      "trainrunId": 7,
-      "resourceId": 0,
-      "specificTrainrunSectionFrequencyId": null,
-      "path": {
-        "path": [
-          {"x": 1534, "y": 976},
-          {"x": 1470, "y": 976},
-          {"x": 1250, "y": 1104},
-          {"x": 1186, "y": 1104}
-        ],
-        "textPositions": {
-          "0": {"x": 1516, "y": 964},
-          "1": {"x": 1488, "y": 988},
-          "2": {"x": 1204, "y": 1116},
-          "3": {"x": 1232, "y": 1092},
-          "4": {"x": 1360, "y": 1028},
-          "5": {"x": 1360, "y": 1028},
-          "6": {"x": 1360, "y": 1052}
-        }
-      },
-      "warnings": null
-    },
-    {
-      "id": 12,
-      "sourceNodeId": 16,
-      "sourcePortId": 23,
-      "targetNodeId": 15,
-      "targetPortId": 24,
-      "travelTime": {
-        "time": 1,
-        "consecutiveTime": 1,
-        "lock": true,
-        "warning": null,
-        "timeFormatter": null
-      },
-      "sourceDeparture": {
-        "time": 0,
-        "consecutiveTime": 120,
-        "lock": false,
-        "warning": null,
-        "timeFormatter": null
-      },
-      "sourceArrival": {
-        "time": 0,
-        "consecutiveTime": 60,
-        "lock": false,
-        "warning": null,
-        "timeFormatter": null
-      },
-      "targetDeparture": {
-        "time": 59,
-        "consecutiveTime": 59,
-        "lock": false,
-        "warning": null,
-        "timeFormatter": null
-      },
-      "targetArrival": {
-        "time": 1,
-        "consecutiveTime": 121,
-        "lock": false,
-        "warning": null,
-        "timeFormatter": null
-      },
-      "numberOfStops": 0,
-      "trainrunId": 8,
-      "resourceId": 0,
-      "specificTrainrunSectionFrequencyId": null,
-      "path": {
-        "path": [
-          {"x": 1694, "y": 1264},
-          {"x": 1630, "y": 1264},
-          {"x": 1634, "y": 1264},
-          {"x": 1570, "y": 1264}
-        ],
-        "textPositions": {
-          "0": {"x": 1676, "y": 1252},
-          "1": {"x": 1648, "y": 1276},
-          "2": {"x": 1588, "y": 1276},
-          "3": {"x": 1616, "y": 1252},
-          "4": {"x": 1632, "y": 1252},
-          "5": {"x": 1632, "y": 1252},
-          "6": {"x": 1632, "y": 1276}
-        }
-      },
-      "warnings": null
-    },
-    {
-      "id": 13,
-      "sourceNodeId": 17,
-      "sourcePortId": 26,
-      "targetNodeId": 16,
-      "targetPortId": 25,
-      "travelTime": {
-        "time": 1,
-        "consecutiveTime": 1,
-        "lock": true,
-        "warning": null,
-        "timeFormatter": null
-      },
-      "sourceDeparture": {
-        "time": 57,
-        "consecutiveTime": 117,
-        "lock": false,
-        "warning": null,
-        "timeFormatter": null
-      },
-      "sourceArrival": {
-        "time": 3,
-        "consecutiveTime": 63,
-        "lock": false,
-        "warning": null,
-        "timeFormatter": null
-      },
-      "targetDeparture": {
-        "time": 2,
-        "consecutiveTime": 62,
-        "lock": false,
-        "warning": null,
-        "timeFormatter": null
-      },
-      "targetArrival": {
-        "time": 58,
-        "consecutiveTime": 118,
-        "lock": false,
-        "warning": null,
-        "timeFormatter": null
-      },
-      "numberOfStops": 0,
-      "trainrunId": 8,
-      "resourceId": 0,
-      "specificTrainrunSectionFrequencyId": null,
-      "path": {
-        "path": [
-          {"x": 1918, "y": 1264},
-          {"x": 1854, "y": 1264},
-          {"x": 1858, "y": 1264},
-          {"x": 1794, "y": 1264}
-        ],
-        "textPositions": {
-          "0": {"x": 1900, "y": 1252},
-          "1": {"x": 1872, "y": 1276},
-          "2": {"x": 1812, "y": 1276},
-          "3": {"x": 1840, "y": 1252},
-          "4": {"x": 1856, "y": 1252},
-          "5": {"x": 1856, "y": 1252},
-          "6": {"x": 1856, "y": 1276}
-        }
-      },
-      "warnings": null
-    },
-    {
-      "id": 14,
-      "sourceNodeId": 7,
-      "sourcePortId": 9,
-      "targetNodeId": 1,
-      "targetPortId": 10,
-      "travelTime": {
-        "time": 1,
-        "consecutiveTime": 1,
-        "lock": true,
-        "warning": null,
-        "timeFormatter": null
-      },
-      "sourceDeparture": {
-        "time": 0,
-        "consecutiveTime": 0,
-        "lock": false,
-        "warning": null,
-        "timeFormatter": null
-      },
-      "sourceArrival": {
-        "time": 0,
-        "consecutiveTime": 180,
-        "lock": false,
-        "warning": null,
-        "timeFormatter": null
-      },
-      "targetDeparture": {
-        "time": 59,
-        "consecutiveTime": 179,
-        "lock": false,
-        "warning": null,
-        "timeFormatter": null
-      },
-      "targetArrival": {
-        "time": 1,
-        "consecutiveTime": 1,
-        "lock": false,
-        "warning": null,
-        "timeFormatter": null
-      },
-      "numberOfStops": 0,
-      "trainrunId": 2,
-      "resourceId": 0,
-      "specificTrainrunSectionFrequencyId": null,
-      "path": {
-        "path": [
-          {"x": 418, "y": 48},
-          {"x": 482, "y": 48},
-          {"x": 766, "y": 48},
-          {"x": 830, "y": 48}
-        ],
-        "textPositions": {
-          "0": {"x": 436, "y": 60},
-          "1": {"x": 464, "y": 36},
-          "2": {"x": 812, "y": 36},
-          "3": {"x": 784, "y": 60},
-          "4": {"x": 624, "y": 36},
-          "5": {"x": 624, "y": 36},
-          "6": {"x": 624, "y": 60}
-        }
-      },
-      "warnings": null
-    },
-    {
-      "id": 15,
-      "sourceNodeId": 1,
-      "sourcePortId": 11,
-      "targetNodeId": 4,
-      "targetPortId": 12,
-      "travelTime": {
-        "time": 5,
-        "consecutiveTime": 1,
-        "lock": true,
-        "warning": null,
-        "timeFormatter": null
-      },
-      "sourceDeparture": {
-        "time": 3,
-        "consecutiveTime": 3,
-        "lock": false,
-        "warning": null,
-        "timeFormatter": null
-      },
-      "sourceArrival": {
-        "time": 57,
-        "consecutiveTime": 177,
-        "lock": false,
-        "warning": null,
-        "timeFormatter": null
-      },
-      "targetDeparture": {
-        "time": 52,
-        "consecutiveTime": 172,
-        "lock": false,
-        "warning": null,
-        "timeFormatter": null
-      },
-      "targetArrival": {
-        "time": 8,
-        "consecutiveTime": 8,
-        "lock": false,
-        "warning": null,
-        "timeFormatter": null
-      },
-      "numberOfStops": 0,
-      "trainrunId": 2,
-      "resourceId": 0,
-      "specificTrainrunSectionFrequencyId": null,
-      "path": {
-        "path": [
-          {"x": 848, "y": 98},
-          {"x": 848, "y": 162},
-          {"x": 848, "y": 382},
-          {"x": 848, "y": 446}
-        ],
-        "textPositions": {
-          "0": {"x": 836, "y": 116},
-          "1": {"x": 860, "y": 144},
-          "2": {"x": 860, "y": 428},
-          "3": {"x": 836, "y": 400},
-          "4": {"x": 836, "y": 272},
-          "5": {"x": 836, "y": 272},
-          "6": {"x": 860, "y": 272}
-        }
-      },
-      "warnings": null
-    },
-    {
-      "id": 16,
-      "sourceNodeId": 4,
-      "sourcePortId": 13,
-      "targetNodeId": 1,
-      "targetPortId": 14,
-      "travelTime": {
-        "time": 1,
-        "consecutiveTime": 1,
-        "lock": true,
-        "warning": null,
-        "timeFormatter": null
-      },
-      "sourceDeparture": {
-        "time": 6,
-        "consecutiveTime": 66,
-        "lock": false,
-        "warning": null,
-        "timeFormatter": null
-      },
-      "sourceArrival": {
-        "time": 54,
-        "consecutiveTime": 114,
-        "lock": false,
-        "warning": null,
-        "timeFormatter": null
-      },
-      "targetDeparture": {
-        "time": 53,
-        "consecutiveTime": 113,
-        "lock": false,
-        "warning": null,
-        "timeFormatter": null
-      },
-      "targetArrival": {
-        "time": 7,
-        "consecutiveTime": 67,
-        "lock": false,
-        "warning": null,
-        "timeFormatter": null
-      },
-      "numberOfStops": 0,
-      "trainrunId": 2,
-      "resourceId": 0,
-      "specificTrainrunSectionFrequencyId": null,
-      "path": {
-        "path": [
-          {"x": 880, "y": 446},
-          {"x": 880, "y": 382},
-          {"x": 880, "y": 162},
-          {"x": 880, "y": 98}
-        ],
-        "textPositions": {
-          "0": {"x": 892, "y": 428},
-          "1": {"x": 868, "y": 400},
-          "2": {"x": 868, "y": 116},
-          "3": {"x": 892, "y": 144},
-          "4": {"x": 868, "y": 272},
-          "5": {"x": 868, "y": 272},
-          "6": {"x": 892, "y": 272}
-        }
-      },
-      "warnings": null
-    },
-    {
-      "id": 17,
-      "sourceNodeId": 1,
-      "sourcePortId": 15,
-      "targetNodeId": 2,
-      "targetPortId": 16,
-      "travelTime": {
-        "time": 1,
-        "consecutiveTime": 1,
-        "lock": true,
-        "warning": null,
-        "timeFormatter": null
-      },
-      "sourceDeparture": {
-        "time": 9,
-        "consecutiveTime": 69,
-        "lock": false,
-        "warning": null,
-        "timeFormatter": null
-      },
-      "sourceArrival": {
-        "time": 51,
-        "consecutiveTime": 111,
         "lock": false,
         "warning": null,
         "timeFormatter": null
       },
       "targetDeparture": {
         "time": 50,
-        "consecutiveTime": 110,
+        "consecutiveTime": 50,
         "lock": false,
         "warning": null,
         "timeFormatter": null
@@ -1042,24 +212,152 @@
         "timeFormatter": null
       },
       "numberOfStops": 0,
-      "trainrunId": 2,
+      "trainrunId": 1,
       "resourceId": 0,
       "specificTrainrunSectionFrequencyId": null,
       "path": {
         "path": [
-          {"x": 930, "y": 48},
-          {"x": 994, "y": 48},
-          {"x": 1566, "y": 48},
-          {"x": 1630, "y": 48}
+          {"x": 318, "y": 208},
+          {"x": 254, "y": 208},
+          {"x": -30, "y": 48},
+          {"x": -94, "y": 48}
         ],
         "textPositions": {
-          "0": {"x": 948, "y": 60},
-          "1": {"x": 976, "y": 36},
-          "2": {"x": 1612, "y": 36},
-          "3": {"x": 1584, "y": 60},
-          "4": {"x": 1280, "y": 36},
-          "5": {"x": 1280, "y": 36},
-          "6": {"x": 1280, "y": 60}
+          "0": {"x": 300, "y": 196},
+          "1": {"x": 272, "y": 220},
+          "2": {"x": -76, "y": 60},
+          "3": {"x": -48, "y": 36},
+          "4": {"x": 112, "y": 116},
+          "5": {"x": 112, "y": 116},
+          "6": {"x": 112, "y": 140}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 3,
+      "sourceNodeId": 0,
+      "sourcePortId": 5,
+      "targetNodeId": 8,
+      "targetPortId": 6,
+      "travelTime": {
+        "time": 10,
+        "consecutiveTime": 10,
+        "lock": true,
+        "warning": null,
+        "timeFormatter": null
+      },
+      "sourceDeparture": {
+        "time": 12,
+        "consecutiveTime": 72,
+        "lock": false,
+        "warning": null,
+        "timeFormatter": null
+      },
+      "sourceArrival": {
+        "time": 48,
+        "consecutiveTime": 48,
+        "lock": false,
+        "warning": null,
+        "timeFormatter": null
+      },
+      "targetDeparture": {
+        "time": 38,
+        "consecutiveTime": 38,
+        "lock": false,
+        "warning": null,
+        "timeFormatter": null
+      },
+      "targetArrival": {
+        "time": 22,
+        "consecutiveTime": 82,
+        "lock": false,
+        "warning": null,
+        "timeFormatter": null
+      },
+      "numberOfStops": 0,
+      "trainrunId": 1,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": -94, "y": 80},
+          {"x": -30, "y": 80},
+          {"x": 254, "y": 240},
+          {"x": 318, "y": 240}
+        ],
+        "textPositions": {
+          "0": {"x": -76, "y": 92},
+          "1": {"x": -48, "y": 68},
+          "2": {"x": 300, "y": 228},
+          "3": {"x": 272, "y": 252},
+          "4": {"x": 112, "y": 148},
+          "5": {"x": 112, "y": 148},
+          "6": {"x": 112, "y": 172}
+        }
+      },
+      "warnings": null
+    },
+    {
+      "id": 4,
+      "sourceNodeId": 8,
+      "sourcePortId": 10,
+      "targetNodeId": 1,
+      "targetPortId": 8,
+      "travelTime": {
+        "time": 10,
+        "consecutiveTime": 10,
+        "lock": true,
+        "warning": null,
+        "timeFormatter": null
+      },
+      "sourceDeparture": {
+        "time": 2,
+        "consecutiveTime": 2,
+        "lock": false,
+        "warning": null,
+        "timeFormatter": null
+      },
+      "sourceArrival": {
+        "time": 58,
+        "consecutiveTime": 118,
+        "lock": false,
+        "warning": null,
+        "timeFormatter": null
+      },
+      "targetDeparture": {
+        "time": 48,
+        "consecutiveTime": 108,
+        "lock": false,
+        "warning": null,
+        "timeFormatter": null
+      },
+      "targetArrival": {
+        "time": 12,
+        "consecutiveTime": 12,
+        "lock": false,
+        "warning": null,
+        "timeFormatter": null
+      },
+      "numberOfStops": 0,
+      "trainrunId": 1,
+      "resourceId": 0,
+      "specificTrainrunSectionFrequencyId": null,
+      "path": {
+        "path": [
+          {"x": 418, "y": 240},
+          {"x": 482, "y": 240},
+          {"x": 766, "y": 80},
+          {"x": 830, "y": 80}
+        ],
+        "textPositions": {
+          "0": {"x": 436, "y": 252},
+          "1": {"x": 464, "y": 228},
+          "2": {"x": 812, "y": 68},
+          "3": {"x": 784, "y": 92},
+          "4": {"x": 624, "y": 148},
+          "5": {"x": 624, "y": 148},
+          "6": {"x": 624, "y": 172}
         }
       },
       "warnings": null
@@ -1067,52 +365,7 @@
   ],
   "trainruns": [
     {
-      "id": 4,
-      "name": "1",
-      "categoryId": 1,
-      "frequencyId": 3,
-      "trainrunTimeCategoryId": 0,
-      "labelIds": [],
-      "direction": "round_trip"
-    },
-    {
-      "id": 5,
-      "name": "2",
-      "categoryId": 3,
-      "frequencyId": 2,
-      "trainrunTimeCategoryId": 0,
-      "labelIds": [],
-      "direction": "round_trip"
-    },
-    {
-      "id": 6,
-      "name": "4",
-      "categoryId": 6,
-      "frequencyId": 3,
-      "trainrunTimeCategoryId": 0,
-      "labelIds": [],
-      "direction": "round_trip"
-    },
-    {
-      "id": 7,
-      "name": "3",
-      "categoryId": 5,
-      "frequencyId": 0,
-      "trainrunTimeCategoryId": 0,
-      "labelIds": [],
-      "direction": "round_trip"
-    },
-    {
-      "id": 8,
-      "name": "X",
-      "categoryId": 1,
-      "frequencyId": 3,
-      "trainrunTimeCategoryId": 0,
-      "labelIds": [],
-      "direction": "round_trip"
-    },
-    {
-      "id": 2,
+      "id": 1,
       "name": "X",
       "categoryId": 1,
       "frequencyId": 3,
@@ -1132,16 +385,10 @@
     {"id": 8, "capacity": 2},
     {"id": 9, "capacity": 2},
     {"id": 10, "capacity": 2},
-    {"id": 11, "capacity": 2},
-    {"id": 12, "capacity": 2},
-    {"id": 13, "capacity": 2},
-    {"id": 14, "capacity": 2},
-    {"id": 15, "capacity": 2},
-    {"id": 16, "capacity": 2},
-    {"id": 17, "capacity": 2},
-    {"id": 18, "capacity": 2}
+    {"id": 11, "capacity": 2}
   ],
   "metadata": {
+    "analyticsSettings": {"originDestinationSettings": {"connectionPenalty": 5}},
     "trainrunCategories": [
       {
         "id": 0,
@@ -1271,16 +518,7 @@
         "frequency": 120,
         "offset": 0,
         "shortName": "120",
-        "name": "verkehrt zweistündlich (gerade)",
-        "linePatternRef": "120"
-      },
-      {
-        "id": 5,
-        "order": 0,
-        "frequency": 120,
-        "offset": 60,
-        "shortName": "120+",
-        "name": "verkehrt zweistündlich (ungerade)",
+        "name": "verkehrt zweistündlich",
         "linePatternRef": "120"
       }
     ],
@@ -1316,21 +554,7 @@
         "linePatternRef": "ZEITWEISE"
       }
     ],
-    "netzgrafikColors": [
-      {
-        "id": 8,
-        "colorRef": "NORMAL",
-        "color": "#767676",
-        "colorFocus": "#000000",
-        "colorMuted": "#DCDCDC",
-        "colorRelated": "#767676",
-        "colorDarkMode": "#767676",
-        "colorDarkModeFocus": "#DCDCDC",
-        "colorDarkModeMuted": "#000000",
-        "colorDarkModeRelated": "#767676"
-      }
-    ],
-    "analyticsSettings": {"originDestinationSettings": {"connectionPenalty": 5}}
+    "netzgrafikColors": []
   },
   "freeFloatingTexts": [],
   "labels": [],


### PR DESCRIPTION
Commit 96304f3cf6f9 ("tests: add missing CUSTOM_ELEMENTS_SCHEMA to testBeds") has updated the reconnect test. However, this commit has overwritten by mistake the test's DTO with the one from the O/D matrices test.

Fix this by restoring the original test DTO and logic. This is effectively a revert of the reconnect-related changes found in the commit (while keeping the test data in a separate JSON file).

The test data was generated by calling `getUnitTestReconnectTrainrunSectionNetzgrafik()` before that commit and encoding the result as JSON.

Extracted from https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/pull/589