### PR TITLE
fix: Select all nodes/notes with `ctrl + a` no longer ignores active filters

### DIFF
--- a/src/app/view/editor-main-view/data-views/editor.keyEvents.ts
+++ b/src/app/view/editor-main-view/data-views/editor.keyEvents.ts
@@ -694,8 +694,16 @@ export class EditorKeyEvents {
       this.uiInteractionService.getEditorMode() === EditorMode.NetzgrafikEditing
     ) {
       this.uiInteractionService.setEditorMode(EditorMode.MultiNodeMoving);
-      this.noteService.getNotes().forEach((n: Note) => n.select());
-      this.nodeService.getNodes().forEach((n: Node) => n.select());
+      this.noteService.getNotes().forEach((n: Note) => {
+        if (this.filterService.filterNote(n)) {
+          n.select();
+        }
+      });
+      this.nodeService.getNodes().forEach((n: Node) => {
+        if (this.filterService.filterNode(n)) {
+          n.select();
+        }
+      });
       this.noteService.notesUpdated();
       this.nodeService.nodesUpdated();
     }


### PR DESCRIPTION


<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->

# Description

When the user  like to select all notes/nodes with `ctrl + a`  the Netzgrafik-Editor should respect active filters. This was no the case. This fix ensure that selecting only "select* visible objects.

<!-- Describe the changes your PR introduces here. -->

# Issues

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

- [x] This PR contains a description of the changes I'm making
- [x] I've read the [Contribution Guidelines](https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/blob/main/CONTRIBUTING.md)
- [ ] I've added tests for changes or features I've introduced
- [ ] I documented any high-level concepts I'm introducing in `documentation/`
- [x] CI is currently green and this is ready for review

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation.
-->
