### PR TITLE
chore(deps): upgrade angular-oauth2-oidc to v19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@angular/platform-browser-dynamic": "^19.2.21",
         "@angular/router": "^19.2.21",
         "@sbb-esta/angular": "^19.1.6",
-        "angular-oauth2-oidc": "^15.0.1",
+        "angular-oauth2-oidc": "^19.0.0",
         "angular-server-side-configuration": "^19.0.1",
         "d3": "^5.16.0",
         "dompurify": "^3.4.1",
@@ -8663,15 +8663,16 @@
       }
     },
     "node_modules/angular-oauth2-oidc": {
-      "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/angular-oauth2-oidc/-/angular-oauth2-oidc-15.0.1.tgz",
-      "integrity": "sha512-5gpqO9QL+qFqMItYFHe8F6H5nOIEaowcNUc9iTDs3P1bfVYnoKoVAaijob53PuPTF4YwzdfwKWZi4Mq6P7GENQ==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/angular-oauth2-oidc/-/angular-oauth2-oidc-19.0.0.tgz",
+      "integrity": "sha512-EogHyF7MpCJSjSKIyVmdB8pJu7dU5Ilj9VNVSnFbLng4F77PIlaE4egwKUlUvk0i4ZvmO9rLXNQCm05R7Tyhcw==",
+      "license": "MIT",
       "dependencies": {
-        "tslib": "^2.0.0"
+        "tslib": "^2.5.2"
       },
       "peerDependencies": {
-        "@angular/common": ">=14.0.0",
-        "@angular/core": ">=14.0.0"
+        "@angular/common": ">=19.0.0",
+        "@angular/core": ">=19.0.0"
       }
     },
     "node_modules/angular-server-side-configuration": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@angular/platform-browser-dynamic": "^19.2.21",
     "@angular/router": "^19.2.21",
     "@sbb-esta/angular": "^19.1.6",
-    "angular-oauth2-oidc": "^15.0.1",
+    "angular-oauth2-oidc": "^19.0.0",
     "angular-server-side-configuration": "^19.0.1",
     "d3": "^5.16.0",
     "dompurify": "^3.4.1",


### PR DESCRIPTION
angular-oauth2-oidc's major versions are synchronized with Angular. We were using angular-oauth2-oidc v15 with Angular v19, which was unsupported.

Release notes indicate no breaking change:
https://github.com/manfredsteyer/angular-oauth2-oidc/releases