### PR TITLE
refactor: add explicit return types for interface methods

### DIFF
--- a/src/app/models/note.model.ts
+++ b/src/app/models/note.model.ts
@@ -5,11 +5,11 @@ import {DataMigration} from "../utils/data-migration";
 // TODO: drop once we upgrade to a newer TypeScript which ships Sanitizer types
 declare global {
   class Sanitizer {
-    allowAttribute(name: string);
-    removeUnsafe();
+    allowAttribute(name: string): void;
+    removeUnsafe(): void;
   }
   interface HTMLElement {
-    setHTML(unsafeHTML: string, options?: {sanitizer: Sanitizer});
+    setHTML(unsafeHTML: string, options?: {sanitizer: Sanitizer}): void;
   }
   interface Window {
     Sanitizer?: typeof Sanitizer;

--- a/src/app/view/util/svg.mouse.controller.ts
+++ b/src/app/view/util/svg.mouse.controller.ts
@@ -6,22 +6,14 @@ import {UndoService} from "../../services/data/undo.service";
 
 export interface SVGMouseControllerObserver {
   onEarlyReturnFromMousemove(): boolean;
-
-  onGraphContainerMouseup(mousePosition: Vec2D, onPaning: boolean);
-
-  zoomFactorChanged(newZoomFactor: number);
-
-  onViewboxChanged(viewboxProperties: ViewboxProperties);
-
-  onStartMultiSelect();
-
-  updateMultiSelect(topLeft: Vec2D, bottomRight: Vec2D);
-
-  onEndMultiSelect();
-
-  onScaleNetzgrafik(factor: number, scaleCenter: Vec2D);
-
-  onCtrlKeyChanged(state: boolean);
+  onGraphContainerMouseup(mousePosition: Vec2D, onPaning: boolean): void;
+  zoomFactorChanged(newZoomFactor: number): void;
+  onViewboxChanged(viewboxProperties: ViewboxProperties): void;
+  onStartMultiSelect(): void;
+  updateMultiSelect(topLeft: Vec2D, bottomRight: Vec2D): void;
+  onEndMultiSelect(): void;
+  onScaleNetzgrafik(factor: number, scaleCenter: Vec2D): void;
+  onCtrlKeyChanged(state: boolean): void;
 }
 
 export class SVGMouseController {


### PR DESCRIPTION
When the return type is unspecified, it implicitly defaults to "any". Set the return type explicitly to "void" to make sure callers don't use the return value by mistake.