### PR TITLE
chore(dependabot): fix update-types type

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,17 +19,17 @@ updates:
           - "patch"
     ignore:
       - dependency-name: "@angular/*"
-        update-types: "version-update:semver-major"
+        update-types: ["version-update:semver-major"]
       - dependency-name: "angular-eslint"
-        update-types: "version-update:semver-major"
+        update-types: ["version-update:semver-major"]
       - dependency-name: "@angular-devkit/build-angular"
-        update-types: "version-update:semver-major"
+        update-types: ["version-update:semver-major"]
       - dependency-name: "@sbb-esta/angular"
-        update-types: "version-update:semver-major"
+        update-types: ["version-update:semver-major"]
       - dependency-name: "angular-oauth2-oidc"
-        update-types: "version-update:semver-major"
+        update-types: ["version-update:semver-major"]
       - dependency-name: "angular-server-side-configuration"
-        update-types: "version-update:semver-major"
+        update-types: ["version-update:semver-major"]
     commit-message:
       prefix: "chore(deps):"
     labels:


### PR DESCRIPTION
Dependabot wants an array here:

> The property '#/updates/0/ignore/0/update-types' of type string
> did not match the following type: array

Regressed in https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/pull/1115