### PR TITLE
fix: correct arrival time for right-to-left ONE_WAY trains

### DIFF
--- a/src/app/streckengrafik/services/sg-3-trainruns.service.ts
+++ b/src/app/streckengrafik/services/sg-3-trainruns.service.ts
@@ -115,24 +115,15 @@ export class Sg3TrainrunsService implements OnDestroy {
              * - Arrival node: occupation from arrival to (arrival + haltezeit)
              *
              * Also, don't use matchingSelectedPathNode (which is related to the path of
-             * selectedTrainrun), but use pathItem = pathItem.getPathNode() instead (which is
+             * selectedTrainrun), but use pathNode = pathItem.getPathNode() instead (which is
              * related to the proper trainrunItem):
              */
             if (trainrunItem.direction === Direction.ONE_WAY) {
-              if (trainrunItem.leftToRight) {
-                if (pathNode.departurePathSection === undefined) {
-                  departureTime = pathItem.arrivalTime + pathNodeHaltezeit;
-                }
-                if (pathNode.arrivalPathSection === undefined) {
-                  arrivalTime = pathItem.departureTime - pathNodeHaltezeit;
-                }
-              } else {
-                if (pathNode.departurePathSection === undefined) {
-                  arrivalTime = pathItem.departureTime - pathNodeHaltezeit;
-                }
-                if (pathNode.arrivalPathSection === undefined) {
-                  departureTime = pathItem.arrivalTime + pathNodeHaltezeit;
-                }
+              if (pathNode.departurePathSection === undefined) {
+                departureTime = pathNode.arrivalTime + pathNodeHaltezeit;
+              }
+              if (pathNode.arrivalPathSection === undefined) {
+                arrivalTime = pathNode.departureTime - pathNodeHaltezeit;
               }
             }
 


### PR DESCRIPTION
# Description

The `leftToRight` branching was incorrectly swapping assignment targets for extremity nodes, because `pathNode.departurePathSection` and `pathNode.arrivalPathSection` are already train-direction-aware.

# Issues

- #786

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

- [x] This PR contains a description of the changes I'm making
- [x] I've read the [Contribution Guidelines](https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/blob/main/CONTRIBUTING.md)
- [x] I've added tests for changes or features I've introduced
- [x] I documented any high-level concepts I'm introducing in `documentation/`
- [x] CI is currently green and this is ready for review
