### PR TITLE
fix: drop extraneous "browser" directory in dist/

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -76,7 +76,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: build
-          path: dist/netzgrafik-frontend/
+          path: dist/
 
   build-standalone:
     runs-on: ubuntu-latest
@@ -92,7 +92,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: build-standalone
-          path: dist/netzgrafik-frontend/
+          path: dist/
 
   build-standalonedemo:
     runs-on: ubuntu-latest
@@ -108,7 +108,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: build-standalone-demo
-          path: dist/netzgrafik-frontend/
+          path: dist/
 
   deploy-preview:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-standalone-github.yml
+++ b/.github/workflows/deploy-standalone-github.yml
@@ -28,5 +28,5 @@ jobs:
       - id: build-publish
         uses: bitovi/github-actions-angular-to-github-pages@v1.0.0
         with:
-          path: dist/netzgrafik-frontend
+          path: dist
           build_command: npm run build:standalonedemo -- --base-href=netzgrafik-frontend

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ADD --chmod=755 docker/99-ngssc.sh /docker-entrypoint.d/
 ADD docker/nginx-angular.conf /etc/nginx/conf.d/default.conf
 
 # copy built application from build stage
-COPY --from=build --chown=nginx:nginx --chmod=755 /build/dist/netzgrafik-frontend /usr/share/nginx/html
+COPY --from=build --chown=nginx:nginx --chmod=755 /build/dist /usr/share/nginx/html
 
 # Validate the nginx configuration
 RUN nginx -t

--- a/angular.json
+++ b/angular.json
@@ -18,7 +18,7 @@
           "builder": "@angular-devkit/build-angular:application",
           "options": {
             "outputPath": {
-              "base": "dist/netzgrafik-frontend",
+              "base": "dist",
               "browser": ""
             },
             "index": "src/index.html",
@@ -40,9 +40,6 @@
           },
           "configurations": {
             "production": {
-              "outputPath": {
-                "base": "dist"
-              },
               "fileReplacements": [
                 {
                   "replace": "src/environments/environment.ts",

--- a/angular.json
+++ b/angular.json
@@ -18,7 +18,8 @@
           "builder": "@angular-devkit/build-angular:application",
           "options": {
             "outputPath": {
-              "base": "dist/netzgrafik-frontend"
+              "base": "dist/netzgrafik-frontend",
+              "browser": ""
             },
             "index": "src/index.html",
             "polyfills": ["src/polyfills.ts"],


### PR DESCRIPTION
### fix: drop extraneous "browser" directory in dist/

Angular v18 now places build artifacts in a "browser" subdirectory in the dist/ directory, so that SSR files are not mixed up with browser files. We have no use for SSR, so let's drop that extraneous directory.

This fixes deployment on GitHub Pages and PR previews.

### chore: harmonize dist directory layout

Sometimes we were using dist/ directly, sometimes we were using dist/netzgrafik-frontend/.

Use dist/ everywhere since we have a single project.