### PR TITLE
feat(node-details): add a collapse button

### DIFF
--- a/src/app/services/data/node.service.ts
+++ b/src/app/services/data/node.service.ts
@@ -905,6 +905,15 @@ export class NodeService implements OnDestroy {
     this.operation.emit(new NodeOperation(OperationType.update, this.getNodeFromId(nodeId)));
   }
 
+  changeIsCollapsed(nodeId: number, isCollapsed: boolean) {
+    this.getNodeFromId(nodeId).setIsCollapsed(isCollapsed);
+    this.nodesUpdated();
+    this.trainrunSectionService.trainrunSectionsUpdated();
+    this.connectionsUpdated();
+    this.transitionsUpdated();
+    this.operation.emit(new NodeOperation(OperationType.update, this.getNodeFromId(nodeId)));
+  }
+
   changeLabels(nodeId: number, labels: string[]) {
     const node = this.getNodeFromId(nodeId);
 

--- a/src/app/view/editor-side-view/editor-node-detail-view/editor-node-detail-view.component.html
+++ b/src/app/view/editor-side-view/editor-node-detail-view/editor-node-detail-view.component.html
@@ -45,6 +45,25 @@
 
   <sbb-expansion-panel [expanded]="true">
     <sbb-expansion-panel-header>{{
+      "app.view.editor-side-view.editor-node-detail-view.display" | translate
+    }}</sbb-expansion-panel-header>
+    <sbb-radio-group
+      [ngModel]="nodeProperties.isCollapsed ? 'collapsed' : 'expanded'"
+      (ngModelChange)="onNodeDisplayModeChanged($event)"
+      [class.readonly]="!versionControlService.getVariantIsWritable()"
+      class="node-display-mode-radio-group"
+    >
+      <sbb-radio-button value="expanded">
+        {{ "app.view.editor-side-view.editor-node-detail-view.expanded" | translate }}
+      </sbb-radio-button>
+      <sbb-radio-button value="collapsed">
+        {{ "app.view.editor-side-view.editor-node-detail-view.collapsed" | translate }}
+      </sbb-radio-button>
+    </sbb-radio-group>
+  </sbb-expansion-panel>
+
+  <sbb-expansion-panel [expanded]="true">
+    <sbb-expansion-panel-header>{{
       "app.view.editor-side-view.editor-node-detail-view.occupancy" | translate
     }}</sbb-expansion-panel-header>
     <div class="sbb-mt-m">

--- a/src/app/view/editor-side-view/editor-node-detail-view/editor-node-detail-view.component.scss
+++ b/src/app/view/editor-side-view/editor-node-detail-view/editor-node-detail-view.component.scss
@@ -71,3 +71,9 @@ table.NodeDataTable.readonly {
   pointer-events: none;
   cursor: default;
 }
+
+.node-display-mode-radio-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}

--- a/src/app/view/editor-side-view/editor-node-detail-view/editor-node-detail-view.component.ts
+++ b/src/app/view/editor-side-view/editor-node-detail-view/editor-node-detail-view.component.ts
@@ -27,6 +27,7 @@ interface NodeProperties {
   nodeResourceId: number;
   nodeCapacity: number;
   labels: string[];
+  isCollapsed: boolean;
 }
 
 @Component({
@@ -47,6 +48,7 @@ export class EditorNodeDetailViewComponent implements OnInit, OnDestroy {
     nodeResourceId: null,
     nodeCapacity: 2,
     labels: [],
+    isCollapsed: false,
   };
 
   private initialNodeLabels: string[];
@@ -102,6 +104,10 @@ export class EditorNodeDetailViewComponent implements OnInit, OnDestroy {
       this.nodeProperties.nodeId,
       this.nodeProperties.nodeConnectionTime,
     );
+  }
+
+  onNodeDisplayModeChanged(display: "expanded" | "collapsed") {
+    this.nodeService.changeIsCollapsed(this.nodeProperties.nodeId, display === "collapsed");
   }
 
   add(chipInputEvent: SbbChipInputEvent) {
@@ -247,6 +253,7 @@ export class EditorNodeDetailViewComponent implements OnInit, OnDestroy {
         nodeResourceId: resource.getId(),
         nodeCapacity: resource.getCapacity(),
         labels: this.labelService.getTextLabelsFromIds(selectedNode.getLabelIds()),
+        isCollapsed: selectedNode.getIsCollapsed(),
       };
       this.initialNodeLabels = [...this.nodeProperties.labels]; // initialize labels
     }

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -447,6 +447,9 @@
       },
       "editor-side-view": {
         "editor-node-detail-view": {
+          "display": "Anzeige",
+          "expanded": "Erweitert",
+          "collapsed": "Zusammengeklappt",
           "base-data": "Stammdaten",
           "operational-point": "Betriebspunkt",
           "name": "Name",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -455,6 +455,9 @@
       },
       "editor-side-view": {
         "editor-node-detail-view": {
+          "display": "Display",
+          "expanded": "Expanded",
+          "collapsed": "Collapsed",
           "base-data": "Base data",
           "operational-point": "Operational point",
           "name": "Name",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -455,6 +455,9 @@
       },
       "editor-side-view": {
         "editor-node-detail-view": {
+          "display": "Affichage",
+          "expanded": "Développé",
+          "collapsed": "Réduit",
           "base-data": "Données de base",
           "operational-point": "Point opérationnel",
           "name": "Nom",


### PR DESCRIPTION
Bonus, because I was bored to keep going to the global node panel.

This follows the mock-ups

<img width="622" height="445" alt="image" src="https://github.com/user-attachments/assets/0b03f3d4-1d9c-4390-ba48-1edbaff858cc" />

https://github.com/user-attachments/assets/6f9a83f9-5c21-48b5-8779-9bb1beb5de73


> [!IMPORTANT]
> The "Tip" feature is not working in the feature branch yet, but will be fixed by https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/pull/731 