### PR TITLE
fix(view): apply border-radius change only to checkbox and not radio buttons

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -79,13 +79,13 @@ sbb-loading-indicator {
   width: 95%;
 }
 
-::ng-deep .sbb-selection-checked .sbb-selection-container {
+::ng-deep .sbb-checkbox .sbb-selection-container {
   border-width: 2px;
   border-radius: 3px;
-}
 
-::ng-deep .sbb-selection-container-checked {
-  svg polyline {
-    stroke-width: 2px;
+  &-checked {
+    svg polyline {
+      stroke-width: 2px;
+    }
   }
 }


### PR DESCRIPTION

[This PR](https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/pull/991) introduces border-radius property to `sbb-checkbox`, which are used for both normal checkboxes and radio buttons.

The changes only apply this property to checkboxes.


|   Before  |  After   |
| --- | --- |
|   <img width="510" height="537" alt="image" src="https://github.com/user-attachments/assets/5c6aa8d5-8392-40a3-b555-20531e4c44cd" />  |   <img width="511" height="432" alt="image" src="https://github.com/user-attachments/assets/d917f164-5144-44e1-993c-f9ab5e70febc" />  |
