### PR TITLE
docs: enhance documentation with filtering details

### DIFF
--- a/documentation/ORIGIN_DESTINATION_MATRIX.md
+++ b/documentation/ORIGIN_DESTINATION_MATRIX.md
@@ -19,7 +19,7 @@ The Origin Destination Matrix view computes the results once (when opened). It a
 
 If some nodes are selected, then the Origin Destination Matrix will only show results between these nodes (but other nodes may be used to compute paths).
 
-The Origin Destination Matrix will only show results between visible nodes (but other nodes may be used to compute paths).
+The Origin Destination Matrix will only show results between non-filtered nodes (but other nodes may be used to compute paths).
 
 The Origin Destination Matrix will only use non-filtered trainruns to compute paths.
 


### PR DESCRIPTION
Added a filtering section to clarify node and trainrun visibility. This improves understanding of how filtering affect o/d matrix.