### PR TITLE
feat: expose operation types to external users

### DIFF
--- a/src/app/models/operation.model.ts
+++ b/src/app/models/operation.model.ts
@@ -36,6 +36,7 @@ abstract class Operation {
   readonly type: OperationType;
   readonly objectType: OperationObjectType;
 
+  /** @internal */
   constructor(type: OperationType, objectType: OperationObjectType) {
     this.type = type;
     this.objectType = objectType;
@@ -45,6 +46,7 @@ abstract class Operation {
 class TrainrunOperation extends Operation {
   readonly trainrun: TrainrunDto;
 
+  /** @internal */
   constructor(operationType: OperationType, trainrun: Trainrun) {
     super(operationType, OperationObjectType.trainrun);
     this.trainrun = trainrun.getDto();
@@ -54,6 +56,7 @@ class TrainrunOperation extends Operation {
 class NodeOperation extends Operation {
   readonly node: NodeDto;
 
+  /** @internal */
   constructor(operationType: OperationType, node: Node) {
     super(operationType, OperationObjectType.node);
     this.node = node.getDto();
@@ -63,6 +66,7 @@ class NodeOperation extends Operation {
 class LabelOperation extends Operation {
   readonly label: LabelDto;
 
+  /** @internal */
   constructor(operationType: OperationType, label: Label) {
     super(operationType, OperationObjectType.label);
     this.label = label.getDto();
@@ -72,6 +76,7 @@ class LabelOperation extends Operation {
 class NoteOperation extends Operation {
   readonly note: FreeFloatingTextDto;
 
+  /** @internal */
   constructor(operationType: OperationType, note: Note) {
     super(operationType, OperationObjectType.note);
     this.note = note.getDto();
@@ -81,6 +86,7 @@ class NoteOperation extends Operation {
 class MetadataOperation extends Operation {
   readonly metadata: MetadataDto;
 
+  /** @internal */
   constructor(metadata: MetadataDto) {
     super(OperationType.update, OperationObjectType.metadata);
     this.metadata = metadata;
@@ -90,6 +96,7 @@ class MetadataOperation extends Operation {
 class FilterSettingOperation extends Operation {
   readonly filterSetting: FilterSettingDto;
 
+  /** @internal */
   constructor(filterSetting: FilterSettingDto) {
     super(OperationType.update, OperationObjectType.filterSetting);
     this.filterSetting = filterSetting;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,2 +1,5 @@
+import type {} from "@angular/localize/init";
+
 export type * from "./app/data-structures/technical.data.structures";
 export type * from "./app/data-structures/business.data.structures";
+export type * from "./app/models/operation.model";

--- a/tsconfig.defs.json
+++ b/tsconfig.defs.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "declaration": true,
     "declarationDir": "dist/types",
-    "typeRoots": []
+    "typeRoots": [],
+    "stripInternal": true
   },
   "files": [],
   "include": ["src/types.ts"]


### PR DESCRIPTION
This is a follow-up for b49d21771e8e ("feat: ship type definitions in NPM package"). Operation types are received by outside users via event listeners. Exposing them improves type safety and allows external users to drop their NGE type copies.

We don't want to expose constructors because outside users shouldn't create operation objects and we don't want to expose our models (these are an unstable, internal NGE API). Mark constructors as @internal and enable TypeScript's stripInternal option.

@angular/localize/init needs to be imported to make TypeScript happy when it encounters @localize decorators.