### PR TITLE
chore(deps): add missing papaparse types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "@types/jasmine": "~3.6.11",
         "@types/jasminewd2": "~2.0.13",
         "@types/node": "^24.12.3",
+        "@types/papaparse": "^5.3.2",
         "angular-eslint": "^19.8.1",
         "browserstack-local": "^1.5.12",
         "eslint": "^9.39.4",
@@ -7583,6 +7584,16 @@
       "version": "1.3.14",
       "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.14.tgz",
       "integrity": "sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/papaparse": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@types/papaparse/-/papaparse-5.5.2.tgz",
+      "integrity": "sha512-gFnFp/JMzLHCwRf7tQHrNnfhN4eYBVYYI897CGX4MY1tzY9l2aLkVyx2IlKZ/SAqDbB3I1AOZW5gTMGGsqWliA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@types/jasmine": "~3.6.11",
     "@types/jasminewd2": "~2.0.13",
     "@types/node": "^24.12.3",
+    "@types/papaparse": "^5.3.2",
     "angular-eslint": "^19.8.1",
     "browserstack-local": "^1.5.12",
     "eslint": "^9.39.4",

--- a/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
+++ b/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
@@ -1,4 +1,4 @@
-import {parse, ParseResult} from "papaparse";
+import {parse} from "papaparse";
 import {Component, ElementRef, ViewChild} from "@angular/core";
 import * as svg from "save-svg-as-png";
 import {DataService} from "../../services/data/data.service";
@@ -182,7 +182,7 @@ export class EditorToolsViewComponent {
     const file = param.target.files[0];
     const reader = new FileReader();
     reader.onload = () => {
-      const finalResult: ParseResult = parse(reader.result.toString(), {
+      const finalResult = parse(reader.result.toString(), {
         header: true,
         delimiter: ";",
       });

--- a/src/integration-testing/basedata.service.test.spec.ts
+++ b/src/integration-testing/basedata.service.test.spec.ts
@@ -1,4 +1,4 @@
-import {parse, ParseResult} from "papaparse";
+import {parse} from "papaparse";
 import {NodeService} from "../app/services/data/node.service";
 import {TrainrunService} from "../app/services/data/trainrun.service";
 import {TrainrunSectionService} from "../app/services/data/trainrunsection.service";
@@ -82,7 +82,7 @@ describe("NodeService Test", () => {
       "AA;Aarau;2;Mitte;2;0;2;0;2;0;0;1;0;1;0.2;4;SBB;-209.4991625;-427.021373;1\n" +
       "ABE;Aarberg;4;Mitte; ;1; ;1; ;1; ;1; ;1;0;0;;0;0;0\n";
 
-    const finalResult: ParseResult = parse(baseDataCSV, {header: true, delimiter: ";"});
+    const finalResult = parse(baseDataCSV, {header: true, delimiter: ";"});
     baseDataService.setBaseData(finalResult.data);
     const aa = baseDataService.getBaseDataByBetriebspunktName("AA");
     expect(aa.getRegions()[0]).toBe("Mitte");
@@ -117,7 +117,7 @@ describe("NodeService Test", () => {
       "ZAZ;Umsteigezeit;Labels;XCoord;YCoord;Create\n" +
       "AA;Aarau;2;Mitte;2;1;2;1;2;1;0;0;0;0;0.2;4;SBB;-209.4991625;-427.021373;1\n";
 
-    const finalResult: ParseResult = parse(legacyBaseDataCSV, {header: true, delimiter: ";"});
+    const finalResult = parse(legacyBaseDataCSV, {header: true, delimiter: ";"});
     baseDataService.setBaseData(finalResult.data);
 
     const aa = baseDataService.getBaseDataByBetriebspunktName("AA");
@@ -134,7 +134,7 @@ describe("NodeService Test", () => {
       "ZAZ (Train dispatching time);ConnectionTime;Labels;XCoord;YCoord;Create\n" +
       "AA;Aarau;2;Mitte;2;2;2;0;0;0.2;4;SBB;-209.4991625;-427.021373;1\n";
 
-    const finalResult: ParseResult = parse(baseDataWithoutPassingThroughStationCSV, {
+    const finalResult = parse(baseDataWithoutPassingThroughStationCSV, {
       header: true,
       delimiter: ";",
     });


### PR DESCRIPTION
papaparse doesn't ship its own TypeScript definitions. We need to install a separate package to grab them.

Remove ParseResult because parse() already declares its return type and it's invalid:

    src/app/view/editor-tools-view-component/editor-tools-view.component.ts:184:26 - error TS2314: Generic type 'ParseResult<T>' requires 1 type argument(s).

    184       const finalResult: ParseResult = parse(reader.result.toString(), {
                                 ~~~~~~~~~~~

    src/integration-testing/stammdaten.service.test.spec.ts:83:24 - error TS2314: Generic type 'ParseResult<T>' requires 1 type argument(s).

    83     const finalResult: ParseResult = parse(stammdatenCSV, {header: true});
                          ~~~~~~~~~~~