### PR TITLE
fix which node is undocked when drag 6+ collapsed nodes dot

### DIFF
--- a/src/app/view/editor-main-view/data-views/trainrunSectionViewObject.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunSectionViewObject.ts
@@ -65,7 +65,12 @@ export class TrainrunSectionViewObject {
 
   getCollapsedNodeToDrag(stopIndex: number): Node {
     const numberOfCollapsedStops = this.getCollapsedStopNodes().length;
-    if (numberOfCollapsedStops >= SHOW_MAX_SINGLE_TRAINRUN_SECTIONS_STOPS) {
+    const lineOrientationVector = Vec2D.sub(this.path[2], this.path[1]);
+    const maxNumberOfStops = Math.min(
+      SHOW_MAX_SINGLE_TRAINRUN_SECTIONS_STOPS,
+      Vec2D.norm(lineOrientationVector) / 20,
+    );
+    if (numberOfCollapsedStops > maxNumberOfStops) {
       return this.getCollapsedStopNodeFromStopIndex(numberOfCollapsedStops - 1);
     }
     return this.getCollapsedStopNodeFromStopIndex(stopIndex);


### PR DESCRIPTION
I made a small fixup because when there was 5 collasped nodes on a tsvo between to uncollapsed node, when draging an uncollapsed node to another node, this was always the first collapsed node who was undock.

This must happend only if there is 6+ node, not 5+.