### PR TITLE
refactor: add missing key events typing

### DIFF
--- a/src/app/view/editor-main-view/data-views/editor.keyEvents.ts
+++ b/src/app/view/editor-main-view/data-views/editor.keyEvents.ts
@@ -26,6 +26,9 @@ import {TrainrunSection} from "../../../models/trainrunsection.model";
 import {Trainrun} from "../../../models/trainrun.model";
 import {PositionTransformationService} from "../../../services/util/position.transformation.service";
 import {Vec2D} from "../../../utils/vec2D";
+import {TrainrunSectionViewObject} from "./trainrunSectionViewObject";
+import {NoteViewObject} from "./noteViewObject";
+import {NodeViewObject} from "./nodeViewObject";
 
 export class EditorKeyEvents {
   private editorMode: EditorMode;
@@ -353,7 +356,7 @@ export class EditorKeyEvents {
     let selectedTrainrunSectionId: number = undefined;
     d3.select(StaticDomTags.EDGE_LINE_DOM_REF + "." + StaticDomTags.TAG_SELECTED).classed(
       "KeyEventHandling",
-      (tsvo) => {
+      (tsvo: TrainrunSectionViewObject) => {
         if (tsvo === undefined) {
           const trainRun = this.trainrunService.getSelectedTrainrun();
           if (trainRun !== null) {
@@ -374,8 +377,8 @@ export class EditorKeyEvents {
     let noteHoveredId: number = undefined;
     d3.select(StaticDomTags.NOTE_ROOT_DOM_REF + "." + StaticDomTags.TAG_HOVER).classed(
       "KeyEventHandling",
-      (tsvo) => {
-        noteHoveredId = tsvo.note.getId();
+      (nvo: NoteViewObject) => {
+        noteHoveredId = nvo.note.getId();
         return false;
       },
     );
@@ -386,7 +389,7 @@ export class EditorKeyEvents {
     let hoveredNodeId: number = undefined;
     d3.select(StaticDomTags.NODE_ROOT_DOM_REF + "." + StaticDomTags.TAG_HOVER).classed(
       "KeyEventHandling",
-      (nvo) => {
+      (nvo: NodeViewObject) => {
         hoveredNodeId = nvo.node.getId();
         return false;
       },


### PR DESCRIPTION
This led to misunderstanding, due to the wrong var name, and the lack of var type.