### PR TITLE
refactor(models): use exhaustive union for Operation

### DIFF
--- a/src/app/models/operation.model.ts
+++ b/src/app/models/operation.model.ts
@@ -32,18 +32,18 @@ type MetadataDto = {
   trafficSide?: TrafficSide;
 };
 
-abstract class BaseOperation {
+abstract class BaseOperation<O extends OperationObjectType> {
   readonly type: OperationType;
-  readonly objectType: OperationObjectType;
+  readonly objectType: O;
 
   /** @internal */
-  constructor(type: OperationType, objectType: OperationObjectType) {
+  constructor(type: OperationType, objectType: O) {
     this.type = type;
     this.objectType = objectType;
   }
 }
 
-class TrainrunOperation extends BaseOperation {
+class TrainrunOperation extends BaseOperation<OperationObjectType.trainrun> {
   readonly trainrun: TrainrunDto;
 
   /** @internal */
@@ -53,7 +53,7 @@ class TrainrunOperation extends BaseOperation {
   }
 }
 
-class NodeOperation extends BaseOperation {
+class NodeOperation extends BaseOperation<OperationObjectType.node> {
   readonly node: NodeDto;
 
   /** @internal */
@@ -63,7 +63,7 @@ class NodeOperation extends BaseOperation {
   }
 }
 
-class LabelOperation extends BaseOperation {
+class LabelOperation extends BaseOperation<OperationObjectType.label> {
   readonly label: LabelDto;
 
   /** @internal */
@@ -73,7 +73,7 @@ class LabelOperation extends BaseOperation {
   }
 }
 
-class NoteOperation extends BaseOperation {
+class NoteOperation extends BaseOperation<OperationObjectType.note> {
   readonly note: FreeFloatingTextDto;
 
   /** @internal */
@@ -83,7 +83,7 @@ class NoteOperation extends BaseOperation {
   }
 }
 
-class MetadataOperation extends BaseOperation {
+class MetadataOperation extends BaseOperation<OperationObjectType.metadata> {
   readonly metadata: MetadataDto;
 
   /** @internal */
@@ -93,7 +93,7 @@ class MetadataOperation extends BaseOperation {
   }
 }
 
-class FilterSettingOperation extends BaseOperation {
+class FilterSettingOperation extends BaseOperation<OperationObjectType.filterSetting> {
   readonly filterSetting: FilterSettingDto;
 
   /** @internal */

--- a/src/app/models/operation.model.ts
+++ b/src/app/models/operation.model.ts
@@ -32,7 +32,7 @@ type MetadataDto = {
   trafficSide?: TrafficSide;
 };
 
-abstract class Operation {
+abstract class BaseOperation {
   readonly type: OperationType;
   readonly objectType: OperationObjectType;
 
@@ -43,7 +43,7 @@ abstract class Operation {
   }
 }
 
-class TrainrunOperation extends Operation {
+class TrainrunOperation extends BaseOperation {
   readonly trainrun: TrainrunDto;
 
   /** @internal */
@@ -53,7 +53,7 @@ class TrainrunOperation extends Operation {
   }
 }
 
-class NodeOperation extends Operation {
+class NodeOperation extends BaseOperation {
   readonly node: NodeDto;
 
   /** @internal */
@@ -63,7 +63,7 @@ class NodeOperation extends Operation {
   }
 }
 
-class LabelOperation extends Operation {
+class LabelOperation extends BaseOperation {
   readonly label: LabelDto;
 
   /** @internal */
@@ -73,7 +73,7 @@ class LabelOperation extends Operation {
   }
 }
 
-class NoteOperation extends Operation {
+class NoteOperation extends BaseOperation {
   readonly note: FreeFloatingTextDto;
 
   /** @internal */
@@ -83,7 +83,7 @@ class NoteOperation extends Operation {
   }
 }
 
-class MetadataOperation extends Operation {
+class MetadataOperation extends BaseOperation {
   readonly metadata: MetadataDto;
 
   /** @internal */
@@ -93,7 +93,7 @@ class MetadataOperation extends Operation {
   }
 }
 
-class FilterSettingOperation extends Operation {
+class FilterSettingOperation extends BaseOperation {
   readonly filterSetting: FilterSettingDto;
 
   /** @internal */
@@ -102,6 +102,14 @@ class FilterSettingOperation extends Operation {
     this.filterSetting = filterSetting;
   }
 }
+
+type Operation =
+  | TrainrunOperation
+  | NodeOperation
+  | LabelOperation
+  | NoteOperation
+  | MetadataOperation
+  | FilterSettingOperation;
 
 export {
   OperationType,


### PR DESCRIPTION
Currently, our exported Operation class is open: there is no guarantee that classes in operation.model.ts are the only ones inheriting from our base Operation class. In fact, even NGE users can create their own class inheriting from Operation.

This is cumbersome for users willing to check the type of an operation: checking for type/objectType isn't enough to narrow down the value to a more specific operation class.

To fix this, rename Operation to BaseOperation and don't export it. Instead, export a union of all of our operations. That way, TypeScript is aware that only the listed choices are valid when handling an Operation object.

See discussion here:
https://github.com/OpenRailAssociation/osrd/pull/17533#discussion_r3557315536