### PR TITLE
fix(streckengrafik): compute leftToRight per trainrun

### DIFF
--- a/src/app/services/data/trainrun.service.ts
+++ b/src/app/services/data/trainrun.service.ts
@@ -932,12 +932,12 @@ export class TrainrunService {
     return labelIDCauntMap;
   }
 
-  isTrainrunTargetRightOrBottom(): boolean {
-    if (!this.getSelectedTrainrun()) {
+  isTrainrunTargetRightOrBottom(trainrun: Trainrun = this.getSelectedTrainrun()): boolean {
+    if (!trainrun) {
       return false;
     }
-    const firstNode = this.getFirstTrainrunSection(this.getSelectedTrainrun()).getSourceNode();
-    const lastNode = this.getLastTrainrunSection(this.getSelectedTrainrun()).getTargetNode();
+    const firstNode = this.getFirstTrainrunSection(trainrun).getSourceNode();
+    const lastNode = this.getLastTrainrunSection(trainrun).getTargetNode();
     return GeneralViewFunctions.getRightOrBottomNode(firstNode, lastNode) === lastNode;
   }
 

--- a/src/app/streckengrafik/services/sg-1-load-trainrun-item.service.ts
+++ b/src/app/streckengrafik/services/sg-1-load-trainrun-item.service.ts
@@ -621,7 +621,7 @@ export class Sg1LoadTrainrunItemService implements OnDestroy {
         trainrun.getCategoryShortName(),
         trainrun.getCategoryColorRef(),
         pathItems,
-        this.trainrunService.isTrainrunTargetRightOrBottom(),
+        this.trainrunService.isTrainrunTargetRightOrBottom(trainrun),
         trainrun.getDirection(),
       ),
       visitedTrainrunSections: visitedTrainrunSections,


### PR DESCRIPTION
# Description

The `isTrainrunTargetRightOrBottom` method was always using the selected trainrun, causing all trainruns to share the same `leftToRight` value.

This PR makes it possible to specify a particular trainrun to that method, allowing multiple one-way trainruns with different leftToRight values to be properly displayed in the Streckengrafik

# Issues

- #749

# Checklist

- [x] This PR contains a description of the changes I'm making
- [x] I've read the [Contribution Guidelines](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/CONTRIBUTING.md)
- [x] I've added tests for changes or features I've introduced
- [x] I documented any high-level concepts I'm introducing in `documentation/`
- [x] CI is currently green and this is ready for review

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation.
-->
