### PR TITLE
fix: special case added (handled) to fix When a trainrun starts end ends at same node the "Streckengrafik" - trainrun section dialog display wrong times (left / right node)

### DIFF
--- a/src/app/services/util/trainrunsection.helper.ts
+++ b/src/app/services/util/trainrunsection.helper.ts
@@ -343,14 +343,26 @@ export class TrainrunsectionHelper {
     const lastLeftNode = this.getNextStopLeftNode(trainrunSection, orderedNodes);
     const lastRightNode = this.getNextStopRightNode(trainrunSection, orderedNodes);
 
-    const leftTrainrunSection =
+    let leftTrainrunSection =
       lastLeftNode.getId() === bothLastNonStopNodes.lastNonStopNode1.getId()
         ? bothLastNonStopTrainrunSections.lastNonStopTrainrunSection1
         : bothLastNonStopTrainrunSections.lastNonStopTrainrunSection2;
-    const rightTrainrunSection =
+    let rightTrainrunSection =
       lastRightNode.getId() === bothLastNonStopNodes.lastNonStopNode1.getId()
         ? bothLastNonStopTrainrunSections.lastNonStopTrainrunSection1
         : bothLastNonStopTrainrunSections.lastNonStopTrainrunSection2;
+
+    if (lastLeftNode.getId() === lastRightNode.getId()) {
+      // special case : when start and end node are equal and no non-stop node in between,
+      // the last non-stop trainrun section is the same for both sides, so we need to determine
+      // the left and right section based on the order of the nodes
+      leftTrainrunSection = this.trainrunService.getFirstNonStopTrainrunSection(trainrunSection);
+      rightTrainrunSection = this.trainrunService.getLastNonStopTrainrunSection(
+        leftTrainrunSection.getSourceNode(),
+        leftTrainrunSection,
+      );
+    }
+
     const cumulativeTravelTime = this.trainrunService.getCumulativeTravelTime(
       trainrunSection,
       lastLeftNode.getId() === bothLastNonStopNodes.lastNonStopNode1.getId()


### PR DESCRIPTION

https://github.com/user-attachments/assets/fcc4bf7d-545e-462c-acb1-ae5af96a22a5

https://github.com/user-attachments/assets/e41b4199-7f96-4107-b745-d305312adf6d



