### PR TITLE
Expose number enums and simpler index.html

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,15 @@
     "dist/*"
   ],
   "types": "dist/types/types.d.ts",
+  "exports": {
+    "./index.html": {
+      "default": "./dist/index.html"
+    },
+    ".": {
+      "types": "./dist/types/types.d.ts",
+      "default": "./dist/out-tsc/types.js"
+    }
+  },
   "dependencies": {
     "@angular/animations": "^19.2.25",
     "@angular/cdk": "^19.2.19",

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import type {} from "@angular/localize/init";
 
-export type * from "./app/data-structures/technical.data.structures";
-export type * from "./app/data-structures/business.data.structures";
+export * from "./app/data-structures/technical.data.structures";
+export * from "./app/data-structures/business.data.structures";
 export type * from "./app/models/operation.model";


### PR DESCRIPTION
Follow-up of:
- https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/pull/1206

Allows to use the types and number enums externally.

Thanks @Pivouane for the help