### PR TITLE
fix: emit single operation in setTimeStructureToTrainrunSections()

### DIFF
--- a/src/app/services/data/trainrunsection.service.ts
+++ b/src/app/services/data/trainrunsection.service.ts
@@ -927,6 +927,7 @@ export class TrainrunSectionService implements OnDestroy {
         rightIsTarget ? trsTimeStructure.rightArrivalTime : trsTimeStructure.leftArrivalTime,
         rightIsTarget ? trsTimeStructure.rightDepartureTime : trsTimeStructure.leftDepartureTime,
         trsTimeStructure.travelTime,
+        false,
       );
 
       trsTimeStructure.leftDepartureTime = trsTimeStructure.rightArrivalTime;
@@ -936,6 +937,7 @@ export class TrainrunSectionService implements OnDestroy {
 
     this.trainrunSectionsUpdated();
     this.nodeService.connectionsUpdated();
+    this.operation.emit(new TrainrunOperation(OperationType.update, trainrunSection.getTrainrun()));
   }
 
   trainrunSectionsUpdated() {


### PR DESCRIPTION
This function was iterating over multiple sections of a trainrun and emitting trainrun update events at each loop iteration. This results in a big number of events being generated for a single logical update.

Instead, emit an operation after the loop has completed.