### PR TITLE
chore: drop two-step CI setup

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -16,18 +16,6 @@ permissions:
   deployments: write
 
 jobs:
-  format:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: ".nvmrc"
-          cache: "npm"
-      - run: npm clean-install
-      - name: Check code formatting
-        run: npx prettier --check .
-
   conventional-commits:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
@@ -50,20 +38,8 @@ jobs:
         if: github.event_name == 'pull_request'
         run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
 
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: ".nvmrc"
-          cache: "npm"
-      - run: npm clean-install
-      - run: npm run lint
-
   test:
     runs-on: ubuntu-latest
-    needs: lint
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -73,9 +49,21 @@ jobs:
       - run: npm clean-install
       - run: npm test
 
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+      - run: npm clean-install
+      - name: Check code formatting
+        run: npx prettier --check .
+      - run: npm run lint
+
   build:
     runs-on: ubuntu-latest
-    needs: lint
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -92,7 +80,6 @@ jobs:
 
   build-standalone:
     runs-on: ubuntu-latest
-    needs: lint
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -109,7 +96,6 @@ jobs:
 
   build-standalonedemo:
     runs-on: ubuntu-latest
-    needs: lint
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Right now, CI runs in two steps: first the lint stage is run, and only when that completes builds are fired up. This increases CI time quite a bit.

Additionally, format and lint steps are spread across multiple jobs. These jobs are quite fast, however each time we need to checkout sources and install dependencies.

Consolidate all of these jobs in a single one, and stop waiting before starting build jobs.