### PR TITLE
test: fix formControl bindings

### DIFF
--- a/src/app/view/project/project-dialog/project-form/project-form.component.spec.ts
+++ b/src/app/view/project/project-dialog/project-form/project-form.component.spec.ts
@@ -1,4 +1,7 @@
 import {ComponentFixture, TestBed} from "@angular/core/testing";
+import {FormsModule, ReactiveFormsModule} from "@angular/forms";
+import {SbbChipsModule} from "@sbb-esta/angular/chips";
+import {SbbTextareaModule} from "@sbb-esta/angular/textarea";
 
 import {
   ProjectFormComponent,
@@ -17,7 +20,7 @@ describe("ProjectFormComponent", () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [ProjectFormComponent],
-      imports: [I18nModule],
+      imports: [I18nModule, FormsModule, ReactiveFormsModule, SbbChipsModule, SbbTextareaModule],
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
     }).compileComponents();
   });

--- a/src/app/view/project/projects-view/projects-view.component.spec.ts
+++ b/src/app/view/project/projects-view/projects-view.component.spec.ts
@@ -1,4 +1,5 @@
 import {ComponentFixture, TestBed} from "@angular/core/testing";
+import {FormsModule, ReactiveFormsModule} from "@angular/forms";
 
 import {ProjectsViewComponent} from "./projects-view.component";
 import {of} from "rxjs";
@@ -22,7 +23,7 @@ describe("ProjectsViewComponent", () => {
 
     await TestBed.configureTestingModule({
       declarations: [ProjectsViewComponent],
-      imports: [SbbDialogModule, I18nModule],
+      imports: [I18nModule, FormsModule, ReactiveFormsModule, SbbDialogModule],
       providers: [
         {provide: ProjectsViewService, useValue: projectViewService},
         {

--- a/src/app/view/variant/variant-dialog/variant-form/variant-form.component.spec.ts
+++ b/src/app/view/variant/variant-dialog/variant-form/variant-form.component.spec.ts
@@ -1,4 +1,5 @@
 import {ComponentFixture, TestBed} from "@angular/core/testing";
+import {FormsModule, ReactiveFormsModule} from "@angular/forms";
 import {VariantFormComponent, VariantFormComponentModel} from "./variant-form.component";
 import {FormModel} from "../../../../utils/form-model";
 import {I18nModule} from "../../../../core/i18n/i18n.module";
@@ -10,7 +11,7 @@ describe("VariantFormComponent", () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [I18nModule],
+      imports: [I18nModule, FormsModule, ReactiveFormsModule],
       declarations: [VariantFormComponent],
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
     }).compileComponents();

--- a/src/app/view/variant/variants-view/variants-view.component.spec.ts
+++ b/src/app/view/variant/variants-view/variants-view.component.spec.ts
@@ -1,4 +1,6 @@
 import {ComponentFixture, TestBed} from "@angular/core/testing";
+import {FormsModule, ReactiveFormsModule} from "@angular/forms";
+import {SbbTextareaModule} from "@sbb-esta/angular/textarea";
 
 import {VariantsViewComponent} from "./variants-view.component";
 import {SbbDialogModule} from "@sbb-esta/angular/dialog";
@@ -60,7 +62,7 @@ describe("VariantsViewComponent", () => {
 
     await TestBed.configureTestingModule({
       declarations: [VariantsViewComponent],
-      imports: [SbbDialogModule, I18nModule],
+      imports: [I18nModule, FormsModule, ReactiveFormsModule, SbbDialogModule, SbbTextareaModule],
       providers: [
         {provide: ActivatedRoute, useValue: activatedRoute},
         {provide: NavigationService, useValue: {}},


### PR DESCRIPTION
Fixes the following kind of errors when running tests:

    ERROR: 'NG0303: Can't bind to 'formControl' since it isn't a known property of 'input' (used in the 'ProjectsViewComponent' component template).
    1. If 'input' is an Angular component and it has the 'formControl' input, then verify that it is a part of an @NgModule where this component is declared.
    2. To allow any property add 'NO_ERRORS_SCHEMA' to the '@NgModule.schemas' of this component.'

FormsModule and ReactiveFormsModule need to be provided to give access to formControl. For formControl attributes on sbb-ensta components, sbb-ensta modules also need to be imported.