### PR TITLE
fix(view): don't use attr() to set js executing attributes

### DIFF
--- a/src/app/view/knoten-auslastung-view/knoten-auslastung-view.component.ts
+++ b/src/app/view/knoten-auslastung-view/knoten-auslastung-view.component.ts
@@ -83,9 +83,9 @@ export class KnotenAuslastungViewComponent implements AfterViewInit, OnDestroy {
   }
 
   ngAfterViewInit(): void {
-    this.svgDrawingContext = d3
-      .select("#knotenAuslastungContainer")
-      .attr("oncontextmenu", "return false;");
+    this.svgDrawingContext = d3.select("#knotenAuslastungContainer").on("contextmenu", () => {
+      d3.event.preventDefault();
+    });
 
     this.init();
   }

--- a/src/app/view/util/svg.mouse.controller.ts
+++ b/src/app/view/util/svg.mouse.controller.ts
@@ -74,11 +74,13 @@ export class SVGMouseController {
 
     this.svgDrawingContext = d3.select("#" + this.svgName);
     this.svgDrawingContext
-      .attr("oncontextmenu", "return false;")
       .attr("x", rectHtml.x)
       .attr("y", rectHtml.y)
       .attr("height", height)
-      .attr("width", width);
+      .attr("width", width)
+      .on("contextmenu", () => {
+        d3.event.preventDefault();
+      });
 
     if (this.svgDrawingContext.node() === null) {
       return undefined;


### PR DESCRIPTION
This doesn't work when using a strict CSP, such as the one introduced by ea5611fb9d0e5. To reproduce, start the app in standalone mode and try to right-click select.