### PR TITLE
feat(view): hide note borders when no mouse over

### DIFF
--- a/src/app/view/editor-main-view/data-views/note.view.scss
+++ b/src/app/view/editor-main-view/data-views/note.view.scss
@@ -8,11 +8,13 @@
   cursor: move;
 }
 
-::ng-deep rect.note_root {
+::ng-deep rect.note_hover_root.hover {
   stroke-width: 1px;
-  stroke: $NODE_COLOR;
-  fill: $COLOR_BACKGROUND;
-  rx: $NODE_ROUND_EDGE_SIZE;
+}
+
+::ng-deep rect.note_root {
+  stroke: none;
+  fill: none;
   cursor: pointer;
 }
 

--- a/src/app/view/editor-main-view/data-views/note.view.scss
+++ b/src/app/view/editor-main-view/data-views/note.view.scss
@@ -8,10 +8,6 @@
   cursor: move;
 }
 
-::ng-deep rect.note_hover_root.hover {
-  stroke-width: 1px;
-}
-
 ::ng-deep rect.note_root {
   stroke: none;
   fill: none;

--- a/src/app/view/editor-main-view/data-views/notes.view.ts
+++ b/src/app/view/editor-main-view/data-views/notes.view.ts
@@ -441,9 +441,6 @@ export class NotesView {
     d3.selectAll(StaticDomTags.NOTE_HOVER_DRAG_AREA_DOM_REF)
       .filter((n: NoteViewObject) => n.note.getId() === note.getId())
       .classed(StaticDomTags.TAG_MUTED, true);
-    d3.selectAll(StaticDomTags.NOTE_HOVER_ROOT_DOM_REF)
-      .filter((n: NoteViewObject) => n.note.getId() === note.getId())
-      .classed(StaticDomTags.TAG_HOVER, true);
     d3.selectAll(StaticDomTags.NOTE_ROOT_DOM_REF)
       .filter((n: NoteViewObject) => n.note.getId() === note.getId())
       .classed(StaticDomTags.TAG_HOVER, true);
@@ -453,9 +450,6 @@ export class NotesView {
     d3.selectAll(StaticDomTags.NOTE_HOVER_DRAG_AREA_DOM_REF)
       .filter((n: NoteViewObject) => n.note.getId() === note.getId())
       .classed(StaticDomTags.TAG_MUTED, false);
-    d3.selectAll(StaticDomTags.NOTE_HOVER_ROOT_DOM_REF)
-      .filter((n: NoteViewObject) => n.note.getId() === note.getId())
-      .classed(StaticDomTags.TAG_HOVER, false);
     d3.selectAll(StaticDomTags.NOTE_ROOT_DOM_REF)
       .filter((n: NoteViewObject) => n.note.getId() === note.getId())
       .classed(StaticDomTags.TAG_HOVER, false);

--- a/src/app/view/editor-main-view/data-views/notes.view.ts
+++ b/src/app/view/editor-main-view/data-views/notes.view.ts
@@ -441,6 +441,9 @@ export class NotesView {
     d3.selectAll(StaticDomTags.NOTE_HOVER_DRAG_AREA_DOM_REF)
       .filter((n: NoteViewObject) => n.note.getId() === note.getId())
       .classed(StaticDomTags.TAG_MUTED, true);
+    d3.selectAll(StaticDomTags.NOTE_HOVER_ROOT_DOM_REF)
+      .filter((n: NoteViewObject) => n.note.getId() === note.getId())
+      .classed(StaticDomTags.TAG_HOVER, true);
     d3.selectAll(StaticDomTags.NOTE_ROOT_DOM_REF)
       .filter((n: NoteViewObject) => n.note.getId() === note.getId())
       .classed(StaticDomTags.TAG_HOVER, true);
@@ -450,6 +453,9 @@ export class NotesView {
     d3.selectAll(StaticDomTags.NOTE_HOVER_DRAG_AREA_DOM_REF)
       .filter((n: NoteViewObject) => n.note.getId() === note.getId())
       .classed(StaticDomTags.TAG_MUTED, false);
+    d3.selectAll(StaticDomTags.NOTE_HOVER_ROOT_DOM_REF)
+      .filter((n: NoteViewObject) => n.note.getId() === note.getId())
+      .classed(StaticDomTags.TAG_HOVER, false);
     d3.selectAll(StaticDomTags.NOTE_ROOT_DOM_REF)
       .filter((n: NoteViewObject) => n.note.getId() === note.getId())
       .classed(StaticDomTags.TAG_HOVER, false);


### PR DESCRIPTION
OSRD users have asked for hiding the note borders when the mouse is not over the note. We did opened a PR for that in our fork (https://github.com/osrd-project/netzgrafik-editor-frontend/pull/29), but this might also interest other users. What do you think @aiAdrian?

https://github.com/user-attachments/assets/b99c76fc-6ba3-4ace-a12f-a3b45f2d4cc0



