### PR TITLE
chore(ci): disable default commitlint ignore rules

### DIFF
--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -3,6 +3,7 @@ import {RuleConfigSeverity} from "@commitlint/types";
 
 const Configuration: UserConfig = {
   extends: ["@commitlint/config-conventional"],
+  defaultIgnores: false,
   rules: {
     "type-enum": [
       RuleConfigSeverity.Error,


### PR DESCRIPTION
By default, commitlint silently accepts commit messages such as "fixup!". This leaves the door open to merging these as-is.

Make it so CI fails in this case.

See https://commitlint.js.org/reference/configuration.html#configuration-object-example