### PR TITLE
fix(service): correctly instantiate TrainrunSection when coming from 3rd party

### DIFF
--- a/src/app/services/data/trainrunsection.service.ts
+++ b/src/app/services/data/trainrunsection.service.ts
@@ -1343,7 +1343,7 @@ export class TrainrunSectionService implements OnDestroy {
     const trainrunId = trainrunMap.get(trainrunSection.trainrunId);
     const trainrun = this.trainrunService.getTrainrunFromId(trainrunId);
 
-    const newTrainrunSection: TrainrunSection = new TrainrunSection();
+    const newTrainrunSection: TrainrunSection = new TrainrunSection(trainrunSection);
     newTrainrunSection.setTrainrun(trainrun);
 
     const sourceNodeId = nodeMap.get(trainrunSection.sourceNodeId);
@@ -1352,15 +1352,6 @@ export class TrainrunSectionService implements OnDestroy {
     const targetNode = this.nodeService.getNodeFromId(targetNodeId);
     newTrainrunSection.setSourceAndTargetNodeReference(sourceNode, targetNode);
 
-    newTrainrunSection.setSourceSymmetry(trainrunSection.sourceSymmetry);
-    newTrainrunSection.setTargetSymmetry(trainrunSection.targetSymmetry);
-    newTrainrunSection.setSourceArrivalDto(trainrunSection.sourceArrival);
-    newTrainrunSection.setTargetArrivalDto(trainrunSection.targetArrival);
-    newTrainrunSection.setSourceDepartureDto(trainrunSection.sourceDeparture);
-    newTrainrunSection.setTargetDepartureDto(trainrunSection.targetDeparture);
-    newTrainrunSection.setTravelTimeDto(trainrunSection.travelTime);
-    newTrainrunSection.setBackwardTravelTimeDto(trainrunSection.backwardTravelTime);
-    newTrainrunSection.setNumberOfStops(trainrunSection.numberOfStops);
     this.trainrunSectionsStore.trainrunSections.push(newTrainrunSection);
     const sourceIsNonStop = this.getIsNonStop(
       trainrunSection.sourceNodeId,


### PR DESCRIPTION
Follow-up of https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/pull/1078

You can test by trying to import this: https://github.com/user-attachments/files/28323164/FV21_Paris-Frankfurt_Viriato_NGE.json

Fixes the third-party import.

Open discussion: it is difficult to maintain the third-party import without being able to use it; how can we do better? Also, I think that the third party import should be updated to be aligned with Netzgrafik-Editor evolutions, as OSRD does.