### PR TITLE
fix: orders transition & free-end ports separately

### DIFF
--- a/src/app/services/util/port-ordering.algo.spec.ts
+++ b/src/app/services/util/port-ordering.algo.spec.ts
@@ -209,32 +209,42 @@ describe("port-ordering", () => {
         expect(groupCrossings).toEqual([]);
       });
     });
-  });
 
-  // Minimal reproduction: two parallel trains turning a 90° corner at HUB,
-  // whose downstream neighbor (MID) is a pass-through continuing to END.
-  // Tested in the 4 corner orientations.
-  describe("Minimal test case", () => {
-    const corners = [
-      {name: "top > right (NE)", arm: {x: 0, y: -100}, mid: {x: 100, y: 0}, end: {x: 200, y: 0}},
-      {name: "right > bottom (SE)", arm: {x: 100, y: 0}, mid: {x: 0, y: 100}, end: {x: 0, y: 200}},
-      {name: "bottom > left (SW)", arm: {x: 0, y: 100}, mid: {x: -100, y: 0}, end: {x: -200, y: 0}},
-      {name: "left > top (NW)", arm: {x: -100, y: 0}, mid: {x: 0, y: -100}, end: {x: 0, y: -200}},
-    ];
+    // Minimal reproduction: two parallel trains turning a 90° corner at HUB,
+    // whose downstream neighbor (MID) is a pass-through continuing to END.
+    // Tested in the 4 corner orientations.
+    describe("Minimal test case", () => {
+      const corners = [
+        {name: "top > right (NE)", arm: {x: 0, y: -100}, mid: {x: 100, y: 0}, end: {x: 200, y: 0}},
+        {
+          name: "right > bottom (SE)",
+          arm: {x: 100, y: 0},
+          mid: {x: 0, y: 100},
+          end: {x: 0, y: 200},
+        },
+        {
+          name: "bottom > left (SW)",
+          arm: {x: 0, y: 100},
+          mid: {x: -100, y: 0},
+          end: {x: -200, y: 0},
+        },
+        {name: "left > top (NW)", arm: {x: -100, y: 0}, mid: {x: 0, y: -100}, end: {x: 0, y: -200}},
+      ];
 
-    corners.forEach(({name, arm, mid, end}) => {
-      it(`should not produce crossings (${name})`, () => {
-        const {nodesArray} = buildNetwork({
-          nodes: {ARM: arm, HUB: {x: 0, y: 0}, MID: mid, END: end},
-          trainruns: [
-            ["ARM", "HUB", "MID", "END"],
-            ["ARM", "HUB", "MID", "END"],
-          ],
+      corners.forEach(({name, arm, mid, end}) => {
+        it(`should not produce crossings (${name})`, () => {
+          const {nodesArray} = buildNetwork({
+            nodes: {ARM: arm, HUB: {x: 0, y: 0}, MID: mid, END: end},
+            trainruns: [
+              ["ARM", "HUB", "MID", "END"],
+              ["ARM", "HUB", "MID", "END"],
+            ],
+          });
+
+          optimizePorts(nodesArray);
+
+          expect(countAllCrossings(nodesArray).crossings).toBe(0);
         });
-
-        optimizePorts(nodesArray);
-
-        expect(countAllCrossings(nodesArray).crossings).toBe(0);
       });
     });
   });

--- a/src/app/services/util/port-ordering.algo.spec.ts
+++ b/src/app/services/util/port-ordering.algo.spec.ts
@@ -248,4 +248,74 @@ describe("port-ordering", () => {
       });
     });
   });
+
+  // The ticket reports two distinct crossings.
+  // The following tests each represent one crossing from the ticket, in a
+  // minimal reticular:
+  describe("Regression #1159", () => {
+    describe("Crossing n°1", () => {
+      const nodes = {
+        LEFT: {x: -1000, y: 0},
+        MID: {x: -500, y: 0},
+        CORNER: {x: 0, y: 0},
+        DOWN_MID: {x: 0, y: 500},
+        HUB: {x: 0, y: 1000},
+        HUB_LEFT: {x: -500, y: 1000},
+        HUB_END: {x: 0, y: 1500},
+      };
+
+      it("is crossing-free", () => {
+        const {nodesArray} = buildNetwork({
+          nodes,
+          trainruns: [
+            ["HUB_LEFT", "HUB"],
+            ["HUB", "DOWN_MID", "CORNER", "MID", "LEFT"],
+            ["LEFT", "MID", "CORNER"],
+            ["LEFT", "MID", "CORNER", "DOWN_MID", "HUB", "HUB_END"],
+          ],
+        });
+
+        optimizePorts(nodesArray);
+
+        const {crossings, groupCrossings} = countAllCrossings(nodesArray);
+        expect(crossings).toBe(0);
+        expect(groupCrossings).toEqual([]);
+      });
+    });
+
+    // This test seems to be order-dependant right now, so here are two cases:
+    // one with an order that breaks, one with an order that does not
+    describe("Crossing n°2", () => {
+      const nodes = {
+        LEFT: {x: -500, y: 0},
+        MID: {x: -250, y: 0},
+        FORK: {x: 0, y: 0},
+        RIGHT_TOP: {x: 250, y: -200},
+        RIGHT_BOTTOM: {x: 250, y: 200},
+      };
+      const toBottom = ["LEFT", "MID", "FORK", "RIGHT_BOTTOM"];
+      const toTop = ["MID", "FORK", "RIGHT_TOP"];
+      const forkToTop = ["FORK", "RIGHT_TOP"];
+      const terminating = ["LEFT", "MID", "FORK"];
+
+      // Same network, varying only the position of the terminating trainrun
+      // (LEFT -> FORK) in the declaration order.
+      const orders = {
+        last: [toBottom, toTop, forkToTop, terminating],
+        early: [toBottom, terminating, toTop, forkToTop],
+      };
+
+      Object.entries(orders).forEach(([name, trainruns]) => {
+        it(`is crossing-free with terminating trainrun declared ${name}`, () => {
+          const {nodesArray} = buildNetwork({nodes, trainruns});
+
+          optimizePorts(nodesArray);
+
+          const {crossings, groupCrossings} = countAllCrossings(nodesArray);
+          expect(crossings).toBe(0);
+          expect(groupCrossings).toEqual([]);
+        });
+      });
+    });
+  });
 });

--- a/src/app/services/util/port-ordering.algo.ts
+++ b/src/app/services/util/port-ordering.algo.ts
@@ -1,4 +1,5 @@
 import {Node} from "../../models/node.model";
+import {Port} from "../../models/port.model";
 import {PortAlignment} from "../../data-structures/technical.data.structures";
 import {Transition} from "../../models/transition.model";
 import {countAllCrossings} from "./port-ordering.crossings";
@@ -186,7 +187,7 @@ export function reorderNodePorts(
   processingOrder.forEach((alignment) => {
     const sidePorts = ports.filter((port) => port.getPositionAlignment() === alignment);
 
-    sidePorts.sort((a, b) => {
+    const compare = (a: Port, b: Port) => {
       const aTransition = portTransitions.get(a.getId());
       const bTransition = portTransitions.get(b.getId());
 
@@ -262,10 +263,23 @@ export function reorderNodePorts(
 
         return (aScore - bScore) * swap;
       }
+    };
+
+    // Transitions are ordered by geometry, free ends only by a tie-break score. Mixing both scales
+    // in a single sort can contradict itself and flip two transitions (which would cross inside the
+    // node), so we sort each kind separately, then insert the free end into the ordered transition
+    const hasTransition = (p: Port) => portTransitions.has(p.getId());
+    const transitionPorts = sidePorts.filter(hasTransition).sort(compare);
+    const freeEndPorts = sidePorts.filter((p) => !hasTransition(p)).sort(compare);
+
+    // Insert each free end before the first transition it should precede (or last if there is none)
+    freeEndPorts.forEach((freeEnd) => {
+      const at = transitionPorts.findIndex((p) => compare(freeEnd, p) < 0);
+      transitionPorts.splice(at === -1 ? transitionPorts.length : at, 0, freeEnd);
     });
 
-    // Apply new order:
-    sidePorts.forEach((port, i) => port.setPositionIndex(i));
+    // Apply new order
+    transitionPorts.forEach((port, i) => port.setPositionIndex(i));
 
     orderedSides.add(alignment);
   });


### PR DESCRIPTION
This fixes #1159.

There are three commits:

- One fixes the indentation of the previous regression tests from #1144 
- One adds two regression tests, one per crossing described in the issue #1159, each reduced to a minimal reticular
- One fixes the code so that the tests pass

The issue was that ports without a transition (free-ends) were sorted by the same comparator as transitions, mixing geometry with the tie-break score (case `4b` in the code) into a non-transitive order. That could flip two transitions and make them cross inside the node.

The fix orders transitions by geometry first, then inserts each free-end into that order, so a free end can never flip two transitions.