### PR TITLE
fix: There is no business requirement to enter very small values for traveltime

### DIFF
--- a/src/app/models/trainrunsection.model.ts
+++ b/src/app/models/trainrunsection.model.ts
@@ -14,6 +14,8 @@ import {TrainrunSectionValidator} from "../services/util/trainrunsection.validat
 import {formatDate} from "@angular/common";
 
 export class TrainrunSection {
+  static MIN_TRAVEL_TIME = 0.01; // 1 / 100 minute = 0.6 second - defined min. travel time
+
   private static currentId = 0;
 
   private id: number;
@@ -386,8 +388,8 @@ export class TrainrunSection {
   }
 
   setTravelTime(time: number) {
-    this.travelTime.time = time;
-    TrainrunSectionValidator.validateTravelTime(this, 1); // TODO: I don't think this should be done here
+    this.travelTime.time = Math.max(time, TrainrunSection.MIN_TRAVEL_TIME);
+    TrainrunSectionValidator.validateTravelTime(this);
   }
 
   setSourceDeparture(time: number) {

--- a/src/app/services/data/trainrun-section-times.service.ts
+++ b/src/app/services/data/trainrun-section-times.service.ts
@@ -321,6 +321,11 @@ export class TrainrunSectionTimesService {
     this.roundAllTimes();
     this.removeOffsetAndBackTransformTimeStructure();
 
+    this.timeStructure.travelTime = Math.max(
+      this.timeStructure.travelTime,
+      TrainrunSection.MIN_TRAVEL_TIME,
+    );
+
     if (!this.lockStructure.rightLock) {
       this.timeStructure.rightArrivalTime = MathUtils.mod60(
         this.timeStructure.leftDepartureTime + this.timeStructure.travelTime,

--- a/src/app/services/data/trainrunsection.service.ts
+++ b/src/app/services/data/trainrunsection.service.ts
@@ -231,10 +231,7 @@ export class TrainrunSectionService implements OnDestroy {
 
     this.trainrunSectionsStore.trainrunSections.forEach((trainrunSection) => {
       TrainrunSectionValidator.validateOneSection(trainrunSection);
-      TrainrunSectionValidator.validateTravelTime(
-        trainrunSection,
-        this.filterService.getTimeDisplayPrecision(),
-      );
+      TrainrunSectionValidator.validateTravelTime(trainrunSection);
     });
   }
 

--- a/src/app/services/util/trainrunsection.validator.ts
+++ b/src/app/services/util/trainrunsection.validator.ts
@@ -82,12 +82,11 @@ export class TrainrunSectionValidator {
     }
   }
 
-  static validateTravelTime(trainrunSection: TrainrunSection, timeDisplayPrecision: number = 1) {
-    const minimumTravelTime = 1 / Math.pow(10, timeDisplayPrecision);
-    if (trainrunSection.getTravelTime() < minimumTravelTime) {
+  static validateTravelTime(trainrunSection: TrainrunSection) {
+    if (trainrunSection.getTravelTime() < TrainrunSection.MIN_TRAVEL_TIME) {
       trainrunSection.setTravelTimeWarning(
-        $localize`:@@app.services.util.trainrunsection-validator.travel-time-less-than-1.title:Travel Time less than ${minimumTravelTime}:minimumTravelTime:`,
-        $localize`:@@app.services.util.trainrunsection-validator.travel-time-less-than-1.description:Travel time must be greater than or equal to ${minimumTravelTime}:minimumTravelTime:`,
+        $localize`:@@app.services.util.trainrunsection-validator.travel-time-less-than-1.title:Travel Time less than ${TrainrunSection.MIN_TRAVEL_TIME}:minimumTravelTime:`,
+        $localize`:@@app.services.util.trainrunsection-validator.travel-time-less-than-1.description:Travel time must be greater than or equal to ${TrainrunSection.MIN_TRAVEL_TIME}:minimumTravelTime:`,
       );
     } else {
       trainrunSection.resetTravelTimeWarning();

--- a/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
+++ b/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
@@ -787,7 +787,7 @@ export class EditorToolsViewComponent {
     // step(6) Validate all trainrun sections
     this.trainrunSectionService.getTrainrunSections().forEach((ts) => {
       TrainrunSectionValidator.validateOneSection(ts);
-      TrainrunSectionValidator.validateTravelTime(ts, this.filterService.getTimeDisplayPrecision());
+      TrainrunSectionValidator.validateTravelTime(ts);
     });
   }
 


### PR DESCRIPTION
Since 0.01 min equals 0.6 s, we enforce that such values are not allowed internally. I double checked this assumption with Martin (BO) Netzgrafik at SBB. 

The validator warning should only be triggered when e.g. a third‑party JSON file is imported. For strategic planning, the minimum allowed value is 0.1.

OSRD? What do you have a  minimal travelTime for edges (second) .... ? 

@louisgreiner 