### PR TITLE
fix: Changed url

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "version": "2.10.7",
   "repository": {
     "type": "git",
-    "url": "https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend.git"
+    "url": "https://github.com/OpenRailAssociation/netzgrafik-editor-frontend.git"
   },
   "files": [
     "dist/*"

--- a/src/app/services/data/trainrunsection.service.spec.ts
+++ b/src/app/services/data/trainrunsection.service.spec.ts
@@ -121,7 +121,7 @@ describe("TrainrunSectionService", () => {
   });
 
   it("TrainrunSectionService.checkMissingTransitionsAfterDeletion", () => {
-    // tests: https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/369
+    // tests: https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/issues/369
     dataService.loadNetzgrafikDto(NetzgrafikUnitTesting.getUnitTestNetzgrafik());
     trainrunSectionService.deleteAllVisibleTrainrunSections();
     nodeService.deleteAllVisibleNodes();

--- a/src/integration-testing/origin.destination.csv.test.spec.ts
+++ b/src/integration-testing/origin.destination.csv.test.spec.ts
@@ -105,7 +105,7 @@ describe("Origin Destination CSV Test", () => {
     });
     const end = new Date().getTime();
 
-    // See https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/199
+    // See https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/issues/199
     expect(res).toEqual(
       new Map([
         // Making sure we traverse E <- F -> G correctly.
@@ -156,7 +156,7 @@ describe("Origin Destination CSV Test", () => {
     });
     const end = new Date().getTime();
 
-    // See https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/199
+    // See https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/issues/199
     expect(res).toEqual(
       new Map([
         // Making sure we consider connections in H -> I -> J -> I -> K.
@@ -213,7 +213,7 @@ describe("Origin Destination CSV Test", () => {
     });
     const end = new Date().getTime();
 
-    // See https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/199
+    // See https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/issues/199
     expect(res).toEqual(
       new Map([
         ["11,13", [22, 1]],
@@ -266,7 +266,7 @@ describe("Origin Destination CSV Test", () => {
       );
     });
 
-    // See https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/issues/199
+    // See https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/issues/199
     expect(res).toEqual(
       new Map([
         ["13,14", [29, 1]],


### PR DESCRIPTION
After pusblishing the netzgrafik-editor under the host of OpenRailAssocation there should no longer the old github url in the repo.

<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->

# Description

<!-- Describe the changes your PR introduces here. -->

# Issues

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

- [ ] This PR contains a description of the changes I'm making
- [ ] I've read the [Contribution Guidelines](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/CONTRIBUTING.md)
- [ ] I've added tests for changes or features I've introduced
- [ ] I documented any high-level concepts I'm introducing in `documentation/`
- [ ] CI is currently green and this is ready for review

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation.
-->
