### PR TITLE
fix(trainrun): validate that travel time respect timePrecision

### DIFF
--- a/src/app/models/trainrunsection.model.ts
+++ b/src/app/models/trainrunsection.model.ts
@@ -387,7 +387,7 @@ export class TrainrunSection {
 
   setTravelTime(time: number) {
     this.travelTime.time = time;
-    TrainrunSectionValidator.validateTravelTime(this);
+    TrainrunSectionValidator.validateTravelTime(this, 1); // TODO: I don't think this should be done here
   }
 
   setSourceDeparture(time: number) {

--- a/src/app/services/data/trainrunsection.service.ts
+++ b/src/app/services/data/trainrunsection.service.ts
@@ -231,7 +231,10 @@ export class TrainrunSectionService implements OnDestroy {
 
     this.trainrunSectionsStore.trainrunSections.forEach((trainrunSection) => {
       TrainrunSectionValidator.validateOneSection(trainrunSection);
-      TrainrunSectionValidator.validateTravelTime(trainrunSection);
+      TrainrunSectionValidator.validateTravelTime(
+        trainrunSection,
+        this.filterService.getTimeDisplayPrecision(),
+      );
     });
   }
 

--- a/src/app/services/util/trainrunsection.validator.ts
+++ b/src/app/services/util/trainrunsection.validator.ts
@@ -82,11 +82,12 @@ export class TrainrunSectionValidator {
     }
   }
 
-  static validateTravelTime(trainrunSection: TrainrunSection) {
-    if (trainrunSection.getTravelTime() < 1) {
+  static validateTravelTime(trainrunSection: TrainrunSection, timeDisplayPrecision: number = 1) {
+    const minimumTravelTime = 1 / Math.pow(10, timeDisplayPrecision);
+    if (trainrunSection.getTravelTime() < minimumTravelTime) {
       trainrunSection.setTravelTimeWarning(
-        $localize`:@@app.services.util.trainrunsection-validator.travel-time-less-than-1.title:Travel Time less than 1`,
-        $localize`:@@app.services.util.trainrunsection-validator.travel-time-less-than-1.description:Travel time must be greater than or equal to 1`,
+        $localize`:@@app.services.util.trainrunsection-validator.travel-time-less-than-1.title:Travel Time less than ${minimumTravelTime}:minimumTravelTime:`,
+        $localize`:@@app.services.util.trainrunsection-validator.travel-time-less-than-1.description:Travel time must be greater than or equal to ${minimumTravelTime}:minimumTravelTime:`,
       );
     } else {
       trainrunSection.resetTravelTimeWarning();

--- a/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
+++ b/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
@@ -787,7 +787,7 @@ export class EditorToolsViewComponent {
     // step(6) Validate all trainrun sections
     this.trainrunSectionService.getTrainrunSections().forEach((ts) => {
       TrainrunSectionValidator.validateOneSection(ts);
-      TrainrunSectionValidator.validateTravelTime(ts);
+      TrainrunSectionValidator.validateTravelTime(ts, this.filterService.getTimeDisplayPrecision());
     });
   }
 

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -96,8 +96,8 @@
             "description": "Quellankunftszeit kann nicht erreicht werden"
           },
           "travel-time-less-than-1": {
-            "title": "Reisezeit weniger als 1",
-            "description": "Die Reisezeit muss größer oder gleich 1 sein."
+            "title": "Reisezeit weniger als {$minimumTravelTime}",
+            "description": "Die Reisezeit muss größer oder gleich {$minimumTravelTime} sein."
           }
         },
         "transition-validator": {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -96,8 +96,8 @@
             "description": "Source arrival time cannot be reached"
           },
           "travel-time-less-than-1": {
-            "title": "Travel Time less than 1",
-            "description": "Travel time must be greater than or equal to 1"
+            "title": "Travel Time less than {$minimumTravelTime}",
+            "description": "Travel time must be greater than or equal to {$minimumTravelTime}"
           }
         },
         "transition-validator": {

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -96,8 +96,8 @@
             "description": "L'heure d'arrivée à l'origine ne peut être atteinte"
           },
           "travel-time-less-than-1": {
-            "title": "Temps de trajet inférieur à 1",
-            "description": "Le temps de trajet doit être supérieur ou égal à 1"
+            "title": "Temps de trajet inférieur à {$minimumTravelTime}",
+            "description": "Le temps de trajet doit être supérieur ou égal à {$minimumTravelTime}"
           }
         },
         "transition-validator": {


### PR DESCRIPTION
Close https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/issues/831

Not fully working, I struggle to get the `timePrecision` value updated if I change it from the UI...

Also, validating from the model makes it impossible to reach the filter service to get the current time precision value.

This PR needs to be fixed for that, but this is a first step.