### PR TITLE
chore: update package name accordingly to openrail

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "netzgrafik-frontend",
+  "name": "@openrail/netzgrafik-editor-frontend",
   "version": "2.10.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "netzgrafik-frontend",
+      "name": "@openrail/netzgrafik-editor-frontend",
       "version": "2.10.19",
       "dependencies": {
         "@angular/animations": "^19.2.21",


### PR DESCRIPTION
This [PR](https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/commit/77dc894336b13341fd004fd3d32747ed84e81f2c) moved the package to OpenRail organization.

Update the `package-lock.json` accordingly.