### PR TITLE
chore: Release-please - disable npm publishing workflow step

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -81,6 +81,4 @@ jobs:
       - run: npm run build:standalone
       - run: npm pkg delete dependencies optionalDependencies devDependencies
 
-      #  Publishing temporarily disabled - it might be removed later on
-      # - run: npm publish --provenance --access public
-      - run: echo "Skipping npm publish (temporarily disabled)"
+      - run: npm publish --provenance --access public


### PR DESCRIPTION
The releases are available on GitHub Projects/Releases and this is sufficient for our distribution needs.  Publishing to registry.npmjs.org is no longer supported, as npm tokens expire every 90 days and must be  renewed manually. We estimate that the benefit of publishing to the npm registry is marginal for this project.

The npm publishing workflow step is therefore skipped for now and may be removed entirely later.


Current situation - the workflows is fully not working 
https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/actions/workflows/release-please.yml

This fix will resolve the failure in workflow execution.