### PR TITLE
fix(ci): switch to actions/upload-pages-artifact for GitHub Pages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,7 @@ jobs:
       - run: npm clean-install
       - run: npm run build:standalonedemo
       - name: Store build artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-pages-artifact@v5
         with:
           name: build-standalone-demo
           path: dist/


### PR DESCRIPTION
GitHub Pages requires the artifact to be a .tar.gz archive. However actions/upload-artifact produces a .zip archive by default.

Switch to actions/upload-pages-artifact, which is guaranteed to create an archive which can be used for GitHub Pages deployments.

Closes: https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/issues/972