### PR TITLE
fix(view): node name ellipsis depending on connection time

### DIFF
--- a/src/app/view/editor-main-view/data-views/nodes.view.ts
+++ b/src/app/view/editor-main-view/data-views/nodes.view.ts
@@ -513,7 +513,7 @@ export class NodesView {
       .attr(StaticDomTags.NODE_ID, (n: NodeViewObject) => n.node.getId())
       .attr("x", NODE_TEXT_LEFT_SPACING)
       .attr("y", (n: NodeViewObject) => n.node.getNodeHeight() - TEXT_SIZE / 2)
-      .attr("width", "74")
+      .attr("width", (n: NodeViewObject) => this.getNodeLabelTextWidth(n.node))
       .text((n: NodeViewObject) =>
         this.editorView.displayNodesFullName()
           ? n.node.getFullName()
@@ -964,5 +964,15 @@ export class NodesView {
         false,
       );
     }
+  }
+
+  private getNodeLabelTextWidth(node: Node): number {
+    const connectionTime = node.getConnectionTime();
+    let width = 0;
+    if (connectionTime !== null) {
+      width = connectionTime === 0 ? 1 : Math.floor(Math.log10(connectionTime)) + 1;
+    }
+    const connectionTimeTextWidth = width * TEXT_SIZE;
+    return node.getNodeWidth() - connectionTimeTextWidth - NODE_TEXT_LEFT_SPACING;
   }
 }


### PR DESCRIPTION
To fix two things:
- when no connection time is set
- when connection time is not 1 digit

<img width="880" height="576" alt="image" src="https://github.com/user-attachments/assets/f628f06b-5454-4729-9a3f-b9b2fe17fe16" />
