### PR TITLE
docs: add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Reporting Security Issues
+
+The Netzgrafik-Editor team and community take security bugs in
+Netzgrafik-Editor seriously. We appreciate your efforts to responsibly disclose
+your findings, and will make every effort to acknowledge your contributions.
+
+The only supported version is the [latest release].
+
+To report a security issue, please use the GitHub Security Advisory ["Report a
+Vulnerability"] tab.
+
+> [!IMPORTANT]
+> Security issues **must not** be reported in Github's public issues.
+
+The Netzgrafik-Editor team will send a response indicating the next steps in
+handling your report. After the initial reply to your report, the team will
+keep you informed of the progress towards a fix and full announcement, and may
+ask for additional information or guidance.
+
+[latest release]: https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/releases/latest
+["Report a Vulnerability"]: https://github.com/OpenRailAssociation/osrd/security/advisories/new


### PR DESCRIPTION
When I found a vulnerability recently, it wasn't clear how to report the issue. Add a security policy to clarify this. This is a good practice for open-source projects.

The policy is identical to OSRD.