### PR TITLE
fix(service): emit NodeOperation when collapsing all nodes and add missing initPortOrdering

### DIFF
--- a/src/app/services/data/node.service.ts
+++ b/src/app/services/data/node.service.ts
@@ -936,13 +936,15 @@ export class NodeService implements OnDestroy {
     this.operation.emit(new NodeOperation(OperationType.update, this.getNodeFromId(nodeId)));
   }
 
-  changeIsCollapsed(nodeId: number, isCollapsed: boolean) {
+  changeIsCollapsed(nodeId: number, isCollapsed: boolean, enforceUpdate: boolean = true) {
     this.getNodeFromId(nodeId).setIsCollapsed(isCollapsed);
-    this.initPortOrdering();
-    this.nodesUpdated();
-    this.trainrunSectionService.trainrunSectionsUpdated();
-    this.connectionsUpdated();
-    this.transitionsUpdated();
+    if (enforceUpdate) {
+      this.initPortOrdering();
+      this.nodesUpdated();
+      this.trainrunSectionService.trainrunSectionsUpdated();
+      this.connectionsUpdated();
+      this.transitionsUpdated();
+    }
     this.operation.emit(new NodeOperation(OperationType.update, this.getNodeFromId(nodeId)));
   }
 

--- a/src/app/view/editor-edit-tools-view-component/global-nodes-management/global-nodes-management.component.ts
+++ b/src/app/view/editor-edit-tools-view-component/global-nodes-management/global-nodes-management.component.ts
@@ -100,9 +100,10 @@ export class GlobalNodesManagementComponent {
       .showConfirmationDiagramDialog(confirmationDialogParameter)
       .subscribe((confirmed: boolean) => {
         if (confirmed) {
-          this.matchingNodes.forEach((node) => {
-            node.setIsCollapsed(newIsCollapsed);
-          });
+          this.matchingNodes.forEach((node) =>
+            this.nodeService.changeIsCollapsed(node.getId(), newIsCollapsed, false),
+          );
+          this.nodeService.initPortOrdering();
           this.dataService.triggerViewUpdate();
         }
       });


### PR DESCRIPTION
When collapsing or expanding all nodes through the global panel, we've forgotten the NodeOperation emition and the `initPortOrdering`, which made all mixed up.