### PR TITLE
fix(service): fix travelTimeOffset for asymmetric trainruns

### DIFF
--- a/src/app/services/data/trainrun.service.ts
+++ b/src/app/services/data/trainrun.service.ts
@@ -902,8 +902,8 @@ export class TrainrunService {
           : arrivalTime - oppositeNodeDepartureTime;
       accumulatedTime += travelTime;
 
-      const travelTimeOffset =
-        nextPair.trainrunSection.getTravelTime() - (nextPair.trainrunSection.getTravelTime() % 60);
+      const directedTravelTime = nextPair.getDirectedTrainrunSectionProxy().getTravelTime();
+      const travelTimeOffset = directedTravelTime - (directedTravelTime % 60);
       accumulatedTime += travelTimeOffset;
 
       nextPair.node.setArrivalConsecutiveTime(nextPair.trainrunSection, accumulatedTime);

--- a/src/integration-testing/trainrunsection.service.test.spec.ts
+++ b/src/integration-testing/trainrunsection.service.test.spec.ts
@@ -312,6 +312,7 @@ describe("TrainrunSection Service Test", () => {
     const startNode = trainrunService.getLeftOrTopNodeWithTrainrunId(2);
     const trainrunSection = startNode.getExtremityTrainrunSection(2);
     trainrunSection.setTravelTime(123);
+    trainrunSection.setBackwardTravelTime(123);
     trainrunService.propagateInitialConsecutiveTimes();
     const startTrainrunSection = startNode.getExtremityTrainrunSection(2);
 
@@ -327,6 +328,39 @@ describe("TrainrunSection Service Test", () => {
     expect(nextTrainrunSection.getSourceArrivalConsecutiveTime()).toBe(261);
     expect(nextTrainrunSection.getTargetDepartureConsecutiveTime()).toBe(251);
     expect(nextTrainrunSection.getTargetArrivalConsecutiveTime()).toBe(169);
+  });
+
+  it("check consecutive time : asymmetric travel time 60min overflow", () => {
+    dataService.loadNetzgrafikDto(NetzgrafikUnitTesting.getUnitTestNetzgrafik());
+    expect(trainrunSections.length).toBe(8);
+
+    const allTrainrunSections = trainrunSectionService.getTrainrunSections();
+    allTrainrunSections.forEach((trs) => {
+      trs.setSourceDepartureConsecutiveTime(undefined);
+      trs.setSourceArrivalConsecutiveTime(undefined);
+      trs.setTargetDepartureConsecutiveTime(undefined);
+      trs.setTargetArrivalConsecutiveTime(undefined);
+    });
+    const startNode = trainrunService.getLeftOrTopNodeWithTrainrunId(2);
+    const trainrunSection = startNode.getExtremityTrainrunSection(2);
+    trainrunSection.setAsymmetry();
+    trainrunSection.setTravelTime(75);
+    trainrunSection.setBackwardTravelTime(50);
+    trainrunService.propagateInitialConsecutiveTimes();
+    const startTrainrunSection = startNode.getExtremityTrainrunSection(2);
+
+    expect(startTrainrunSection.getSourceDepartureConsecutiveTime()).toBe(0);
+    expect(startTrainrunSection.getSourceArrivalConsecutiveTime()).toBe(240);
+    expect(startTrainrunSection.getTargetDepartureConsecutiveTime()).toBe(201);
+    expect(startTrainrunSection.getTargetArrivalConsecutiveTime()).toBe(99);
+
+    const nextTrainrunSection = startNode
+      .getOppositeNode(startTrainrunSection)
+      .getNextTrainrunSection(startTrainrunSection);
+    expect(nextTrainrunSection.getSourceDepartureConsecutiveTime()).toBe(99);
+    expect(nextTrainrunSection.getSourceArrivalConsecutiveTime()).toBe(201);
+    expect(nextTrainrunSection.getTargetDepartureConsecutiveTime()).toBe(191);
+    expect(nextTrainrunSection.getTargetArrivalConsecutiveTime()).toBe(109);
   });
 
   it("path router check", () => {


### PR DESCRIPTION
Fixes the calculation of `travelTimeOffset` to use `getDirectedTrainrunSectionProxy().getTravelTime()` instead of `trainrunSection.getTravelTime()` ensuring the correct travelTime is used (forward or backward).
Adds a test to check consecutive time with travel time over 60min for an asymmetric run