### PR TITLE
fix(model): make Node.connectionTime nullable

### DIFF
--- a/src/app/data-structures/business.data.structures.ts
+++ b/src/app/data-structures/business.data.structures.ts
@@ -184,7 +184,7 @@ export interface NodeDto {
 
   resourceId: number; // reference to the algined (resource - not yet implemented)
   perronkanten: number; // number of tracks where train can stop
-  connectionTime: number; // aka Umsteigezeit - time used to change train in minutes
+  connectionTime: number | null; // aka Umsteigezeit - time used to change train in minutes
   trainrunCategoryHaltezeiten: TrainrunCategoryHaltezeit; // user can over-write the halte times
   symmetryAxis: number; // deprecate ???
   warnings: WarningDto[]; // business logic failures - warnings storage

--- a/src/app/models/node.model.ts
+++ b/src/app/models/node.model.ts
@@ -36,7 +36,7 @@ export class Node {
   private connections: Connection[];
   private resourceId: number;
   private perronkanten: number;
-  private connectionTime: number;
+  private connectionTime: number | null;
   private trainrunCategoryHaltezeiten: TrainrunCategoryHaltezeit;
   private symmetryAxis: number;
   private warnings: WarningDto[];
@@ -243,11 +243,11 @@ export class Node {
     this.fullName = name;
   }
 
-  getConnectionTime(): number {
+  getConnectionTime(): number | null {
     return this.connectionTime;
   }
 
-  setConnectionTime(connectionTime: number) {
+  setConnectionTime(connectionTime: number | null) {
     this.connectionTime = connectionTime;
   }
 

--- a/src/app/services/data/node.service.ts
+++ b/src/app/services/data/node.service.ts
@@ -921,7 +921,7 @@ export class NodeService implements OnDestroy {
     this.operation.emit(new NodeOperation(OperationType.update, this.getNodeFromId(nodeId)));
   }
 
-  changeConnectionTime(nodeId: number, connectionTime: number) {
+  changeConnectionTime(nodeId: number, connectionTime: number | null) {
     this.getNodeFromId(nodeId).setConnectionTime(connectionTime);
     this.nodesUpdated();
     this.operation.emit(new NodeOperation(OperationType.update, this.getNodeFromId(nodeId)));

--- a/src/app/view/editor-side-view/editor-node-detail-view/editor-node-detail-view.component.ts
+++ b/src/app/view/editor-side-view/editor-node-detail-view/editor-node-detail-view.component.ts
@@ -22,7 +22,7 @@ interface NodeProperties {
   nodeId: number;
   nodeBetriebspunktName: string;
   nodeBetriebspunktFullName: string;
-  nodeConnectionTime: number;
+  nodeConnectionTime: number | null;
   nodeTrainrunCategoryHaltezeit: TrainrunCategoryHaltezeit;
   nodeResourceId: number;
   nodeCapacity: number;


### PR DESCRIPTION
Node.connectionTime has always been nullable, since the value of it is set by an input that allows an empty input, resulting in a null value: https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/blob/c7cc792103a7ce04e23e2223172c48ad8092c975/src/app/view/editor-side-view/editor-node-detail-view/editor-node-detail-view.component.html#L36-L42

This PR aligns this behavior and the data model.