### PR TITLE
refactor(view): hunt down "any" types for d3

### DIFF
--- a/src/app/view/editor-main-view/data-views/connections.view.ts
+++ b/src/app/view/editor-main-view/data-views/connections.view.ts
@@ -11,7 +11,7 @@ import {ConnectionsViewObject} from "./connectionViewObject";
 import {LevelOfDetail} from "../../../services/ui/level.of.detail.service";
 
 export class ConnectionsView {
-  connectionsGroup;
+  connectionsGroup: d3.Selection<SVGElement, undefined, Element, undefined>;
   editorView: EditorView;
 
   constructor(editorView: EditorView) {
@@ -66,7 +66,7 @@ export class ConnectionsView {
     return ts.getPositionAtTargetNode();
   }
 
-  setGroup(connectionsGroup) {
+  setGroup(connectionsGroup: d3.Selection<SVGElement, undefined, Element, undefined>) {
     this.connectionsGroup = connectionsGroup;
     this.connectionsGroup.attr("class", "ConnectionsView");
   }
@@ -123,7 +123,9 @@ export class ConnectionsView {
     return false;
   }
 
-  createConnectionCurve(drawingGroup: d3.Selection<SVGElement, undefined, HTMLElement, undefined>) {
+  createConnectionCurve(
+    drawingGroup: d3.Selection<SVGElement, ConnectionsViewObject, Element, undefined>,
+  ) {
     drawingGroup
       .append(StaticDomTags.CONNECTION_LINE_SVG)
       .attr("class", StaticDomTags.CONNECTION_LINE_CLASS)
@@ -149,11 +151,11 @@ export class ConnectionsView {
   }
 
   createConnectionSinglePin(
-    drawingGroup: d3.Selection<SVGElement, undefined, HTMLElement, undefined>,
+    drawingGroup: d3.Selection<SVGElement, ConnectionsViewObject, Element, undefined>,
     pinPos: Vec2D,
   ) {
     const draggable = d3
-      .drag()
+      .drag<SVGElement, ConnectionsViewObject>()
       .on("start", (cv: ConnectionsViewObject, i, a) =>
         this.onConnectionPinDragStart(cv.connection, a[i]),
       )
@@ -193,7 +195,9 @@ export class ConnectionsView {
       );
   }
 
-  createConnectionPins(drawingGroup: d3.Selection<SVGElement, undefined, HTMLElement, undefined>) {
+  createConnectionPins(
+    drawingGroup: d3.Selection<SVGElement, ConnectionsViewObject, Element, undefined>,
+  ) {
     const selectedTrainrun = this.editorView.getSelectedTrainrun();
 
     drawingGroup.each((c: ConnectionsViewObject, i, a) => {
@@ -278,7 +282,9 @@ export class ConnectionsView {
     ).raise();
   }
 
-  renderConnectionObject(groupEnter: any) {
+  renderConnectionObject(
+    groupEnter: d3.Selection<SVGElement, ConnectionsViewObject, Element, undefined>,
+  ) {
     switch (this.editorView.getLevelOfDetail()) {
       case LevelOfDetail.LEVEL3: {
         //statements;
@@ -307,55 +313,65 @@ export class ConnectionsView {
     }
   }
 
-  makeConnectionLODFull(groupEnter: any) {
+  makeConnectionLODFull(
+    groupEnter: d3.Selection<SVGElement, ConnectionsViewObject, Element, undefined>,
+  ) {
     this.createConnectionCurve(groupEnter);
     this.createConnectionPins(groupEnter);
   }
 
-  makeConnectionLOD3(groupEnter: any) {
+  makeConnectionLOD3(
+    groupEnter: d3.Selection<SVGElement, ConnectionsViewObject, Element, undefined>,
+  ) {
     this.createConnectionCurve(groupEnter);
     this.createConnectionPins(groupEnter);
   }
 
-  makeConnectionLOD2(groupEnter: any) {
+  makeConnectionLOD2(
+    groupEnter: d3.Selection<SVGElement, ConnectionsViewObject, Element, undefined>,
+  ) {
     this.createConnectionCurve(groupEnter);
   }
 
-  makeConnectionLOD1(groupEnter: any) {
+  makeConnectionLOD1(
+    groupEnter: d3.Selection<SVGElement, ConnectionsViewObject, Element, undefined>,
+  ) {
     this.createConnectionCurve(groupEnter);
   }
 
-  makeConnectionLOD0(groupEnter: any) {}
+  makeConnectionLOD0(
+    groupEnter: d3.Selection<SVGElement, ConnectionsViewObject, Element, undefined>,
+  ) {}
 
-  onConnectionMouseup(connection: Connection, domObj: any, node: Node) {
+  onConnectionMouseup(connection: Connection, domObj: SVGElement, node: Node) {
     d3.event.stopPropagation();
     this.editorView.nodesView.handleMouseUpEvent(node);
   }
 
-  onConnectionMouseover(connection: Connection, domObj: any, node: Node) {
+  onConnectionMouseover(connection: Connection, domObj: SVGElement, node: Node) {
     this.editorView.nodesView.hoverNodeDockable(node, null);
   }
 
-  onConnectionMouseout(connection: Connection, domObj: any, node: Node) {
+  onConnectionMouseout(connection: Connection, domObj: SVGElement, node: Node) {
     this.editorView.nodesView.unhoverNodeDockable(node, null);
   }
 
-  onConnectionPinMouseover(connection: Connection, domObj: any, node: Node) {
+  onConnectionPinMouseover(connection: Connection, domObj: SVGElement, node: Node) {
     d3.select(domObj).classed(StaticDomTags.TAG_HOVER, true);
     this.editorView.nodesView.hoverNodeDockable(node, null);
   }
 
-  onConnectionPinMouseout(connection: Connection, domObj: any, node: Node) {
+  onConnectionPinMouseout(connection: Connection, domObj: SVGElement, node: Node) {
     d3.select(domObj).classed(StaticDomTags.TAG_HOVER, false);
     this.editorView.nodesView.unhoverNodeDockable(node, null);
   }
 
-  onConnectionPinDragStart(connection: Connection, domObj: any) {
+  onConnectionPinDragStart(connection: Connection, domObj: SVGElement) {
     d3.select(domObj).classed(StaticDomTags.CONNECTION_PIN_DRAGGING, true);
     D3Utils.disableTrainrunSectionForEventHandling();
   }
 
-  onConnectionPinDragged(connection: Connection, domObj: any) {
+  onConnectionPinDragged(connection: Connection, domObj: SVGElement) {
     d3.select(domObj).classed(StaticDomTags.CONNECTION_PIN_DRAGGING, true);
     const currentMousePosition = this.editorView.svgMouseController.getCurrentMousePosition();
     const obj = d3.select(domObj);
@@ -363,7 +379,7 @@ export class ConnectionsView {
     obj.attr("cy", currentMousePosition.getY());
   }
 
-  onConnectionPinDragEnd(connection: Connection, domObj: any, node: Node) {
+  onConnectionPinDragEnd(connection: Connection, domObj: SVGElement, node: Node) {
     D3Utils.resetTrainrunSectionForEventHandling();
     d3.select(domObj).classed(StaticDomTags.CONNECTION_PIN_DRAGGING, false);
     if (this.editorView.nodesView.isNodeHovered(node)) {
@@ -377,7 +393,7 @@ export class ConnectionsView {
     this.setUnderlyingTrainrunAsSelected(connection, domObj, node);
   }
 
-  private setUnderlyingTrainrunAsSelected(connection: Connection, domObj: any, node: Node) {
+  private setUnderlyingTrainrunAsSelected(connection: Connection, domObj: SVGElement, node: Node) {
     const trainrunID = d3.select(domObj).attr(StaticDomTags.CONNECTION_TRAINRUN_ID);
     const trainrunPort1 = ConnectionsView.getTrainrunSectionPort1(connection, node).getTrainrun();
     const trainrunPort2 = ConnectionsView.getTrainrunSectionPort2(connection, node).getTrainrun();

--- a/src/app/view/editor-main-view/data-views/d3.utils.ts
+++ b/src/app/view/editor-main-view/data-views/d3.utils.ts
@@ -41,7 +41,11 @@ export class D3Utils {
     ).raise();
   }
 
-  static hoverTrainrunSection(trainrunSection: TrainrunSection, bringToFront = true, domObj: any) {
+  static hoverTrainrunSection(
+    trainrunSection: TrainrunSection,
+    bringToFront = true,
+    domObj: SVGElement,
+  ) {
     d3.selectAll(StaticDomTags.EDGE_LINE_ARROW_DOM_REF)
       .filter(
         (d: TrainrunSectionViewObject) =>

--- a/src/app/view/editor-main-view/data-views/editor.view.ts
+++ b/src/app/view/editor-main-view/data-views/editor.view.ts
@@ -51,7 +51,7 @@ export class EditorView implements SVGMouseControllerObserver {
   controller: EditorMainViewComponent;
   svgMouseController: SVGMouseController;
   editorKeyEvents: EditorKeyEvents;
-  rootContainer: any;
+  rootContainer: d3.Selection<SVGElement, undefined, Element, undefined>;
   nodesView: NodesView;
   transitionsView: TransitionsView;
   connectionsView: ConnectionsView;

--- a/src/app/view/editor-main-view/data-views/multiSelectRenderer.ts
+++ b/src/app/view/editor-main-view/data-views/multiSelectRenderer.ts
@@ -5,7 +5,7 @@ import {Vec2D} from "../../../utils/vec2D";
 export class MultiSelectRenderer {
   private isBoxDrawing = false;
 
-  static setGroup(nodeGroup: d3.Selection<SVGElement, undefined, HTMLElement, undefined>) {
+  static setGroup(nodeGroup: d3.Selection<SVGElement, undefined, Element, undefined>) {
     nodeGroup
       .append(StaticDomTags.PREVIEW_MULTISELECT_ROOT_BOX_SVG)
       .attr("class", StaticDomTags.PREVIEW_MULTISELECT_ROOT_BOX_CLASS);

--- a/src/app/view/editor-main-view/data-views/nodes.view.ts
+++ b/src/app/view/editor-main-view/data-views/nodes.view.ts
@@ -25,25 +25,25 @@ import {LevelOfDetail} from "../../../services/ui/level.of.detail.service";
 
 export class NodesView {
   dragPreviousMousePosition: Vec2D;
-  nodeGroup;
-  draggable: any;
+  nodeGroup: d3.Selection<SVGElement, undefined, Element, undefined>;
+  draggable: d3.DragBehavior<SVGElement, NodeViewObject, unknown>;
   private LevelOfDetails: LevelOfDetail;
 
   constructor(private editorView: EditorView) {
     this.draggable = d3
-      .drag()
+      .drag<SVGElement, NodeViewObject>()
       .on("start", (n: NodeViewObject, i, a) => this.onNodeDragStart(n.node, a[i]))
       .on("drag", (n: NodeViewObject) => this.onNodeDragged(n.node))
       .on("end", (n: NodeViewObject, i, a) => this.onNodeDragEnd(n.node, a[i]));
     this.dragPreviousMousePosition = new Vec2D();
   }
 
-  setGroup(nodeGroup: d3.Selection<SVGElement, undefined, HTMLElement, undefined>) {
+  setGroup(nodeGroup: d3.Selection<SVGElement, undefined, Element, undefined>) {
     this.nodeGroup = nodeGroup;
     this.nodeGroup.attr("class", "NodesView");
   }
 
-  onNodeDragStart(node: Node, domObj: any) {
+  onNodeDragStart(node: Node, domObj: SVGElement) {
     D3Utils.enableFastRenderingUpdate();
     d3.select(domObj).classed(StaticDomTags.TAG_HOVER, true);
     d3.select(domObj).classed(StaticDomTags.TAG_DRAGGING, true);
@@ -64,7 +64,7 @@ export class NodesView {
     this.editorView.disableElementDragging();
   }
 
-  onNodeDragEnd(node: Node, domObj: any) {
+  onNodeDragEnd(node: Node, domObj: SVGElement) {
     D3Utils.disableFastRenderingUpdate();
 
     this.editorView.startUndoRecording();
@@ -128,7 +128,7 @@ export class NodesView {
     group.exit().remove();
   }
 
-  renderNodeObject(groupEnter: any) {
+  renderNodeObject(groupEnter: d3.Selection<SVGElement, NodeViewObject, Element, undefined>) {
     switch (this.editorView.getLevelOfDetail()) {
       case LevelOfDetail.LEVEL3: {
         //statements;
@@ -157,7 +157,7 @@ export class NodesView {
     }
   }
 
-  adjustTextWithEllipsis(text: d3.Selection<SVGTextElement, unknown, HTMLElement, any>) {
+  adjustTextWithEllipsis(text: d3.Selection<SVGTextElement, unknown, Element, unknown>) {
     text.each(function () {
       const text = d3.select(this);
       const chars = text.text().split("");
@@ -179,7 +179,7 @@ export class NodesView {
     });
   }
 
-  makeNodeLODFull(groupEnter: any) {
+  makeNodeLODFull(groupEnter: d3.Selection<SVGElement, NodeViewObject, Element, undefined>) {
     this.makeNodeHoverRoot(groupEnter);
     this.makeNodeRoot(groupEnter);
     this.makeBackground(groupEnter);
@@ -196,7 +196,7 @@ export class NodesView {
     this.makeLabelConnectionText(groupEnter);
   }
 
-  makeNodeLODLevel3(groupEnter: any) {
+  makeNodeLODLevel3(groupEnter: d3.Selection<SVGElement, NodeViewObject, Element, undefined>) {
     this.makeNodeHoverRoot(groupEnter);
     this.makeNodeRoot(groupEnter);
     this.makeBackground(groupEnter);
@@ -209,7 +209,7 @@ export class NodesView {
     this.makeLabelConnectionText(groupEnter);
   }
 
-  makeNodeLODLevel2(groupEnter: any) {
+  makeNodeLODLevel2(groupEnter: d3.Selection<SVGElement, NodeViewObject, Element, undefined>) {
     this.makeNodeHoverRoot(groupEnter);
     this.makeNodeRoot(groupEnter);
     this.makeBackground(groupEnter);
@@ -220,7 +220,7 @@ export class NodesView {
     this.makeLabelConnectionText(groupEnter);
   }
 
-  makeNodeLODLevel1(groupEnter: any) {
+  makeNodeLODLevel1(groupEnter: d3.Selection<SVGElement, NodeViewObject, Element, undefined>) {
     this.makeNodeHoverRoot(groupEnter);
     this.makeBackground(groupEnter);
     this.makeNodeDockable(groupEnter);
@@ -228,13 +228,15 @@ export class NodesView {
     this.makeLabelText(groupEnter);
   }
 
-  makeNodeLODLevel0(groupEnter: any) {
+  makeNodeLODLevel0(groupEnter: d3.Selection<SVGElement, NodeViewObject, Element, undefined>) {
     this.makeNodeHoverRoot(groupEnter);
     this.makeNodeDockable(groupEnter);
     this.makeAnalyticsArea(groupEnter);
   }
 
-  private makeNodeHoverRoot(groupEnter: any) {
+  private makeNodeHoverRoot(
+    groupEnter: d3.Selection<SVGElement, NodeViewObject, Element, undefined>,
+  ) {
     groupEnter
       .append(StaticDomTags.NODE_HOVER_ROOT_SVG)
       .attr("class", StaticDomTags.NODE_HOVER_ROOT_CLASS)
@@ -255,7 +257,7 @@ export class NodesView {
       .on("dblclick", (n: NodeViewObject) => this.onNodeDetailsClicked(n.node));
   }
 
-  private makeNodeRoot(groupEnter: any) {
+  private makeNodeRoot(groupEnter: d3.Selection<SVGElement, NodeViewObject, Element, undefined>) {
     groupEnter
       .append(StaticDomTags.NODE_ROOT_SVG)
       .attr("class", StaticDomTags.NODE_ROOT_CLASS)
@@ -276,7 +278,7 @@ export class NodesView {
       .on("dblclick", (n: NodeViewObject) => this.onNodeDetailsClicked(n.node));
   }
 
-  private makeBackground(groupEnter: any) {
+  private makeBackground(groupEnter: d3.Selection<SVGElement, NodeViewObject, Element, undefined>) {
     groupEnter
       .append(StaticDomTags.NODE_BACKGROUND_SVG)
       .attr("class", StaticDomTags.NODE_BACKGROUND_CLASS)
@@ -297,7 +299,7 @@ export class NodesView {
       .on("dblclick", (n: NodeViewObject) => this.onNodeDetailsClicked(n.node));
   }
 
-  private makeLabelArea(groupEnter: any) {
+  private makeLabelArea(groupEnter: d3.Selection<SVGElement, NodeViewObject, Element, undefined>) {
     groupEnter
       .append(StaticDomTags.NODE_LABELAREA_SVG)
       .attr("class", StaticDomTags.NODE_LABELAREA_CLASS)
@@ -318,7 +320,9 @@ export class NodesView {
       .on("dblclick", (n: NodeViewObject) => this.onNodeDetailsClicked(n.node));
   }
 
-  private makeHoverDragBackground(groupEnter: any) {
+  private makeHoverDragBackground(
+    groupEnter: d3.Selection<SVGElement, NodeViewObject, Element, undefined>,
+  ) {
     const added = groupEnter.append(StaticDomTags.NODE_HOVER_DRAG_AREA_BACKGROUND_SVG);
     added
       .attr("class", StaticDomTags.NODE_HOVER_DRAG_AREA_BACKGROUND_CLASS)
@@ -345,7 +349,9 @@ export class NodesView {
       .on("dblclick", (n: NodeViewObject) => this.onNodeDblClick(n.node));
   }
 
-  private makeHoverDragRoot(groupEnter: any) {
+  private makeHoverDragRoot(
+    groupEnter: d3.Selection<SVGElement, NodeViewObject, Element, undefined>,
+  ) {
     if (!this.editorView.trainrunSectionPreviewLineView.getVariantIsWritable()) {
       return;
     }
@@ -375,7 +381,9 @@ export class NodesView {
       .on("dblclick", (n: NodeViewObject) => this.onNodeDblClick(n.node));
   }
 
-  private makeEditButtonBackground(groupEnter: any) {
+  private makeEditButtonBackground(
+    groupEnter: d3.Selection<SVGElement, NodeViewObject, Element, undefined>,
+  ) {
     groupEnter
       .append(StaticDomTags.NODE_EDIT_AREA_BACKGROUND_SVG)
       .attr("class", StaticDomTags.NODE_EDIT_AREA_BACKGROUND_CLASS)
@@ -391,7 +399,7 @@ export class NodesView {
       .on("mouseup", (n: NodeViewObject) => this.onNodeMouseup(n.node));
   }
 
-  private makeEditButton(groupEnter: any) {
+  private makeEditButton(groupEnter: d3.Selection<SVGElement, NodeViewObject, Element, undefined>) {
     groupEnter
       .append(StaticDomTags.NODE_EDIT_AREA_SVG)
       .attr("class", StaticDomTags.NODE_EDIT_AREA_CLASS)
@@ -421,7 +429,9 @@ export class NodesView {
       .on("mouseup", (n: NodeViewObject) => this.onNodeMouseup(n.node));
   }
 
-  private makeNodeDockable(groupEnter: any) {
+  private makeNodeDockable(
+    groupEnter: d3.Selection<SVGElement, NodeViewObject, Element, undefined>,
+  ) {
     groupEnter
       .append(StaticDomTags.NODE_DOCKABLE_SVG)
       .attr("class", StaticDomTags.NODE_DOCKABLE_CLASS)
@@ -447,7 +457,9 @@ export class NodesView {
       .on("dblclick", (n: NodeViewObject) => this.onNodeDetailsClicked(n.node));
   }
 
-  private makeAnalyticsArea(groupEnter: any) {
+  private makeAnalyticsArea(
+    groupEnter: d3.Selection<SVGElement, NodeViewObject, Element, undefined>,
+  ) {
     groupEnter
       .append(StaticDomTags.NODE_ANALYTICSAREA_SVG)
       .attr("class", StaticDomTags.NODE_ANALYTICSAREA_CLASS)
@@ -473,7 +485,9 @@ export class NodesView {
       .on("mouseup", (n: NodeViewObject) => this.onNodeMouseup(n.node));
   }
 
-  private makeAnalyticsTextLeftArea(groupEnter: any) {
+  private makeAnalyticsTextLeftArea(
+    groupEnter: d3.Selection<SVGElement, NodeViewObject, Element, undefined>,
+  ) {
     groupEnter
       .append(StaticDomTags.NODE_ANALYTICSAREA_TEXT_LEFT_SVG)
       .attr("class", StaticDomTags.NODE_ANALYTICSAREA_TEXT_LEFT_CLASS)
@@ -489,7 +503,9 @@ export class NodesView {
       .attr(StaticDomTags.NODE_ID, (n: NodeViewObject) => n.node.getId());
   }
 
-  private makeAnalyticsTextRightArea(groupEnter: any) {
+  private makeAnalyticsTextRightArea(
+    groupEnter: d3.Selection<SVGElement, NodeViewObject, Element, undefined>,
+  ) {
     groupEnter
       .append(StaticDomTags.NODE_ANALYTICSAREA_TEXT_RIGHT_SVG)
       .attr("class", StaticDomTags.NODE_ANALYTICSAREA_TEXT_RIGHT_CLASS)
@@ -505,7 +521,7 @@ export class NodesView {
       .attr(StaticDomTags.NODE_ID, (n: NodeViewObject) => n.node.getId());
   }
 
-  private makeLabelText(groupEnter: any) {
+  private makeLabelText(groupEnter: d3.Selection<SVGElement, NodeViewObject, Element, undefined>) {
     const added = groupEnter.append(StaticDomTags.NODE_LABELAREA_TEXT_SVG);
     added
       .attr("class", `${StaticDomTags.NODE_LABELAREA_TEXT_CLASS} node_name_text`)
@@ -542,7 +558,9 @@ export class NodesView {
       .on("dblclick", (n: NodeViewObject) => this.onNodeDblClick(n.node));
   }
 
-  private makeLabelConnectionText(groupEnter: any) {
+  private makeLabelConnectionText(
+    groupEnter: d3.Selection<SVGElement, NodeViewObject, Element, undefined>,
+  ) {
     groupEnter
       .append(StaticDomTags.NODE_CONNECTIONTIME_TEXT_SVG)
       .attr("class", StaticDomTags.NODE_CONNECTIONTIME_TEXT_CLASS)
@@ -566,11 +584,11 @@ export class NodesView {
     this.editorView.showNodeInformation(node);
   }
 
-  onNodeDockableMouseover(node: Node, domObj: any) {
+  onNodeDockableMouseover(node: Node, domObj: SVGElement) {
     this.hoverNodeDockable(node, domObj);
   }
 
-  onNodeDockableMouseout(node: Node, domObj: any) {
+  onNodeDockableMouseout(node: Node, domObj: SVGElement) {
     this.unhoverNodeDockable(node, domObj);
   }
 
@@ -582,15 +600,15 @@ export class NodesView {
     this.highlightPinsAsConnectionDroppable(node, false);
   }
 
-  onNodeMouseover(node: Node, domObj: any) {
+  onNodeMouseover(node: Node, domObj: SVGElement) {
     this.hoverNode(node, domObj);
   }
 
-  onNodeMousemove(node: Node, domObj: any) {
+  onNodeMousemove(node: Node, domObj: SVGElement) {
     this.hoverPinsAsConnectionDroppable(node);
   }
 
-  onNodeLabelAreaMouseover(node: Node, domObj: any) {
+  onNodeLabelAreaMouseover(node: Node, domObj: SVGElement) {
     this.hoverNode(node, domObj);
     d3.selectAll(StaticDomTags.NODE_HOVER_DRAG_AREA_DOM_REF)
       .filter((n: NodeViewObject) => n.node.getId() === node.getId())
@@ -600,32 +618,32 @@ export class NodesView {
       .classed(StaticDomTags.TAG_MUTED, true);
   }
 
-  onNodeMouseout(node: Node, domObj: any) {
+  onNodeMouseout(node: Node, domObj: SVGElement) {
     this.unhoverNode(node, domObj);
   }
 
-  onNodeMouseoverEditButton(node: Node, domObj: any) {
+  onNodeMouseoverEditButton(node: Node, domObj: SVGElement) {
     this.hoverNode(node, domObj);
     d3.selectAll(StaticDomTags.NODE_EDIT_AREA_DOM_REF)
       .filter((n: NodeViewObject) => n.node.getId() === node.getId())
       .classed(StaticDomTags.TAG_HOVER, true);
   }
 
-  onNodeMouseoutEditButton(node: Node, domObj: any) {
+  onNodeMouseoutEditButton(node: Node, domObj: SVGElement) {
     d3.selectAll(StaticDomTags.NODE_EDIT_AREA_DOM_REF)
       .filter((n: NodeViewObject) => n.node.getId() === node.getId())
       .classed(StaticDomTags.TAG_HOVER, false);
     this.unhoverNode(node, domObj);
   }
 
-  onNodeMouseoverDragButton(node: Node, domObj: any) {
+  onNodeMouseoverDragButton(node: Node, domObj: SVGElement) {
     this.hoverNode(node, domObj);
     d3.selectAll(StaticDomTags.NODE_HOVER_DRAG_AREA_DOM_REF)
       .filter((n: NodeViewObject) => n.node.getId() === node.getId())
       .classed(StaticDomTags.TAG_HOVER, true);
   }
 
-  onNodeMouseoutDragButton(node: Node, domObj: any) {
+  onNodeMouseoutDragButton(node: Node, domObj: SVGElement) {
     d3.selectAll(StaticDomTags.NODE_HOVER_DRAG_AREA_DOM_REF)
       .filter((n: NodeViewObject) => n.node.getId() === node.getId())
       .classed(StaticDomTags.TAG_HOVER, false);
@@ -705,7 +723,7 @@ export class NodesView {
       .classed(StaticDomTags.TAG_HOVER);
   }
 
-  hoverNode(node: Node, domObj: any) {
+  hoverNode(node: Node, domObj: SVGElement) {
     if (domObj !== null) {
       d3.select(domObj).raise().classed(StaticDomTags.TAG_HOVER, true);
     }
@@ -716,7 +734,7 @@ export class NodesView {
     this.hoverPinsAsConnectionDroppable(node);
   }
 
-  unhoverNode(node: Node, domObj: any) {
+  unhoverNode(node: Node, domObj: SVGElement) {
     if (domObj !== null) {
       d3.select(domObj).raise().classed(StaticDomTags.TAG_HOVER, false);
     }
@@ -733,14 +751,14 @@ export class NodesView {
     this.unhoverPinsAsConnectionDroppable(node);
   }
 
-  hoverNodeDockable(node: Node, domObj: any) {
+  hoverNodeDockable(node: Node, domObj: SVGElement) {
     d3.selectAll(StaticDomTags.NODE_DOCKABLE_DOM_REF)
       .filter((n: NodeViewObject) => n.node.getId() === node.getId())
       .classed(StaticDomTags.TAG_HOVER, true);
     this.hoverNode(node, domObj);
   }
 
-  unhoverNodeDockable(node: Node, domObj: any) {
+  unhoverNodeDockable(node: Node, domObj: SVGElement) {
     d3.selectAll(StaticDomTags.NODE_DOCKABLE_DOM_REF)
       .filter((n: NodeViewObject) => n.node.getId() === node.getId())
       .classed(StaticDomTags.TAG_HOVER, false);

--- a/src/app/view/editor-main-view/data-views/notes.view.ts
+++ b/src/app/view/editor-main-view/data-views/notes.view.ts
@@ -19,12 +19,12 @@ import {LevelOfDetail} from "../../../services/ui/level.of.detail.service";
 
 export class NotesView {
   dragPreviousMousePosition: Vec2D;
-  notesGroup;
-  draggable: any;
+  notesGroup: d3.Selection<SVGElement, undefined, Element, undefined>;
+  draggable: d3.DragBehavior<SVGElement, NoteViewObject, unknown>;
 
   constructor(private editorView: EditorView) {
     this.draggable = d3
-      .drag()
+      .drag<SVGElement, NoteViewObject>()
       .on("start", (n: NoteViewObject, i, a) => this.onNoteDragStart(n.note, a[i]))
       .on("drag", (n: NoteViewObject) => this.onNoteDragged(n.note))
       .on("end", (n: NoteViewObject, i, a) => this.onNoteDragEnd(n.note, a[i]));
@@ -86,7 +86,7 @@ export class NotesView {
     return Math.max(n.getWidth(), maxLen * NOTE_TEXT_LEFT_SPACING) + NOTE_TEXT_LEFT_SPACING;
   }
 
-  setGroup(connectionsGroup) {
+  setGroup(connectionsGroup: d3.Selection<SVGElement, undefined, Element, undefined>) {
     this.notesGroup = connectionsGroup;
     this.notesGroup.attr("class", "NotesView");
   }
@@ -138,7 +138,7 @@ export class NotesView {
     group.exit().remove();
   }
 
-  renderNoteObject(groupEnter: any) {
+  renderNoteObject(groupEnter: d3.Selection<SVGElement, NoteViewObject, Element, undefined>) {
     switch (this.editorView.getLevelOfDetail()) {
       case LevelOfDetail.LEVEL3: {
         //statements;
@@ -167,7 +167,7 @@ export class NotesView {
     }
   }
 
-  makeNodeLODFull(groupEnter: any) {
+  makeNodeLODFull(groupEnter: d3.Selection<SVGElement, NoteViewObject, Element, undefined>) {
     this.makeNoteHoverRoot(groupEnter);
     this.makeNoteRoot(groupEnter);
     this.makeNoteTitleArea(groupEnter);
@@ -178,7 +178,7 @@ export class NotesView {
     this.makeNoteDragArea(groupEnter);
   }
 
-  makeNoteLODLevel3(groupEnter: any) {
+  makeNoteLODLevel3(groupEnter: d3.Selection<SVGElement, NoteViewObject, Element, undefined>) {
     this.makeNoteHoverRoot(groupEnter);
     this.makeNoteRoot(groupEnter);
     this.makeNoteTitleArea(groupEnter);
@@ -187,23 +187,25 @@ export class NotesView {
     this.makeNoteText(groupEnter);
   }
 
-  makeNoteLODLevel2(groupEnter: any) {
+  makeNoteLODLevel2(groupEnter: d3.Selection<SVGElement, NoteViewObject, Element, undefined>) {
     this.makeNoteRoot(groupEnter);
     this.makeNoteTitleAreaText(groupEnter);
     this.makeNoteText(groupEnter);
   }
 
-  makeNoteLODLevel1(groupEnter: any) {
+  makeNoteLODLevel1(groupEnter: d3.Selection<SVGElement, NoteViewObject, Element, undefined>) {
     this.makeNoteRoot(groupEnter);
     this.makeNoteTitleAreaText(groupEnter);
   }
 
-  makeNoteLODLevel0(groupEnter: any) {
+  makeNoteLODLevel0(groupEnter: d3.Selection<SVGElement, NoteViewObject, Element, undefined>) {
     this.makeNoteRoot(groupEnter);
     this.makeNoteTitleAreaText(groupEnter);
   }
 
-  private makeNoteHoverRoot(groupEnter: any) {
+  private makeNoteHoverRoot(
+    groupEnter: d3.Selection<SVGElement, NoteViewObject, Element, undefined>,
+  ) {
     const added = groupEnter.append(StaticDomTags.NOTE_HOVER_ROOT_SVG);
     added
       .attr("class", StaticDomTags.NOTE_HOVER_ROOT_CLASS)
@@ -223,7 +225,7 @@ export class NotesView {
       .on("mouseover", (n: NoteViewObject, i, a) => this.onNoteMouseover(n.note, a[i]));
   }
 
-  private makeNoteRoot(groupEnter: any) {
+  private makeNoteRoot(groupEnter: d3.Selection<SVGElement, NoteViewObject, Element, undefined>) {
     groupEnter
       .append(StaticDomTags.NOTE_ROOT_SVG)
       .attr("class", StaticDomTags.NOTE_ROOT_CLASS)
@@ -243,7 +245,9 @@ export class NotesView {
       .on("mouseover", (n: NoteViewObject, i, a) => this.onNoteMouseover(n.note, a[i]));
   }
 
-  private makeNoteTitleArea(groupEnter: any) {
+  private makeNoteTitleArea(
+    groupEnter: d3.Selection<SVGElement, NoteViewObject, Element, undefined>,
+  ) {
     groupEnter
       .append(StaticDomTags.NOTE_TITELAREA_SVG)
       .attr("class", StaticDomTags.NOTE_TITELAREA_CLASS)
@@ -263,7 +267,9 @@ export class NotesView {
       .on("mouseover", (n: NoteViewObject, i, a) => this.onNoteMouseover(n.note, a[i]));
   }
 
-  private makeNoteTextArea(groupEnter: any) {
+  private makeNoteTextArea(
+    groupEnter: d3.Selection<SVGElement, NoteViewObject, Element, undefined>,
+  ) {
     groupEnter
       .append(StaticDomTags.NOTE_TEXTAREA_SVG)
       .attr("class", StaticDomTags.NOTE_TEXTAREA_CLASS)
@@ -286,7 +292,9 @@ export class NotesView {
       .on("mouseover", (n: NoteViewObject, i, a) => this.onNoteMouseover(n.note, a[i]));
   }
 
-  private makeNoteTitleAreaText(groupEnter: any) {
+  private makeNoteTitleAreaText(
+    groupEnter: d3.Selection<SVGElement, NoteViewObject, Element, undefined>,
+  ) {
     groupEnter
       .append(StaticDomTags.NOTE_TITELAREA_TEXT_SVG)
       .attr("class", StaticDomTags.NOTE_TITELAREA_TEXT_CLASS)
@@ -299,7 +307,7 @@ export class NotesView {
       .on("mouseover", (n: NoteViewObject, i, a) => this.onNoteMouseover(n.note, a[i]));
   }
 
-  private makeNoteText(groupEnter: any) {
+  private makeNoteText(groupEnter: d3.Selection<SVGElement, NoteViewObject, Element, undefined>) {
     groupEnter
       .append(StaticDomTags.NOTE_TEXT_SVG)
       .attr("class", StaticDomTags.NOTE_TEXT_CLASS)
@@ -312,7 +320,9 @@ export class NotesView {
       .on("mouseover", (n: NoteViewObject, i, a) => this.onNoteMouseover(n.note, a[i]));
   }
 
-  private makeNoteDragAreaBackground(groupEnter: any) {
+  private makeNoteDragAreaBackground(
+    groupEnter: d3.Selection<SVGElement, NoteViewObject, Element, undefined>,
+  ) {
     const added = groupEnter.append(StaticDomTags.NOTE_HOVER_DRAG_AREA_BACKGROUND_SVG);
 
     added
@@ -335,7 +345,9 @@ export class NotesView {
       .call(this.draggable);
   }
 
-  private makeNoteDragArea(groupEnter: any) {
+  private makeNoteDragArea(
+    groupEnter: d3.Selection<SVGElement, NoteViewObject, Element, undefined>,
+  ) {
     if (!this.editorView.trainrunSectionPreviewLineView.getVariantIsWritable()) {
       return;
     }
@@ -376,7 +388,7 @@ export class NotesView {
     }
   }
 
-  onNoteMouseup(note: Note, domObj: any) {
+  onNoteMouseup(note: Note, domObj: SVGElement) {
     if (!this.editorView.trainrunSectionPreviewLineView.getVariantIsWritable()) {
       d3.event.stopPropagation();
       return;
@@ -405,11 +417,11 @@ export class NotesView {
     this.editorView.editNote(note.getId(), clickPosition);
   }
 
-  onNoteMouseout(note: Note, domObj: any) {
+  onNoteMouseout(note: Note, domObj: SVGElement) {
     this.unhoverNote(note, domObj);
   }
 
-  onNoteMouseover(note: Note, domObj: any) {
+  onNoteMouseover(note: Note, domObj: SVGElement) {
     if (this.editorView.trainrunSectionPreviewLineView.getMode() !== PreviewLineMode.NotDragging) {
       return;
     }
@@ -423,21 +435,21 @@ export class NotesView {
     this.hoverNote(note, domObj);
   }
 
-  onNoteMouseoverDragButton(note: Note, domObj: any) {
+  onNoteMouseoverDragButton(note: Note, domObj: SVGElement) {
     this.onNoteMouseover(note, domObj);
     d3.selectAll(StaticDomTags.NOTE_HOVER_DRAG_AREA_DOM_REF)
       .filter((n: NoteViewObject) => n.note.getId() === note.getId())
       .classed(StaticDomTags.TAG_HOVER, true);
   }
 
-  onNoteMouseoutDragButton(note: Note, domObj: any) {
+  onNoteMouseoutDragButton(note: Note, domObj: SVGElement) {
     d3.selectAll(StaticDomTags.NOTE_HOVER_DRAG_AREA_DOM_REF)
       .filter((n: NoteViewObject) => n.note.getId() === note.getId())
       .classed(StaticDomTags.TAG_HOVER, false);
     this.onNoteMouseout(note, domObj);
   }
 
-  hoverNote(note: Note, domObj: any) {
+  hoverNote(note: Note, domObj: SVGElement) {
     d3.selectAll(StaticDomTags.NOTE_HOVER_DRAG_AREA_DOM_REF)
       .filter((n: NoteViewObject) => n.note.getId() === note.getId())
       .classed(StaticDomTags.TAG_MUTED, true);
@@ -446,7 +458,7 @@ export class NotesView {
       .classed(StaticDomTags.TAG_HOVER, true);
   }
 
-  unhoverNote(note: Note, domObj: any) {
+  unhoverNote(note: Note, domObj: SVGElement) {
     d3.selectAll(StaticDomTags.NOTE_HOVER_DRAG_AREA_DOM_REF)
       .filter((n: NoteViewObject) => n.note.getId() === note.getId())
       .classed(StaticDomTags.TAG_MUTED, false);
@@ -455,7 +467,7 @@ export class NotesView {
       .classed(StaticDomTags.TAG_HOVER, false);
   }
 
-  onNoteDragStart(note: Note, domObj: any) {
+  onNoteDragStart(note: Note, domObj: SVGElement) {
     d3.select(domObj).classed(StaticDomTags.TAG_HOVER, true);
     d3.select(domObj).classed(StaticDomTags.TAG_DRAGGING, true);
     this.dragPreviousMousePosition = this.editorView.svgMouseController.getCurrentMousePosition();
@@ -468,7 +480,7 @@ export class NotesView {
     this.editorView.disableElementDragging();
   }
 
-  onNoteDragEnd(note: Note, domObj: any) {
+  onNoteDragEnd(note: Note, domObj: SVGElement) {
     this.editorView.startUndoRecording();
     d3.select(domObj).classed(StaticDomTags.TAG_HOVER, false);
     d3.select(domObj).classed(StaticDomTags.TAG_DRAGGING, false);

--- a/src/app/view/editor-main-view/data-views/trainrunsection.previewline.view.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunsection.previewline.view.ts
@@ -60,15 +60,13 @@ export class TrainrunSectionPreviewLineView {
     private versionControlService: VersionControlService,
   ) {}
 
-  static setGroup(nodeGroup: d3.Selection<SVGElement, undefined, HTMLElement, undefined>) {
+  static setGroup(nodeGroup: d3.Selection<SVGElement, undefined, Element, undefined>) {
     nodeGroup
       .append(StaticDomTags.PREVIEW_LINE_ROOT_SVG)
       .attr("class", StaticDomTags.PREVIEW_LINE_ROOT_CLASS);
   }
 
-  static setConnectionGroup(
-    nodeGroup: d3.Selection<SVGElement, undefined, HTMLElement, undefined>,
-  ) {
+  static setConnectionGroup(nodeGroup: d3.Selection<SVGElement, undefined, Element, undefined>) {
     nodeGroup
       .append(StaticDomTags.PREVIEW_CONNECTION_LINE_ROOT_SVG)
       .attr("class", StaticDomTags.PREVIEW_CONNECTION_LINE_ROOT_CLASS);

--- a/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
@@ -32,7 +32,7 @@ import {LinePatternRefs} from "../../../data-structures/business.data.structures
 import {TrainrunsectionHelper} from "src/app/services/util/trainrunsection.helper";
 
 export class TrainrunSectionsView {
-  trainrunSectionGroup;
+  trainrunSectionGroup: d3.Selection<SVGElement, undefined, Element, undefined>;
 
   constructor(private editorView: EditorView) {}
 
@@ -989,7 +989,7 @@ export class TrainrunSectionsView {
     }
   }
 
-  setGroup(trainrunSectionGroup: d3.Selection<SVGElement, undefined, HTMLElement, undefined>) {
+  setGroup(trainrunSectionGroup: d3.Selection<SVGElement, undefined, Element, undefined>) {
     trainrunSectionGroup.attr("class", "TrainrunSectionsView");
     this.trainrunSectionGroup = trainrunSectionGroup
       .append(StaticDomTags.GROUP_SVG)
@@ -997,7 +997,7 @@ export class TrainrunSectionsView {
   }
 
   createTrainrunSectionTextBackgrounds(
-    groupEnter: d3.Selection<SVGElement, undefined, HTMLElement, undefined>,
+    groupEnter: d3.Selection<SVGElement, TrainrunSectionViewObject, Element, undefined>,
     lineTextElement: TrainrunSectionText,
     selectedTrainrun: Trainrun,
     connectedTrainIds: number[],
@@ -1122,7 +1122,7 @@ export class TrainrunSectionsView {
    * @param enableEvents - Optional flag to enable or disable mouse event handlers on the arrows. Defaults to true.
    */
   createDirectionArrows(
-    groupLinesEnter: d3.Selection<SVGElement, undefined, HTMLElement, undefined>,
+    groupLinesEnter: d3.Selection<SVGElement, TrainrunSectionViewObject, Element, undefined>,
     selectedTrainrun: Trainrun,
     connectedTrainIds: number[],
     enableEvents = true,
@@ -1183,7 +1183,7 @@ export class TrainrunSectionsView {
   }
 
   createAsymmetryArrows(
-    groupLinesEnter: d3.Selection<SVGElement, undefined, HTMLElement, undefined>,
+    groupLinesEnter: d3.Selection<SVGElement, TrainrunSectionViewObject, Element, undefined>,
     selectedTrainrun: Trainrun,
     connectedTrainIds: number[],
     enableEvents = true,
@@ -1258,7 +1258,7 @@ export class TrainrunSectionsView {
   }
 
   createTrainrunSection(
-    groupEnter: d3.Selection<SVGElement, undefined, HTMLElement, undefined>,
+    groupEnter: d3.Selection<SVGElement, TrainrunSectionViewObject, Element, undefined>,
     classRef,
     levelFreqFilter: LinePatternRefs[],
     selectedTrainrun: Trainrun,
@@ -1314,7 +1314,7 @@ export class TrainrunSectionsView {
   }
 
   createTrainrunsectionSemicircleAtNode(
-    groupEnter: d3.Selection<SVGElement, undefined, HTMLElement, undefined>,
+    groupEnter: d3.Selection<SVGElement, TrainrunSectionViewObject, Element, undefined>,
     selectedTrainrun: Trainrun,
     connectedTrainIds: number[],
     atSource: boolean,
@@ -1380,7 +1380,7 @@ export class TrainrunSectionsView {
   }
 
   createTrainrunsectionSemicircles(
-    groupEnter: d3.Selection<SVGElement, undefined, HTMLElement, undefined>,
+    groupEnter: d3.Selection<SVGElement, TrainrunSectionViewObject, Element, undefined>,
     selectedTrainrun: Trainrun,
     connectedTrainIds: number[],
   ) {
@@ -1405,7 +1405,7 @@ export class TrainrunSectionsView {
   }
 
   createPinOnTrainrunsection(
-    groupEnter: d3.Selection<SVGElement, undefined, HTMLElement, undefined>,
+    groupEnter: d3.Selection<SVGElement, TrainrunSectionViewObject, Element, undefined>,
     selectedTrainrun: Trainrun,
     connectedTrainIds: number[],
     atSource: boolean,
@@ -1489,7 +1489,7 @@ export class TrainrunSectionsView {
   }
 
   private createInternTrainrunSectionElementFilteringWarningElements(
-    groupEnter: d3.Selection<SVGElement, undefined, HTMLElement, undefined>,
+    groupEnter: d3.Selection<SVGElement, TrainrunSectionViewObject, Element, undefined>,
     selectedTrainrun: Trainrun,
     connectedTrainIds: number[],
     textElement: TrainrunSectionText,
@@ -1596,7 +1596,7 @@ export class TrainrunSectionsView {
   }
 
   createTrainrunSectionElement(
-    groupEnter: d3.Selection<SVGElement, undefined, HTMLElement, undefined>,
+    groupEnter: d3.Selection<SVGElement, TrainrunSectionViewObject, Element, undefined>,
     selectedTrainrun: Trainrun,
     connectedTrainIds: number[],
     textElement: TrainrunSectionText,
@@ -1624,7 +1624,7 @@ export class TrainrunSectionsView {
   }
 
   createTrainrunSectionGotoInfoElement(
-    groupEnter: d3.Selection<SVGElement, undefined, HTMLElement, undefined>,
+    groupEnter: d3.Selection<SVGElement, TrainrunSectionViewObject, Element, undefined>,
     selectedTrainrun: Trainrun,
     connectedTrainIds: number[],
     atSource: boolean,
@@ -1679,7 +1679,7 @@ export class TrainrunSectionsView {
   }
 
   createNumberOfStopsTextElement(
-    groupEnter: d3.Selection<SVGElement, undefined, HTMLElement, undefined>,
+    groupEnter: d3.Selection<SVGElement, undefined, Element, undefined>,
     trainrunSection: TrainrunSection,
     selectedTrainrun: Trainrun,
     connectedTrainIds: number[],
@@ -1724,7 +1724,7 @@ export class TrainrunSectionsView {
   }
 
   createIntermediateStops(
-    groupEnter: d3.Selection<SVGElement, undefined, HTMLElement, undefined>,
+    groupEnter: d3.Selection<SVGElement, undefined, Element, undefined>,
     trainrunSection: TrainrunSection,
     selectedTrainrun: Trainrun,
     connectedTrainIds: number[],
@@ -1786,7 +1786,7 @@ export class TrainrunSectionsView {
   }
 
   createAllIntermediateStops(
-    groupEnter: d3.Selection<SVGGElement, undefined, HTMLElement, undefined>,
+    groupEnter: d3.Selection<SVGGElement, TrainrunSectionViewObject, Element, undefined>,
     selectedTrainrun: Trainrun,
     connectedTrainIds: number[],
   ) {
@@ -1885,7 +1885,7 @@ export class TrainrunSectionsView {
     D3Utils.bringTrainrunSectionToFront();
   }
 
-  onTrainrunSectionTextMouseover(trainrunSection: TrainrunSection, domObj: any) {
+  onTrainrunSectionTextMouseover(trainrunSection: TrainrunSection, domObj: SVGElement) {
     if (this.editorView.trainrunSectionPreviewLineView.getMode() === PreviewLineMode.NotDragging) {
       d3.select(domObj).classed(StaticDomTags.TAG_HOVER, true);
     }
@@ -1895,7 +1895,7 @@ export class TrainrunSectionsView {
     trainrunSection: TrainrunSection,
     stopIndex: number,
     position: Vec2D,
-    domObj: any,
+    domObj: SVGElement,
   ) {
     d3.event.stopPropagation();
     if (d3.event.buttons === 0) {
@@ -1907,7 +1907,7 @@ export class TrainrunSectionsView {
     trainrunSection: TrainrunSection,
     stopIndex: number,
     position: Vec2D,
-    domObj: any,
+    domObj: SVGElement,
   ) {
     d3.event.stopPropagation();
     d3.select(domObj).classed(StaticDomTags.TAG_HOVER, true);
@@ -1917,7 +1917,7 @@ export class TrainrunSectionsView {
     trainrunSection: TrainrunSection,
     stopIndex: number,
     position: Vec2D,
-    domObj: any,
+    domObj: SVGElement,
   ) {
     if (this.editorView.editorMode === EditorMode.MultiNodeMoving) {
       d3.event.stopPropagation();
@@ -1936,7 +1936,7 @@ export class TrainrunSectionsView {
     this.editorView.trainrunSectionPreviewLineView.updatePreviewLine();
   }
 
-  onIntermediateStopMouseUp(trainrunSection: TrainrunSection, domObj: any) {
+  onIntermediateStopMouseUp(trainrunSection: TrainrunSection, domObj: SVGElement) {
     d3.event.stopPropagation();
     if (this.editorView.editorMode === EditorMode.MultiNodeMoving) {
       this.handleMultiNodeMovingTrainrunSectionMouseUp(trainrunSection);
@@ -1947,13 +1947,13 @@ export class TrainrunSectionsView {
     this.editorView.setTrainrunAsSelected(trainrunSection.getTrainrun());
   }
 
-  onTrainrunSectionTextMouseout(trainrunSection: TrainrunSection, domObj: any) {
+  onTrainrunSectionTextMouseout(trainrunSection: TrainrunSection, domObj: SVGElement) {
     d3.select(domObj).classed(StaticDomTags.TAG_HOVER, false);
   }
 
   onTrainrunSectionElementClicked(
     trainrunSection: TrainrunSection,
-    domObj: any,
+    domObj: SVGElement,
     textElement: TrainrunSectionText,
   ) {
     d3.event.stopPropagation();
@@ -1977,7 +1977,7 @@ export class TrainrunSectionsView {
     );
   }
 
-  onTrainrunDirectionArrowMouseUp(trainrunSection: TrainrunSection, domObj: any) {
+  onTrainrunDirectionArrowMouseUp(trainrunSection: TrainrunSection, domObj: SVGElement) {
     d3.event.stopPropagation();
     if (this.editorView.editorMode === EditorMode.MultiNodeMoving) {
       this.handleMultiNodeMovingTrainrunSectionMouseUp(trainrunSection);
@@ -1992,7 +1992,7 @@ export class TrainrunSectionsView {
     this.editorView.showTrainrunOneWayInformation(trainrunSection, clickPosition);
   }
 
-  onTrainrunAsymmetryArrowMouseUp(trainrunSection: TrainrunSection, domObj: any) {
+  onTrainrunAsymmetryArrowMouseUp(trainrunSection: TrainrunSection, domObj: SVGElement) {
     d3.event.stopPropagation();
     const rect: DOMRect = d3.select(domObj).node().getBoundingClientRect();
     const clickPosition = new Vec2D(rect.x + rect.width / 2, rect.y + rect.height / 2);
@@ -2040,7 +2040,7 @@ export class TrainrunSectionsView {
     this.editorView.clickSelectedTrainrunSection(param);
   }
 
-  onTrainrunSectionMouseUp(trainrunSection: TrainrunSection, domObj: any) {
+  onTrainrunSectionMouseUp(trainrunSection: TrainrunSection, domObj: SVGElement) {
     d3.event.stopPropagation();
     if (this.editorView.editorMode === EditorMode.MultiNodeMoving) {
       this.handleMultiNodeMovingTrainrunSectionMouseUp(trainrunSection);
@@ -2049,7 +2049,7 @@ export class TrainrunSectionsView {
     this.handleDefaultTrainrunSectionMouseUp(trainrunSection);
   }
 
-  onTrainrunSectionMouseoverPath(trainrunSection: TrainrunSection, domObj: any) {
+  onTrainrunSectionMouseoverPath(trainrunSection: TrainrunSection, domObj: SVGElement) {
     if (this.editorView.trainrunSectionPreviewLineView.getMode() === PreviewLineMode.NotDragging) {
       D3Utils.hoverTrainrunSection(
         trainrunSection,
@@ -2059,11 +2059,11 @@ export class TrainrunSectionsView {
     }
   }
 
-  onTrainrunSectionMouseoutPath(trainrunSection: TrainrunSection, domObj: any) {
+  onTrainrunSectionMouseoutPath(trainrunSection: TrainrunSection, domObj: SVGElement) {
     D3Utils.unhoverTrainrunSection(trainrunSection);
   }
 
-  onTrainrunSectionMouseoverPin(node: Node, domObj: any) {
+  onTrainrunSectionMouseoverPin(node: Node, domObj: SVGElement) {
     if (this.editorView.trainrunSectionPreviewLineView.getMode() === PreviewLineMode.NotDragging) {
       this.editorView.nodesView.unhoverNode(node, null);
     } else {
@@ -2072,7 +2072,11 @@ export class TrainrunSectionsView {
     d3.select(domObj).classed(StaticDomTags.TAG_HOVER, true);
   }
 
-  onTrainrunSectionMouseoutPin(trainrunSection: TrainrunSection, domObj: any, atSource: boolean) {
+  onTrainrunSectionMouseoutPin(
+    trainrunSection: TrainrunSection,
+    domObj: SVGElement,
+    atSource: boolean,
+  ) {
     d3.select(domObj).classed(StaticDomTags.TAG_HOVER, false);
     if (this.editorView.trainrunSectionPreviewLineView.getMode() !== PreviewLineMode.NotDragging) {
       return;
@@ -2347,10 +2351,10 @@ export class TrainrunSectionsView {
   }
 
   private oneNodeHiddenTrainrunSectionsRendering(
-    inGroupLines,
+    inGroupLines: d3.Selection<SVGElement, TrainrunSectionViewObject, Element, undefined>,
     selectedTrainrun: Trainrun,
     connectedTrainIds: number[],
-    inGroupLabels,
+    inGroupLabels: d3.Selection<SVGElement, TrainrunSectionViewObject, Element, undefined>,
   ) {
     const groupLines = inGroupLines.filter(
       (d: TrainrunSectionViewObject) =>
@@ -2472,10 +2476,10 @@ export class TrainrunSectionsView {
   }
 
   private defaultTrainrunSectionsRendering(
-    inGroupLines,
+    inGroupLines: d3.Selection<SVGElement, TrainrunSectionViewObject, Element, undefined>,
     selectedTrainrun: Trainrun,
     connectedTrainIds: number[],
-    inGroupLabels,
+    inGroupLabels: d3.Selection<SVGGElement, TrainrunSectionViewObject, Element, undefined>,
   ) {
     const groupLines = inGroupLines.filter((d: TrainrunSectionViewObject) =>
       this.filterOutAllTrainrunSectionWithHiddenNodeConnection(d.trainrunSection),
@@ -2634,10 +2638,10 @@ export class TrainrunSectionsView {
   }
 
   make4LayerTrainrunSectionLines(
-    groupLines: any,
+    groupLines: d3.Selection<SVGElement, TrainrunSectionViewObject, Element, undefined>,
     selectedTrainrun: Trainrun,
     connectedTrainIds: number[],
-    inGroupLabels,
+    inGroupLabels: d3.Selection<SVGElement, TrainrunSectionViewObject, Element, undefined>,
     enableEvents: boolean,
   ) {
     this.createTrainrunSection(
@@ -2679,7 +2683,7 @@ export class TrainrunSectionsView {
     lineOrientationVector: Vec2D,
     stopIndex: number,
     drawNumberOfStops: number,
-    groupEnter: d3.Selection<SVGElement, undefined, HTMLElement, undefined>,
+    groupEnter: d3.Selection<SVGElement, undefined, Element, undefined>,
     selectedTrainrun: Trainrun,
     connectedTrainIds: number[],
     numberOfStops: number,

--- a/src/app/view/editor-main-view/data-views/transitions.view.ts
+++ b/src/app/view/editor-main-view/data-views/transitions.view.ts
@@ -11,8 +11,8 @@ import {TransitionViewObject} from "./transitionViewObject";
 import {LinePatternRefs} from "../../../data-structures/business.data.structures";
 
 export class TransitionsView {
-  transitionsGroup;
-  selectedTransitionsGroup;
+  transitionsGroup: d3.Selection<SVGElement, undefined, Element, undefined>;
+  selectedTransitionsGroup: d3.Selection<SVGElement, undefined, Element, undefined>;
   editorView: EditorView;
 
   constructor(editorView: EditorView) {
@@ -82,7 +82,7 @@ export class TransitionsView {
   }
 
   static createTransitionLineLayer(
-    grpEnter: d3.Selection<SVGElement, undefined, HTMLElement, undefined>,
+    grpEnter: d3.Selection<SVGElement, TransitionViewObject, Element, undefined>,
     classRef: string,
     levelFreqFilter: LinePatternRefs[],
     selectedTrainrun: Trainrun,
@@ -122,7 +122,7 @@ export class TransitionsView {
   }
 
   createNonStopToggle(
-    grpEnter: d3.Selection<SVGElement, undefined, HTMLElement, undefined>,
+    grpEnter: d3.Selection<SVGElement, TransitionViewObject, Element, undefined>,
     selectedTrainrun: Trainrun,
     connectedTrainIds: number[],
   ) {
@@ -166,7 +166,7 @@ export class TransitionsView {
       );
   }
 
-  setGroup(transitionsGroup) {
+  setGroup(transitionsGroup: d3.Selection<SVGElement, undefined, Element, undefined>) {
     transitionsGroup.attr("class", "TransitionsView");
     this.transitionsGroup = transitionsGroup.append(StaticDomTags.GROUP_SVG);
     this.transitionsGroup.attr("class", "transitions");
@@ -275,7 +275,7 @@ export class TransitionsView {
     transitionsGroup.exit().remove();
   }
 
-  onTransitionMouseup(trainrun: Trainrun, domObj: any, transition: Transition) {
+  onTransitionMouseup(trainrun: Trainrun, domObj: SVGElement, transition: Transition) {
     d3.event.stopPropagation();
     const node: Node = this.editorView.getNodeFromTransition(transition);
     if (this.editorView.trainrunSectionPreviewLineView.getMode() === PreviewLineMode.NotDragging) {
@@ -301,7 +301,7 @@ export class TransitionsView {
     this.editorView.trainrunSectionPreviewLineView.stopPreviewLine();
   }
 
-  onTransitionButtonOut(trainrun: Trainrun, domObj: any, transition: Transition) {
+  onTransitionButtonOut(trainrun: Trainrun, domObj: SVGElement, transition: Transition) {
     d3.select(domObj).classed(StaticDomTags.TAG_HOVER, false);
 
     const node: Node = this.editorView.getNodeFromTransition(transition);
@@ -333,11 +333,11 @@ export class TransitionsView {
     this.editorView.trainrunSectionPreviewLineView.updatePreviewLine();
   }
 
-  onTransitionMousemove(domObj: any) {
+  onTransitionMousemove(domObj: SVGElement) {
     d3.event.stopPropagation();
   }
 
-  onTransitionMouseover(trainrun: Trainrun, domObj: any, transition: Transition) {
+  onTransitionMouseover(trainrun: Trainrun, domObj: SVGElement, transition: Transition) {
     const node: Node = this.editorView.getNodeFromTransition(transition);
     if (this.editorView.trainrunSectionPreviewLineView.getMode() === PreviewLineMode.NotDragging) {
       const port1 = node.getPort(transition.getPortId1());

--- a/src/app/view/knoten-auslastung-view/knoten-auslastung-view.component.ts
+++ b/src/app/view/knoten-auslastung-view/knoten-auslastung-view.component.ts
@@ -19,7 +19,7 @@ import {Subject} from "rxjs";
   standalone: false,
 })
 export class KnotenAuslastungViewComponent implements AfterViewInit, OnDestroy {
-  private svgDrawingContext: any;
+  private svgDrawingContext: d3.Selection<SVGElement, undefined, Element, undefined>;
   private knotenAuslastungDataPreparation: KnotenAuslastungDataPreparation;
   private destroyed = new Subject<void>();
 
@@ -83,9 +83,11 @@ export class KnotenAuslastungViewComponent implements AfterViewInit, OnDestroy {
   }
 
   ngAfterViewInit(): void {
-    this.svgDrawingContext = d3.select("#knotenAuslastungContainer").on("contextmenu", () => {
-      d3.event.preventDefault();
-    });
+    this.svgDrawingContext = d3
+      .select<SVGElement, undefined>("#knotenAuslastungContainer")
+      .on("contextmenu", () => {
+        d3.event.preventDefault();
+      });
 
     this.init();
   }

--- a/src/app/view/util/svg.mouse.controller.ts
+++ b/src/app/view/util/svg.mouse.controller.ts
@@ -20,7 +20,7 @@ export class SVGMouseController {
   private static ZOOM_FACTOR_PERCENT = 10;
   private viewboxProperties: ViewboxProperties;
 
-  private svgDrawingContext: any;
+  private svgDrawingContext: d3.Selection<SVGElement, undefined, Element, undefined>;
   private cachedSvgDrawingContextNode = null;
   private previousPanMousePosition: Vec2D = null;
   private previousMultiSelectShiftPosition: Vec2D = null;


### PR DESCRIPTION
A good chunk of the editor main view logic doesn't use explicit types for d3: either the `any` type is used, either no type is specified at all (ie, `any` is implicitly used). `any` effectively disables TypeScript checks.

Replace all of these with explicit types.

Most of the changes replace `any` with `d3.Selection`. Some of the existing `d3.Selection` types needed adjustments:

- The "datum" type (second generic argument) was undefined, but logic inside functions required a non-undefined type (e.g. `TrainrunSectionViewObject`).
- The "parent" type (third generic argument) was HTMLElement. However, inside an `<svg>` element, the parent may be either an `HTMLElement` (e.g. `<div>`), either an `SVGElement` (e.g. `<g>`). Use the `Element` type instead which covers both. The parent is unused (we never walk up the DOM) but using the correct type is safer.

I'd like to merge this before continuing to work on https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/pull/1123.