### PR TITLE
fix: drop favicon from standalone index.html

### DIFF
--- a/src/environments/standalone/index.html
+++ b/src/environments/standalone/index.html
@@ -3,9 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <title>Netzgrafik-Editor</title>
-    <!--CONFIG-->
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="icon" type="image/x-icon" href="favicon.ico" />
   </head>
   <body>
     <sbb-root></sbb-root>


### PR DESCRIPTION
7660295326f3 ("chore: omit <base> for standalone builds") has introduced a new index.html file used for standalone builds. 517583c092dc ("chore: drop favicon") has dropped favicon.ico for the main index.html file, but was merged in parallel with that other change. As a result, the standalone-specific index.html file references the dropped favicon.

Backport the main index.html change to the standalone one to fix this.