### PR TITLE
Aeg/893 rerouting adjacent sections breaks direction consistency in oneway trainruns

### DIFF
--- a/src/app/services/data/trainrunsection.service.ts
+++ b/src/app/services/data/trainrunsection.service.ts
@@ -716,7 +716,7 @@ export class TrainrunSectionService implements OnDestroy {
         false,
       );
     }
-
+    this.enforceConsistentSectionDirection(trainrunSection.getTrainrunId());
     this.trainrunService.propagateConsecutiveTimesForTrainrun(trainrunSection.getId());
 
     if (enforceUpdate) {

--- a/src/integration-testing/reconnect.trainrunsections.test.spec.ts
+++ b/src/integration-testing/reconnect.trainrunsections.test.spec.ts
@@ -110,7 +110,7 @@ describe("Reconnect TrainrunSection Test", () => {
       trainrunSectionOfInterest4.getSourceNode(),
       trainrunSectionOfInterest4,
     );
-    expect(endNode4.getId()).toBe(7);
+    expect(endNode4.getId()).toBe(1);
 
     trainrunSectionService.reconnectTrainrunSection(
       7,


### PR DESCRIPTION

https://github.com/user-attachments/assets/d7b5d289-be7f-4034-bb32-94766167fdd7

fixed.