### PR TITLE
chore(github): bump Dependabot max PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,7 @@ updates:
       prefix: "chore(deps):"
     labels:
       - "dependencies"
+    open-pull-requests-limit: 100
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -34,6 +35,7 @@ updates:
     labels:
       - "dependencies"
       - "area:ci"
+    open-pull-requests-limit: 100
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
@@ -44,3 +46,4 @@ updates:
       prefix: "chore(deps):"
     labels:
       - "dependencies"
+    open-pull-requests-limit: 100


### PR DESCRIPTION
Dependabot stops opening PRs when 5 are already open: https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#open-pull-requests-limit-

This is not enough: we have lots of dependencies and some PRs may be blocked because they require manual action. Still, we don't want to loose other updates.

Use the same limit as OSRD.