### PR TITLE
Fix missing `initPortOrdering` updates accordingly to ordering algorithm setting

### DIFF
--- a/src/app/services/data/node.service.ts
+++ b/src/app/services/data/node.service.ts
@@ -285,7 +285,10 @@ export class NodeService implements OnDestroy {
     this.filterService.clearDeletetFilterNodeLabels(deletetLabelIds);
     this.deleteNodeWithoutUpdate(nodeId, enforceUpdate);
     if (enforceUpdate) {
-      this.nodesUpdated();
+      this.initPortOrdering();
+      this.trainrunSectionService.trainrunSectionsUpdated();
+      this.connectionsUpdated();
+      this.transitionsUpdated();
     }
     this.operation.emit(new NodeOperation(OperationType.delete, node));
   }

--- a/src/app/services/data/trainrun.service.ts
+++ b/src/app/services/data/trainrun.service.ts
@@ -534,8 +534,9 @@ export class TrainrunService {
     );
     this.setTrainrunAsSelected(copiedtrainrun.getId(), false);
     if (enforceUpdate) {
+      this.nodeService.initPortOrdering();
+      this.nodeService.connectionsUpdated();
       this.nodeService.transitionsUpdated();
-      this.nodeService.nodesUpdated();
       this.trainrunsUpdated();
     }
     this.operation.emit(new TrainrunOperation(OperationType.create, copiedtrainrun));

--- a/src/app/services/data/trainrunsection.service.ts
+++ b/src/app/services/data/trainrunsection.service.ts
@@ -831,6 +831,7 @@ export class TrainrunSectionService implements OnDestroy {
     });
     if (lastTrs !== undefined) {
       this.deleteTrainrunSectionAndCleanupNodes(lastTrs, false);
+      this.nodeService.initPortOrdering();
       this.nodeService.transitionsUpdated();
       this.nodeService.connectionsUpdated();
       this.trainrunService.trainrunsUpdated();

--- a/src/app/services/data/trainrunsection.service.ts
+++ b/src/app/services/data/trainrunsection.service.ts
@@ -795,6 +795,7 @@ export class TrainrunSectionService implements OnDestroy {
         );
       });
     if (enforceUpdate) {
+      this.nodeService.initPortOrdering();
       this.nodeService.transitionsUpdated();
       this.nodeService.connectionsUpdated();
       this.trainrunSectionsUpdated();

--- a/src/app/services/data/trainrunsection.service.ts
+++ b/src/app/services/data/trainrunsection.service.ts
@@ -636,7 +636,10 @@ export class TrainrunSectionService implements OnDestroy {
     // Ensure consistent section direction considering the previous ones
     this.enforceConsistentSectionDirection(trainrunSection.getTrainrunId());
 
-    //this.trainrunSectionsUpdated();
+    this.nodeService.initPortOrdering();
+    this.nodeService.connectionsUpdated();
+    this.nodeService.transitionsUpdated();
+    this.trainrunSectionsUpdated();
     this.trainrunService.trainrunsUpdated();
 
     if (initialTrainrunsLength !== this.trainrunService.trainrunsStore.trainruns.length) {


### PR DESCRIPTION
_See individual commits_

This fixes this bug (using trainrun selection + key "D" and trainrun selection + key "Delete")

https://github.com/user-attachments/assets/10a0ccaf-3870-48db-93f5-d6f8928bbf65

With this fix:

https://github.com/user-attachments/assets/abfbd793-bf62-465f-bb11-5ad52d49ab78

