### PR TITLE
feat: ship type definitions in NPM package

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start:standalone": "ng serve --configuration=standalone",
     "start:standalonedemo": "ng serve --configuration=standalonedemo",
     "build": "ng run netzgrafik-frontend:ngsscbuild",
-    "build:standalone": "ng build --configuration=standalone",
+    "build:standalone": "ng build --configuration=standalone && tsc --project tsconfig.defs.json",
     "build:standalonedemo": "ng build --configuration=standalonedemo",
     "test": "ng test -c ci",
     "format": "prettier --write .",
@@ -27,6 +27,7 @@
   "files": [
     "dist/*"
   ],
+  "types": "dist/types/types.d.ts",
   "dependencies": {
     "@angular/animations": "^19.2.25",
     "@angular/cdk": "^19.2.19",

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,2 @@
+export type * from "./app/data-structures/technical.data.structures";
+export type * from "./app/data-structures/business.data.structures";

--- a/tsconfig.defs.json
+++ b/tsconfig.defs.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationDir": "dist/types",
+    "typeRoots": []
+  },
+  "files": [],
+  "include": ["src/types.ts"]
+}


### PR DESCRIPTION
This change exposes type definitions for NGE data structures in the NPM package. That way, users don't need to duplicate these definitions and get type errors when there's a mismatch.

typeRoots is required to avoid missing minimatch type definitions (because we're stuck with an old version).

Note, operations would be nice to expose as well, but require more thought (currently these pull in a number of internal NGE types, e.g. models).