### PR TITLE
chore(deps): drop explicit @angular-devkit/architect dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,6 @@
         "zone.js": "~0.15.1"
       },
       "devDependencies": {
-        "@angular-devkit/architect": "^0.1902.24",
         "@angular-devkit/build-angular": "^19.2.27",
         "@angular/cli": "^19.2.27",
         "@angular/compiler-cli": "^19.2.21",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "zone.js": "~0.15.1"
   },
   "devDependencies": {
-    "@angular-devkit/architect": "^0.1902.24",
     "@angular-devkit/build-angular": "^19.2.27",
     "@angular/cli": "^19.2.27",
     "@angular/compiler-cli": "^19.2.21",


### PR DESCRIPTION
The Angular project template doesn't have this as an explicit dev dependency. It's pulled in by @angular-devkit/build-angular already and we don't use it directly.

Drop it so that Dependabot doesn't bug us with updates.