### PR TITLE
refactor(service): remove mapLeftAndRightTimes

### DIFF
--- a/src/app/services/data/trainrun-section-times.service.ts
+++ b/src/app/services/data/trainrun-section-times.service.ts
@@ -762,11 +762,7 @@ export class TrainrunSectionTimesService {
     }
 
     this.trainrunSectionService.setTimeStructureToTrainrunSections(
-      this.trainrunSectionHelper.mapLeftAndRightTimes(
-        this.selectedTrainrunSection,
-        this.nodesOrdered,
-        this.timeStructure,
-      ),
+      this.timeStructure,
       this.selectedTrainrunSection,
       this.filterService.getTimeDisplayPrecision(),
     );

--- a/src/app/services/util/trainrunsection.helper.ts
+++ b/src/app/services/util/trainrunsection.helper.ts
@@ -293,30 +293,6 @@ export class TrainrunsectionHelper {
     return undefined;
   }
 
-  mapLeftAndRightTimes(
-    trainrunSection: TrainrunSection,
-    orderedNodes: Node[],
-    timeStructure: LeftAndRightTimeStructure,
-  ): LeftAndRightTimeStructure {
-    const bothLastNonStopNodes = this.trainrunService.getBothLastNonStopNodes(trainrunSection);
-    const leftNode = GeneralViewFunctions.getLeftOrTopNode(
-      bothLastNonStopNodes.lastNonStopNode1,
-      bothLastNonStopNodes.lastNonStopNode2,
-    );
-    const localLeftNode = this.getNextStopLeftNode(trainrunSection, orderedNodes);
-    if (leftNode.getId() !== localLeftNode.getId()) {
-      const mappedTimeStructure = TrainrunsectionHelper.getDefaultTimeStructure(timeStructure);
-      mappedTimeStructure.rightArrivalTime = timeStructure.leftArrivalTime;
-      mappedTimeStructure.leftArrivalTime = timeStructure.rightArrivalTime;
-      mappedTimeStructure.rightDepartureTime = timeStructure.leftDepartureTime;
-      mappedTimeStructure.leftDepartureTime = timeStructure.rightDepartureTime;
-      mappedTimeStructure.travelTime = timeStructure.bottomTravelTime;
-      mappedTimeStructure.bottomTravelTime = timeStructure.travelTime;
-      return mappedTimeStructure;
-    }
-    return timeStructure;
-  }
-
   getLeftAndRightTimes(
     trainrunSection: TrainrunSection,
     orderedNodes: Node[],


### PR DESCRIPTION
The if branch was unreachable because the method was only called when nodesOrdered is empty, and, in that case, the two values are compared through getLeftOrTopNode on the same last-non-stop nodes.

Close #808 