### PR TITLE
fix(model): initialize potential missing TrainrunSection.path

### DIFF
--- a/src/app/models/trainrunsection.model.ts
+++ b/src/app/models/trainrunsection.model.ts
@@ -78,7 +78,10 @@ export class TrainrunSection {
       trainrunId,
       resourceId,
       specificTrainrunSectionFrequencyId,
-      path,
+      path = {
+        path: [],
+        textPositions: {...EMPTY_TEXT_POSITIONS},
+      },
       warnings,
     }: TrainrunSectionDto = {
       id: TrainrunSection.incrementId(),

--- a/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
+++ b/src/app/view/editor-tools-view-component/editor-tools-view.component.ts
@@ -714,11 +714,7 @@ export class EditorToolsViewComponent {
     return (
       netzgrafikDto.nodes.find((n: NodeDto) => n.ports === undefined) !== undefined ||
       netzgrafikDto.nodes.filter((n: NodeDto) => n.ports?.length === 0).length ===
-        netzgrafikDto.nodes.length ||
-      netzgrafikDto.trainrunSections.find(
-        (ts: TrainrunSectionDto) =>
-          ts.path === undefined || ts.path?.path === undefined || ts.path?.path?.length === 0,
-      ) !== undefined
+        netzgrafikDto.nodes.length
     );
   }
 


### PR DESCRIPTION
Also fixes the third-party import by removing the check on TrainrunSection.path which is useless, since this attribute is always recomputed.

This needs to be tested internally at SBB with the third party software.