### PR TITLE
feat: Adding stretching and shrinking of train sections

### DIFF
--- a/src/app/services/data/node.service.ts
+++ b/src/app/services/data/node.service.ts
@@ -1193,7 +1193,7 @@ export class NodeService implements OnDestroy {
     this.nodesStore.nodes = this.nodesStore.nodes.filter((n) => n.getId() !== nodeId);
   }
 
-  private changeNodePositionWithoutUpdate(
+  changeNodePositionWithoutUpdate(
     nodeId: number,
     newPositionX: number,
     newPositionY: number,

--- a/src/app/services/util/position.transformation.service.spec.ts
+++ b/src/app/services/util/position.transformation.service.spec.ts
@@ -105,6 +105,7 @@ describe("PositionTransformationService", () => {
 
     positionTransformationService = new PositionTransformationService(
       trainrunSectionService,
+      trainrunService,
       nodeService,
       noteService,
       uiInteractionService,

--- a/src/app/services/util/position.transformation.service.ts
+++ b/src/app/services/util/position.transformation.service.ts
@@ -294,16 +294,6 @@ export class PositionTransformationService {
 
   stretchShortSections(sections: TrainrunSection[], onlyShort = true, sign = 1): void {
     const MIN_SECTION_LENGTH_PX = 200;
-    const groups = new Map<
-      string,
-      {
-        trains: string[];
-        length: number;
-        direction: string;
-        centerX: number;
-        centerY: number;
-      }
-    >();
 
     const toDirection = (a: PortAlignment) =>
       a === PortAlignment.Left || a === PortAlignment.Right ? "horizontal" : "vertical";
@@ -328,32 +318,16 @@ export class PositionTransformationService {
       );
       const direction = srcDir === tgtDir ? srcDir : `${srcDir}/${tgtDir}`;
       const key = [srcNodeObj.getBetriebspunktName(), tgtNodeObj.getBetriebspunktName()]
-        .sort()
-        .join(" – ");
-      if (!groups.has(key)) {
-        groups.set(key, {
-          trains: [],
-          length: Math.round(length),
-          direction,
-          centerX: (src.getX() + tgt.getX()) / 2,
-          centerY: (src.getY() + tgt.getY()) / 2,
-        });
-      }
-      groups.get(key).trains.push(section.getTrainrun().getTitle());
-    });
+            .sort()
+            .join(" – ");
 
-    if (groups.size === 0) {
-      console.log("[KeyI/E] No matching sections found.");
-      return;
-    }
-
-    groups.forEach(({trains, length, direction, centerX, centerY}, key) => {
       const deficit = MIN_SECTION_LENGTH_PX - length;
       const steps = Math.max(Math.ceil(deficit / (2 * RASTERING_BASIC_GRID_SIZE)), 1);
       const delta = steps * RASTERING_BASIC_GRID_SIZE;
 
       if (direction === "horizontal") {
         this.nodeService.getNodes().forEach((node: Node) => {
+          const centerX = (src.getX() + tgt.getX()) / 2;
           const nodeCenterX = node.getPositionX() + node.getNodeWidth() / 2;
           const dx = (nodeCenterX <= centerX ? -1 : 1) * sign * delta;
           this.nodeService.changeNodePositionWithoutUpdate(
@@ -366,6 +340,7 @@ export class PositionTransformationService {
         });
       } else if (direction === "vertical") {
         this.nodeService.getNodes().forEach((node: Node) => {
+          const centerY = (src.getY() + tgt.getY()) / 2;
           const nodeCenterY = node.getPositionY() + node.getNodeHeight() / 2;
           const dy = (nodeCenterY <= centerY ? -1 : 1) * sign * delta;
           this.nodeService.changeNodePositionWithoutUpdate(
@@ -382,7 +357,7 @@ export class PositionTransformationService {
       }
 
       const action = sign >= 0 ? "stretched" : "shrunk";
-      console.log(`  [${action}] ${key} (${length}px, ${direction}): ${trains.join(", ")}`);
+      console.log(`  [${action}] ${key} (${length}px, ${direction})`);
     });
 
     this.nodeService.nodesUpdated();

--- a/src/app/services/util/position.transformation.service.ts
+++ b/src/app/services/util/position.transformation.service.ts
@@ -323,11 +323,27 @@ export class PositionTransformationService {
 
       const deficit = MIN_SECTION_LENGTH_PX - length;
       const steps = Math.max(Math.ceil(deficit / (2 * RASTERING_BASIC_GRID_SIZE)), 1);
-      const delta = steps * RASTERING_BASIC_GRID_SIZE;
+      let delta = steps * RASTERING_BASIC_GRID_SIZE;
+
+      const centerX = (src.getX() + tgt.getX()) / 2;
+      const centerY = (src.getY() + tgt.getY()) / 2;
+
+      if (sign < 0) {
+        delta = this.limitDeltaForMinEdgeLength(
+          delta,
+          direction,
+          centerX,
+          centerY,
+          MIN_SECTION_LENGTH_PX,
+        );
+        if (delta <= 0) {
+          console.log(`  [skip] ${key}: cannot shrink without violating minimum edge length`);
+          return;
+        }
+      }
 
       if (direction === "horizontal") {
         this.nodeService.getNodes().forEach((node: Node) => {
-          const centerX = (src.getX() + tgt.getX()) / 2;
           const nodeCenterX = node.getPositionX() + node.getNodeWidth() / 2;
           const dx = (nodeCenterX <= centerX ? -1 : 1) * sign * delta;
           this.nodeService.changeNodePositionWithoutUpdate(
@@ -340,7 +356,6 @@ export class PositionTransformationService {
         });
       } else if (direction === "vertical") {
         this.nodeService.getNodes().forEach((node: Node) => {
-          const centerY = (src.getY() + tgt.getY()) / 2;
           const nodeCenterY = node.getPositionY() + node.getNodeHeight() / 2;
           const dy = (nodeCenterY <= centerY ? -1 : 1) * sign * delta;
           this.nodeService.changeNodePositionWithoutUpdate(
@@ -357,12 +372,61 @@ export class PositionTransformationService {
       }
 
       const action = sign >= 0 ? "stretched" : "shrunk";
-      console.log(`  [${action}] ${key} (${length}px, ${direction})`);
+      console.log(`  [${action}] ${key} (${Math.round(length)}px, ${direction})`);
     });
 
     this.nodeService.nodesUpdated();
     this.nodeService.transitionsUpdated();
     this.trainrunService.trainrunsUpdated();
     this.trainrunSectionService.trainrunSectionsUpdated();
+  }
+
+  private limitDeltaForMinEdgeLength(
+    delta: number,
+    direction: string,
+    centerX: number,
+    centerY: number,
+    minLength: number,
+  ): number {
+    const allSections = this.trainrunSectionService.getTrainrunSections();
+    let maxDelta = delta;
+
+    for (const section of allSections) {
+      if (section.isPathInvalid()) {
+        continue;
+      }
+      const src = section.getPositionAtSourceNode();
+      const tgt = section.getPositionAtTargetNode();
+      const srcNode = section.getSourceNode();
+      const tgtNode = section.getTargetNode();
+      const edgeKey = `${srcNode.getBetriebspunktName()} – ${tgtNode.getBetriebspunktName()}`;
+
+      const isHorizontal = direction === "horizontal";
+      const srcCenter = isHorizontal
+        ? srcNode.getPositionX() + srcNode.getNodeWidth() / 2
+        : srcNode.getPositionY() + srcNode.getNodeHeight() / 2;
+      const tgtCenter = isHorizontal
+        ? tgtNode.getPositionX() + tgtNode.getNodeWidth() / 2
+        : tgtNode.getPositionY() + tgtNode.getNodeHeight() / 2;
+      const center = isHorizontal ? centerX : centerY;
+
+      if (!isHorizontal && direction !== "vertical") {
+        continue;
+      }
+      if ((srcCenter <= center) === (tgtCenter <= center)) {
+        continue;
+      }
+
+      const currentLength = Vec2D.norm(Vec2D.sub(tgt, src));
+      const allowable = Math.floor(
+        (currentLength - minLength) / 2 / RASTERING_BASIC_GRID_SIZE,
+      ) * RASTERING_BASIC_GRID_SIZE;
+      if (allowable < maxDelta) {
+        console.log(`  [limit] edge ${edgeKey} (${Math.round(currentLength)}px) constrains delta to ${allowable}px`);
+      }
+      maxDelta = Math.min(maxDelta, allowable);
+    }
+
+    return maxDelta;
   }
 }

--- a/src/app/services/util/position.transformation.service.ts
+++ b/src/app/services/util/position.transformation.service.ts
@@ -292,7 +292,12 @@ export class PositionTransformationService {
     this.updateRendering();
   }
 
-  stretchShortSections(sections: TrainrunSection[], onlyShort = true, sign = 1): void {
+  stretchShortSections(
+    sections: TrainrunSection[],
+    onlyShort = true,
+    sign = 1,
+    maxShrink = false,
+  ): void {
     const MIN_SECTION_LENGTH_PX = 200;
 
     const toDirection = (a: PortAlignment) =>
@@ -323,7 +328,8 @@ export class PositionTransformationService {
 
       const deficit = MIN_SECTION_LENGTH_PX - length;
       const steps = Math.max(Math.ceil(deficit / (2 * RASTERING_BASIC_GRID_SIZE)), 1);
-      let delta = steps * RASTERING_BASIC_GRID_SIZE;
+      let delta =
+        sign < 0 && maxShrink ? Number.MAX_SAFE_INTEGER : steps * RASTERING_BASIC_GRID_SIZE;
 
       const centerX = (src.getX() + tgt.getX()) / 2;
       const centerY = (src.getY() + tgt.getY()) / 2;

--- a/src/app/services/util/position.transformation.service.ts
+++ b/src/app/services/util/position.transformation.service.ts
@@ -294,16 +294,15 @@ export class PositionTransformationService {
 
   stretchShortSections(
     sections: TrainrunSection[],
-    onlyShort = true,
+    runGlobally = true,
     sign = 1,
-    maxShrink = false,
   ): void {
     const MIN_SECTION_LENGTH_PX = 200;
 
     const toDirection = (a: PortAlignment) =>
       a === PortAlignment.Left || a === PortAlignment.Right ? "horizontal" : "vertical";
 
-    const processed = new Set<string>();
+    const processed = !(runGlobally && sign >= 0) ? new Set<string>() : null;
     sections.forEach((section: TrainrunSection) => {
       if (section.isPathInvalid()) {
         return;
@@ -311,7 +310,7 @@ export class PositionTransformationService {
       const src = section.getPositionAtSourceNode();
       const tgt = section.getPositionAtTargetNode();
       const length = Vec2D.norm(Vec2D.sub(tgt, src));
-      if (onlyShort && length >= MIN_SECTION_LENGTH_PX) {
+      if (runGlobally && sign >= 0 && length >= MIN_SECTION_LENGTH_PX) {
         return;
       }
       const srcNodeObj = section.getSourceNode();
@@ -327,15 +326,15 @@ export class PositionTransformationService {
         .sort()
         .join(" – ");
 
-      if (processed.has(key)) {
+      if (processed?.has(key)) {
         return;
       }
-      processed.add(key);
+      processed?.add(key);
 
       const deficit = MIN_SECTION_LENGTH_PX - length;
       const steps = Math.max(Math.ceil(deficit / (2 * RASTERING_BASIC_GRID_SIZE)), 1);
       let delta =
-        sign < 0 && maxShrink ? Number.MAX_SAFE_INTEGER : steps * RASTERING_BASIC_GRID_SIZE;
+        sign < 0 && runGlobally ? Number.MAX_SAFE_INTEGER : steps * RASTERING_BASIC_GRID_SIZE;
 
       const centerX = (src.getX() + tgt.getX()) / 2;
       const centerY = (src.getY() + tgt.getY()) / 2;

--- a/src/app/services/util/position.transformation.service.ts
+++ b/src/app/services/util/position.transformation.service.ts
@@ -303,6 +303,7 @@ export class PositionTransformationService {
     const toDirection = (a: PortAlignment) =>
       a === PortAlignment.Left || a === PortAlignment.Right ? "horizontal" : "vertical";
 
+    const processed = new Set<string>();
     sections.forEach((section: TrainrunSection) => {
       if (section.isPathInvalid()) {
         return;
@@ -325,6 +326,11 @@ export class PositionTransformationService {
       const key = [srcNodeObj.getBetriebspunktName(), tgtNodeObj.getBetriebspunktName()]
         .sort()
         .join(" – ");
+
+      if (processed.has(key)) {
+        return;
+      }
+      processed.add(key);
 
       const deficit = MIN_SECTION_LENGTH_PX - length;
       const steps = Math.max(Math.ceil(deficit / (2 * RASTERING_BASIC_GRID_SIZE)), 1);

--- a/src/app/services/util/position.transformation.service.ts
+++ b/src/app/services/util/position.transformation.service.ts
@@ -1,5 +1,6 @@
 import {EventEmitter, Injectable} from "@angular/core";
 import {TrainrunSectionService} from "../data/trainrunsection.service";
+import {TrainrunService} from "../data/trainrun.service";
 import {UiInteractionService} from "../ui/ui.interaction.service";
 import {NodeService} from "../data/node.service";
 import {NoteService} from "../data/note.service";
@@ -8,6 +9,9 @@ import {Node} from "../../models/node.model";
 import {ViewportCullService} from "../ui/viewport.cull.service";
 import {NodeOperation, Operation, OperationType} from "src/app/models/operation.model";
 import {Note} from "../../models/note.model";
+import {TrainrunSection} from "../../models/trainrunsection.model";
+import {PortAlignment} from "../../data-structures/technical.data.structures";
+import {RASTERING_BASIC_GRID_SIZE} from "../../view/rastering/definitions";
 
 @Injectable({
   providedIn: "root",
@@ -15,6 +19,7 @@ import {Note} from "../../models/note.model";
 export class PositionTransformationService {
   constructor(
     private readonly trainrunSectionService: TrainrunSectionService,
+    private readonly trainrunService: TrainrunService,
     private readonly nodeService: NodeService,
     private readonly noteService: NoteService,
     private readonly uiInteractionService: UiInteractionService,
@@ -285,5 +290,104 @@ export class PositionTransformationService {
     }
 
     this.updateRendering();
+  }
+
+  stretchShortSections(sections: TrainrunSection[], onlyShort = true, sign = 1): void {
+    const MIN_SECTION_LENGTH_PX = 200;
+    const groups = new Map<
+      string,
+      {
+        trains: string[];
+        length: number;
+        direction: string;
+        centerX: number;
+        centerY: number;
+      }
+    >();
+
+    const toDirection = (a: PortAlignment) =>
+      a === PortAlignment.Left || a === PortAlignment.Right ? "horizontal" : "vertical";
+
+    sections.forEach((section: TrainrunSection) => {
+      if (section.isPathInvalid()) {
+        return;
+      }
+      const src = section.getPositionAtSourceNode();
+      const tgt = section.getPositionAtTargetNode();
+      const length = Vec2D.norm(Vec2D.sub(tgt, src));
+      if (onlyShort && length >= MIN_SECTION_LENGTH_PX) {
+        return;
+      }
+      const srcNodeObj = section.getSourceNode();
+      const tgtNodeObj = section.getTargetNode();
+      const srcDir = toDirection(
+        srcNodeObj.getPort(section.getSourcePortId()).getPositionAlignment(),
+      );
+      const tgtDir = toDirection(
+        tgtNodeObj.getPort(section.getTargetPortId()).getPositionAlignment(),
+      );
+      const direction = srcDir === tgtDir ? srcDir : `${srcDir}/${tgtDir}`;
+      const key = [srcNodeObj.getBetriebspunktName(), tgtNodeObj.getBetriebspunktName()]
+        .sort()
+        .join(" – ");
+      if (!groups.has(key)) {
+        groups.set(key, {
+          trains: [],
+          length: Math.round(length),
+          direction,
+          centerX: (src.getX() + tgt.getX()) / 2,
+          centerY: (src.getY() + tgt.getY()) / 2,
+        });
+      }
+      groups.get(key).trains.push(section.getTrainrun().getTitle());
+    });
+
+    if (groups.size === 0) {
+      console.log("[KeyI/E] No matching sections found.");
+      return;
+    }
+
+    groups.forEach(({trains, length, direction, centerX, centerY}, key) => {
+      const deficit = MIN_SECTION_LENGTH_PX - length;
+      const steps = Math.max(Math.ceil(deficit / (2 * RASTERING_BASIC_GRID_SIZE)), 1);
+      const delta = steps * RASTERING_BASIC_GRID_SIZE;
+
+      if (direction === "horizontal") {
+        this.nodeService.getNodes().forEach((node: Node) => {
+          const nodeCenterX = node.getPositionX() + node.getNodeWidth() / 2;
+          const dx = (nodeCenterX <= centerX ? -1 : 1) * sign * delta;
+          this.nodeService.changeNodePositionWithoutUpdate(
+            node.getId(),
+            node.getPositionX() + dx,
+            node.getPositionY(),
+            true,
+            false,
+          );
+        });
+      } else if (direction === "vertical") {
+        this.nodeService.getNodes().forEach((node: Node) => {
+          const nodeCenterY = node.getPositionY() + node.getNodeHeight() / 2;
+          const dy = (nodeCenterY <= centerY ? -1 : 1) * sign * delta;
+          this.nodeService.changeNodePositionWithoutUpdate(
+            node.getId(),
+            node.getPositionX(),
+            node.getPositionY() + dy,
+            true,
+            false,
+          );
+        });
+      } else {
+        console.log(`  [skip] ${key}: mixed port directions (${direction})`);
+        return;
+      }
+
+      const action = sign >= 0 ? "stretched" : "shrunk";
+      console.log(`  [${action}] ${key} (${length}px, ${direction}): ${trains.join(", ")}`);
+    });
+
+    this.nodeService.nodesUpdated();
+    this.nodeService.transitionsUpdated();
+    this.trainrunService.trainrunsUpdated();
+    this.trainrunSectionService.trainrunSectionsUpdated();
   }
 }

--- a/src/app/services/util/position.transformation.service.ts
+++ b/src/app/services/util/position.transformation.service.ts
@@ -318,8 +318,8 @@ export class PositionTransformationService {
       );
       const direction = srcDir === tgtDir ? srcDir : `${srcDir}/${tgtDir}`;
       const key = [srcNodeObj.getBetriebspunktName(), tgtNodeObj.getBetriebspunktName()]
-            .sort()
-            .join(" – ");
+        .sort()
+        .join(" – ");
 
       const deficit = MIN_SECTION_LENGTH_PX - length;
       const steps = Math.max(Math.ceil(deficit / (2 * RASTERING_BASIC_GRID_SIZE)), 1);
@@ -413,16 +413,18 @@ export class PositionTransformationService {
       if (!isHorizontal && direction !== "vertical") {
         continue;
       }
-      if ((srcCenter <= center) === (tgtCenter <= center)) {
+      if (srcCenter <= center === tgtCenter <= center) {
         continue;
       }
 
       const currentLength = Vec2D.norm(Vec2D.sub(tgt, src));
-      const allowable = Math.floor(
-        (currentLength - minLength) / 2 / RASTERING_BASIC_GRID_SIZE,
-      ) * RASTERING_BASIC_GRID_SIZE;
+      const allowable =
+        Math.floor((currentLength - minLength) / 2 / RASTERING_BASIC_GRID_SIZE) *
+        RASTERING_BASIC_GRID_SIZE;
       if (allowable < maxDelta) {
-        console.log(`  [limit] edge ${edgeKey} (${Math.round(currentLength)}px) constrains delta to ${allowable}px`);
+        console.log(
+          `  [limit] edge ${edgeKey} (${Math.round(currentLength)}px) constrains delta to ${allowable}px`,
+        );
       }
       maxDelta = Math.min(maxDelta, allowable);
     }

--- a/src/app/view/editor-main-view/data-views/d3.utils.spec.ts
+++ b/src/app/view/editor-main-view/data-views/d3.utils.spec.ts
@@ -132,13 +132,13 @@ describe("3d.Utils.tests", () => {
     );
 
     const positionTransformationService = new PositionTransformationService(
-          trainrunSectionService,
-          trainrunService,
-          nodeService,
-          noteService,
-          uiInteractionService,
-          viewportCullService,
-        );
+      trainrunSectionService,
+      trainrunService,
+      nodeService,
+      noteService,
+      uiInteractionService,
+      viewportCullService,
+    );
 
     const controller = new EditorMainViewComponent(
       nodeService,

--- a/src/app/view/editor-main-view/data-views/d3.utils.spec.ts
+++ b/src/app/view/editor-main-view/data-views/d3.utils.spec.ts
@@ -132,12 +132,13 @@ describe("3d.Utils.tests", () => {
     );
 
     const positionTransformationService = new PositionTransformationService(
-      trainrunSectionService,
-      nodeService,
-      noteService,
-      uiInteractionService,
-      viewportCullService,
-    );
+          trainrunSectionService,
+          trainrunService,
+          nodeService,
+          noteService,
+          uiInteractionService,
+          viewportCullService,
+        );
 
     const controller = new EditorMainViewComponent(
       nodeService,

--- a/src/app/view/editor-main-view/data-views/data.view.spec.ts
+++ b/src/app/view/editor-main-view/data-views/data.view.spec.ts
@@ -137,12 +137,13 @@ describe("Editor-DataView", () => {
     const levelOfDetailService = new LevelOfDetailService(uiInteractionService);
 
     const positionTransformationService = new PositionTransformationService(
-      trainrunSectionService,
-      nodeService,
-      noteService,
-      uiInteractionService,
-      viewportCullService,
-    );
+          trainrunSectionService,
+          trainrunService,
+          nodeService,
+          noteService,
+          uiInteractionService,
+          viewportCullService,
+        );
 
     const controller = new EditorMainViewComponent(
       nodeService,

--- a/src/app/view/editor-main-view/data-views/data.view.spec.ts
+++ b/src/app/view/editor-main-view/data-views/data.view.spec.ts
@@ -137,13 +137,13 @@ describe("Editor-DataView", () => {
     const levelOfDetailService = new LevelOfDetailService(uiInteractionService);
 
     const positionTransformationService = new PositionTransformationService(
-          trainrunSectionService,
-          trainrunService,
-          nodeService,
-          noteService,
-          uiInteractionService,
-          viewportCullService,
-        );
+      trainrunSectionService,
+      trainrunService,
+      nodeService,
+      noteService,
+      uiInteractionService,
+      viewportCullService,
+    );
 
     const controller = new EditorMainViewComponent(
       nodeService,

--- a/src/app/view/editor-main-view/data-views/editor.keyEvents.ts
+++ b/src/app/view/editor-main-view/data-views/editor.keyEvents.ts
@@ -142,7 +142,11 @@ export class EditorKeyEvents {
           }
           break;
         case "KeyI":
-          this.positionTransformationService.stretchShortSections(this.trainrunSectionService.getTrainrunSections());
+          if (shiftKey) {
+            this.positionTransformationService.stretchShortSections(this.trainrunSectionService.getTrainrunSections(), false, -1);
+          } else {
+            this.positionTransformationService.stretchShortSections(this.trainrunSectionService.getTrainrunSections());
+          }
           break;
         case "KeyE":
           if (shiftKey) {

--- a/src/app/view/editor-main-view/data-views/editor.keyEvents.ts
+++ b/src/app/view/editor-main-view/data-views/editor.keyEvents.ts
@@ -143,16 +143,30 @@ export class EditorKeyEvents {
           break;
         case "KeyI":
           if (shiftKey) {
-            this.positionTransformationService.stretchShortSections(this.trainrunSectionService.getTrainrunSections(), false, -1);
+            this.positionTransformationService.stretchShortSections(
+              this.trainrunSectionService.getTrainrunSections(),
+              false,
+              -1,
+            );
           } else {
-            this.positionTransformationService.stretchShortSections(this.trainrunSectionService.getTrainrunSections());
+            this.positionTransformationService.stretchShortSections(
+              this.trainrunSectionService.getTrainrunSections(),
+            );
           }
           break;
         case "KeyE":
           if (shiftKey) {
-            this.positionTransformationService.stretchShortSections(this.getSelectedTrainrunSections(), false, -1);
+            this.positionTransformationService.stretchShortSections(
+              this.getSelectedTrainrunSections(),
+              false,
+              -1,
+            );
           } else {
-            this.positionTransformationService.stretchShortSections(this.getSelectedTrainrunSections(), false, 1);
+            this.positionTransformationService.stretchShortSections(
+              this.getSelectedTrainrunSections(),
+              false,
+              1,
+            );
           }
           break;
         case "ArrowLeft":
@@ -177,7 +191,6 @@ export class EditorKeyEvents {
       }
     });
   }
-
 
   private onKeySPressed() {
     if (this.splitSelectedTrainrunSectionsWithNewNode()) {

--- a/src/app/view/editor-main-view/data-views/editor.keyEvents.ts
+++ b/src/app/view/editor-main-view/data-views/editor.keyEvents.ts
@@ -142,13 +142,13 @@ export class EditorKeyEvents {
           }
           break;
         case "KeyI":
-          this.stretchShortSections(this.trainrunSectionService.getTrainrunSections());
+          this.positionTransformationService.stretchShortSections(this.trainrunSectionService.getTrainrunSections());
           break;
         case "KeyE":
           if (shiftKey) {
-            this.stretchShortSections(this.getSelectedTrainrunSections(), false, -1);
+            this.positionTransformationService.stretchShortSections(this.getSelectedTrainrunSections(), false, -1);
           } else {
-            this.stretchShortSections(this.getSelectedTrainrunSections(), false, 1);
+            this.positionTransformationService.stretchShortSections(this.getSelectedTrainrunSections(), false, 1);
           }
           break;
         case "ArrowLeft":
@@ -174,101 +174,6 @@ export class EditorKeyEvents {
     });
   }
 
-  private stretchShortSections(sections: TrainrunSection[], onlyShort = true, sign = 1): void {
-    const MIN_SECTION_LENGTH_PX = 200;
-    const groups = new Map<
-      string,
-      {
-        trains: string[];
-        length: number;
-        direction: string;
-        centerX: number;
-        centerY: number;
-      }
-    >();
-
-    const toDirection = (a: PortAlignment) =>
-      a === PortAlignment.Left || a === PortAlignment.Right ? "horizontal" : "vertical";
-
-    sections.forEach((section: TrainrunSection) => {
-      if (section.isPathInvalid()) {
-        return;
-      }
-      const src = section.getPositionAtSourceNode();
-      const tgt = section.getPositionAtTargetNode();
-      const length = Vec2D.norm(Vec2D.sub(tgt, src));
-      if (onlyShort && length >= MIN_SECTION_LENGTH_PX) {
-        return;
-      }
-      const srcNodeObj = section.getSourceNode();
-      const tgtNodeObj = section.getTargetNode();
-      const srcDir = toDirection(
-        srcNodeObj.getPort(section.getSourcePortId()).getPositionAlignment(),
-      );
-      const tgtDir = toDirection(
-        tgtNodeObj.getPort(section.getTargetPortId()).getPositionAlignment(),
-      );
-      const direction = srcDir === tgtDir ? srcDir : `${srcDir}/${tgtDir}`;
-      const key = [srcNodeObj.getBetriebspunktName(), tgtNodeObj.getBetriebspunktName()]
-        .sort()
-        .join(" – ");
-      if (!groups.has(key)) {
-        groups.set(key, {
-          trains: [],
-          length: Math.round(length),
-          direction,
-          centerX: (src.getX() + tgt.getX()) / 2,
-          centerY: (src.getY() + tgt.getY()) / 2,
-        });
-      }
-      groups.get(key).trains.push(section.getTrainrun().getTitle());
-    });
-
-    if (groups.size === 0) {
-      console.log("[KeyI/E] No matching sections found.");
-      return;
-    }
-
-    groups.forEach(({trains, length, direction, centerX, centerY}, key) => {
-      const deficit = MIN_SECTION_LENGTH_PX - length;
-      const steps = Math.max(Math.ceil(deficit / (2 * RASTERING_BASIC_GRID_SIZE)), 1);
-      const delta = steps * RASTERING_BASIC_GRID_SIZE;
-
-      if (direction === "horizontal") {
-        this.nodeService.getNodes().forEach((node: Node) => {
-          const nodeCenterX = node.getPositionX() + node.getNodeWidth() / 2;
-          const dx = (nodeCenterX <= centerX ? -1 : 1) * sign * delta;
-          this.nodeService.changeNodePositionWithoutUpdate(
-            node.getId(),
-            node.getPositionX() + dx,
-            node.getPositionY(),
-            true,
-            false,
-          );
-        });
-      } else if (direction === "vertical") {
-        this.nodeService.getNodes().forEach((node: Node) => {
-          const nodeCenterY = node.getPositionY() + node.getNodeHeight() / 2;
-          const dy = (nodeCenterY <= centerY ? -1 : 1) * sign * delta;
-          this.nodeService.changeNodePositionWithoutUpdate(
-            node.getId(),
-            node.getPositionX(),
-            node.getPositionY() + dy,
-            true,
-            false,
-          );
-        });
-      } else {
-        console.log(`  [skip] ${key}: mixed port directions (${direction})`);
-        return;
-      }
-
-      const action = sign >= 0 ? "stretched" : "shrunk";
-      console.log(`  [${action}] ${key} (${length}px, ${direction}): ${trains.join(", ")}`);
-    });
-
-    this.servicesUpdate();
-  }
 
   private onKeySPressed() {
     if (this.splitSelectedTrainrunSectionsWithNewNode()) {

--- a/src/app/view/editor-main-view/data-views/editor.keyEvents.ts
+++ b/src/app/view/editor-main-view/data-views/editor.keyEvents.ts
@@ -157,18 +157,21 @@ export class EditorKeyEvents {
           }
           break;
         case "KeyE":
-          if (shiftKey) {
-            this.positionTransformationService.stretchShortSections(
-              this.getSelectedTrainrunSections(),
-              false,
-              -1,
-            );
-          } else {
-            this.positionTransformationService.stretchShortSections(
-              this.getSelectedTrainrunSections(),
-              false,
-              1,
-            );
+          {
+            const sectionsForE = this.getSectionsForLocalOperation();
+            if (shiftKey) {
+              this.positionTransformationService.stretchShortSections(
+                sectionsForE,
+                false,
+                -1,
+              );
+            } else {
+              this.positionTransformationService.stretchShortSections(
+                sectionsForE,
+                false,
+                1,
+              );
+            }
           }
           break;
         case "ArrowLeft":
@@ -264,6 +267,21 @@ export class EditorKeyEvents {
 
   private getSelectedTrainrunSections(): TrainrunSection[] {
     return this.trainrunSectionService.getAllSelectedTrainrunSections() ?? [];
+  }
+
+  private getSectionsForLocalOperation(): TrainrunSection[] {
+    const selectedSections = this.getSelectedTrainrunSections();
+    if (selectedSections.length > 0) {
+      return selectedSections;
+    }
+    const selectedNodes = this.nodeService.getSelectedNodes();
+    if (selectedNodes.length < 2) {
+      return [];
+    }
+    const nodeIds = new Set(selectedNodes.map((n) => n.getId()));
+    return this.trainrunSectionService.getTrainrunSections().filter(
+      (ts) => nodeIds.has(ts.getSourceNode().getId()) && nodeIds.has(ts.getTargetNode().getId()),
+    );
   }
 
   private groupSectionsByNodePairs(sections: TrainrunSection[]): Map<string, TrainrunSection[]> {

--- a/src/app/view/editor-main-view/data-views/editor.keyEvents.ts
+++ b/src/app/view/editor-main-view/data-views/editor.keyEvents.ts
@@ -145,13 +145,14 @@ export class EditorKeyEvents {
           if (shiftKey) {
             this.positionTransformationService.stretchShortSections(
               this.trainrunSectionService.getTrainrunSections(),
-              false,
-              -1,
               true,
+              -1,
             );
           } else {
             this.positionTransformationService.stretchShortSections(
               this.trainrunSectionService.getTrainrunSections(),
+              true,
+              1,
             );
           }
           break;

--- a/src/app/view/editor-main-view/data-views/editor.keyEvents.ts
+++ b/src/app/view/editor-main-view/data-views/editor.keyEvents.ts
@@ -26,6 +26,7 @@ import {TrainrunSection} from "../../../models/trainrunsection.model";
 import {Trainrun} from "../../../models/trainrun.model";
 import {PositionTransformationService} from "../../../services/util/position.transformation.service";
 import {Vec2D} from "../../../utils/vec2D";
+import {PortAlignment} from "../../../data-structures/technical.data.structures";
 import {TrainrunSectionViewObject} from "./trainrunSectionViewObject";
 import {NoteViewObject} from "./noteViewObject";
 import {NodeViewObject} from "./nodeViewObject";
@@ -82,6 +83,7 @@ export class EditorKeyEvents {
 
       const keycode = d3.event.code;
       const ctrlKey = d3.event.ctrlKey;
+      const shiftKey = d3.event.shiftKey;
       switch (keycode) {
         case "Delete":
           this.onKeyPressedDelete();
@@ -133,9 +135,20 @@ export class EditorKeyEvents {
           }
           break;
         case "KeyD":
+          console.log("KeyD pressed");
           if (ctrlKey) {
             this.onDuplicate();
             d3.event.preventDefault();
+          }
+          break;
+        case "KeyI":
+          this.stretchShortSections(this.trainrunSectionService.getTrainrunSections());
+          break;
+        case "KeyE":
+          if (shiftKey) {
+            this.stretchShortSections(this.getSelectedTrainrunSections(), false, -1);
+          } else {
+            this.stretchShortSections(this.getSelectedTrainrunSections(), false, 1);
           }
           break;
         case "ArrowLeft":
@@ -159,6 +172,102 @@ export class EditorKeyEvents {
           break;
       }
     });
+  }
+
+  private stretchShortSections(sections: TrainrunSection[], onlyShort = true, sign = 1): void {
+    const MIN_SECTION_LENGTH_PX = 200;
+    const groups = new Map<
+      string,
+      {
+        trains: string[];
+        length: number;
+        direction: string;
+        centerX: number;
+        centerY: number;
+      }
+    >();
+
+    const toDirection = (a: PortAlignment) =>
+      a === PortAlignment.Left || a === PortAlignment.Right ? "horizontal" : "vertical";
+
+    sections.forEach((section: TrainrunSection) => {
+      if (section.isPathInvalid()) {
+        return;
+      }
+      const src = section.getPositionAtSourceNode();
+      const tgt = section.getPositionAtTargetNode();
+      const length = Vec2D.norm(Vec2D.sub(tgt, src));
+      if (onlyShort && length >= MIN_SECTION_LENGTH_PX) {
+        return;
+      }
+      const srcNodeObj = section.getSourceNode();
+      const tgtNodeObj = section.getTargetNode();
+      const srcDir = toDirection(
+        srcNodeObj.getPort(section.getSourcePortId()).getPositionAlignment(),
+      );
+      const tgtDir = toDirection(
+        tgtNodeObj.getPort(section.getTargetPortId()).getPositionAlignment(),
+      );
+      const direction = srcDir === tgtDir ? srcDir : `${srcDir}/${tgtDir}`;
+      const key = [srcNodeObj.getBetriebspunktName(), tgtNodeObj.getBetriebspunktName()]
+        .sort()
+        .join(" – ");
+      if (!groups.has(key)) {
+        groups.set(key, {
+          trains: [],
+          length: Math.round(length),
+          direction,
+          centerX: (src.getX() + tgt.getX()) / 2,
+          centerY: (src.getY() + tgt.getY()) / 2,
+        });
+      }
+      groups.get(key).trains.push(section.getTrainrun().getTitle());
+    });
+
+    if (groups.size === 0) {
+      console.log("[KeyI/E] No matching sections found.");
+      return;
+    }
+
+    groups.forEach(({trains, length, direction, centerX, centerY}, key) => {
+      const deficit = MIN_SECTION_LENGTH_PX - length;
+      const steps = Math.max(Math.ceil(deficit / (2 * RASTERING_BASIC_GRID_SIZE)), 1);
+      const delta = steps * RASTERING_BASIC_GRID_SIZE;
+
+      if (direction === "horizontal") {
+        this.nodeService.getNodes().forEach((node: Node) => {
+          const nodeCenterX = node.getPositionX() + node.getNodeWidth() / 2;
+          const dx = (nodeCenterX <= centerX ? -1 : 1) * sign * delta;
+          this.nodeService.changeNodePositionWithoutUpdate(
+            node.getId(),
+            node.getPositionX() + dx,
+            node.getPositionY(),
+            true,
+            false,
+          );
+        });
+      } else if (direction === "vertical") {
+        this.nodeService.getNodes().forEach((node: Node) => {
+          const nodeCenterY = node.getPositionY() + node.getNodeHeight() / 2;
+          const dy = (nodeCenterY <= centerY ? -1 : 1) * sign * delta;
+          this.nodeService.changeNodePositionWithoutUpdate(
+            node.getId(),
+            node.getPositionX(),
+            node.getPositionY() + dy,
+            true,
+            false,
+          );
+        });
+      } else {
+        console.log(`  [skip] ${key}: mixed port directions (${direction})`);
+        return;
+      }
+
+      const action = sign >= 0 ? "stretched" : "shrunk";
+      console.log(`  [${action}] ${key} (${length}px, ${direction}): ${trains.join(", ")}`);
+    });
+
+    this.servicesUpdate();
   }
 
   private onKeySPressed() {

--- a/src/app/view/editor-main-view/data-views/editor.keyEvents.ts
+++ b/src/app/view/editor-main-view/data-views/editor.keyEvents.ts
@@ -147,6 +147,7 @@ export class EditorKeyEvents {
               this.trainrunSectionService.getTrainrunSections(),
               false,
               -1,
+              true,
             );
           } else {
             this.positionTransformationService.stretchShortSections(

--- a/src/app/view/editor-main-view/data-views/nodes.view.spec.ts
+++ b/src/app/view/editor-main-view/data-views/nodes.view.spec.ts
@@ -132,12 +132,13 @@ describe("Nodes-View", () => {
     );
 
     const positionTransformationService = new PositionTransformationService(
-      trainrunSectionService,
-      nodeService,
-      noteService,
-      uiInteractionService,
-      viewportCullService,
-    );
+          trainrunSectionService,
+          trainrunService,
+          nodeService,
+          noteService,
+          uiInteractionService,
+          viewportCullService,
+        );
 
     const controller = new EditorMainViewComponent(
       nodeService,

--- a/src/app/view/editor-main-view/data-views/nodes.view.spec.ts
+++ b/src/app/view/editor-main-view/data-views/nodes.view.spec.ts
@@ -132,13 +132,13 @@ describe("Nodes-View", () => {
     );
 
     const positionTransformationService = new PositionTransformationService(
-          trainrunSectionService,
-          trainrunService,
-          nodeService,
-          noteService,
-          uiInteractionService,
-          viewportCullService,
-        );
+      trainrunSectionService,
+      trainrunService,
+      nodeService,
+      noteService,
+      uiInteractionService,
+      viewportCullService,
+    );
 
     const controller = new EditorMainViewComponent(
       nodeService,

--- a/src/app/view/editor-main-view/data-views/notes.view.spec.ts
+++ b/src/app/view/editor-main-view/data-views/notes.view.spec.ts
@@ -132,13 +132,13 @@ describe("Notes-View", () => {
     );
 
     const positionTransformationService = new PositionTransformationService(
-          trainrunSectionService,
-          trainrunService,
-          nodeService,
-          noteService,
-          uiInteractionService,
-          viewportCullService,
-        );
+      trainrunSectionService,
+      trainrunService,
+      nodeService,
+      noteService,
+      uiInteractionService,
+      viewportCullService,
+    );
 
     const controller = new EditorMainViewComponent(
       nodeService,

--- a/src/app/view/editor-main-view/data-views/notes.view.spec.ts
+++ b/src/app/view/editor-main-view/data-views/notes.view.spec.ts
@@ -132,12 +132,13 @@ describe("Notes-View", () => {
     );
 
     const positionTransformationService = new PositionTransformationService(
-      trainrunSectionService,
-      nodeService,
-      noteService,
-      uiInteractionService,
-      viewportCullService,
-    );
+          trainrunSectionService,
+          trainrunService,
+          nodeService,
+          noteService,
+          uiInteractionService,
+          viewportCullService,
+        );
 
     const controller = new EditorMainViewComponent(
       nodeService,

--- a/src/app/view/editor-main-view/data-views/trainrunsections.view.spec.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunsections.view.spec.ts
@@ -134,13 +134,13 @@ describe("TrainrunSection-View", () => {
     );
 
     const positionTransformationService = new PositionTransformationService(
-          trainrunSectionService,
-          trainrunService,
-          nodeService,
-          noteService,
-          uiInteractionService,
-          viewportCullService,
-        );
+      trainrunSectionService,
+      trainrunService,
+      nodeService,
+      noteService,
+      uiInteractionService,
+      viewportCullService,
+    );
 
     const controller = new EditorMainViewComponent(
       nodeService,

--- a/src/app/view/editor-main-view/data-views/trainrunsections.view.spec.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunsections.view.spec.ts
@@ -134,12 +134,13 @@ describe("TrainrunSection-View", () => {
     );
 
     const positionTransformationService = new PositionTransformationService(
-      trainrunSectionService,
-      nodeService,
-      noteService,
-      uiInteractionService,
-      viewportCullService,
-    );
+          trainrunSectionService,
+          trainrunService,
+          nodeService,
+          noteService,
+          uiInteractionService,
+          viewportCullService,
+        );
 
     const controller = new EditorMainViewComponent(
       nodeService,

--- a/src/app/view/editor-main-view/data-views/transitions.view.spec.ts
+++ b/src/app/view/editor-main-view/data-views/transitions.view.spec.ts
@@ -132,13 +132,13 @@ describe("Transitions-View", () => {
     );
 
     const positionTransformationService = new PositionTransformationService(
-          trainrunSectionService,
-          trainrunService,
-          nodeService,
-          noteService,
-          uiInteractionService,
-          viewportCullService,
-        );
+      trainrunSectionService,
+      trainrunService,
+      nodeService,
+      noteService,
+      uiInteractionService,
+      viewportCullService,
+    );
 
     const controller = new EditorMainViewComponent(
       nodeService,

--- a/src/app/view/editor-main-view/data-views/transitions.view.spec.ts
+++ b/src/app/view/editor-main-view/data-views/transitions.view.spec.ts
@@ -132,12 +132,13 @@ describe("Transitions-View", () => {
     );
 
     const positionTransformationService = new PositionTransformationService(
-      trainrunSectionService,
-      nodeService,
-      noteService,
-      uiInteractionService,
-      viewportCullService,
-    );
+          trainrunSectionService,
+          trainrunService,
+          nodeService,
+          noteService,
+          uiInteractionService,
+          viewportCullService,
+        );
 
     const controller = new EditorMainViewComponent(
       nodeService,


### PR DESCRIPTION
In this PR, we've introduced a new algorithm for shrinking and stretching of train sections. You can select specific sections to shrink or stretch. Alternatively there is the option to optimize the whole graph by stretching sections that are below a minimum length or shrink the graph as much as possible.

To stretch or shrink a selection of sections:
1. Select the sections or nodes
2. Press "e" (expand) on the keyboard, for shrinking press "Shift" + "E"

To stretch or shrink the whole graph:
1. Press "i" for expanding the whole graph, for shrinking press "Shift" + "I"

It's especially useful for adding new stops which don't fit into the graph. Instead of moving around all nodes, this automatically stretches the whole graph.

In this PR, there is the assumption of a fixed section size, which doesn't work with long train names. However, there is the follow-up task https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/pull/1166 that solves it and integrates with this PR.


https://github.com/user-attachments/assets/5142d2f2-033d-43e6-b7f2-615fb4fa46d0