### PR TITLE
chore(ci): re-enable NPM package publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,10 +60,7 @@ jobs:
 
   release-npm-package:
     needs: release-please
-    #  Workflow step temporarily disabled - it might be removed later on  or we have to fix the publishing final step
-    #  If the packages are still on github release published whe don't neet the npmjs.org anymore
-    if: false
-    # if: ${{ needs.release-please.outputs.release_created }}
+    if: ${{ needs.release-please.outputs.release_created }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/README.md
+++ b/README.md
@@ -152,6 +152,13 @@ The user manual can be found here [USERMANUAL.md](documentation/USERMANUAL.md)
 
 ( [Sample Netzgrafik](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/src/app/sample-netzgrafik/Demo_Netzgrafik_Fernverkehr_2024.json) - [How to Import JSON](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/documentation/technical/DATA_MODEL_JSON.md) )
 
+## Packages
+
+Netzgrafik-Editor is published:
+
+- [As a Docker image](https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/pkgs/container/netzgrafik-editor-frontend), for use in a Docker environment
+- [As a NPM package](https://www.npmjs.com/package/@openrail/netzgrafik-editor-frontend), for integration in another webapp
+
 ## Setup Local Demo Environment with Docker Compose
 
 Use [extern: netzgrafik-editor-docker-compose](https://github.com/flatland-association/netzgrafik-editor-docker-compose) for a one-line setup based

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "local-test": "ng test --watch --code-coverage",
     "extract-i18n": "ng extract-i18n"
   },
-  "name": "netzgrafik-frontend",
+  "name": "@openrail/netzgrafik-editor-frontend",
   "version": "2.10.19",
   "repository": {
     "type": "git",


### PR DESCRIPTION
_See individual commits._

I've manually published the last release at [`@openrail/netzgrafik-editor-frontend`](https://www.npmjs.com/package/@openrail/netzgrafik-editor-frontend). This PR sets up CI to publish the NPM package automatically.

The new NPM package has been set up correctly for trusted publishers: https://docs.npmjs.com/trusted-publishers
