### PR TITLE
feat: add distance service to check the length needed between two nodes

### DIFF
--- a/src/app/services/util/position.transformation.service.spec.ts
+++ b/src/app/services/util/position.transformation.service.spec.ts
@@ -19,6 +19,7 @@ import {NetzgrafikUnitTesting} from "../../../integration-testing/netzgrafik.uni
 import {ViewportCullService} from "../../services/ui/viewport.cull.service";
 import {PositionTransformationService} from "./position.transformation.service";
 import {Vec2D} from "../../utils/vec2D";
+import {TrainrunDistanceService} from "./trainrun-distance.service";
 
 describe("PositionTransformationService", () => {
   let dataService: DataService;
@@ -103,6 +104,8 @@ describe("PositionTransformationService", () => {
       trainrunSectionService,
     );
 
+    const trainrunDistanceService = new TrainrunDistanceService();
+
     positionTransformationService = new PositionTransformationService(
       trainrunSectionService,
       trainrunService,
@@ -110,6 +113,7 @@ describe("PositionTransformationService", () => {
       noteService,
       uiInteractionService,
       viewportCullService,
+      trainrunDistanceService,
     );
   });
 

--- a/src/app/services/util/position.transformation.service.ts
+++ b/src/app/services/util/position.transformation.service.ts
@@ -12,6 +12,7 @@ import {Note} from "../../models/note.model";
 import {TrainrunSection} from "../../models/trainrunsection.model";
 import {PortAlignment} from "../../data-structures/technical.data.structures";
 import {RASTERING_BASIC_GRID_SIZE} from "../../view/rastering/definitions";
+import {TrainrunDistanceService} from "./trainrun-distance.service";
 
 @Injectable({
   providedIn: "root",
@@ -24,6 +25,7 @@ export class PositionTransformationService {
     private readonly noteService: NoteService,
     private readonly uiInteractionService: UiInteractionService,
     private readonly viewportCullService: ViewportCullService,
+    private readonly trainrunDistanceService: TrainrunDistanceService,
   ) {}
   readonly operation = new EventEmitter<Operation>();
 
@@ -297,20 +299,20 @@ export class PositionTransformationService {
     runGlobally = true,
     sign = 1,
   ): void {
-    const MIN_SECTION_LENGTH_PX = 200;
-
     const toDirection = (a: PortAlignment) =>
       a === PortAlignment.Left || a === PortAlignment.Right ? "horizontal" : "vertical";
 
     const processed = !(runGlobally && sign >= 0) ? new Set<string>() : null;
     sections.forEach((section: TrainrunSection) => {
+      const minSectionLengthPx = this.trainrunDistanceService.getMinSectionLengthInPx(section);
+
       if (section.isPathInvalid()) {
         return;
       }
       const src = section.getPositionAtSourceNode();
       const tgt = section.getPositionAtTargetNode();
       const length = Vec2D.norm(Vec2D.sub(tgt, src));
-      if (runGlobally && sign >= 0 && length >= MIN_SECTION_LENGTH_PX) {
+      if (runGlobally && sign >= 0 && length >= minSectionLengthPx) {
         return;
       }
       const srcNodeObj = section.getSourceNode();
@@ -331,7 +333,7 @@ export class PositionTransformationService {
       }
       processed?.add(key);
 
-      const deficit = MIN_SECTION_LENGTH_PX - length;
+      const deficit = minSectionLengthPx - length;
       const steps = Math.max(Math.ceil(deficit / (2 * RASTERING_BASIC_GRID_SIZE)), 1);
       let delta =
         sign < 0 && runGlobally ? Number.MAX_SAFE_INTEGER : steps * RASTERING_BASIC_GRID_SIZE;
@@ -345,7 +347,7 @@ export class PositionTransformationService {
           direction,
           centerX,
           centerY,
-          MIN_SECTION_LENGTH_PX,
+          minSectionLengthPx,
         );
         if (delta <= 0) {
           console.log(`  [skip] ${key}: cannot shrink without violating minimum edge length`);

--- a/src/app/services/util/trainrun-distance.service.spec.ts
+++ b/src/app/services/util/trainrun-distance.service.spec.ts
@@ -1,0 +1,243 @@
+import {TrainrunDistanceService} from "./trainrun-distance.service";
+import {TrainrunSection} from "../../models/trainrunsection.model";
+import {Node} from "../../models/node.model";
+import {PortAlignment} from "../../data-structures/technical.data.structures";
+import {Vec2D} from "../../utils/vec2D";
+
+describe("TrainrunDistanceService", () => {
+  let service: TrainrunDistanceService;
+  let measureTextWidthSpy: jasmine.Spy;
+
+  const mockPort = (overrides: any = {}) => ({
+    getId: () => 1,
+    getTrainrunSectionId: () => 100,
+    getPositionAlignment: () => PortAlignment.Left,
+    getTrainrunSection: () => undefined,
+    ...overrides,
+  });
+
+  const mockNode = (ports: any[] = [], isNonStop = false): Node =>
+    ({
+      getPorts: () => ports,
+      isNonStop: () => isNonStop,
+    }) as unknown as Node;
+
+  const mockSourceNode = (
+    sectionId = 100,
+    alignment: PortAlignment = PortAlignment.Left,
+    isNonStop = false,
+  ): Node =>
+    mockNode(
+      [
+        mockPort({
+          getTrainrunSectionId: () => sectionId,
+          getPositionAlignment: () => alignment,
+        }),
+      ],
+      isNonStop,
+    );
+
+  const mockSection = (overrides: any = {}): TrainrunSection => {
+    const defaults = {
+      id: 100,
+      trainrunId: 10,
+      path: [new Vec2D(0, 0), new Vec2D(1000, 0)],
+      categoryShortName: "IC",
+      title: "1",
+      travelTime: 30,
+      sourceDeparture: 0,
+      targetArrival: 30,
+      sourceAlignment: PortAlignment.Left,
+      sourceIsNonStop: false,
+      targetIsNonStop: false,
+      sourceNode: undefined,
+      targetNode: undefined,
+      targetPortId: 2,
+    };
+
+    const o = {...defaults, ...overrides};
+
+    const sourceNode = o.sourceNode ?? mockSourceNode(o.id, o.sourceAlignment, o.sourceIsNonStop);
+
+    const targetNode = o.targetNode ?? mockNode([], o.targetIsNonStop);
+
+    return {
+      getId: () => o.id,
+      getPath: () => o.path,
+      getTrainrun: () => ({
+        getCategoryShortName: () => o.categoryShortName,
+        getTitle: () => o.title,
+      }),
+      getTrainrunId: () => o.trainrunId,
+      getTravelTime: () => o.travelTime,
+      getSourceDeparture: () => o.sourceDeparture,
+      getTargetArrival: () => o.targetArrival,
+      getSourceNode: () => sourceNode,
+      getTargetNode: () => targetNode,
+      getTargetPortId: () => o.targetPortId,
+    } as unknown as TrainrunSection;
+  };
+
+  beforeEach(() => {
+    service = new TrainrunDistanceService();
+
+    measureTextWidthSpy = spyOn<any>(service, "measureTextWidth").and.callFake(
+      (text: string) => text.length,
+    );
+  });
+
+  it("should be created", () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe("getMinSectionLengthInPx", () => {
+    it("is based on the measured text width of category, title, travel time and timings", () => {
+      const section = mockSection();
+
+      service.getMinSectionLengthInPx(section);
+
+      expect(measureTextWidthSpy).toHaveBeenCalledOnceWith("IC1'30030");
+    });
+
+    it("returns a strictly positive number", () => {
+      const section = mockSection();
+      expect(service.getMinSectionLengthInPx(section)).toBeGreaterThan(0);
+    });
+
+    it("scales linearly with the measured text width", () => {
+      // Two sections that only differ in the length of their title => only the
+      // measured text differs. The relationship between their results must be
+      // linear (textWidth * factor + margin).
+      const shortSection = mockSection({title: "1"});
+      const longSection = mockSection({title: "1234567890"});
+
+      const shortLen = service.getMinSectionLengthInPx(shortSection);
+      const longLen = service.getMinSectionLengthInPx(longSection);
+
+      // Difference must equal exactly the difference in measured text width
+      // multiplied by the (unknown) factor. We just check it's >0 and stable.
+      expect(longLen).toBeGreaterThan(shortLen);
+
+      // A third data point lets us verify linearity without knowing constants.
+      const mediumSection = mockSection({title: "12345"});
+      const mediumLen = service.getMinSectionLengthInPx(mediumSection);
+
+      const factorA = (longLen - shortLen) / ("1234567890".length - "1".length);
+      const factorB = (mediumLen - shortLen) / ("12345".length - "1".length);
+      expect(factorA).toBeCloseTo(factorB, 6);
+    });
+
+    it("does not use the path length", () => {
+      const shortPathSection = mockSection({
+        path: [new Vec2D(0, 0), new Vec2D(50, 0)],
+      });
+      const longPathSection = mockSection({
+        path: [new Vec2D(0, 0), new Vec2D(10000, 0)],
+      });
+
+      expect(service.getMinSectionLengthInPx(shortPathSection)).toBe(
+        service.getMinSectionLengthInPx(longPathSection),
+      );
+    });
+  });
+
+  describe("port alignment", () => {
+    const longTimeSection = (alignment: PortAlignment) =>
+      mockSection({
+        sourceAlignment: alignment,
+        sourceDeparture: 123456789012345,
+        targetArrival: 123456789012345,
+      });
+
+    it("treats Top and Bottom as vertical (same result for both)", () => {
+      const top = service.getMinSectionLengthInPx(longTimeSection(PortAlignment.Top));
+      const bottom = service.getMinSectionLengthInPx(longTimeSection(PortAlignment.Bottom));
+      expect(top).toBe(bottom);
+    });
+
+    it("treats Left and Right as horizontal (same result for both)", () => {
+      const left = service.getMinSectionLengthInPx(longTimeSection(PortAlignment.Left));
+      const right = service.getMinSectionLengthInPx(longTimeSection(PortAlignment.Right));
+      expect(left).toBe(right);
+    });
+
+    it("includes departure and arrival times in measured text for horizontal alignment", () => {
+      service.getMinSectionLengthInPx(longTimeSection(PortAlignment.Left));
+      expect(measureTextWidthSpy).toHaveBeenCalledOnceWith(
+        `IC1'30${123456789012345}${123456789012345}`,
+      );
+    });
+
+    it("excludes departure and arrival times from measured text for vertical alignment", () => {
+      service.getMinSectionLengthInPx(longTimeSection(PortAlignment.Top));
+      expect(measureTextWidthSpy).toHaveBeenCalledOnceWith("IC1'30");
+    });
+
+    it("makes horizontal sections (with long times) longer than vertical ones", () => {
+      // For long source/target times the horizontal variant must produce a
+      // larger min length because the times contribute to the measured text.
+      const horizontal = service.getMinSectionLengthInPx(longTimeSection(PortAlignment.Left));
+      const vertical = service.getMinSectionLengthInPx(longTimeSection(PortAlignment.Top));
+      expect(horizontal).toBeGreaterThan(vertical);
+    });
+  });
+
+  describe("non-stop handling", () => {
+    it("excludes target arrival from horizontal text when target is non-stop and adds parentheses", () => {
+      const common = {
+        sourceDeparture: 123456789012345,
+        targetArrival: 123456789012345,
+      };
+
+      const stopSection = mockSection({
+        ...common,
+        targetNode: mockNode([], false),
+      });
+
+      const nonStopSection = mockSection({
+        ...common,
+        targetNode: mockNode([], true),
+      });
+
+      service.getMinSectionLengthInPx(stopSection);
+      expect(measureTextWidthSpy).toHaveBeenCalledOnceWith(
+        `IC1'30${123456789012345}${123456789012345}`,
+      );
+
+      measureTextWidthSpy.calls.reset();
+
+      service.getMinSectionLengthInPx(nonStopSection);
+      expect(measureTextWidthSpy).toHaveBeenCalledOnceWith(`IC1'30${123456789012345}()`);
+
+      // And the resulting min length must be smaller for the non-stop case
+      // (less text to fit).
+      expect(service.getMinSectionLengthInPx(nonStopSection)).toBeLessThan(
+        service.getMinSectionLengthInPx(stopSection),
+      );
+    });
+
+    it("adds parentheses and calculated travel time when source is non-stop and target is not", () => {
+      const section = mockSection({
+        sourceDeparture: 123456789012345,
+        targetArrival: 123456789012345,
+        sourceNode: mockSourceNode(100, PortAlignment.Left, true),
+        targetNode: mockNode([], false),
+        travelTime: 30,
+      });
+
+      service.getMinSectionLengthInPx(section);
+
+      expect(measureTextWidthSpy).toHaveBeenCalledOnceWith(
+        `IC1'30${123456789012345}${123456789012345}()(30)`,
+      );
+    });
+
+    it("handles a target non-stop node without throwing", () => {
+      const section = mockSection({
+        targetNode: mockNode([], true),
+      });
+
+      expect(() => service.getMinSectionLengthInPx(section)).not.toThrow();
+    });
+  });
+});

--- a/src/app/services/util/trainrun-distance.service.ts
+++ b/src/app/services/util/trainrun-distance.service.ts
@@ -3,7 +3,6 @@ import {TrainrunSection} from "../../models/trainrunsection.model";
 import {PortAlignment} from "../../data-structures/technical.data.structures";
 
 const FONT = "16px Arial";
-const VERTICAL_ADDITION = 2;
 const MARGIN_CONSTANT = 100;
 const MULTIPLICATION_FACTOR_DUE_TO_ALIGNMENT = 1.9;
 
@@ -48,7 +47,8 @@ export class TrainrunDistanceService {
 
     value += "'" + trainrunSection.getTravelTime().toString();
     if (isVertical) {
-      length += VERTICAL_ADDITION + (isTargetNonStop ? 0 : VERTICAL_ADDITION);
+      const height = this.measureTextHeight("09");
+      length += height + (isTargetNonStop ? 0 : height);
     } else {
       value +=
         trainrunSection.getSourceDeparture().toString() +
@@ -67,6 +67,10 @@ export class TrainrunDistanceService {
   }
 
   private calculateTravelTime(trainrunSection: TrainrunSection): number {
+    if (!trainrunSection) {
+      return 0;
+    }
+
     const travelTime = trainrunSection.getTravelTime();
     if (!trainrunSection.getTargetNode().isNonStop(trainrunSection)) {
       return travelTime;
@@ -92,5 +96,24 @@ export class TrainrunDistanceService {
   private measureTextWidth(text: string): number {
     const ctx = this.canvas.getContext("2d");
     return ctx.measureText(text).width;
+  }
+
+  private measureTextHeight(text: string): number {
+    const ctx = this.canvas.getContext("2d");
+    const metrics = ctx.measureText(text);
+
+    const actualHeight =
+      (metrics.actualBoundingBoxAscent ?? 0) + (metrics.actualBoundingBoxDescent ?? 0);
+    if (actualHeight > 0) {
+      return actualHeight;
+    }
+
+    const fontHeight = (metrics.fontBoundingBoxAscent ?? 0) + (metrics.fontBoundingBoxDescent ?? 0);
+    if (fontHeight > 0) {
+      return fontHeight;
+    }
+
+    const fontSize = Number.parseFloat(FONT);
+    return Number.isFinite(fontSize) ? fontSize : 16;
   }
 }

--- a/src/app/services/util/trainrun-distance.service.ts
+++ b/src/app/services/util/trainrun-distance.service.ts
@@ -4,8 +4,8 @@ import {PortAlignment} from "../../data-structures/technical.data.structures";
 
 const FONT = "16px Arial";
 const VERTICAL_ADDITION = 2;
-const MARGIN_CONSTANT = 50;
-const MULTIPLICATION_FACTOR_DUE_TO_ALIGNMENT = 2;
+const MARGIN_CONSTANT = 100;
+const MULTIPLICATION_FACTOR_DUE_TO_ALIGNMENT = 1.9;
 
 @Injectable({
   providedIn: "root",

--- a/src/app/services/util/trainrun-distance.service.ts
+++ b/src/app/services/util/trainrun-distance.service.ts
@@ -1,0 +1,96 @@
+import {Injectable} from "@angular/core";
+import {TrainrunSection} from "../../models/trainrunsection.model";
+import {PortAlignment} from "../../data-structures/technical.data.structures";
+
+const FONT = "16px Arial";
+const VERTICAL_ADDITION = 2;
+const MARGIN_CONSTANT = 50;
+const MULTIPLICATION_FACTOR_DUE_TO_ALIGNMENT = 2;
+
+@Injectable({
+  providedIn: "root",
+})
+export class TrainrunDistanceService {
+  private canvas: OffscreenCanvas;
+
+  constructor() {
+    this.canvas = new OffscreenCanvas(1, 1);
+    this.canvas.getContext("2d").font = FONT;
+  }
+
+  public getMinSectionLengthInPx(trainrunSection: TrainrunSection) {
+    const isVertical = this.calculateIfPortIsVertical(trainrunSection);
+    const textWidth = this.trainrunSectionNameLength(trainrunSection, isVertical);
+    return textWidth * MULTIPLICATION_FACTOR_DUE_TO_ALIGNMENT + MARGIN_CONSTANT;
+  }
+
+  private calculateIfPortIsVertical(trainrunSection: TrainrunSection) {
+    // both ports have the same position alignment, so we can just check the source port
+    const sourcePort = trainrunSection
+      .getSourceNode()
+      .getPorts()
+      .find((port) => port.getTrainrunSectionId() === trainrunSection.getId());
+
+    return (
+      sourcePort.getPositionAlignment() === PortAlignment.Bottom ||
+      sourcePort.getPositionAlignment() === PortAlignment.Top
+    );
+  }
+
+  private trainrunSectionNameLength(trainrunSection: TrainrunSection, isVertical: boolean) {
+    let value =
+      trainrunSection.getTrainrun().getCategoryShortName() +
+      trainrunSection.getTrainrun().getTitle();
+    let length = 0;
+
+    const isSourceNonStop = trainrunSection.getSourceNode().isNonStop(trainrunSection);
+    const isTargetNonStop = trainrunSection.getTargetNode().isNonStop(trainrunSection);
+
+    value += "'" + trainrunSection.getTravelTime().toString();
+    if (isVertical) {
+      length += VERTICAL_ADDITION + (isTargetNonStop ? 0 : VERTICAL_ADDITION);
+    } else {
+      value +=
+        trainrunSection.getSourceDeparture().toString() +
+        (isTargetNonStop ? "" : trainrunSection.getTargetArrival().toString());
+    }
+
+    if (isSourceNonStop || isTargetNonStop) {
+      value += "()";
+    }
+
+    if (isSourceNonStop && !isTargetNonStop) {
+      value += "(" + this.calculateTravelTime(trainrunSection).toString() + ")";
+    }
+
+    return this.measureTextWidth(value) + length;
+  }
+
+  private calculateTravelTime(trainrunSection: TrainrunSection): number {
+    const travelTime = trainrunSection.getTravelTime();
+    if (!trainrunSection.getTargetNode().isNonStop(trainrunSection)) {
+      return travelTime;
+    }
+
+    return (
+      travelTime +
+      this.calculateTravelTime(
+        trainrunSection
+          .getTargetNode()
+          .getPorts()
+          .filter(
+            (port) =>
+              port.getTrainrunSection().getTrainrunId() === trainrunSection.getTrainrunId() &&
+              port.getId() !== trainrunSection.getTargetPortId(),
+          )
+          .map((port) => port.getTrainrunSection())
+          .at(0),
+      )
+    );
+  }
+
+  private measureTextWidth(text: string): number {
+    const ctx = this.canvas.getContext("2d");
+    return ctx.measureText(text).width;
+  }
+}

--- a/src/app/view/editor-main-view/data-views/d3.utils.spec.ts
+++ b/src/app/view/editor-main-view/data-views/d3.utils.spec.ts
@@ -25,6 +25,7 @@ import {Vec2D} from "../../../utils/vec2D";
 import {LevelOfDetailService} from "../../../services/ui/level.of.detail.service";
 import {ViewportCullService} from "../../../services/ui/viewport.cull.service";
 import {PositionTransformationService} from "../../../services/util/position.transformation.service";
+import {TrainrunDistanceService} from "../../../services/util/trainrun-distance.service";
 
 describe("3d.Utils.tests", () => {
   let dataService: DataService;
@@ -131,6 +132,8 @@ describe("3d.Utils.tests", () => {
       trainrunSectionService,
     );
 
+    const trainrunDistanceService = new TrainrunDistanceService();
+
     const positionTransformationService = new PositionTransformationService(
       trainrunSectionService,
       trainrunService,
@@ -138,6 +141,7 @@ describe("3d.Utils.tests", () => {
       noteService,
       uiInteractionService,
       viewportCullService,
+      trainrunDistanceService,
     );
 
     const controller = new EditorMainViewComponent(

--- a/src/app/view/editor-main-view/data-views/data.view.spec.ts
+++ b/src/app/view/editor-main-view/data-views/data.view.spec.ts
@@ -29,6 +29,7 @@ import {StaticDomTags} from "./static.dom.tags";
 import {LevelOfDetailService} from "../../../services/ui/level.of.detail.service";
 import {ViewportCullService} from "../../../services/ui/viewport.cull.service";
 import {PositionTransformationService} from "../../../services/util/position.transformation.service";
+import {TrainrunDistanceService} from "../../../services/util/trainrun-distance.service";
 
 describe("Editor-DataView", () => {
   let dataService: DataService;
@@ -136,6 +137,8 @@ describe("Editor-DataView", () => {
 
     const levelOfDetailService = new LevelOfDetailService(uiInteractionService);
 
+    const trainrunDistanceService = new TrainrunDistanceService();
+
     const positionTransformationService = new PositionTransformationService(
       trainrunSectionService,
       trainrunService,
@@ -143,6 +146,7 @@ describe("Editor-DataView", () => {
       noteService,
       uiInteractionService,
       viewportCullService,
+      trainrunDistanceService,
     );
 
     const controller = new EditorMainViewComponent(

--- a/src/app/view/editor-main-view/data-views/nodes.view.spec.ts
+++ b/src/app/view/editor-main-view/data-views/nodes.view.spec.ts
@@ -24,6 +24,7 @@ import {NodesView} from "./nodes.view";
 import {LevelOfDetailService} from "../../../services/ui/level.of.detail.service";
 import {ViewportCullService} from "../../../services/ui/viewport.cull.service";
 import {PositionTransformationService} from "../../../services/util/position.transformation.service";
+import {TrainrunDistanceService} from "../../../services/util/trainrun-distance.service";
 
 describe("Nodes-View", () => {
   let dataService: DataService;
@@ -131,6 +132,8 @@ describe("Nodes-View", () => {
       trainrunSectionService,
     );
 
+    const trainrunDistanceService = new TrainrunDistanceService();
+
     const positionTransformationService = new PositionTransformationService(
       trainrunSectionService,
       trainrunService,
@@ -138,6 +141,7 @@ describe("Nodes-View", () => {
       noteService,
       uiInteractionService,
       viewportCullService,
+      trainrunDistanceService,
     );
 
     const controller = new EditorMainViewComponent(

--- a/src/app/view/editor-main-view/data-views/notes.view.spec.ts
+++ b/src/app/view/editor-main-view/data-views/notes.view.spec.ts
@@ -24,6 +24,7 @@ import {NetzgrafikUnitTesting} from "../../../../integration-testing/netzgrafik.
 import {LevelOfDetailService} from "../../../services/ui/level.of.detail.service";
 import {ViewportCullService} from "../../../services/ui/viewport.cull.service";
 import {PositionTransformationService} from "../../../services/util/position.transformation.service";
+import {TrainrunDistanceService} from "../../../services/util/trainrun-distance.service";
 
 describe("Notes-View", () => {
   let dataService: DataService;
@@ -131,6 +132,8 @@ describe("Notes-View", () => {
       trainrunSectionService,
     );
 
+    const trainrunDistanceService = new TrainrunDistanceService();
+
     const positionTransformationService = new PositionTransformationService(
       trainrunSectionService,
       trainrunService,
@@ -138,6 +141,7 @@ describe("Notes-View", () => {
       noteService,
       uiInteractionService,
       viewportCullService,
+      trainrunDistanceService,
     );
 
     const controller = new EditorMainViewComponent(

--- a/src/app/view/editor-main-view/data-views/trainrunsections.view.spec.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunsections.view.spec.ts
@@ -26,6 +26,7 @@ import {Vec2D} from "../../../utils/vec2D";
 import {LevelOfDetailService} from "../../../services/ui/level.of.detail.service";
 import {ViewportCullService} from "../../../services/ui/viewport.cull.service";
 import {PositionTransformationService} from "../../../services/util/position.transformation.service";
+import {TrainrunDistanceService} from "../../../services/util/trainrun-distance.service";
 
 describe("TrainrunSection-View", () => {
   let dataService: DataService;
@@ -133,6 +134,8 @@ describe("TrainrunSection-View", () => {
       trainrunSectionService,
     );
 
+    const trainrunDistanceService = new TrainrunDistanceService();
+
     const positionTransformationService = new PositionTransformationService(
       trainrunSectionService,
       trainrunService,
@@ -140,6 +143,7 @@ describe("TrainrunSection-View", () => {
       noteService,
       uiInteractionService,
       viewportCullService,
+      trainrunDistanceService,
     );
 
     const controller = new EditorMainViewComponent(

--- a/src/app/view/editor-main-view/data-views/transitions.view.spec.ts
+++ b/src/app/view/editor-main-view/data-views/transitions.view.spec.ts
@@ -24,6 +24,7 @@ import {TransitionsView} from "./transitions.view";
 import {LevelOfDetailService} from "../../../services/ui/level.of.detail.service";
 import {ViewportCullService} from "../../../services/ui/viewport.cull.service";
 import {PositionTransformationService} from "../../../services/util/position.transformation.service";
+import {TrainrunDistanceService} from "../../../services/util/trainrun-distance.service";
 
 describe("Transitions-View", () => {
   let dataService: DataService;
@@ -131,6 +132,8 @@ describe("Transitions-View", () => {
       trainrunSectionService,
     );
 
+    const trainrunDistanceService = new TrainrunDistanceService();
+
     const positionTransformationService = new PositionTransformationService(
       trainrunSectionService,
       trainrunService,
@@ -138,6 +141,7 @@ describe("Transitions-View", () => {
       noteService,
       uiInteractionService,
       viewportCullService,
+      trainrunDistanceService,
     );
 
     const controller = new EditorMainViewComponent(


### PR DESCRIPTION
# Automatic minimum distance calculation
This PR will add a service that checks whether a certain trainrunSection is too small and needs to be expanded by the auto-layouting algorithm.

## How it works
The algorithm looks at each individual trainrunSection and calculates how long the text will be that will be displayed. Meaning the departure time, the train number, arrival time etc.. based on what should be visible. It does not take into account the visibility filter a user could set as then it would need to change the layout when changing the visibility filters. If a trainrunSection is vertical, it will calculate it slightly differently, as the departure and arrival time is still horizontal, meaning the text height instead of the width is used.
As the text is only on the left side of the trainrunSection, it almost doubles the width needed in order to accompany that.

## How it can be changed
In the service, there are some constants that can be changed which change how much the text is taken into account and also which margin is used in addition to the text width.