### PR TITLE
fix(services): bail out from propagateConsecutiveTimesForTrainrun() on infinite loop

### DIFF
--- a/src/app/services/data/trainrun.service.ts
+++ b/src/app/services/data/trainrun.service.ts
@@ -643,11 +643,20 @@ export class TrainrunService {
       );
 
       // filter all still visited trainrun sections
-      alltrainrunsections = alltrainrunsections.filter(
+      const remainingTrainrunSections = alltrainrunsections.filter(
         (ts) =>
           propDataForward.visitedTrainrunSections.indexOf(ts) === -1 &&
           propDataBackward.visitedTrainrunSections.indexOf(ts) === -1,
       );
+
+      // Ensure forward progress: if we hit an infinite loop in
+      // TrainrunIterator, then we stop iterating leaving some sections
+      // unvisited. If we haven't visited new sections, bail out.
+      if (alltrainrunsections.length === remainingTrainrunSections.length) {
+        break;
+      }
+
+      alltrainrunsections = remainingTrainrunSections;
     }
   }
 


### PR DESCRIPTION
When TrainrunIterator encounters an infinite loop, it stops iteration, leaving some trainrun sections unvisited.

propagateConsecutiveTimesForTrainrun() assumes that all sections of a trainrun will be eventually visited when calling TrainrunIterator repeatedly. This won't be the case when an infinite loop is hit.

Check whether forward progress is made: if an iteration doesn't decrease alltrainrunsections.length, then we've entered an infinite loop. Bail out in this case.

Closes: https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/issues/951