### PR TITLE
fixup! feat: adds global nodes management panel

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -156,7 +156,6 @@ import {GlobalNodesManagementComponent} from "./view/editor-edit-tools-view-comp
     NavigationBarComponent,
     EditorPropertiesViewComponent,
     EditorEditToolsViewComponent,
-    GlobalNodesManagementComponent,
     FilterableLabelDialogComponent,
     FilterableLabelFormComponent,
     NoteDialogComponent,
@@ -188,6 +187,7 @@ import {GlobalNodesManagementComponent} from "./view/editor-edit-tools-view-comp
     TrainRunSectionStopsComponentComponent,
     PathGridComponent,
     ToggleSwitchButtonComponent,
+    GlobalNodesManagementComponent,
   ],
   bootstrap: environment.customElement ? [] : [AppComponent],
   imports: [

--- a/src/app/view/editor-edit-tools-view-component/global-nodes-management/global-nodes-management.component.ts
+++ b/src/app/view/editor-edit-tools-view-component/global-nodes-management/global-nodes-management.component.ts
@@ -18,6 +18,7 @@ function normalizeStr(str: string): string {
   selector: "sbb-global-nodes-management",
   templateUrl: "./global-nodes-management.component.html",
   styleUrl: "./global-nodes-management.component.scss",
+  standalone: false,
 })
 export class GlobalNodesManagementComponent {
   query: string;


### PR DESCRIPTION
With angular 19 standalone is the new base component so it was needed to precise standalone:false on this one GlobalNodesManagementPanel