### PR TITLE
fix: add missing .js file extension to ESM imports

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import type {} from "@angular/localize/init";
 
-export * from "./app/data-structures/technical.data.structures";
-export * from "./app/data-structures/business.data.structures";
-export type * from "./app/models/operation.model";
+export * from "./app/data-structures/technical.data.structures.ts";
+export * from "./app/data-structures/business.data.structures.ts";
+export type * from "./app/models/operation.model.ts";

--- a/tsconfig.defs.json
+++ b/tsconfig.defs.json
@@ -4,7 +4,8 @@
     "declaration": true,
     "declarationDir": "dist/types",
     "typeRoots": [],
-    "stripInternal": true
+    "stripInternal": true,
+    "rewriteRelativeImportExtensions": true
   },
   "files": [],
   "include": ["src/types.ts"]


### PR DESCRIPTION
ESM requires explicit file extensions:
https://nodejs.org/api/esm.html#mandatory-file-extensions

TypeScript doesn't add file extensions when producing .js files. This results in broken imports when trying to use NGE from Node.

Fix this by adding explicit file extensions on the TypeScript side and enabling rewriteRelativeImportExtensions:
https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-7.html#path-rewriting-for-relative-paths