### PR TITLE
docs(readme): reformat and expand testing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,20 +266,18 @@ npm run format
 ### Testing
 
 ```sh
-
-### Testing
-
-```
-
-# just run the test once
-
+# just run all tests once
 npm run test
 
-# or run the test in the browser
+# re-run tests when a file changes
+npm run test -- --watch
 
+# run tests in a Chrome browser window
 npm run test -- --browsers Chrome
 
-````
+# run tests with Chromium instead of Chrome
+npm run test -- --browsers ChromiumHeadless
+```
 
 ## Backend API code generation
 
@@ -298,7 +296,7 @@ The new API Service files can be generated using the following command:
 
 ```shell
 npm run generate:api
-````
+```
 
 ## Documentation
 


### PR DESCRIPTION
Code blocks were malformed in there, resulting in level 1 headings (starting with `#`) instead of shell comments. Correctly wrap comments inside the code block to fix this.

Add two more commands: one to watch changed files, and one to start with Chromium instead of Chrome (the former is fully open-source and commonly installed on Linux).