### PR TITLE
refactor(services): drop legacy anonymous functions from O/D matrix

### DIFF
--- a/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
@@ -294,17 +294,17 @@ export class OriginDestinationComponent implements OnInit, AfterViewInit, OnDest
         .style("top", `${event.offsetY + 64 < 0 ? 0 : event.offsetY + 64}px`);
     };
 
-    const mouseleave = (event: MouseEvent, _d: OriginDestination) => {
+    const mouseleave = (event: MouseEvent, d: OriginDestination) => {
       tooltip.style("opacity", 0);
       d3.select(D3Utils.getMouseEventCurrentTarget(event))
         .style("stroke", "none")
         .style("opacity", (d: OriginDestination) => (d.originId === d.destinationId ? 0 : 0.8));
 
       // Remove boldness from the axis labels
-      d3.selectAll(`[data-origin-label="${_d.originId}"]`)
+      d3.selectAll(`[data-origin-label="${d.originId}"]`)
         .style("font-weight", null)
         .style("font-size", null);
-      d3.selectAll(`[data-destination-label="${_d.destinationId}"]`)
+      d3.selectAll(`[data-destination-label="${d.destinationId}"]`)
         .style("font-weight", null)
         .style("font-size", null);
     };

--- a/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
@@ -252,7 +252,7 @@ export class OriginDestinationComponent implements OnInit, AfterViewInit, OnDest
       .attr("class", "tooltip");
 
     // Three function that change the tooltip when user hover / move / leave a cell
-    const mouseover = function (event: MouseEvent, d: OriginDestination) {
+    const mouseover = (event: MouseEvent, d: OriginDestination) => {
       if (d.found) {
         tooltip.style("opacity", 1);
         d3.select(D3Utils.getMouseEventCurrentTarget(event))
@@ -276,7 +276,7 @@ export class OriginDestinationComponent implements OnInit, AfterViewInit, OnDest
 
     const nodeNameMap = new Map(nodeNames.map((n) => [n.id, n.fullName]));
 
-    const mousemove = function (event: MouseEvent, d: OriginDestination) {
+    const mousemove = (event: MouseEvent, d: OriginDestination) => {
       let details = "";
       if (d.found) {
         details += "<br><hr> ";
@@ -294,7 +294,7 @@ export class OriginDestinationComponent implements OnInit, AfterViewInit, OnDest
         .style("top", `${event.offsetY + 64 < 0 ? 0 : event.offsetY + 64}px`);
     };
 
-    const mouseleave = function (event: MouseEvent, _d: OriginDestination) {
+    const mouseleave = (event: MouseEvent, _d: OriginDestination) => {
       tooltip.style("opacity", 0);
       d3.select(D3Utils.getMouseEventCurrentTarget(event))
         .style("stroke", "none")
@@ -318,7 +318,7 @@ export class OriginDestinationComponent implements OnInit, AfterViewInit, OnDest
       .attr("x", (d: OriginDestination) => {
         return x(d.destinationId);
       })
-      .attr("y", function (d: OriginDestination) {
+      .attr("y", (d: OriginDestination) => {
         return y(d.originId);
       })
       .attr("rx", 4)
@@ -346,7 +346,7 @@ export class OriginDestinationComponent implements OnInit, AfterViewInit, OnDest
       .attr("x", (d: OriginDestination) => {
         return x(d.destinationId) + x.bandwidth() / 2;
       })
-      .attr("y", function (d: OriginDestination) {
+      .attr("y", (d: OriginDestination) => {
         return y(d.originId) + y.bandwidth() / 2;
       })
       .text((d: OriginDestination) => this.getCellText(d))

--- a/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
@@ -251,7 +251,7 @@ export class OriginDestinationComponent implements OnInit, AfterViewInit, OnDest
       .attr("class", "tooltip");
 
     // Three function that change the tooltip when user hover / move / leave a cell
-    const mouseover = function (d: OriginDestination) {
+    const mouseover = function (event: MouseEvent, d: OriginDestination) {
       if (d.found) {
         tooltip.style("opacity", 1);
         d3.select(this).style("stroke", "black").style("stroke-width", "2px").style("opacity", 1);

--- a/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
+++ b/src/app/services/analytics/origin-destination/components/origin-destination.component.ts
@@ -14,6 +14,7 @@ import {FilterService} from "../../../ui/filter.service";
 import {NodeService} from "../../../data/node.service";
 import {TrainrunService} from "../../../data/trainrun.service";
 import {TrainrunSectionService} from "../../../data/trainrunsection.service";
+import {D3Utils} from "src/app/view/editor-main-view/data-views/d3.utils";
 
 type FieldName = "totalCost" | "travelTime" | "transfers";
 type ColorSetName = "red" | "blue" | "orange" | "gray";
@@ -254,7 +255,10 @@ export class OriginDestinationComponent implements OnInit, AfterViewInit, OnDest
     const mouseover = function (event: MouseEvent, d: OriginDestination) {
       if (d.found) {
         tooltip.style("opacity", 1);
-        d3.select(this).style("stroke", "black").style("stroke-width", "2px").style("opacity", 1);
+        d3.select(D3Utils.getMouseEventCurrentTarget(event))
+          .style("stroke", "black")
+          .style("stroke-width", "2px")
+          .style("opacity", 1);
       }
 
       // Highlight axis labels in bold when hovering over a cell
@@ -290,9 +294,9 @@ export class OriginDestinationComponent implements OnInit, AfterViewInit, OnDest
         .style("top", `${event.offsetY + 64 < 0 ? 0 : event.offsetY + 64}px`);
     };
 
-    const mouseleave = function (_event: MouseEvent, _d: OriginDestination) {
+    const mouseleave = function (event: MouseEvent, _d: OriginDestination) {
       tooltip.style("opacity", 0);
-      d3.select(this)
+      d3.select(D3Utils.getMouseEventCurrentTarget(event))
         .style("stroke", "none")
         .style("opacity", (d: OriginDestination) => (d.originId === d.destinationId ? 0 : 0.8));
 


### PR DESCRIPTION
_See individual commits._

O/D matrix tooltips were broken, this PR fixes them. Additionally, it improves type safety, removing an implicit `any` cast due to `this` usage in a legacy anonymous function.