### PR TITLE
fix(service): missing `initPortOrdering` in trainrun updates

### DIFF
--- a/src/app/services/data/trainrun.service.ts
+++ b/src/app/services/data/trainrun.service.ts
@@ -230,6 +230,7 @@ export class TrainrunService {
 
     this.nodeService.reorderPortsOnNodesForTrainrun(trainrun, false);
     this.propagateTrainrunInitialConsecutiveTimes(trainrun);
+    this.nodeService.initPortOrdering();
     this.trainrunsUpdated();
     this.operation.emit(new TrainrunOperation(OperationType.update, trainrun));
     return freqOffset;
@@ -242,6 +243,7 @@ export class TrainrunService {
     }
     this.getTrainrunFromId(trainrun.getId()).setTrainrunCategory(category);
     this.nodeService.reorderPortsOnNodesForTrainrun(trainrun, false);
+    this.nodeService.initPortOrdering();
     this.trainrunsUpdated();
     this.operation.emit(new TrainrunOperation(OperationType.update, trainrun));
   }
@@ -254,6 +256,7 @@ export class TrainrunService {
 
     this.getTrainrunFromId(trainrun.getId()).setTrainrunTimeCategory(timeCategory);
     this.nodeService.reorderPortsOnNodesForTrainrun(trainrun, false);
+    this.nodeService.initPortOrdering();
     this.trainrunsUpdated();
     this.operation.emit(new TrainrunOperation(OperationType.update, trainrun));
   }
@@ -261,6 +264,7 @@ export class TrainrunService {
   updateTrainrunTitle(trainrun: Trainrun, title: string) {
     this.getTrainrunFromId(trainrun.getId()).setTitle(title);
     this.nodeService.reorderPortsOnNodesForTrainrun(trainrun, false);
+    this.nodeService.initPortOrdering();
     this.trainrunsUpdated();
     this.operation.emit(new TrainrunOperation(OperationType.update, trainrun));
   }


### PR DESCRIPTION
> [!NOTE]
> The update methods should be refactored soon, see [issue](https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/issues/1079) (@Math-R has an interesting idea for that) 

`initPortOrdering` was missing in trainrun updates:
- trainrun name update
- trainrun category update
- trainrun frequency update
- trainrun time category update

You can test these actions with this file: [reticulaire.json](https://github.com/user-attachments/files/28588787/reticulaire.json)

Before:

https://github.com/user-attachments/assets/34e70bc7-d3fb-439d-af1c-f17b4fcd73b3

After:

https://github.com/user-attachments/assets/964bcacb-0769-4e8d-8629-f57935887b6b