### PR TITLE
fix(editor-main-view): clear all objects when loading new DTO

### DIFF
--- a/src/app/view/editor-main-view/data-views/d3.utils.spec.ts
+++ b/src/app/view/editor-main-view/data-views/d3.utils.spec.ts
@@ -147,6 +147,7 @@ describe("3d.Utils.tests", () => {
       uiInteractionService,
       noteService,
       undefined,
+      dataService,
       undoService,
       copyService,
       logService,

--- a/src/app/view/editor-main-view/data-views/data.view.spec.ts
+++ b/src/app/view/editor-main-view/data-views/data.view.spec.ts
@@ -152,6 +152,7 @@ describe("Editor-DataView", () => {
       uiInteractionService,
       noteService,
       undefined,
+      dataService,
       undoService,
       copyService,
       logService,

--- a/src/app/view/editor-main-view/data-views/nodes.view.spec.ts
+++ b/src/app/view/editor-main-view/data-views/nodes.view.spec.ts
@@ -147,6 +147,7 @@ describe("Nodes-View", () => {
       uiInteractionService,
       noteService,
       undefined,
+      dataService,
       undoService,
       copyService,
       logService,

--- a/src/app/view/editor-main-view/data-views/notes.view.spec.ts
+++ b/src/app/view/editor-main-view/data-views/notes.view.spec.ts
@@ -147,6 +147,7 @@ describe("Notes-View", () => {
       uiInteractionService,
       noteService,
       undefined,
+      dataService,
       undoService,
       copyService,
       logService,

--- a/src/app/view/editor-main-view/data-views/trainrunsections.view.spec.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunsections.view.spec.ts
@@ -149,6 +149,7 @@ describe("TrainrunSection-View", () => {
       uiInteractionService,
       noteService,
       undefined,
+      dataService,
       undoService,
       copyService,
       logService,

--- a/src/app/view/editor-main-view/data-views/transitions.view.spec.ts
+++ b/src/app/view/editor-main-view/data-views/transitions.view.spec.ts
@@ -147,6 +147,7 @@ describe("Transitions-View", () => {
       uiInteractionService,
       noteService,
       undefined,
+      dataService,
       undoService,
       copyService,
       logService,

--- a/src/app/view/editor-main-view/editor-main-view.component.ts
+++ b/src/app/view/editor-main-view/editor-main-view.component.ts
@@ -34,6 +34,7 @@ import {NoteDialogParameter, NoteDialogType} from "../dialogs/note-dialog/note-d
 import {AnalyticsService} from "../../services/analytics/analytics.service";
 import {Note} from "../../models/note.model";
 import {LogService} from "../../logger/log.service";
+import {DataService} from "../../services/data/data.service";
 import {UndoService} from "../../services/data/undo.service";
 import {CopyService} from "../../services/data/copy.service";
 import {StreckengrafikDrawingContext} from "../../streckengrafik/model/util/streckengrafik.drawing.context";
@@ -72,6 +73,7 @@ export class EditorMainViewComponent implements AfterViewInit, OnDestroy {
     private uiInteractionService: UiInteractionService,
     private noteService: NoteService,
     private analyticsService: AnalyticsService,
+    private dataService: DataService,
     private undoService: UndoService,
     private copyService: CopyService,
     private logService: LogService,
@@ -552,5 +554,20 @@ export class EditorMainViewComponent implements AfterViewInit, OnDestroy {
     this.nodeService.nodes.pipe(takeUntil(this.destroyed)).subscribe(() => {
       this.handleVariantChanged();
     });
+
+    this.dataService
+      .getNetzgrafikLoadedInfo()
+      .pipe(takeUntil(this.destroyed))
+      .subscribe((info) => {
+        if (!info.load) return;
+
+        // When starting to load a new graph, clear any existing graph to avoid
+        // clashes between old and new model objects
+        this.editorView.nodesView.displayNodes([]);
+        this.editorView.transitionsView.displayTransitions([]);
+        this.editorView.connectionsView.displayConnections([]);
+        this.editorView.trainrunSectionsView.displayTrainrunSection([]);
+        this.editorView.notesView.displayNotes([]);
+      });
   }
 }


### PR DESCRIPTION
When a new DTO is loaded, the editor main view will re-use old SVG elements for new objects with the same ID. d3 captures the old model objects, causing some havoc in event handlers: these mix model objects originating from the old and new DTO.

To fix this, clear all model objects when starting to load a new DTO.

Closes: https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/issues/851