### PR TITLE
chore(deps): remove devtools-protocol from dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "angular-oauth2-oidc": "^15.0.1",
         "angular-server-side-configuration": "^18.2.0",
         "d3": "^5.16.0",
-        "devtools-protocol": "0.0.1612613",
         "dompurify": "^3.3.3",
         "extract-i18n": "^1.0.0",
         "ngx-editor": "^15.0.1",


### PR DESCRIPTION
This dependency is removed after running `npm install`.