### PR TITLE
fix: Swap the O/D data

### DIFF
--- a/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
@@ -160,7 +160,7 @@ export class OriginDestinationComponent implements OnInit, AfterViewInit, OnDest
       .attr("id", "zoom-group")
       .attr("transform", `translate(${offsetX}, ${offsetY})`);
 
-    // Build X scales and axis:
+    // Build X scales and axis (destinations):
     const x = d3
       .scaleBand()
       .range([0, width])
@@ -182,7 +182,7 @@ export class OriginDestinationComponent implements OnInit, AfterViewInit, OnDest
       .call((g) =>
         g
           .selectAll("text")
-          .attr("data-origin-label", (d: string) => d)
+          .attr("data-destination-label", (d: string) => d)
           .style("text-anchor", "start")
           .attr("dx", "-0.8em")
           .attr("dy", "0.4em")
@@ -192,7 +192,7 @@ export class OriginDestinationComponent implements OnInit, AfterViewInit, OnDest
       .select(".domain")
       .remove();
 
-    // Build Y scales and axis:
+    // Build Y scales and axis (origins):
     const y = d3
       .scaleBand()
       .range([height, 0])
@@ -208,7 +208,7 @@ export class OriginDestinationComponent implements OnInit, AfterViewInit, OnDest
           .tickFormat((d) => this.nodeService.getNodeFromId(d).getBetriebspunktName()),
       )
       .style("user-select", "none")
-      .call((g) => g.selectAll("text").attr("data-destination-label", (d: string) => d))
+      .call((g) => g.selectAll("text").attr("data-origin-label", (d: string) => d))
       .select(".domain")
       .remove();
 
@@ -286,10 +286,10 @@ export class OriginDestinationComponent implements OnInit, AfterViewInit, OnDest
       .enter()
       .append("rect")
       .attr("x", (d: OriginDestination) => {
-        return x(d.originId);
+        return x(d.destinationId);
       })
       .attr("y", function (d: OriginDestination) {
-        return y(d.destinationId);
+        return y(d.originId);
       })
       .attr("rx", 4)
       .attr("ry", 4)
@@ -314,10 +314,10 @@ export class OriginDestinationComponent implements OnInit, AfterViewInit, OnDest
       .append("text")
       .style("pointer-events", "none")
       .attr("x", (d: OriginDestination) => {
-        return x(d.originId) + x.bandwidth() / 2;
+        return x(d.destinationId) + x.bandwidth() / 2;
       })
       .attr("y", function (d: OriginDestination) {
-        return y(d.destinationId) + y.bandwidth() / 2;
+        return y(d.originId) + y.bandwidth() / 2;
       })
       .text((d: OriginDestination) => this.getCellText(d))
       .style("text-anchor", "middle")


### PR DESCRIPTION
The fix just swaps the xy-axis for the matrix (visualisation) and the readability is much improved.


### Before fix 


|  2.10.16  |   |
| ------------- | ------------- |
| <img width="1908" height="998" alt="chrome-capture-2026-02-25 (4)" src="https://github.com/user-attachments/assets/59367ec3-5ef9-4acb-8d34-c70a8737d089" /> | <img width="1908" height="998" alt="chrome-capture-2026-02-25 (5)" src="https://github.com/user-attachments/assets/8462e4bd-4d60-492c-889a-3bda6b5ee8b8" /> |



### After fix 

|  fixed version|   |
| ------------- | ------------- |
| <img width="1908" height="998" alt="chrome-capture-2026-02-25 (2)" src="https://github.com/user-attachments/assets/6d63268a-dd71-473a-957c-efe6aba135fe" /> | <img width="1908" height="998" alt="chrome-capture-2026-02-25 (6)" src="https://github.com/user-attachments/assets/b5da2a4c-ae0d-44ad-ab4d-0eae3d413ce7" /> |


