### PR TITLE
refactor: move left-and-right structures to service

### DIFF
--- a/src/app/services/data/trainrun-section-times.service.ts
+++ b/src/app/services/data/trainrun-section-times.service.ts
@@ -1,16 +1,26 @@
 import {Injectable} from "@angular/core";
 import {MathUtils} from "../../utils/math";
 import {LeftAndRightElement, TrainrunsectionHelper} from "../util/trainrunsection.helper";
-import {
-  LeftAndRightLockStructure,
-  LeftAndRightTimeStructure,
-} from "../../view/dialogs/trainrun-and-section-dialog/trainrunsection-tab/trainrun-section-tab.component";
 import {TrainrunService} from "./trainrun.service";
 import {TrainrunSectionService} from "./trainrunsection.service";
 import {FilterService} from "../ui/filter.service";
 import {TrainrunSection} from "../../models/trainrunsection.model";
 import {Node} from "../../models/node.model";
 import {LoadPerlenketteService} from "../../perlenkette/service/load-perlenkette.service";
+
+export interface LeftAndRightTimeStructure {
+  leftDepartureTime: number;
+  leftArrivalTime: number;
+  rightDepartureTime: number;
+  rightArrivalTime: number;
+  travelTime: number;
+}
+
+export interface LeftAndRightLockStructure {
+  leftLock: boolean;
+  rightLock: boolean;
+  travelTimeLock: boolean;
+}
 
 @Injectable({
   providedIn: "root",

--- a/src/app/services/data/trainrunsection.service.ts
+++ b/src/app/services/data/trainrunsection.service.ts
@@ -13,7 +13,7 @@ import {TrainrunSectionValidator} from "../util/trainrunsection.validator";
 import {Trainrun} from "../../models/trainrun.model";
 import {MathUtils} from "../../utils/math";
 import {GeneralViewFunctions} from "../../view/util/generalViewFunctions";
-import {LeftAndRightTimeStructure} from "../../view/dialogs/trainrun-and-section-dialog/trainrunsection-tab/trainrun-section-tab.component";
+import {LeftAndRightTimeStructure} from "./trainrun-section-times.service";
 import {TrainrunsectionHelper} from "../util/trainrunsection.helper";
 import {LogService} from "../../logger/log.service";
 import {Transition} from "../../models/transition.model";

--- a/src/app/services/util/trainrunsection.helper.spec.ts
+++ b/src/app/services/util/trainrunsection.helper.spec.ts
@@ -3,6 +3,7 @@ import {NodeService} from "../data/node.service";
 import {ResourceService} from "../data/resource.service";
 import {TrainrunService} from "../data/trainrun.service";
 import {TrainrunSectionService} from "../data/trainrunsection.service";
+import {LeftAndRightTimeStructure} from "../data/trainrun-section-times.service";
 import {StammdatenService} from "../data/stammdaten.service";
 import {NoteService} from "../data/note.service";
 import {Node} from "../../models/node.model";
@@ -15,7 +16,6 @@ import {NetzgrafikUnitTesting} from "../../../integration-testing/netzgrafik.uni
 import {FilterService} from "../ui/filter.service";
 import {NetzgrafikColoringService} from "../data/netzgrafikColoring.service";
 import {TrainrunsectionHelper} from "./trainrunsection.helper";
-import {LeftAndRightTimeStructure} from "../../view/dialogs/trainrun-and-section-dialog/trainrunsection-tab/trainrun-section-tab.component";
 
 describe("TrainrunsectionHelper", () => {
   let dataService: DataService;

--- a/src/app/services/util/trainrunsection.helper.ts
+++ b/src/app/services/util/trainrunsection.helper.ts
@@ -1,14 +1,14 @@
 import {TrainrunSection} from "../../models/trainrunsection.model";
 import {Node} from "../../models/node.model";
 import {GeneralViewFunctions} from "../../view/util/generalViewFunctions";
-import {
-  LeftAndRightLockStructure,
-  LeftAndRightTimeStructure,
-} from "../../view/dialogs/trainrun-and-section-dialog/trainrunsection-tab/trainrun-section-tab.component";
 import {MathUtils} from "../../utils/math";
 import {TrainrunSectionText} from "../../data-structures/technical.data.structures";
 import {TrainrunService} from "../data/trainrun.service";
 import {TrainrunSectionService} from "../data/trainrunsection.service";
+import {
+  LeftAndRightLockStructure,
+  LeftAndRightTimeStructure,
+} from "../data/trainrun-section-times.service";
 
 export enum LeftAndRightElement {
   LeftDeparture,

--- a/src/app/view/dialogs/trainrun-and-section-dialog/trainrunsection-card/trainrun-section-card.component.ts
+++ b/src/app/view/dialogs/trainrun-and-section-dialog/trainrunsection-card/trainrun-section-card.component.ts
@@ -8,8 +8,10 @@ import {Node} from "../../../../models/node.model";
 import {Direction, LinePatternRefs} from "../../../../data-structures/business.data.structures";
 import {StaticDomTags} from "../../../editor-main-view/data-views/static.dom.tags";
 import {ColorRefType} from "../../../../data-structures/technical.data.structures";
-import {TrainrunSectionTimesService} from "../../../../services/data/trainrun-section-times.service";
-import {LeftAndRightTimeStructure} from "../trainrunsection-tab/trainrun-section-tab.component";
+import {
+  TrainrunSectionTimesService,
+  LeftAndRightTimeStructure,
+} from "../../../../services/data/trainrun-section-times.service";
 
 @Component({
   selector: "sbb-trainrunsection-card",

--- a/src/app/view/dialogs/trainrun-and-section-dialog/trainrunsection-tab/trainrun-section-tab.component.ts
+++ b/src/app/view/dialogs/trainrun-and-section-dialog/trainrunsection-tab/trainrun-section-tab.component.ts
@@ -22,22 +22,12 @@ import {Subject} from "rxjs";
 import {LinePatternRefs} from "../../../../data-structures/business.data.structures";
 import {StaticDomTags} from "../../../editor-main-view/data-views/static.dom.tags";
 import {ColorRefType} from "../../../../data-structures/technical.data.structures";
-import {TrainrunSectionTimesService} from "../../../../services/data/trainrun-section-times.service";
+import {
+  TrainrunSectionTimesService,
+  LeftAndRightLockStructure,
+  LeftAndRightTimeStructure,
+} from "../../../../services/data/trainrun-section-times.service";
 import {VersionControlService} from "../../../../services/data/version-control.service";
-
-export interface LeftAndRightTimeStructure {
-  leftDepartureTime: number;
-  leftArrivalTime: number;
-  rightDepartureTime: number;
-  rightArrivalTime: number;
-  travelTime: number;
-}
-
-export interface LeftAndRightLockStructure {
-  leftLock: boolean;
-  rightLock: boolean;
-  travelTimeLock: boolean;
-}
 
 @Component({
   selector: "sbb-trainrunsection-tab",


### PR DESCRIPTION
Currently, LeftAndRightTimeStructure and LeftAndRightLockStructure are defined in trainrun-section-tab.component.ts. The component is imported in various places just to grab these two types.

Define these types in the service to avoid importing components from services.