### PR TITLE
fix: perlenkette node name ellipsis when connection time is undefined

### DIFF
--- a/src/app/perlenkette/perlenkette-node/perlenkette-node.component.ts
+++ b/src/app/perlenkette/perlenkette-node/perlenkette-node.component.ts
@@ -409,7 +409,12 @@ export class PerlenketteNodeComponent implements OnInit, AfterViewInit {
     const textElement = nativeElement.querySelector(".node_text");
     const nodeConnectionTime = nativeElement.querySelector(".node_connection_time").getBBox();
     const mainRect = nativeElement.querySelector(".main_rect").getBBox();
-    this.truncateTextWithEllipsis(textElement, nodeConnectionTime.x - mainRect.x);
+    const mainRectPadding = 10;
+    const maxWidth =
+      nodeConnectionTime.width > 0
+        ? nodeConnectionTime.x - mainRect.x
+        : mainRect.width - mainRectPadding;
+    this.truncateTextWithEllipsis(textElement, maxWidth);
   }
 
   private adjustTerminalStationWithEllipsis() {


### PR DESCRIPTION
When `connectionTime` is not defined (= field is cleared is node details menu), then the Perlenkette behaved weird and did not display the node name, as you see in the video:

Before fix:

https://github.com/user-attachments/assets/7ed14901-fbc1-46aa-a8c6-cd69f1f66c45

After fix:

https://github.com/user-attachments/assets/5e568086-ae01-4ef0-9ccd-3b124a1738c1

Close https://github.com/OpenRailAssociation/osrd/issues/17548