### PR TITLE
feat: improves port ordering problem decomposition

### DIFF
--- a/src/app/services/util/port-ordering.algo.spec.ts
+++ b/src/app/services/util/port-ordering.algo.spec.ts
@@ -175,6 +175,52 @@ describe("port-ordering", () => {
       expect(countCrossingsInNode(nodesMap.get("B1"))).toBe(0);
       expect(countCrossingsInNode(nodesMap.get("B2"))).toBe(0);
     });
+
+    it("optimizes a junction shared by two independent reticulars", () => {
+      // A vertical reticular (TA/TB -CENTER- BA/BB) and a horizontal one
+      // (LA/LB -CENTER- RA/RB) meet at CENTER but never share a side, so
+      // each owns a different pair of CENTER's sides:
+      //       TA  TB
+      //        |  |
+      // LA --        -- RA
+      //       CENTER
+      // LB --        -- RB
+      //        |  |
+      //       BA  BB
+      const {
+        nodesMap,
+        nodesArray,
+        trainrunIDs: [v0, v1, h0, h1],
+      } = buildNetwork({
+        nodes: {
+          CENTER: {x: 0, y: 0},
+          TA: {x: -50, y: -100},
+          TB: {x: 50, y: -100},
+          BA: {x: -50, y: 100},
+          BB: {x: 50, y: 100},
+          LA: {x: -100, y: -50},
+          RA: {x: 100, y: -50},
+          LB: {x: -100, y: 50},
+          RB: {x: 100, y: 50},
+        },
+        trainruns: [
+          ["TA", "CENTER", "BA"],
+          ["TB", "CENTER", "BB"],
+          ["LA", "CENTER", "RA"],
+          ["LB", "CENTER", "RB"],
+        ],
+      });
+
+      optimizePorts(nodesArray);
+
+      // The only crossings we should end up with are the 4 unavoidable crossings within the center
+      // node:
+      expect(countAllCrossings(nodesArray).crossings).toBe(4);
+      expect(getTrainrunIDsOnSide(nodesMap.get("CENTER"), "top")).toEqual([v0, v1]);
+      expect(getTrainrunIDsOnSide(nodesMap.get("CENTER"), "bottom")).toEqual([v0, v1]);
+      expect(getTrainrunIDsOnSide(nodesMap.get("CENTER"), "left")).toEqual([h0, h1]);
+      expect(getTrainrunIDsOnSide(nodesMap.get("CENTER"), "right")).toEqual([h0, h1]);
+    });
   });
 
   describe("Regression #1140", () => {

--- a/src/app/services/util/port-ordering.algo.ts
+++ b/src/app/services/util/port-ordering.algo.ts
@@ -3,7 +3,7 @@ import {Port} from "../../models/port.model";
 import {PortAlignment} from "../../data-structures/technical.data.structures";
 import {Transition} from "../../models/transition.model";
 import {countAllCrossings} from "./port-ordering.crossings";
-import {getConnectedComponents, getPortOppositeNodeId} from "./port-ordering.components";
+import {getComponents, getPortOppositeNodeId} from "./port-ordering.components";
 import {
   ALIGNMENTS_CLOCKWISE_ORDER,
   getOppositeAlignmentScore,
@@ -12,12 +12,40 @@ import {
 } from "./port-ordering.helpers";
 
 /**
+ * Creates a view of a node exposing only one component's ports and transitions, so the optimizer
+ * reorders and counts within a single component, without disturbing a shared node's other sides.
+ * The ports stay the same objects, so reordering them still mutates the real network. Everything
+ * else (id, position, ...) is delegated to the real node.
+ */
+function getScopedNode(node: Node, sides: Set<PortAlignment>): Node {
+  const ports = node.getPorts().filter((p) => sides.has(p.getPositionAlignment()));
+  const portIds = new Set(ports.map((p) => p.getId()));
+  const transitions = node
+    .getTransitions()
+    .filter((t) => portIds.has(t.getPortId1()) && portIds.has(t.getPortId2()));
+  const view: Node = Object.create(node);
+  view.getPorts = () => ports;
+  view.getTransitions = () => transitions;
+  view.getPort = (id: number) => ports.find((p) => p.getId() === id);
+  return view;
+}
+
+/**
  * This function orders all ports in all nodes to minimize crossings. It first calls
- * getConnectedComponents, and then optimizeComponentPorts on each connected component.
+ * getComponents, then runs optimizeComponentPorts on each component, scoped to its own ports so
+ * that nodes shared between components (a junction crossed by two independent reticulars for
+ * instance) have each side optimized by its owning component only.
  */
 export function optimizePorts(nodes: Node[]): void {
-  const components = getConnectedComponents(nodes);
-  components.forEach((componentNodes) => optimizeComponentPorts(componentNodes));
+  getComponents(nodes).forEach((component) => {
+    const sidesByNode = new Map<Node, Set<PortAlignment>>();
+    component.forEach(({node, side}) => {
+      const sides = sidesByNode.get(node);
+      if (sides) sides.add(side);
+      else sidesByNode.set(node, new Set([side]));
+    });
+    optimizeComponentPorts([...sidesByNode].map(([node, sides]) => getScopedNode(node, sides)));
+  });
 }
 
 type OptimizeComponentPortsOptions = {
@@ -319,17 +347,13 @@ function reorderComponentPorts(nodes: Node[], trainrunScores: Record<number, num
     for (const neighborId of new Set(
       node.getPorts().map((p) => getPortOppositeNodeId(p, nodeId)),
     )) {
-      if (visited.has(neighborId)) continue;
+      // A port can lead outside the component (e.g. a single-trainrun bridge whose far end belongs
+      // to another reticular), so here we only follow neighbors that are part of this component:
+      if (visited.has(neighborId) || !nodeMap.has(neighborId)) continue;
 
       visited.add(neighborId);
       queue.push(neighborId);
       reorderNodePorts(nodeMap.get(neighborId), visited, trainrunScores);
     }
-  }
-
-  if (visited.size !== nodesWithPorts.length) {
-    throw new Error(
-      `Input is not a connected component: reached ${visited.size}/${nodesWithPorts.length} nodes`,
-    );
   }
 }

--- a/src/app/services/util/port-ordering.components.spec.ts
+++ b/src/app/services/util/port-ordering.components.spec.ts
@@ -1,5 +1,12 @@
 import {buildNetwork} from "./port-ordering.test-helpers";
-import {getConnectedComponents} from "./port-ordering.components";
+import {getComponents, getConnectedComponents, SidesComponent} from "./port-ordering.components";
+
+// Maps components to a canonical, order-independent form: each component as a sorted list of node
+// names, the whole list sorted, so assertions don't depend on traversal order.
+const asNames = (components: SidesComponent[]): string[][] =>
+  components
+    .map((c) => [...new Set(c.map(({node}) => node.getBetriebspunktName()))].sort())
+    .sort((a, b) => a.join().localeCompare(b.join()));
 
 describe("getConnectedComponents", () => {
   it("should return single component for connected graph", () => {
@@ -36,5 +43,178 @@ describe("getConnectedComponents", () => {
     expect(components.length).toBe(2);
     expect(components[0].length).toBe(2);
     expect(components[1].length).toBe(2);
+  });
+});
+
+describe("getComponents", () => {
+  it("returns nothing for a single trainrun (no ports to order)", () => {
+    const {nodesArray} = buildNetwork({
+      nodes: {A: {x: 0}, B: {x: 100}, C: {x: 200}},
+      trainruns: [["A", "B", "C"]],
+    });
+
+    expect(getComponents(nodesArray)).toEqual([]);
+  });
+
+  it("keeps a parallel bundle together", () => {
+    const {nodesArray} = buildNetwork({
+      nodes: {A: {x: 0}, B: {x: 100}, C: {x: 200}},
+      trainruns: [
+        ["A", "B", "C"],
+        ["A", "B", "C"],
+      ],
+    });
+
+    expect(asNames(getComponents(nodesArray))).toEqual([["A", "B", "C"]]);
+  });
+
+  it("separates disconnected bundles", () => {
+    const {nodesArray} = buildNetwork({
+      nodes: {
+        A1: {x: 0, y: 0},
+        B1: {x: 100, y: 0},
+        A2: {x: 0, y: 200},
+        B2: {x: 100, y: 200},
+      },
+      trainruns: [
+        ["A1", "B1"],
+        ["A1", "B1"],
+        ["A2", "B2"],
+        ["A2", "B2"],
+      ],
+    });
+
+    expect(asNames(getComponents(nodesArray))).toEqual([
+      ["A1", "B1"],
+      ["A2", "B2"],
+    ]);
+  });
+
+  it("separates two components that share only a node", () => {
+    const {nodesArray} = buildNetwork({
+      nodes: {
+        TOP: {x: 0, y: -100},
+        BOTTOM: {x: 0, y: 100},
+        LEFT: {x: -100, y: 0},
+        RIGHT: {x: 100, y: 0},
+        CENTER: {x: 0, y: 0},
+      },
+      trainruns: [
+        ["TOP", "CENTER", "BOTTOM"],
+        ["TOP", "CENTER", "BOTTOM"],
+        ["LEFT", "CENTER", "RIGHT"],
+        ["LEFT", "CENTER", "RIGHT"],
+      ],
+    });
+
+    expect(asNames(getComponents(nodesArray))).toEqual([
+      ["BOTTOM", "CENTER", "TOP"],
+      ["CENTER", "LEFT", "RIGHT"],
+    ]);
+  });
+
+  it("separates two bundles meeting at a node without passing through", () => {
+    const {nodesArray} = buildNetwork({
+      nodes: {A: {x: -100}, B: {x: 0}, C: {x: 100}},
+      trainruns: [
+        ["A", "B"],
+        ["A", "B"],
+        ["B", "C"],
+        ["B", "C"],
+      ],
+    });
+
+    expect(asNames(getComponents(nodesArray))).toEqual([
+      ["A", "B"],
+      ["B", "C"],
+    ]);
+  });
+
+  it("keeps a through bundle together but separates a terminating bundle", () => {
+    const {nodesArray} = buildNetwork({
+      nodes: {A: {x: -100, y: 0}, B: {x: 0, y: 0}, C: {x: 100, y: 0}, D: {x: 0, y: 100}},
+      trainruns: [
+        ["A", "B", "C"],
+        ["A", "B", "C"],
+        ["B", "D"],
+        ["B", "D"],
+      ],
+    });
+
+    expect(asNames(getComponents(nodesArray))).toEqual([
+      ["A", "B", "C"],
+      ["B", "D"],
+    ]);
+  });
+
+  it("separates two components joined by a single section", () => {
+    const {nodesArray} = buildNetwork({
+      nodes: {A: {x: 0}, B: {x: 100}, C: {x: 200}, D: {x: 300}, E: {x: 400}, F: {x: 500}},
+      trainruns: [
+        ["A", "B", "C"],
+        ["A", "B", "C"],
+        ["D", "E", "F"],
+        ["D", "E", "F"],
+        ["C", "D"], // lone bridging section: dropped, the cores stay split
+      ],
+    });
+
+    expect(asNames(getComponents(nodesArray))).toEqual([
+      ["A", "B", "C"],
+      ["D", "E", "F"],
+    ]);
+  });
+
+  it("separates two components joined by a single trainrun through a shared node", () => {
+    const {nodesArray} = buildNetwork({
+      nodes: {A: {x: 0}, B: {x: -100}, C: {x: -200}, D: {x: 100}, E: {x: 200}},
+      trainruns: [
+        ["A", "B", "C"],
+        ["A", "B", "C"],
+        ["A", "D", "E"],
+        ["A", "D", "E"],
+        ["C", "B", "A", "D", "E"], // lone trainrun passing through A
+      ],
+    });
+
+    expect(asNames(getComponents(nodesArray))).toEqual([
+      ["A", "B", "C"],
+      ["A", "D", "E"],
+    ]);
+  });
+
+  it("separates two components connected at several single-trainrun points", () => {
+    const {nodesArray} = buildNetwork({
+      nodes: {A: {x: 0}, B: {x: 100}, C: {x: 200}, D: {x: 300}, E: {x: 400}, F: {x: 500}},
+      trainruns: [
+        ["A", "B", "C"],
+        ["A", "B", "C"],
+        ["D", "E", "F"],
+        ["D", "E", "F"],
+        ["C", "D"], // two lone bridges, neither a graph cut-edge but each a single
+        ["A", "F"], // trainrun, so both are dropped
+      ],
+    });
+
+    expect(asNames(getComponents(nodesArray))).toEqual([
+      ["A", "B", "C"],
+      ["D", "E", "F"],
+    ]);
+  });
+
+  it("keeps two components joined by a parallel through bundle together", () => {
+    const {nodesArray} = buildNetwork({
+      nodes: {A: {x: 0}, B: {x: 100}, C: {x: 200}, D: {x: 300}, E: {x: 400}, F: {x: 500}},
+      trainruns: [
+        ["A", "B", "C"],
+        ["A", "B", "C"],
+        ["D", "E", "F"],
+        ["D", "E", "F"],
+        ["B", "C", "D", "E"], // parallel through bundle binds both sides via C and D
+        ["B", "C", "D", "E"],
+      ],
+    });
+
+    expect(asNames(getComponents(nodesArray))).toEqual([["A", "B", "C", "D", "E", "F"]]);
   });
 });

--- a/src/app/services/util/port-ordering.components.spec.ts
+++ b/src/app/services/util/port-ordering.components.spec.ts
@@ -1,5 +1,5 @@
 import {buildNetwork} from "./port-ordering.test-helpers";
-import {getComponents, getConnectedComponents, SidesComponent} from "./port-ordering.components";
+import {getComponents, SidesComponent} from "./port-ordering.components";
 
 // Maps components to a canonical, order-independent form: each component as a sorted list of node
 // names, the whole list sorted, so assertions don't depend on traversal order.
@@ -7,44 +7,6 @@ const asNames = (components: SidesComponent[]): string[][] =>
   components
     .map((c) => [...new Set(c.map(({node}) => node.getBetriebspunktName()))].sort())
     .sort((a, b) => a.join().localeCompare(b.join()));
-
-describe("getConnectedComponents", () => {
-  it("should return single component for connected graph", () => {
-    const {nodesArray} = buildNetwork({
-      nodes: {A: {x: 0}, B: {x: 100}, C: {x: 200}},
-      trainruns: [
-        ["A", "B", "C"],
-        ["A", "B", "C"],
-      ],
-    });
-
-    const components = getConnectedComponents(nodesArray);
-
-    expect(components.length).toBe(1);
-    expect(components[0].length).toBe(3);
-  });
-
-  it("should return multiple components for disconnected graphs", () => {
-    const {nodesArray} = buildNetwork({
-      nodes: {
-        A1: {x: 0, y: 0},
-        B1: {x: 100, y: 0},
-        A2: {x: 0, y: 200},
-        B2: {x: 100, y: 200},
-      },
-      trainruns: [
-        ["A1", "B1"],
-        ["A2", "B2"],
-      ],
-    });
-
-    const components = getConnectedComponents(nodesArray);
-
-    expect(components.length).toBe(2);
-    expect(components[0].length).toBe(2);
-    expect(components[1].length).toBe(2);
-  });
-});
 
 describe("getComponents", () => {
   it("returns nothing for a single trainrun (no ports to order)", () => {

--- a/src/app/services/util/port-ordering.components.ts
+++ b/src/app/services/util/port-ordering.components.ts
@@ -1,5 +1,8 @@
 import {Port} from "../../models/port.model";
 import {Node} from "../../models/node.model";
+import {Transition} from "../../models/transition.model";
+import {PortAlignment} from "../../data-structures/technical.data.structures";
+import {groupBy} from "../../utils/collection";
 
 export function getPortOppositeNodeId(port: Port, nodeId: number): number {
   const ts = port.getTrainrunSection();
@@ -41,4 +44,115 @@ export function getConnectedComponents(nodes: Node[]): Node[][] {
   }
 
   return components;
+}
+
+export type SidesComponent = {node: Node; side: PortAlignment}[];
+
+/**
+ * Splits a network into as many independent components as possible, with "independent" meaning
+ * here that ordering the ports of one can never change the best port ordering of another.
+ *
+ * It groups node sides, not nodes: independence is per side, so one node can have one side belong
+ * to a component, and another side belong to a different one.
+ *
+ * Node sides are grouped only when they are coupled. Two things couple them:
+ *   1. The two ends of a bundle (a link of at least two parallel sections between two nodes)
+ *   2. The sides joined by at least two pass-through sections sharing a side within a node
+ *
+ * A single section couples nothing (one lone link between two nodes, or one lone pass-through
+ * section inside a node), so it is a "bridge" that gets cut.
+ *
+ * And because cuts happen at these bridges exactly, two components can share a node (each owning a
+ * different subset of its ports) or even a trainrun (its ports falling on either side of a cut).
+ */
+export function getComponents(nodes: Node[]): SidesComponent[] {
+  // Helpers to manage what group each port is in:
+  const portGroupsIds = new Map<number, number>();
+  const getPortRoot = (portId: number): number => {
+    let root = portId;
+    while (portGroupsIds.get(root) !== root) root = portGroupsIds.get(root)!;
+    while (portId !== root) {
+      const next = portGroupsIds.get(portId)!;
+      portGroupsIds.set(portId, root);
+      portId = next;
+    }
+    return root;
+  };
+  const mergePortGroups = (portAId: number, portBId: number) =>
+    portGroupsIds.set(getPortRoot(portAId), getPortRoot(portBId));
+
+  const allPorts = nodes.flatMap((node) => node.getPorts().map((port) => ({port, node})));
+  const sectionPorts = groupBy(
+    allPorts.map(({port}) => port),
+    (p) => p.getTrainrunSectionId(),
+  );
+
+  // Each port is in its own group initially:
+  allPorts.forEach(({port}) => portGroupsIds.set(port.getId(), port.getId()));
+
+  nodes.forEach((node) => {
+    const id = node.getId();
+
+    // 0. Group all ports on the same side
+    // Ports on the same side of the same node are grouped together
+    groupBy(node.getPorts(), (p) => p.getPositionAlignment()).forEach((side) =>
+      side.forEach((p) => mergePortGroups(p.getId(), side[0].getId())),
+    );
+
+    // 1. Bundle link:
+    // A link with at least two parallel sections groups all its ports together
+    groupBy(node.getPorts(), (p) => getPortOppositeNodeId(p, id)).forEach((linkPorts) => {
+      if (linkPorts.length < 2) return;
+      linkPorts.forEach((p) =>
+        sectionPorts
+          .get(p.getTrainrunSectionId())!
+          .forEach((q) => mergePortGroups(p.getId(), q.getId())),
+      );
+    });
+
+    // 2. Shared-side transition:
+    // When two or more trainruns pass through a node sharing at least one side, the ports of all
+    // the related sections (of these trainruns, in that node) are grouped together
+    const transitionsBySide = new Map<PortAlignment, Transition[]>();
+    node.getTransitions().forEach((t) => {
+      const sides = new Set([
+        node.getPort(t.getPortId1()).getPositionAlignment(),
+        node.getPort(t.getPortId2()).getPositionAlignment(),
+      ]);
+      sides.forEach((side) => {
+        const group = transitionsBySide.get(side);
+        if (group) group.push(t);
+        else transitionsBySide.set(side, [t]);
+      });
+    });
+    transitionsBySide.forEach((group) => {
+      if (group.length < 2) return;
+      group.forEach((t) => {
+        mergePortGroups(t.getPortId1(), t.getPortId2());
+        mergePortGroups(t.getPortId1(), group[0].getPortId1());
+      });
+    });
+  });
+
+  // Translate "ports groups" to "sides components":
+  // A component is worth ordering only if some side holds at least two ports
+  const orderableRoots = new Set<number>();
+  nodes.forEach((node) =>
+    groupBy(node.getPorts(), (p) => p.getPositionAlignment()).forEach((side) => {
+      if (side.length >= 2) orderableRoots.add(getPortRoot(side[0].getId()));
+    }),
+  );
+
+  const componentsByRoot = new Map<number, SidesComponent>();
+  nodes.forEach((node) =>
+    groupBy(node.getPorts(), (p) => p.getPositionAlignment()).forEach((sidePorts, side) => {
+      const root = getPortRoot(sidePorts[0].getId());
+      if (!orderableRoots.has(root)) return;
+      const component = componentsByRoot.get(root);
+      if (component) component.push({node, side});
+      else componentsByRoot.set(root, [{node, side}]);
+    }),
+  );
+
+  return [...componentsByRoot.values()];
 }

--- a/src/app/services/util/port-ordering.components.ts
+++ b/src/app/services/util/port-ordering.components.ts
@@ -9,43 +9,6 @@ export function getPortOppositeNodeId(port: Port, nodeId: number): number {
   return ts.getSourceNodeId() === nodeId ? ts.getTargetNodeId() : ts.getSourceNodeId();
 }
 
-/**
- * This function takes a graph (as an array of nodes), and returns an array of all connected
- * components in it.
- */
-export function getConnectedComponents(nodes: Node[]): Node[][] {
-  const nodeMap = new Map(nodes.map((n) => [n.getId(), n]));
-  const visited = new Set<number>();
-  const components: Node[][] = [];
-
-  for (const startNode of nodes) {
-    if (visited.has(startNode.getId())) continue;
-
-    const componentNodes: Node[] = [];
-    const nodesToProcess: number[] = [startNode.getId()];
-
-    while (nodesToProcess.length > 0) {
-      const nodeId = nodesToProcess.pop();
-      if (visited.has(nodeId)) continue;
-
-      visited.add(nodeId);
-      const node = nodeMap.get(nodeId)!;
-      componentNodes.push(node);
-
-      node.getPorts().forEach((port) => {
-        const neighborId = getPortOppositeNodeId(port, nodeId);
-        if (!visited.has(neighborId) && nodeMap.has(neighborId)) {
-          nodesToProcess.push(neighborId);
-        }
-      });
-    }
-
-    components.push(componentNodes);
-  }
-
-  return components;
-}
-
 export type SidesComponent = {node: Node; side: PortAlignment}[];
 
 /**

--- a/src/app/utils/collection.ts
+++ b/src/app/utils/collection.ts
@@ -1,0 +1,10 @@
+export function groupBy<T, K>(items: T[], key: (item: T) => K): Map<K, T[]> {
+  const groups = new Map<K, T[]>();
+  items.forEach((item) => {
+    const k = key(item);
+    const group = groups.get(k);
+    if (group) group.push(item);
+    else groups.set(k, [item]);
+  });
+  return groups;
+}


### PR DESCRIPTION
This refines how the port-ordering optimizer scopes its work.

Until now, the optimizer ran per connected component (`getConnectedComponents`): a node where two unrelated reticulars merely cross was treated as one block and optimized together, even though ordering one can never affect the other. And since the optimizer uses one single tie-breaker for all crossings, fixing one group crossing was often messing up the rest of the network.

This PR updates the way the optimizer splits the network:

1. The new `getComponents` function groups node sides (not whole nodes) into independent components, with "independent" meaning here that ordering the ports of one can never change the best port ordering of another. Two sides are coupled only when at least two parallel sections or two pass-through transitions tie them. A lone single section is a "bridge" that gets cut. So two components can share a node (each owning a different subset of its ports), or even share a trainrun.

2. `optimizePorts` now runs over these side-components. Each is fed to the optimizer through `getScopedNode`, a read-only `Node` view exposing only that component's ports and transitions, so a shared node has each side optimized by its owning component only, without disturbing the others.

3. `getConnectedComponents` is removed (now dead).

And we end up with more, simpler problems to solve, which strictly improves the global crossings reduction.

_Note to @louisgreiner: I'm quite sure this is the most promising break-through I made on the port ordering algorithm. It's still only optimizing crossings between nodes for now, but I'll update and finalize #1157 soon, to also improve other clutter types._