### PR TITLE
fix(perlenkette): do not display asymmetry arrow when trainrun is one-way

### DIFF
--- a/src/app/perlenkette/perlenkette-section/perlenkette-section.component.ts
+++ b/src/app/perlenkette/perlenkette-section/perlenkette-section.component.ts
@@ -213,6 +213,7 @@ export class PerlenketteSectionComponent implements OnInit, AfterContentInit, On
   }
 
   shouldDisplayAsymmetryArrow(arrowLocation: "top" | "bottom"): boolean {
+    if (!this.trainrunSection.getTrainrun().isRoundTrip()) return false;
     if (this.getLeftToRightDirection(arrowLocation) === "sourceToTarget") {
       return !this.trainrunSection.isSourceSymmetricOrTimesSymmetric();
     } else {


### PR DESCRIPTION
When a trainrun is non-symmetric:
<img width="1154" height="656" alt="image" src="https://github.com/user-attachments/assets/6daaab51-b03c-4333-9287-a7623e4876c6" />

we used to display both arrows (asymmetry AND one-way) in the perlenkette:
<img width="1182" height="653" alt="image" src="https://github.com/user-attachments/assets/ada6d4aa-37d5-4aa5-bd09-2ff8bcd468f9" />

With this fix:
<img width="1108" height="632" alt="image" src="https://github.com/user-attachments/assets/c114acf1-1b48-4a39-9ef3-5e21b35984f3" />
