### PR TITLE
feat: add strict Content-Security-Policy for standalone mode

### DIFF
--- a/src/environments/standalone/index.html
+++ b/src/environments/standalone/index.html
@@ -2,6 +2,18 @@
 <html id="NetzgrafikRootHtml" lang="en" class="sbb-lean">
   <head>
     <meta charset="utf-8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="
+        default-src 'self';
+        frame-src 'none';
+        object-src 'none';
+        connect-src 'self' https://icons.app.sbb.ch;
+        img-src 'self' data: https://icons.app.sbb.ch;
+        font-src 'self' https://cdn.app.sbb.ch;
+        style-src 'self' 'unsafe-inline' https://cdn.app.sbb.ch;
+      "
+    />
     <title>Netzgrafik-Editor</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
   </head>


### PR DESCRIPTION
Content-Security-Policy can help mitigate XSS injections. They restrict where content can be loaded from by the browser. More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy

This policy would've helped reduce the impact of the following XSS vulnerability:
https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/pull/702

The policy is applied to the standalone mode only for now, to not regress production deployments which may need to phone internal backends hosted at a different origin.

The policy is as strict as possible without making code changes. The browser will print an error to the console when the webapp tries to load something forbidden by the policy.

The policy needs to be relaxed in a few spots:

- SBB icons are loaded by JavaScript from icons.app.sbb.ch. This requires this domain name to be added to connect-src, and data: URLs to be added to img-src.
- Fonts and styles are loaded from cdn.app.sbb.ch.
- Some CSS style is generated by JavaScript and set via the style HTML/SVG attribute. This requires 'unsafe-inline' to be added to style-src.

References: https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/issues/706