### PR TITLE
refactor: add missing d3 types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "@commitlint/types": "^21.0.1",
         "@eslint/js": "^9.39.4",
         "@openapitools/openapi-generator-cli": "^2.34.0",
+        "@types/d3": "^5.16.0",
         "@types/jasmine": "~6.0.0",
         "@types/jasminewd2": "~2.0.13",
         "@types/node": "^24.12.3",
@@ -7421,6 +7422,298 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/d3": {
+      "version": "5.16.7",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-5.16.7.tgz",
+      "integrity": "sha512-GMwYYRuI+BNHS6c5B1OUDx6yKWtnolVYq1YxUkXn0HhlQyzKcpgpxJd7BKuazq+1+TridBbQjs4kztX6nIhl9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "^1",
+        "@types/d3-axis": "^1",
+        "@types/d3-brush": "^1",
+        "@types/d3-chord": "^1",
+        "@types/d3-collection": "*",
+        "@types/d3-color": "^1",
+        "@types/d3-contour": "^1",
+        "@types/d3-dispatch": "^1",
+        "@types/d3-drag": "^1",
+        "@types/d3-dsv": "^1",
+        "@types/d3-ease": "^1",
+        "@types/d3-fetch": "^1",
+        "@types/d3-force": "^1",
+        "@types/d3-format": "^1",
+        "@types/d3-geo": "^1",
+        "@types/d3-hierarchy": "^1",
+        "@types/d3-interpolate": "^1",
+        "@types/d3-path": "^1",
+        "@types/d3-polygon": "^1",
+        "@types/d3-quadtree": "^1",
+        "@types/d3-random": "^1",
+        "@types/d3-scale": "^2",
+        "@types/d3-scale-chromatic": "^1",
+        "@types/d3-selection": "^1",
+        "@types/d3-shape": "^1",
+        "@types/d3-time": "^1",
+        "@types/d3-time-format": "^2",
+        "@types/d3-timer": "^1",
+        "@types/d3-transition": "^1",
+        "@types/d3-voronoi": "*",
+        "@types/d3-zoom": "^1"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-1.2.12.tgz",
+      "integrity": "sha512-zIq9wCg/JO7MGC6vq3HRDaVYkqgSPIDjpo3JhAQxl7PHYVPA5D9SMiBfjW/ZoAvPd2a+rkovqBg0nS0QOChsJQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-1.0.19.tgz",
+      "integrity": "sha512-rXxE2jJYv6kar/6YWS8rM0weY+jjvnJvBxHKrIUqt3Yzomrfbf5tncpKG6jq6Aaw6TZyBcb1bxEWc0zGzcmbiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "^1"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-1.1.8.tgz",
+      "integrity": "sha512-tPVjYAjJt02fgazF9yiX/309sj6qhIiIopLuHhP4FFFq9VKqu9NQBeCK3ger0RHVZGs9RKaSBUWyPUzii5biGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "^1"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-1.0.14.tgz",
+      "integrity": "sha512-W9rCIbSAhwtmydW5iGg9dwTQIi3SGBOh68/T3ke3PyOgejuSLozmtAMaWNViGaGJCeuM4aFJHTUHQvMedl4ugA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-collection": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@types/d3-collection/-/d3-collection-1.0.13.tgz",
+      "integrity": "sha512-v0Rgw3IZebRyamcwVmtTDCZ8OmQcj4siaYjNc7wGMZT7PmdSHawGsCOQMxyLvZ7lWjfohYLK0oXtilMOMgfY8A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-1.4.5.tgz",
+      "integrity": "sha512-5sNP3DmtSnSozxcjqmzQKsDOuVJXZkceo1KJScDc1982kk/TS9mTPc6lpli1gTu1MIBF1YWutpHpjucNWcIj5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-1.3.6.tgz",
+      "integrity": "sha512-RM/QHCx8j1ovj/p4cWCM3b48EIas6TTmfG+LR2Ud8npTqgrWTjMNCpHtoj47Qa3dJsifONXGu54VuFkXWL2mIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "^1",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-1.0.12.tgz",
+      "integrity": "sha512-vrhleoVNhGJGx7GQZ4207lYGyMbW/yj/iJTSvLKyfAp8nXFF+19dnMpPN/nEVs6fudIsQc7ZelBFUMe3aJDmKw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-1.2.8.tgz",
+      "integrity": "sha512-QM6H8E6r9/51BcE4NEluQ0f9dTECCTDEALJSQIWn183+Mtz/6KvEjOxW8VzKYSnhhL+qMljMKKA1WOUUf/4Qhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "^1"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-1.2.8.tgz",
+      "integrity": "sha512-x1m1s0lVstZQ5/Kzp4bVIMee3fFuDm+hphVnvrYA7wU16XqwgbCBfeVvHYZzVQQIy4jyi3MEtgduLVuwIRCKLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-1.0.13.tgz",
+      "integrity": "sha512-VAA4H8YNaNN0+UNIlpkwkLOj7xL5EGdyiQpdlAvOIRHckjGFCLK8eMoUd4+IMNEhQgweq0Yk/Dfzr70xhUo6hA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-1.2.5.tgz",
+      "integrity": "sha512-5SpBGkHtH01Zi5gMGfEXZp72NcQJB83uskIrlj9N0z9w4vVP7dHIgDu3v8BLhhqn8Oj98wuIrlatdiYK3+q3tA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "^1"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-1.2.7.tgz",
+      "integrity": "sha512-zySqZfnxn67RVEGWzpD9dQA0AbNIp4Rj0qGvAuUdUNfGLrwuGCbEGAGze5hEdNaHJKQT2gTqr6j+qAzncm11ew==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-1.4.5.tgz",
+      "integrity": "sha512-mLxrC1MSWupOSncXN/HOlWUAAIffAEBaI4+PKy2uMPsKe4FNZlk7qrbTjmzJXITQQqBHivaks4Td18azgqnotA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "1.12.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-1.12.7.tgz",
+      "integrity": "sha512-QetZrWWjuMfCe0BHLjD+dOThlgk7YGZ2gj+yhFAbDN5TularNBEQiBs5/CIgX0+IBDjt7/fbkDd5V70J1LjjKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-1.1.11.tgz",
+      "integrity": "sha512-lnQiU7jV+Gyk9oQYk0GGYccuexmQPTp08E0+4BidgFdiJivjEvf+esPSdZqCZ2C7UwTWejWpqetVaU8A+eX3FA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-1.4.5.tgz",
+      "integrity": "sha512-k9L18hXXv7OvK4PqW1kSFYIzasGOvfhPUWmHFkoZ8/ci99EAmY4HoF6zMefrHl0SGV7XYc7Qq2MNh8dK3edg5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "^1"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-1.0.11.tgz",
+      "integrity": "sha512-4pQMp8ldf7UaB/gR8Fvvy69psNHkTpD/pVw3vmEi8iZAB9EPMBruB1JvHO4BIq9QkUUd2lV1F5YXpMNj7JPBpw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-1.0.10.tgz",
+      "integrity": "sha512-+hbHsFdCMs23vk9p/SpvIkHkCpl0vxkP2qWR2vEk0wRi0BXODWgB/6aHnfrz/BeQnk20XzZiQJIZ+11TGxuYMQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-1.0.13.tgz",
+      "integrity": "sha512-BAQD6gTHnXqmI7JRhXwM2pEYJJF27AT1f6zCC192BKAUhigzd5HZjdje5ufRXmYcUM/fr2IJ9KqVMeXaljmmOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-1.1.5.tgz",
+      "integrity": "sha512-gB5CR+7xYMj56pt5zmSyDBjTNMEy96PdfUb2qBaAT9bmPcf4P/YHfhhTI5y8JoiqaSRLJY+3mqtaE9loBgB6Ng==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "2.2.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-2.2.10.tgz",
+      "integrity": "sha512-j4V7qQ+CQzK2KpvI5NDejdPAcds+fTzNGqWXrCXv1zNR33HRir0bMdhzN1OHDQLNXYffW/zOr3FOS2qlHDEgrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "^1"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-1.5.4.tgz",
+      "integrity": "sha512-HwLVEm8laYTNOR9Kc9745XDKgRa69VIIChNkSKJgrJOsDLI9QSiFSH2Bi4wMbGrvFs+X64azev7NfBPq+VOFVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-1.4.7.tgz",
+      "integrity": "sha512-aLaTOjdOJEFPhij59NdNwppvpHBheZFlLbcb7cIZZYLC0he9Wmdd/u4+1NZxlr7ncK+mq1PLmowMPw1GONrIQg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "1.3.12",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-1.3.12.tgz",
+      "integrity": "sha512-8oMzcd4+poSLGgV0R1Q1rOlx/xdmozS4Xab7np0eamFFUYq71AU9pOCJEFnkXW2aI/oXdVYJzw6pssbSut7Z9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "^1"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-1.1.4.tgz",
+      "integrity": "sha512-JIvy2HjRInE+TXOmIGN5LCmeO0hkFZx5f9FZ7kiN+D+YTcc8pptsiLiuHsvwxwC7VVKmJ2ExHUgNlAiV7vQM9g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-2.3.4.tgz",
+      "integrity": "sha512-xdDXbpVO74EvadI3UDxjxTdR6QIxm1FKzEA/+F8tL4GWWUg/hgvBqf6chql64U5A9ZUGWo7pEu4eNlyLwbKdhg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-1.0.12.tgz",
+      "integrity": "sha512-Tv9tkA4y3UvGQnrHyYAQhf5x/297FuYwotS4UW2TpwLblvRahbyL8r9HFYTJLPfPRqS63hwlqRItjKGmKtJxNg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-1.3.6.tgz",
+      "integrity": "sha512-Y8NwxuHV4ElbCkN7tJcuwENYKiAL+ktU6tNDLHqZ141YsaT3kwa5ZA5eqiJwHYWQzXMjF+FgL6/Sxo9IGSwmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "^1"
+      }
+    },
+    "node_modules/@types/d3-voronoi": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@types/d3-voronoi/-/d3-voronoi-1.1.12.tgz",
+      "integrity": "sha512-DauBl25PKZZ0WVJr42a6CNvI6efsdzofl9sajqZr2Gf5Gu733WkDdUGiPkUHXiUvYGzNNlFQde2wdZdfQPG+yw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "1.8.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-1.8.7.tgz",
+      "integrity": "sha512-HJWci3jXwFIuFKDqGn5PmuwrhZvuFdrnUmtSKCLXFAWyf2lAIUKMKh1/lHOkWBl/f4KVupGricJiqkQy+cVTog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "^1",
+        "@types/d3-selection": "^1"
+      }
+    },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
@@ -7475,6 +7768,13 @@
         "@types/range-parser": "*",
         "@types/send": "*"
       }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/glob": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@commitlint/types": "^21.0.1",
     "@eslint/js": "^9.39.4",
     "@openapitools/openapi-generator-cli": "^2.34.0",
+    "@types/d3": "^5.16.0",
     "@types/jasmine": "~6.0.0",
     "@types/jasminewd2": "~2.0.13",
     "@types/node": "^24.12.3",

--- a/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
@@ -163,10 +163,9 @@ export class OriginDestinationComponent implements OnInit, AfterViewInit, OnDest
 
     // Build X scales and axis (destinations):
     const x = d3
-      .scaleBand()
+      .scaleBand<number>()
       .range([0, width])
       .domain(nodeNames.map((n) => n.id))
-
       .padding(0.05);
 
     graphContentGroup
@@ -175,7 +174,7 @@ export class OriginDestinationComponent implements OnInit, AfterViewInit, OnDest
       .attr("transform", "translate(0, -20)")
       .call(
         d3
-          .axisBottom(x)
+          .axisBottom<number>(x)
           .tickSize(0)
           .tickFormat((d) => this.nodeService.getNodeFromId(d).getBetriebspunktName()),
       )
@@ -195,7 +194,7 @@ export class OriginDestinationComponent implements OnInit, AfterViewInit, OnDest
 
     // Build Y scales and axis (origins):
     const y = d3
-      .scaleBand()
+      .scaleBand<number>()
       .range([height, 0])
       .domain(nodeNames.map((n) => n.id).reverse())
       .padding(0.05);
@@ -204,7 +203,7 @@ export class OriginDestinationComponent implements OnInit, AfterViewInit, OnDest
       .style("pointer-events", "none")
       .call(
         d3
-          .axisLeft(y)
+          .axisLeft<number>(y)
           .tickSize(0)
           .tickFormat((d) => this.nodeService.getNodeFromId(d).getBetriebspunktName()),
       )

--- a/src/app/view/editor-main-view/data-views/connections.view.ts
+++ b/src/app/view/editor-main-view/data-views/connections.view.ts
@@ -123,7 +123,7 @@ export class ConnectionsView {
     return false;
   }
 
-  createConnectionCurve(drawingGroup: d3.selector) {
+  createConnectionCurve(drawingGroup: d3.Selection<SVGElement, undefined, HTMLElement, undefined>) {
     drawingGroup
       .append(StaticDomTags.CONNECTION_LINE_SVG)
       .attr("class", StaticDomTags.CONNECTION_LINE_CLASS)
@@ -148,7 +148,10 @@ export class ConnectionsView {
       );
   }
 
-  createConnectionSinglePin(drawingGroup: d3.selector, pinPos: Vec2D) {
+  createConnectionSinglePin(
+    drawingGroup: d3.Selection<SVGElement, undefined, HTMLElement, undefined>,
+    pinPos: Vec2D,
+  ) {
     const draggable = d3
       .drag()
       .on("start", (cv: ConnectionsViewObject, i, a) =>
@@ -190,7 +193,7 @@ export class ConnectionsView {
       );
   }
 
-  createConnectionPins(drawingGroup: d3.selector) {
+  createConnectionPins(drawingGroup: d3.Selection<SVGElement, undefined, HTMLElement, undefined>) {
     const selectedTrainrun = this.editorView.getSelectedTrainrun();
 
     drawingGroup.each((c: ConnectionsViewObject, i, a) => {

--- a/src/app/view/editor-main-view/data-views/d3.utils.ts
+++ b/src/app/view/editor-main-view/data-views/d3.utils.ts
@@ -116,7 +116,9 @@ export class D3Utils {
   }
 
   static updateTrainrunSectionPreviewLine(startPos: Vec2D) {
-    const mousePos = d3.mouse(d3.select(StaticDomTags.PREVIEW_LINE_DOM_REF).node());
+    const mousePos = d3.mouse(
+      d3.select<SVGPathElement, undefined>(StaticDomTags.PREVIEW_LINE_DOM_REF).node(),
+    );
     const mousePosVec: Vec2D = new Vec2D(mousePos[0], mousePos[1]);
     const fromPos: Vec2D = Vec2D.add(
       startPos,
@@ -136,7 +138,9 @@ export class D3Utils {
   }
 
   static updateIntermediateStopOrTransitionPreviewLine(startPos: Vec2D, endPos: Vec2D) {
-    const mousePos = d3.mouse(d3.select(StaticDomTags.PREVIEW_LINE_DOM_REF).node());
+    const mousePos = d3.mouse(
+      d3.select<SVGPathElement, undefined>(StaticDomTags.PREVIEW_LINE_DOM_REF).node(),
+    );
     const mousePosVec: Vec2D = new Vec2D(mousePos[0], mousePos[1]);
     const fromPos: Vec2D = Vec2D.add(
       startPos,
@@ -164,7 +168,9 @@ export class D3Utils {
   }
 
   static updateConnectionPreviewLine(startPos: Vec2D, canCombineTwoTrainrunsFlag: boolean) {
-    const mousePos = d3.mouse(d3.select(StaticDomTags.PREVIEW_CONNECTION_LINE_DOM_REF).node());
+    const mousePos = d3.mouse(
+      d3.select<SVGPathElement, undefined>(StaticDomTags.PREVIEW_CONNECTION_LINE_DOM_REF).node(),
+    );
     const mousePosVec: Vec2D = new Vec2D(mousePos[0], mousePos[1]);
     const fromPos: Vec2D = Vec2D.add(
       startPos,

--- a/src/app/view/editor-main-view/data-views/multiSelectRenderer.ts
+++ b/src/app/view/editor-main-view/data-views/multiSelectRenderer.ts
@@ -5,7 +5,7 @@ import {Vec2D} from "../../../utils/vec2D";
 export class MultiSelectRenderer {
   private isBoxDrawing = false;
 
-  static setGroup(nodeGroup: d3.Selector) {
+  static setGroup(nodeGroup: d3.Selection<SVGElement, undefined, HTMLElement, undefined>) {
     nodeGroup
       .append(StaticDomTags.PREVIEW_MULTISELECT_ROOT_BOX_SVG)
       .attr("class", StaticDomTags.PREVIEW_MULTISELECT_ROOT_BOX_CLASS);

--- a/src/app/view/editor-main-view/data-views/nodes.view.ts
+++ b/src/app/view/editor-main-view/data-views/nodes.view.ts
@@ -38,7 +38,7 @@ export class NodesView {
     this.dragPreviousMousePosition = new Vec2D();
   }
 
-  setGroup(nodeGroup: d3.Selector) {
+  setGroup(nodeGroup: d3.Selection<SVGElement, undefined, HTMLElement, undefined>) {
     this.nodeGroup = nodeGroup;
     this.nodeGroup.attr("class", "NodesView");
   }

--- a/src/app/view/editor-main-view/data-views/nodes.view.ts
+++ b/src/app/view/editor-main-view/data-views/nodes.view.ts
@@ -748,7 +748,7 @@ export class NodesView {
     }
 
     if (existingTrainrunSection === null) {
-      const sourceObj = d3.select(
+      const sourceObj = d3.select<SVGRectElement, undefined>(
         StaticDomTags.NODE_DOCKABLE_DOM_REF + '[id="' + startNode.getId() + '"]',
       );
       const sourceRect: DOMRect = sourceObj.node().getBoundingClientRect();
@@ -761,7 +761,7 @@ export class NodesView {
         endNode.getPositionX() + endNode.getNodeWidth() / 2,
         endNode.getPositionY() + endNode.getNodeHeight() / 2,
       );
-      const targetObj = d3.select(
+      const targetObj = d3.select<SVGRectElement, undefined>(
         StaticDomTags.NODE_DOCKABLE_DOM_REF + '[id="' + endNode.getId() + '"]',
       );
       if (targetObj.node() !== null) {

--- a/src/app/view/editor-main-view/data-views/static.dom.tags.ts
+++ b/src/app/view/editor-main-view/data-views/static.dom.tags.ts
@@ -46,9 +46,9 @@ export class StaticDomTags {
   /*
        GROUP object
      */
-  static SVG = "svg";
-  static GROUP_SVG = "g";
-  static GROUP_DOM_REF = "g";
+  static SVG = "svg" as const;
+  static GROUP_SVG = "g" as const;
+  static GROUP_DOM_REF = "g" as const;
 
   /*
       NODE (root group)
@@ -59,7 +59,7 @@ export class StaticDomTags {
        |- NODE_LABELAREA_TEXT        : text in-front of the node label are (drag node)
        |- NODE_CONNECTIONTIME_TEXT   : text in-front of the node connection time open detail view dialog on the right
      */
-  static NODE_SVG = "g";
+  static NODE_SVG = "g" as const;
   static NODE_ROOT_CONTAINER = "root_container_nodes";
   static NODE_ROOT_CONTAINER_DOM_REF = "g.root_container_nodes";
   static NODE_CLASS = "node";
@@ -74,59 +74,59 @@ export class StaticDomTags {
   static NODE_HAS_CONNECTIONS = "has_connections";
   static NODE_READONLY = "readonly";
 
-  static NODE_HOVER_ROOT_SVG = "rect";
+  static NODE_HOVER_ROOT_SVG = "rect" as const;
   static NODE_HOVER_ROOT_CLASS = "node_hover_root";
   static NODE_HOVER_ROOT_DOM_REF = "rect.node_hover_root";
 
-  static NODE_ROOT_SVG = "rect";
+  static NODE_ROOT_SVG = "rect" as const;
   static NODE_ROOT_CLASS = "node_root";
   static NODE_ROOT_DOM_REF = "rect.node_root";
 
-  static NODE_BACKGROUND_SVG = "rect";
+  static NODE_BACKGROUND_SVG = "rect" as const;
   static NODE_BACKGROUND_CLASS = "node_background";
   static NODE_BACKGROUND_DOM_REF = "rect.node_background";
 
-  static NODE_DOCKABLE_SVG = "rect";
+  static NODE_DOCKABLE_SVG = "rect" as const;
   static NODE_DOCKABLE_CLASS = "node_dockable";
   static NODE_DOCKABLE_DOM_REF = "rect.node_dockable";
 
-  static NODE_LABELAREA_SVG = "rect";
+  static NODE_LABELAREA_SVG = "rect" as const;
   static NODE_LABELAREA_CLASS = "node_labelarea";
   static NODE_LABELAREA_DOM_REF = "rect.node_labelarea";
 
-  static NODE_ANALYTICSAREA_SVG = "rect";
+  static NODE_ANALYTICSAREA_SVG = "rect" as const;
   static NODE_ANALYTICSAREA_CLASS = "node_analyticsarea";
   static NODE_ANALYTICSAREA_DOM_REF = "rect.node_analyticsarea";
 
-  static NODE_ANALYTICSAREA_TEXT_LEFT_SVG = "text";
+  static NODE_ANALYTICSAREA_TEXT_LEFT_SVG = "text" as const;
   static NODE_ANALYTICSAREA_TEXT_LEFT_CLASS = "node_title_analyticsarea_left";
   static NODE_ANALYTICSAREA_TEXT_LEFT_DOM_REF = "text.node_title_analyticsarea_left";
 
-  static NODE_ANALYTICSAREA_TEXT_RIGHT_SVG = "text";
+  static NODE_ANALYTICSAREA_TEXT_RIGHT_SVG = "text" as const;
   static NODE_ANALYTICSAREA_TEXT_RIGHT_CLASS = "node_title_analyticsarea_right";
   static NODE_ANALYTICSAREA_TEXT_RIGHT_DOM_REF = "text.node_title_analyticsarea_right";
 
-  static NODE_LABELAREA_TEXT_SVG = "text";
+  static NODE_LABELAREA_TEXT_SVG = "text" as const;
   static NODE_LABELAREA_TEXT_CLASS = "node_text";
   static NODE_LABELAREA_TEXT_DOM_REF = "text.node_text";
 
-  static NODE_CONNECTIONTIME_TEXT_SVG = "text";
+  static NODE_CONNECTIONTIME_TEXT_SVG = "text" as const;
   static NODE_CONNECTIONTIME_TEXT_CLASS = "node_connection_time";
   static NODE_CONNECTIONTIME_TEXT_DOM_REF = "text.node_connection_time";
 
-  static NODE_HOVER_DRAG_AREA_SVG = "path";
+  static NODE_HOVER_DRAG_AREA_SVG = "path" as const;
   static NODE_HOVER_DRAG_AREA_CLASS = "node_hover_drag_root";
   static NODE_HOVER_DRAG_AREA_DOM_REF = "path.node_hover_drag_root";
 
-  static NODE_HOVER_DRAG_AREA_BACKGROUND_SVG = "rect";
+  static NODE_HOVER_DRAG_AREA_BACKGROUND_SVG = "rect" as const;
   static NODE_HOVER_DRAG_AREA_BACKGROUND_CLASS = "node_hover_drag_root_background";
   static NODE_HOVER_DRAG_AREA_BACKGROUND_DOM_REF = "rect.node_hover_drag_root_background";
 
-  static NODE_EDIT_AREA_SVG = "path";
+  static NODE_EDIT_AREA_SVG = "path" as const;
   static NODE_EDIT_AREA_CLASS = "node_edit_button";
   static NODE_EDIT_AREA_DOM_REF = "path.node_edit_button";
 
-  static NODE_EDIT_AREA_BACKGROUND_SVG = "rect";
+  static NODE_EDIT_AREA_BACKGROUND_SVG = "rect" as const;
   static NODE_EDIT_AREA_BACKGROUND_CLASS = "node_edit_button_background";
   static NODE_EDIT_AREA_BACKGROUND_DOM_REF = "rect.node_edit_button_background";
 
@@ -145,7 +145,7 @@ export class StaticDomTags {
      |- EDGE_LINE_LAYER_2   : rendering layer 2
      |- EDGE_LINE_LAYER_3   : rendering layer 3
    */
-  static EDGE_SVG = "g";
+  static EDGE_SVG = "g" as const;
   static EDGE_ROOT_CONTAINER = "root_container_edges";
   static EDGE_ROOT_CONTAINER_DOM_REF = "g.root_container_edges";
   static EDGE_CLASS = "edge";
@@ -157,7 +157,7 @@ export class StaticDomTags {
   static EDGE_IS_END_NODE = "is_end_node";
   static EDGE_IS_NOT_END_NODE = "is_not_end_node";
 
-  static EDGE_LINE_SVG = "path";
+  static EDGE_LINE_SVG = "path" as const;
   static EDGE_LINE_CLASS = "edge_line";
   static EDGE_LINE_DOM_REF = "path.edge_line";
   static EDGE_LINE_LINE_ID = "trainrunId";
@@ -169,37 +169,37 @@ export class StaticDomTags {
   static EDGE_LINE_LAYER_3 = StaticDomTags.LINE_LAYER + "_3";
   static EDGE_LINE_GRAYEDOUT = StaticDomTags.TAG_GRAYEDOUT;
 
-  static EDGE_LINE_ARROW_SVG = "path";
+  static EDGE_LINE_ARROW_SVG = "path" as const;
   static EDGE_LINE_ARROW_CLASS = "edge_line_arrow";
   static EDGE_LINE_ARROW_DOM_REF = "path.edge_line_arrow";
   static TAG_LINE_ARROW_EDITOR = "editor";
 
-  static EDGE_LINE_PIN_SVG = "circle";
+  static EDGE_LINE_PIN_SVG = "circle" as const;
   static EDGE_LINE_PIN_CLASS = "edge_line_pin";
   static EDGE_LINE_PIN_DOM_REF = "circle.edge_line_pin";
   static EDGE_LINE_PIN_CONNECTION = "connection_pin";
   static EDGE_LINE_PIN_CONNECTION_DOM_REF = "circle.connection_line_pin";
 
-  static EDGE_LINE_STOP_ICON_SVG = "path";
+  static EDGE_LINE_STOP_ICON_SVG = "path" as const;
   static EDGE_LINE_STOP_ICON_CLASS = "edge_line_stop_arcs";
   static EDGE_LINE_STOP_ICON_CLASS_DOM_REF = "path.edge_line_stop_arcs";
 
-  static EDGE_LINE_TEXT_SVG = "text";
+  static EDGE_LINE_TEXT_SVG = "text" as const;
   static EDGE_LINE_TEXT_CLASS = "edge_text";
   static EDGE_LINE_TEXT_DOM_REF = "text.edge_text";
   static EDGE_LINE_TEXT_INDEX = "edge_text_index";
   static EDGE_DISABLE_EVENTS = "no_event";
   static EDGE_LINE_TEXT_ODD_FREQUENCY = "OddFrequency";
 
-  static EDGE_LINE_TEXT_BACKGROUND_SVG = "rect";
+  static EDGE_LINE_TEXT_BACKGROUND_SVG = "rect" as const;
   static EDGE_LINE_TEXT_BACKGROUND_CLASS = "edge_text_background";
   static EDGE_LINE_TEXT_BACKGROUND_DOM_REF = "rect.edge_text_background";
 
-  static EDGE_LINE_STOPS_GROUP_SVG = "g";
+  static EDGE_LINE_STOPS_GROUP_SVG = "g" as const;
   static EDGE_LINE_STOPS_GROUP_CLASS = "edge_line_stops_group";
   static EDGE_LINE_STOPS_GROUP_DOM_REF = "g.edge_line_stops_group";
 
-  static EDGE_LINE_STOPS_SVG = "circle";
+  static EDGE_LINE_STOPS_SVG = "circle" as const;
   static EDGE_LINE_STOPS_CLASS = "edge_line_stops";
   static EDGE_LINE_STOPS_DOM_REF = "circle.edge_line_stops";
   static EDGE_LINE_STOPS_INDEX = "StopIndex";
@@ -219,14 +219,14 @@ export class StaticDomTags {
   static TRANSITION_ROOT_CONTAINER_DOM_REF = "g.root_container_transition";
   static TRANSITION_GROUP_CLASS = "transition_group";
   static TRANSITION_GROUP_ATTR_TRANSITION_ID = "id";
-  static TRANSITION_LINE_SVG = "path";
+  static TRANSITION_LINE_SVG = "path" as const;
   static TRANSITION_LINE_CLASS = "transition_line";
   static TRANSITION_LINE_DOM_REF = "path.transition_line";
   static TRANSITION_LINE_CLASS_0 = StaticDomTags.LINE_LAYER + "_0";
   static TRANSITION_LINE_CLASS_1 = StaticDomTags.LINE_LAYER + "_1";
   static TRANSITION_LINE_CLASS_2 = StaticDomTags.LINE_LAYER + "_2";
   static TRANSITION_LINE_CLASS_3 = StaticDomTags.LINE_LAYER + "_3";
-  static TRANSITION_BUTTON_SVG = "polygon";
+  static TRANSITION_BUTTON_SVG = "polygon" as const;
   static TRANSITION_BUTTON_CLASS = "transition_pin";
   static TRANSITION_BUTTON_DOM_REF = "polygon.transition_pin";
   static TRANSITION_BUTTON_SIZE = 8;
@@ -243,7 +243,7 @@ export class StaticDomTags {
   static CONNECTION_ATTR_NODE_ID = "node_id";
   static CONNECTION_GROUP_CLASS = "connection_group";
   static CONNECTION_GROUP_ATTR_CONNECTION_ID = "id";
-  static CONNECTION_LINE_SVG = "path";
+  static CONNECTION_LINE_SVG = "path" as const;
   static CONNECTION_LINE_CLASS = "connection_line";
   static CONNECTION_LINE_DOM_REF = "path.connection_line";
   static CONNECTION_LINE_CLASS_0 = StaticDomTags.LINE_LAYER + "_0";
@@ -252,7 +252,7 @@ export class StaticDomTags {
   static CONNECTION_LINE_CLASS_3 = StaticDomTags.LINE_LAYER + "_3";
   static CONNECTION_TAG_ONGOING_DRAGGING = "connection_ongoing_dragging";
 
-  static CONNECTION_LINE_PIN_SVG = "circle";
+  static CONNECTION_LINE_PIN_SVG = "circle" as const;
   static CONNECTION_LINE_PIN_CLASS = "connection_line_pin";
   static CONNECTION_LINE_PIN_DOM_REF = "circle.connection_line_pin";
   static CONNECTION_ID = "id";
@@ -264,68 +264,68 @@ export class StaticDomTags {
   /*
     Multi Select Box
    */
-  static PREVIEW_MULTISELECT_ROOT_BOX_SVG = "g";
+  static PREVIEW_MULTISELECT_ROOT_BOX_SVG = "g" as const;
   static PREVIEW_MULTISELECT_ROOT_BOX_CLASS = "multi_select_box_root";
   static PREVIEW_MULTISELECT_ROOT_BOX_DOM_REF = "g.multi_select_box_root";
 
-  static PREVIEW_MULTISELECT_BOX_SVG = "rect";
+  static PREVIEW_MULTISELECT_BOX_SVG = "rect" as const;
   static PREVIEW_MULTISELECT_BOX_CLASS = "multi_select_box_root";
   static PREVIEW_MULTISELECT_BOX_DOM_REF = "rect.multi_select_box_root";
   /*
     PREVIEW_LINE
    */
-  static PREVIEW_LINE_ROOT_SVG = "g";
+  static PREVIEW_LINE_ROOT_SVG = "g" as const;
   static PREVIEW_LINE_ROOT_CLASS = "preview_line_root";
   static PREVIEW_LINE_ROOT_DOM_REF = "g.preview_line_root";
 
-  static PREVIEW_CONNECTION_LINE_ROOT_SVG = "g";
+  static PREVIEW_CONNECTION_LINE_ROOT_SVG = "g" as const;
   static PREVIEW_CONNECTION_LINE_ROOT_CLASS = "connection_preview_line_root";
   static PREVIEW_CONNECTION_LINE_ROOT_DOM_REF = "g.connection_preview_line_root";
 
-  static PREVIEW_LINE_SVG = "path";
+  static PREVIEW_LINE_SVG = "path" as const;
   static PREVIEW_LINE_CLASS = "preview_line";
   static PREVIEW_LINE_DOM_REF = "path.preview_line";
 
-  static PREVIEW_CONNECTION_LINE_SVG = "path";
+  static PREVIEW_CONNECTION_LINE_SVG = "path" as const;
   static PREVIEW_CONNECTION_LINE_CLASS = "preview_connection_line";
   static PREVIEW_CONNECTION_LINE_DOM_REF = "path.preview_connection_line";
 
   /* Note */
   static NOTE_ID = "id";
-  static NOTE_SVG = "g";
+  static NOTE_SVG = "g" as const;
   static NOTE_ROOT_CONTAINER = "root_container_notes";
   static NOTE_ROOT_CONTAINER_DOM_REF = "g.root_container_notes";
   static NOTE_CLASS = "note";
 
-  static NOTE_HOVER_ROOT_SVG = "rect";
+  static NOTE_HOVER_ROOT_SVG = "rect" as const;
   static NOTE_HOVER_ROOT_CLASS = "note_hover_root";
   static NOTE_HOVER_ROOT_DOM_REF = "rect.note_hover_root";
 
-  static NOTE_HOVER_DRAG_AREA_SVG = "path";
+  static NOTE_HOVER_DRAG_AREA_SVG = "path" as const;
   static NOTE_HOVER_DRAG_AREA_CLASS = "note_hover_drag_root";
   static NOTE_HOVER_DRAG_AREA_DOM_REF = "path.note_hover_drag_root";
 
-  static NOTE_HOVER_DRAG_AREA_BACKGROUND_SVG = "rect";
+  static NOTE_HOVER_DRAG_AREA_BACKGROUND_SVG = "rect" as const;
   static NOTE_HOVER_DRAG_AREA_BACKGROUND_CLASS = "note_hover_drag_root_background";
   static NOTE_HOVER_DRAG_AREA_BACKGROUND_DOM_REF = "rect.note_hover_drag_root_background";
 
-  static NOTE_ROOT_SVG = "rect";
+  static NOTE_ROOT_SVG = "rect" as const;
   static NOTE_ROOT_CLASS = "note_root";
   static NOTE_ROOT_DOM_REF = "rect.note_root";
 
-  static NOTE_TITELAREA_SVG = "rect";
+  static NOTE_TITELAREA_SVG = "rect" as const;
   static NOTE_TITELAREA_CLASS = "note_titelarea";
   static NOTE_TITELAREA_DOM_REF = "rect.note_titelarea";
 
-  static NOTE_TITELAREA_TEXT_SVG = "text";
+  static NOTE_TITELAREA_TEXT_SVG = "text" as const;
   static NOTE_TITELAREA_TEXT_CLASS = "titel_text";
   static NOTE_TITELAREA_TEXT_DOM_REF = "text.titel_text";
 
-  static NOTE_TEXTAREA_SVG = "rect";
+  static NOTE_TEXTAREA_SVG = "rect" as const;
   static NOTE_TEXTAREA_CLASS = "note_textarea";
   static NOTE_TEXTAREA_DOM_REF = "rect.note_textarea";
 
-  static NOTE_TEXT_SVG = "text";
+  static NOTE_TEXT_SVG = "text" as const;
   static NOTE_TEXT_CLASS = "note_text";
   static NOTE_TEXT_DOM_REF = "text.note_text";
 

--- a/src/app/view/editor-main-view/data-views/trainrunsection.previewline.view.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunsection.previewline.view.ts
@@ -154,7 +154,9 @@ export class TrainrunSectionPreviewLineView {
       return;
     }
     this.mode = PreviewLineMode.DragNewTrainrunSection;
-    const mousePosition = d3.mouse(d3.select(StaticDomTags.PREVIEW_LINE_ROOT_DOM_REF).node());
+    const mousePosition = d3.mouse(
+      d3.select<SVGGElement, undefined>(StaticDomTags.PREVIEW_LINE_ROOT_DOM_REF).node(),
+    );
     const startPosition = new Vec2D(mousePosition[0], mousePosition[1]);
     const startNode: Node = this.nodeService.getNodeFromId(nodeId);
     this.startPreviewLineAtPosition(startNode, startPosition);

--- a/src/app/view/editor-main-view/data-views/trainrunsection.previewline.view.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunsection.previewline.view.ts
@@ -60,13 +60,15 @@ export class TrainrunSectionPreviewLineView {
     private versionControlService: VersionControlService,
   ) {}
 
-  static setGroup(nodeGroup: d3.Selector) {
+  static setGroup(nodeGroup: d3.Selection<SVGElement, undefined, HTMLElement, undefined>) {
     nodeGroup
       .append(StaticDomTags.PREVIEW_LINE_ROOT_SVG)
       .attr("class", StaticDomTags.PREVIEW_LINE_ROOT_CLASS);
   }
 
-  static setConnectionGroup(nodeGroup: d3.Selector) {
+  static setConnectionGroup(
+    nodeGroup: d3.Selection<SVGElement, undefined, HTMLElement, undefined>,
+  ) {
     nodeGroup
       .append(StaticDomTags.PREVIEW_CONNECTION_LINE_ROOT_SVG)
       .attr("class", StaticDomTags.PREVIEW_CONNECTION_LINE_ROOT_CLASS);

--- a/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
@@ -137,7 +137,7 @@ export class TrainrunSectionsView {
       .innerRadius(0)
       .startAngle(-Math.PI / 2 + rotate)
       .endAngle(Math.PI / 2 + rotate);
-    return arcGenerator();
+    return arcGenerator(undefined);
   }
 
   static getPosition(trainrunSection: TrainrunSection, atSource: boolean): Vec2D {

--- a/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
@@ -974,7 +974,7 @@ export class TrainrunSectionsView {
     }
   }
 
-  setGroup(trainrunSectionGroup: d3.Selector) {
+  setGroup(trainrunSectionGroup: d3.Selection<SVGElement, undefined, HTMLElement, undefined>) {
     trainrunSectionGroup.attr("class", "TrainrunSectionsView");
     this.trainrunSectionGroup = trainrunSectionGroup
       .append(StaticDomTags.GROUP_SVG)
@@ -982,7 +982,7 @@ export class TrainrunSectionsView {
   }
 
   createTrainrunSectionTextBackgrounds(
-    groupEnter: d3.Selector,
+    groupEnter: d3.Selection<SVGElement, undefined, HTMLElement, undefined>,
     lineTextElement: TrainrunSectionText,
     selectedTrainrun: Trainrun,
     connectedTrainIds: any,
@@ -1107,7 +1107,7 @@ export class TrainrunSectionsView {
    * @param enableEvents - Optional flag to enable or disable mouse event handlers on the arrows. Defaults to true.
    */
   createDirectionArrows(
-    groupLinesEnter: d3.Selection,
+    groupLinesEnter: d3.Selection<SVGElement, undefined, HTMLElement, undefined>,
     selectedTrainrun: Trainrun,
     connectedTrainIds: any,
     enableEvents = true,
@@ -1168,7 +1168,7 @@ export class TrainrunSectionsView {
   }
 
   createAsymmetryArrows(
-    groupLinesEnter: d3.Selection,
+    groupLinesEnter: d3.Selection<SVGElement, undefined, HTMLElement, undefined>,
     selectedTrainrun: Trainrun,
     connectedTrainIds: any,
     enableEvents = true,
@@ -1243,7 +1243,7 @@ export class TrainrunSectionsView {
   }
 
   createTrainrunSection(
-    groupEnter: d3.Selector,
+    groupEnter: d3.Selection<SVGElement, undefined, HTMLElement, undefined>,
     classRef,
     levelFreqFilter: LinePatternRefs[],
     selectedTrainrun: Trainrun,
@@ -1299,7 +1299,7 @@ export class TrainrunSectionsView {
   }
 
   createTrainrunsectionSemicircleAtNode(
-    groupEnter: d3.Selector,
+    groupEnter: d3.Selection<SVGElement, undefined, HTMLElement, undefined>,
     selectedTrainrun: Trainrun,
     connectedTrainIds: any,
     atSource: boolean,
@@ -1365,7 +1365,7 @@ export class TrainrunSectionsView {
   }
 
   createTrainrunsectionSemicircles(
-    groupEnter: d3.Selector,
+    groupEnter: d3.Selection<SVGElement, undefined, HTMLElement, undefined>,
     selectedTrainrun: Trainrun,
     connectedTrainIds: any,
   ) {
@@ -1390,7 +1390,7 @@ export class TrainrunSectionsView {
   }
 
   createPinOnTrainrunsection(
-    groupEnter: d3.Selector,
+    groupEnter: d3.Selection<SVGElement, undefined, HTMLElement, undefined>,
     selectedTrainrun: Trainrun,
     connectedTrainIds: any,
     atSource: boolean,
@@ -1474,7 +1474,7 @@ export class TrainrunSectionsView {
   }
 
   private createInternTrainrunSectionElementFilteringWarningElements(
-    groupEnter: d3.Selector,
+    groupEnter: d3.Selection<SVGElement, undefined, HTMLElement, undefined>,
     selectedTrainrun: Trainrun,
     connectedTrainIds: any,
     textElement: TrainrunSectionText,
@@ -1581,7 +1581,7 @@ export class TrainrunSectionsView {
   }
 
   createTrainrunSectionElement(
-    groupEnter: d3.Selector,
+    groupEnter: d3.Selection<SVGElement, undefined, HTMLElement, undefined>,
     selectedTrainrun: Trainrun,
     connectedTrainIds: any,
     textElement: TrainrunSectionText,
@@ -1609,7 +1609,7 @@ export class TrainrunSectionsView {
   }
 
   createTrainrunSectionGotoInfoElement(
-    groupEnter: d3.Selector,
+    groupEnter: d3.Selection<SVGElement, undefined, HTMLElement, undefined>,
     selectedTrainrun: Trainrun,
     connectedTrainIds: any,
     atSource: boolean,
@@ -1664,7 +1664,7 @@ export class TrainrunSectionsView {
   }
 
   createNumberOfStopsTextElement(
-    groupEnter: d3.Selector,
+    groupEnter: d3.Selection<SVGElement, undefined, HTMLElement, undefined>,
     trainrunSection: TrainrunSection,
     selectedTrainrun: Trainrun,
     connectedTrainIds: any,
@@ -1709,7 +1709,7 @@ export class TrainrunSectionsView {
   }
 
   createIntermediateStops(
-    groupEnter: d3.Selector,
+    groupEnter: d3.Selection<SVGElement, undefined, HTMLElement, undefined>,
     trainrunSection: TrainrunSection,
     selectedTrainrun: Trainrun,
     connectedTrainIds: any,
@@ -1771,7 +1771,7 @@ export class TrainrunSectionsView {
   }
 
   createAllIntermediateStops(
-    groupEnter: d3.Selector,
+    groupEnter: d3.Selection<SVGGElement, undefined, HTMLElement, undefined>,
     selectedTrainrun: Trainrun,
     connectedTrainIds: any,
   ) {
@@ -2664,7 +2664,7 @@ export class TrainrunSectionsView {
     lineOrientationVector: Vec2D,
     stopIndex: number,
     drawNumberOfStops,
-    groupEnter: d3.Selector,
+    groupEnter: d3.Selection<SVGElement, undefined, HTMLElement, undefined>,
     selectedTrainrun: Trainrun,
     connectedTrainIds: any,
     numberOfStops: number,

--- a/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
@@ -1777,7 +1777,7 @@ export class TrainrunSectionsView {
   ) {
     groupEnter.each((t: TrainrunSectionViewObject, i, a) => {
       const grp = d3
-        .select(a[i])
+        .select<SVGGElement, undefined>(a[i])
         .append(StaticDomTags.EDGE_LINE_STOPS_GROUP_SVG)
         .attr("class", StaticDomTags.EDGE_LINE_STOPS_GROUP_CLASS);
       this.createIntermediateStops(grp, t.trainrunSection, selectedTrainrun, connectedTrainIds);

--- a/src/app/view/editor-main-view/data-views/transitions.view.ts
+++ b/src/app/view/editor-main-view/data-views/transitions.view.ts
@@ -82,7 +82,7 @@ export class TransitionsView {
   }
 
   static createTransitionLineLayer(
-    grpEnter: d3.selector,
+    grpEnter: d3.Selection<SVGElement, undefined, HTMLElement, undefined>,
     classRef: string,
     levelFreqFilter: LinePatternRefs[],
     selectedTrainrun: Trainrun,
@@ -121,7 +121,11 @@ export class TransitionsView {
       .attr("d", (t: TransitionViewObject) => D3Utils.getPathAsSVGString(t.transition.getPath()));
   }
 
-  createNonStopToggle(grpEnter: d3.selector, selectedTrainrun: Trainrun, connectedTrainIds: any) {
+  createNonStopToggle(
+    grpEnter: d3.Selection<SVGElement, undefined, HTMLElement, undefined>,
+    selectedTrainrun: Trainrun,
+    connectedTrainIds: any,
+  ) {
     if (!this.editorView.trainrunSectionPreviewLineView.getVariantIsWritable()) {
       return;
     }

--- a/src/app/view/themes/theme-gray-dark.ts
+++ b/src/app/view/themes/theme-gray-dark.ts
@@ -34,107 +34,107 @@ export class ThemeGrayDark extends ThemeBase {
 
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_NORMAL: " +
-        d3.scaleLinear().domain([0, 100]).range(["#666666", "#FFFFFF"])(normal),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#666666", "#FFFFFF"])(normal),
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_NORMAL_FOCUS: " +
-        d3.scaleLinear().domain([0, 100]).range(["#666666", "#FFFFFF"])(focus),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#666666", "#FFFFFF"])(focus),
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_NORMAL_MUTED: " +
-        d3.scaleLinear().domain([0, 100]).range(["#333333", "#FFFFFF"])(muted),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#333333", "#FFFFFF"])(muted),
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_NORMAL_RELATED: " +
-        d3.scaleLinear().domain([0, 100]).range(["#dddddd", "#FFFFFF"])(related),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#dddddd", "#FFFFFF"])(related),
 
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_EC: " +
-        d3.scaleLinear().domain([0, 100]).range(["#cccccc", "#FFFFFF"])(normal),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#cccccc", "#FFFFFF"])(normal),
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_EC_FOCUS: " +
-        d3.scaleLinear().domain([0, 100]).range(["#cccccc", "#FFFFFF"])(focus),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#cccccc", "#FFFFFF"])(focus),
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_EC_MUTED: " +
-        d3.scaleLinear().domain([0, 100]).range(["#333333", "#FFFFFF"])(muted),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#333333", "#FFFFFF"])(muted),
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_EC_RELATED:" +
-        d3.scaleLinear().domain([0, 100]).range(["#dddddd", "#FFFFFF"])(related),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#dddddd", "#FFFFFF"])(related),
 
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_IC: " +
-        d3.scaleLinear().domain([0, 100]).range(["#cccccc", "#FFFFFF"])(normal),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#cccccc", "#FFFFFF"])(normal),
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_IC_FOCUS: " +
-        d3.scaleLinear().domain([0, 100]).range(["#cccccc", "#FFFFFF"])(focus),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#cccccc", "#FFFFFF"])(focus),
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_IC_MUTED: " +
-        d3.scaleLinear().domain([0, 100]).range(["#333333", "#FFFFFF"])(muted),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#333333", "#FFFFFF"])(muted),
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_IC_RELATED: " +
-        d3.scaleLinear().domain([0, 100]).range(["#dddddd", "#FFFFFF"])(related),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#dddddd", "#FFFFFF"])(related),
 
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_IR:" +
-        d3.scaleLinear().domain([0, 100]).range(["#cccccc", "#FFFFFF"])(normal),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#cccccc", "#FFFFFF"])(normal),
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_IR_FOCUS: " +
-        d3.scaleLinear().domain([0, 100]).range(["#cccccc", "#FFFFFF"])(focus),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#cccccc", "#FFFFFF"])(focus),
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_IR_MUTED: " +
-        d3.scaleLinear().domain([0, 100]).range(["#333333", "#FFFFFF"])(muted),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#333333", "#FFFFFF"])(muted),
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_IR_RELATED: " +
-        d3.scaleLinear().domain([0, 100]).range(["#dddddd", "#FFFFFF"])(related),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#dddddd", "#FFFFFF"])(related),
 
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_RE: " +
-        d3.scaleLinear().domain([0, 100]).range(["#bbbbbb", "#FFFFFF"])(normal),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#bbbbbb", "#FFFFFF"])(normal),
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_RE_FOCUS:" +
-        d3.scaleLinear().domain([0, 100]).range(["#bbbbbb", "#FFFFFF"])(focus),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#bbbbbb", "#FFFFFF"])(focus),
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_RE_MUTED:" +
-        d3.scaleLinear().domain([0, 100]).range(["#333333", "#FFFFFF"])(muted),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#333333", "#FFFFFF"])(muted),
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_RE_RELATED: " +
-        d3.scaleLinear().domain([0, 100]).range(["#bbbbbb", "#FFFFFF"])(related),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#bbbbbb", "#FFFFFF"])(related),
 
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_S: " +
-        d3.scaleLinear().domain([0, 100]).range(["#aaaaaa", "#FFFFFF"])(normal),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#aaaaaa", "#FFFFFF"])(normal),
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_S_FOCUS: " +
-        d3.scaleLinear().domain([0, 100]).range(["#aaaaaa", "#FFFFFF"])(focus),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#aaaaaa", "#FFFFFF"])(focus),
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_S_MUTED: " +
-        d3.scaleLinear().domain([0, 100]).range(["#333333", "#FFFFFF"])(muted),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#333333", "#FFFFFF"])(muted),
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_S_RELATED: " +
-        d3.scaleLinear().domain([0, 100]).range(["#aaaaaa", "#FFFFFF"])(related),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#aaaaaa", "#FFFFFF"])(related),
 
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_GEX:" +
-        d3.scaleLinear().domain([0, 100]).range(["#888888", "#FFFFFF"])(normal),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#888888", "#FFFFFF"])(normal),
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_GEX_FOCUS: " +
-        d3.scaleLinear().domain([0, 100]).range(["#888888", "#FFFFFF"])(focus),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#888888", "#FFFFFF"])(focus),
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_GEX_MUTED: " +
-        d3.scaleLinear().domain([0, 100]).range(["#333333", "#FFFFFF"])(muted),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#333333", "#FFFFFF"])(muted),
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_GEX_RELATED: " +
-        d3.scaleLinear().domain([0, 100]).range(["#999999", "#FFFFFF"])(related),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#999999", "#FFFFFF"])(related),
 
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_G: " +
-        d3.scaleLinear().domain([0, 100]).range(["#666666", "#FFFFFF"])(normal),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#666666", "#FFFFFF"])(normal),
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_G_FOCUS: " +
-        d3.scaleLinear().domain([0, 100]).range(["#666666", "#FFFFFF"])(focus),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#666666", "#FFFFFF"])(focus),
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_G_MUTED:" +
-        d3.scaleLinear().domain([0, 100]).range(["#333333", "#FFFFFF"])(muted),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#333333", "#FFFFFF"])(muted),
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_G_RELATED: " +
-        d3.scaleLinear().domain([0, 100]).range(["#777777", "#FFFFFF"])(related),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#777777", "#FFFFFF"])(related),
 
       "COLOR_GRAYEDOUT: #121212",
       "COLOR_TRANSITION_GRAYEDOUT: #242424",

--- a/src/app/view/themes/theme-gray.ts
+++ b/src/app/view/themes/theme-gray.ts
@@ -30,107 +30,107 @@ export class ThemeGray extends ThemeBase {
 
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_NORMAL: " +
-        d3.scaleLinear().domain([0, 100]).range(["#dddddd", "#000000"])(normal),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#dddddd", "#000000"])(normal),
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_NORMAL_FOCUS: " +
-        d3.scaleLinear().domain([0, 100]).range(["#dddddd", "#000000"])(focus),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#dddddd", "#000000"])(focus),
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_NORMAL_MUTED: " +
-        d3.scaleLinear().domain([0, 100]).range(["#dddddd", "#000000"])(muted),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#dddddd", "#000000"])(muted),
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_NORMAL_RELATED: " +
-        d3.scaleLinear().domain([0, 100]).range(["#dddddd", "#000000"])(related),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#dddddd", "#000000"])(related),
 
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_EC: " +
-        d3.scaleLinear().domain([0, 100]).range(["#dddddd", "#000000"])(normal),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#dddddd", "#000000"])(normal),
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_EC_FOCUS: " +
-        d3.scaleLinear().domain([0, 100]).range(["#dddddd", "#000000"])(focus),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#dddddd", "#000000"])(focus),
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_EC_MUTED: " +
-        d3.scaleLinear().domain([0, 100]).range(["#dddddd", "#000000"])(muted),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#dddddd", "#000000"])(muted),
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_EC_RELATED:" +
-        d3.scaleLinear().domain([0, 100]).range(["#dddddd", "#000000"])(related),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#dddddd", "#000000"])(related),
 
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_IC: " +
-        d3.scaleLinear().domain([0, 100]).range(["#dddddd", "#000000"])(normal),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#dddddd", "#000000"])(normal),
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_IC_FOCUS: " +
-        d3.scaleLinear().domain([0, 100]).range(["#dddddd", "#000000"])(focus),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#dddddd", "#000000"])(focus),
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_IC_MUTED: " +
-        d3.scaleLinear().domain([0, 100]).range(["#dddddd", "#000000"])(muted),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#dddddd", "#000000"])(muted),
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_IC_RELATED: " +
-        d3.scaleLinear().domain([0, 100]).range(["#dddddd", "#000000"])(related),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#dddddd", "#000000"])(related),
 
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_IR:" +
-        d3.scaleLinear().domain([0, 100]).range(["#dddddd", "#000000"])(normal),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#dddddd", "#000000"])(normal),
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_IR_FOCUS: " +
-        d3.scaleLinear().domain([0, 100]).range(["#dddddd", "#000000"])(focus),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#dddddd", "#000000"])(focus),
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_IR_MUTED: " +
-        d3.scaleLinear().domain([0, 100]).range(["#dddddd", "#000000"])(muted),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#dddddd", "#000000"])(muted),
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_IR_RELATED: " +
-        d3.scaleLinear().domain([0, 100]).range(["#dddddd", "#000000"])(related),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#dddddd", "#000000"])(related),
 
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_RE: " +
-        d3.scaleLinear().domain([0, 100]).range(["#bbbbbb", "#000000"])(normal),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#bbbbbb", "#000000"])(normal),
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_RE_FOCUS:" +
-        d3.scaleLinear().domain([0, 100]).range(["#bbbbbb", "#000000"])(focus),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#bbbbbb", "#000000"])(focus),
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_RE_MUTED:" +
-        d3.scaleLinear().domain([0, 100]).range(["#dddddd", "#000000"])(muted),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#dddddd", "#000000"])(muted),
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_RE_RELATED: " +
-        d3.scaleLinear().domain([0, 100]).range(["#bbbbbb", "#000000"])(related),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#bbbbbb", "#000000"])(related),
 
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_S: " +
-        d3.scaleLinear().domain([0, 100]).range(["#aaaaaa", "#000000"])(normal),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#aaaaaa", "#000000"])(normal),
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_S_FOCUS: " +
-        d3.scaleLinear().domain([0, 100]).range(["#aaaaaa", "#000000"])(focus),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#aaaaaa", "#000000"])(focus),
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_S_MUTED: " +
-        d3.scaleLinear().domain([0, 100]).range(["#dddddd", "#000000"])(muted),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#dddddd", "#000000"])(muted),
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_S_RELATED: " +
-        d3.scaleLinear().domain([0, 100]).range(["#aaaaaa", "#000000"])(related),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#aaaaaa", "#000000"])(related),
 
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_GEX:" +
-        d3.scaleLinear().domain([0, 100]).range(["#999999", "#000000"])(normal),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#999999", "#000000"])(normal),
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_GEX_FOCUS: " +
-        d3.scaleLinear().domain([0, 100]).range(["#999999", "#000000"])(focus),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#999999", "#000000"])(focus),
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_GEX_MUTED: " +
-        d3.scaleLinear().domain([0, 100]).range(["#dddddd", "#000000"])(muted),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#dddddd", "#000000"])(muted),
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_GEX_RELATED: " +
-        d3.scaleLinear().domain([0, 100]).range(["#999999", "#000000"])(related),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#999999", "#000000"])(related),
 
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_G: " +
-        d3.scaleLinear().domain([0, 100]).range(["#777777", "#000000"])(normal),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#777777", "#000000"])(normal),
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_G_FOCUS: " +
-        d3.scaleLinear().domain([0, 100]).range(["#777777", "#000000"])(focus),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#777777", "#000000"])(focus),
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_G_MUTED:" +
-        d3.scaleLinear().domain([0, 100]).range(["#dddddd", "#000000"])(muted),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#dddddd", "#000000"])(muted),
       StaticDomTags.PREFIX_COLOR_VARIABLE +
         "_G_RELATED: " +
-        d3.scaleLinear().domain([0, 100]).range(["#777777", "#000000"])(related),
+        d3.scaleLinear<string>().domain([0, 100]).range(["#777777", "#000000"])(related),
 
       "COLOR_GRAYEDOUT: white",
       "COLOR_TRANSITION_GRAYEDOUT: whitesmoke",

--- a/src/app/view/util/generalViewFunctions.ts
+++ b/src/app/view/util/generalViewFunctions.ts
@@ -10,7 +10,7 @@ export class GeneralViewFunctions {
       The SVG (netzgrafik) rendering area has its own local coordinate system and can be different
       to the real screen visible coordinates.
      */
-    const element = d3.select("html").node();
+    const element = d3.select<HTMLElement, undefined>("html").node();
     const rectHtml = element.getBoundingClientRect();
 
     return GeneralViewFunctions.calcDialogTopLeftScreenCoordinateClientRectInfo(

--- a/src/app/view/util/svg.mouse.controller.ts
+++ b/src/app/view/util/svg.mouse.controller.ts
@@ -65,7 +65,7 @@ export class SVGMouseController {
 
   init(viewboxProperties: ViewboxProperties) {
     this.viewboxProperties = viewboxProperties;
-    const element = d3.select("html").node();
+    const element = d3.select<HTMLElement, undefined>("html").node();
     const rectHtml = element.getBoundingClientRect();
     const height = rectHtml.height;
     const width = rectHtml.width;


### PR DESCRIPTION
_See individual commits._

d3 packages don't provide their own type definitions. We need to grab them via @types/d3.

A handful of preliminary commits fix the resulting ~180 type errors.

Closes: https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/issues/678