### PR TITLE
chore(deps): drop explicit devtools-protocol dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "angular-oauth2-oidc": "^15.0.1",
         "angular-server-side-configuration": "^18.2.0",
         "d3": "^5.16.0",
-        "devtools-protocol": "0.0.1618660",
         "dompurify": "^3.4.1",
         "extract-i18n": "^1.0.0",
         "ngx-editor": "^18.0.0",
@@ -71,7 +70,6 @@
         "typescript": "^5.4.5"
       },
       "optionalDependencies": {
-        "devtools-protocol": "*",
         "puppeteer": "^22.13.1"
       }
     },
@@ -9328,7 +9326,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1618660.tgz",
       "integrity": "sha512-v5VhJapC7B50sILnKt8POKCgdqfc3qY0huByQjNlrAlBJxzX0p4hx5ZuKG4QH8VwGBXvYYa0xmC5GRGa3uIE7Q==",
       "license": "BSD-3-Clause",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/di": {
       "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "zone.js": "~0.14.10"
   },
   "optionalDependencies": {
-    "devtools-protocol": "*",
     "puppeteer": "^22.13.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This was added back in 2892b14320b5 ("chore: add explicit devtools-protocol optional dependency") to fix CI for Dependabot PRs. However, having this as a direct dependency induces a lot of noise because devtools-protocol is updated *very* often.
    
Let's see if that Dependabot bug is fixed now.