### PR TITLE
chore(github): fix CODEOWNERS for new maintainer team name

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-# https://github.com/OpenRailAssociation/openrail-org-config/blob/main/teams/nge.yaml
-* @openrailassociation/NGE-Admins
+# https://github.com/OpenRailAssociation/openrail-org-config/blob/main/teams/project-nge.yaml
+* @openrailassociation/NGE-Maintainers


### PR DESCRIPTION
The admin/maintainer team has been renamed to NGE-Maintainers in this patch:
https://github.com/OpenRailAssociation/openrail-org-config/pull/175

The CODEOWNERS file was not updated. As a result, pull requests could be merged without any maintainer approval.