### PR TITLE
feat(view): enable node detail modal to be opened on clicking on a collapsed node

### DIFF
--- a/src/app/view/editor-main-view/data-views/editor.view.ts
+++ b/src/app/view/editor-main-view/data-views/editor.view.ts
@@ -121,12 +121,12 @@ export class EditorView implements SVGMouseControllerObserver {
 
   constructor(
     controller: EditorMainViewComponent,
-    private nodeService: NodeService,
+    public nodeService: NodeService,
     private trainrunService: TrainrunService,
     private trainrunSectionService: TrainrunSectionService,
     private noteService: NoteService,
     private filterService: FilterService,
-    private uiInteractionService: UiInteractionService,
+    public uiInteractionService: UiInteractionService,
     private undoService: UndoService,
     private copyService: CopyService,
     private logService: LogService,

--- a/src/app/view/editor-main-view/data-views/trainrunsections.view.edgeline.scss
+++ b/src/app/view/editor-main-view/data-views/trainrunsections.view.edgeline.scss
@@ -142,6 +142,7 @@
   r: $TRAINRUN_SECTION_STOP_RADIUS;
   fill: $COLOR_BACKGROUND;
   stroke-width: 1px;
+  cursor: pointer;
 }
 
 ::ng-deep path.edge_line_stop_arcs.hover {

--- a/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
@@ -1812,11 +1812,17 @@ export class TrainrunSectionsView {
     this.editorView.trainrunSectionPreviewLineView.updatePreviewLine();
   }
 
-  onCollapsedNodeMouseUp(viewObject: TrainrunSectionViewObject, domObj: any) {
+  onCollapsedNodeMouseUp(viewObject: TrainrunSectionViewObject, domObj: any, stopIndex?: number) {
     d3.event.stopPropagation();
     D3Utils.removeGrayout(viewObject);
     this.editorView.trainrunSectionPreviewLineView.stopPreviewLine();
     this.editorView.setTrainrunAsSelected(viewObject.getTrainrun());
+    if (stopIndex !== undefined) {
+      this.editorView.nodeService.setSingleNodeAsSelected(
+        viewObject.getCollapsedStopNodeFromStopIndex(stopIndex).getId(),
+      );
+      this.editorView.uiInteractionService.showNodeStammdaten();
+    }
   }
 
   onTrainrunSectionTextMouseout(trainrunSection: TrainrunSection, domObj: any) {
@@ -2597,7 +2603,9 @@ export class TrainrunSectionsView {
       .on("mousedown", (t: TrainrunSectionViewObject, i, a) =>
         this.onCollapsedNodeMouseDown(t, numberOfStops, position, stopIndex, a[i]),
       )
-      .on("mouseup", (t: TrainrunSectionViewObject, i, a) => this.onCollapsedNodeMouseUp(t, a[i]));
+      .on("mouseup", (t: TrainrunSectionViewObject, i, a) =>
+        this.onCollapsedNodeMouseUp(t, a[i], stopIndex),
+      );
   }
 
   private createNewTrainrunSectionAfterPinDropped(endNode: any, trainrunSection: TrainrunSection) {


### PR DESCRIPTION
I think the behavior is sometimes weird, but it helps a lot

https://github.com/user-attachments/assets/cf18c572-9160-4bdc-b74e-1261410999f0

