### PR TITLE
Fix travelTime and backwardTravelTime textElement

### DIFF
--- a/src/app/models/trainrunsection.model.ts
+++ b/src/app/models/trainrunsection.model.ts
@@ -770,7 +770,6 @@ export class TrainrunSection {
     this.path.textPositions = SimpleTrainrunSectionRouter.placeTextOnTrainrunSection(
       this.pathVec2D,
       this.sourceNode.getPort(this.sourcePortId),
-      !this.areTravelTimesEqual(),
     );
   }
 

--- a/src/app/services/util/trainrunsection.routing.ts
+++ b/src/app/services/util/trainrunsection.routing.ts
@@ -305,7 +305,6 @@ export class SimpleTrainrunSectionRouter {
   static placeTextOnTrainrunSection(
     lineWayPoints: Vec2D[],
     sourcePort: Port,
-    isBackwardTravelTimeDisplayed: boolean,
   ): TrainrunSectionTextPositions {
     const s = lineWayPoints[0];
     const s1 = lineWayPoints[1];
@@ -426,16 +425,13 @@ export class SimpleTrainrunSectionRouter {
       namePosOffsetDirection,
     );
 
-    const trainrunSectionTravelTimePos = isBackwardTravelTimeDisplayed
-      ? Vec2D.add(
-          Vec2D.scale(Vec2D.add(s1, t1), 0.5),
-          Vec2D.scale(
-            rDeltaS,
-            invertTrafficSide *
-              (-TRAINRUN_SECTION_LINE_TEXT_HEIGHT / 2 + TRAINRUN_SECTION_TIME_TOP),
-          ),
-        )
-      : trainrunSectionNamePos;
+    const trainrunSectionTravelTimePos = Vec2D.add(
+      Vec2D.scale(Vec2D.add(s1, t1), 0.5),
+      Vec2D.scale(
+        rDeltaS,
+        invertTrafficSide * (-TRAINRUN_SECTION_LINE_TEXT_HEIGHT / 2 + TRAINRUN_SECTION_TIME_TOP),
+      ),
+    );
     const trainrunSectionBackwardTravelTimePos = Vec2D.add(
       Vec2D.scale(Vec2D.add(s1, t1), 0.5),
       Vec2D.scale(


### PR DESCRIPTION
Fixes the travel times positions. Bug can only be reproduce in a specific source-target position.

Before fix (bug, positions overlap):

https://github.com/user-attachments/assets/0284cb62-9e93-43fb-b941-9e8edc2a0b95

After fix:

https://github.com/user-attachments/assets/ddff3ac1-03d1-4600-8a5e-a4bc03418a6b

Bug can be reproduced using this: [networkGraphic(9).json](https://github.com/user-attachments/files/27647233/networkGraphic.9.json)
