### PR TITLE
fix: Add extra check for MultiNodeMoving trainrun section  

### DIFF
--- a/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
@@ -1846,9 +1846,10 @@ export class TrainrunSectionsView {
   }
 
   handleMultiNodeMovingTrainrunSectionMouseUp(trainrunSection: TrainrunSection) {
-    if (d3.event.button === 2) {
+    if (d3.event.button === 2 || (d3.event.shiftKey && d3.event.button === 0)) {
       // Right mouse button released → do not deselect,
       // otherwise multi‑selection will not work correctly.
+      this.editorView.onEndMultiSelect();
       return;
     }
     this.editorView.unselectTrainrunSection(trainrunSection.getId());


### PR DESCRIPTION
Add extra check for MultiNodeMoving trainrun section (multi‑sele…ction). Issue was caused by incorrect mouseup handling: when the right mouse button is released, do not deselect, otherwise multi‑selection breaks.

<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->

# Description

<!-- Describe the changes your PR introduces here. -->

# Issues

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

- [x] This PR contains a description of the changes I'm making
- [x] I've read the [Contribution Guidelines](https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/blob/main/CONTRIBUTING.md)
- [ ] I've added tests for changes or features I've introduced
- [ ] I documented any high-level concepts I'm introducing in `documentation/`
- [x] CI is currently green and this is ready for review

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation.
-->
