### PR TITLE
chore: set NGE-Admins as code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-# Adrian should be the default reviewer
-* @aiAdrian
+# https://github.com/OpenRailAssociation/openrail-org-config/blob/main/teams/nge.yaml
+* @openrailassociation/NGE-Admins


### PR DESCRIPTION
In the following of the new [governance](https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/blob/main/GOVERNANCE.md), including [OSRD](https://github.com/OpenRailAssociation/osrd) as active members in the development of Netzgrafik-Editor.